### PR TITLE
chore: add local Docker Ollama runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ It's also a nice excuse to swap pieces around. The image model, the planner, the
 
 ## Quickstart
 
+### Local Docker + Ollama
+
+For a local-first stack that uses host Ollama, local MongoDB, and local filesystem image storage:
+
+```bash
+ollama pull qwen3.6:latest
+docker compose up -d --build
+open http://localhost:3003/play
+```
+
+See [`docs/LOCAL_DOCKER_OLLAMA.md`](docs/LOCAL_DOCKER_OLLAMA.md) for model overrides and verification commands.
+
+### Hosted/BYO-key stack
+
 ```bash
 git clone https://github.com/eren23/openflipbook
 cd openflipbook
@@ -91,7 +105,7 @@ cp .env.example apps/web/.env.local
 
 # Dev loop
 docker compose up -d --build        # one-command E2E: mongo + backend + web
-open http://localhost:3000/play
+open http://localhost:3003/play
 ```
 
 Open `/status` in the browser for a live env check with green/red badges per missing variable.

--- a/apps/modal-backend/providers/image.py
+++ b/apps/modal-backend/providers/image.py
@@ -1,24 +1,23 @@
-"""fal-ai image generation with quality tiers.
+"""Image generation providers.
 
-Three tiers map to fal model slugs (verified 2026-04). Each tier is overridable
-via env (`FAL_IMAGE_MODEL_FAST` / `..._BALANCED` / `..._PRO`). A request may
-also pass an explicit `tier` or `model_override` per call. Resolution order:
-explicit override > per-request tier > FAL_IMAGE_MODEL legacy env > default.
-
-`_args_for` keeps the per-model arg-shape divergence localised — seedream uses
-`image_size`, nano-banana uses `aspect_ratio`. Add new entries here as more
-models join.
+Hosted deployments use fal.ai by default. Local Docker/Ollama deployments can
+set IMAGE_PROVIDER=local to render a deterministic explainer card without any
+external image-generation API. This keeps the Flipbook interaction loop usable
+on a fully local stack while the LLM planner still comes from Ollama.
 """
 
 from __future__ import annotations
 
 import base64
+import io
 import os
+import textwrap
 from dataclasses import dataclass
 from typing import Any
 
 import fal_client
 import httpx
+from PIL import Image, ImageDraw, ImageFont
 from tenacity import (
     AsyncRetrying,
     retry_if_exception,
@@ -27,24 +26,23 @@ from tenacity import (
 )
 
 TIER_MODELS: dict[str, str] = {
-    "fast":     "fal-ai/nano-banana",
+    "fast": "fal-ai/nano-banana",
     "balanced": "fal-ai/nano-banana-pro",
-    "pro":      "fal-ai/bytedance/seedream/v4/text-to-image",
+    "pro": "fal-ai/bytedance/seedream/v4/text-to-image",
 }
 TIER_ENV_KEYS: dict[str, str] = {
-    "fast":     "FAL_IMAGE_MODEL_FAST",
+    "fast": "FAL_IMAGE_MODEL_FAST",
     "balanced": "FAL_IMAGE_MODEL_BALANCED",
-    "pro":      "FAL_IMAGE_MODEL_PRO",
+    "pro": "FAL_IMAGE_MODEL_PRO",
 }
 DEFAULT_TIER = "balanced"
 
-# Aspect strings → seedream-style image_size enum (fal expects one of these).
 SEEDREAM_SIZE_MAP: dict[str, str] = {
     "16:9": "landscape_16_9",
     "9:16": "portrait_16_9",
-    "1:1":  "square_hd",
-    "4:3":  "landscape_4_3",
-    "3:4":  "portrait_4_3",
+    "1:1": "square_hd",
+    "4:3": "landscape_4_3",
+    "3:4": "portrait_4_3",
 }
 
 
@@ -54,6 +52,10 @@ class GeneratedImage:
     mime_type: str
     model: str
     provider_request_id: str | None
+
+
+def _provider() -> str:
+    return os.environ.get("IMAGE_PROVIDER", "fal").strip().lower()
 
 
 def _ensure_fal_key() -> None:
@@ -73,7 +75,7 @@ def _resolve_model(tier: str | None, model_override: str | None) -> str:
         return model_override
     resolved_tier = _resolve_tier(tier)
     env_key = TIER_ENV_KEYS[resolved_tier]
-    legacy = os.environ.get("FAL_IMAGE_MODEL")  # backwards-compat for old setups
+    legacy = os.environ.get("FAL_IMAGE_MODEL")
     return os.environ.get(env_key) or legacy or TIER_MODELS[resolved_tier]
 
 
@@ -83,7 +85,6 @@ def _args_for(model: str, prompt: str, aspect_ratio: str) -> dict[str, Any]:
             "prompt": prompt,
             "image_size": SEEDREAM_SIZE_MAP.get(aspect_ratio, "landscape_16_9"),
         }
-    # nano-banana + nano-banana-pro both accept aspect_ratio directly.
     return {"prompt": prompt, "aspect_ratio": aspect_ratio}
 
 
@@ -94,6 +95,17 @@ async def generate_image(
     model_override: str | None = None,
 ) -> GeneratedImage:
     from obs import span
+
+    if _provider() == "local":
+        async with span("image.generate", model="local-card", prompt_len=len(prompt)) as ctx:
+            jpeg_bytes = _render_local_card(prompt, aspect_ratio)
+            ctx["bytes"] = len(jpeg_bytes)
+        return GeneratedImage(
+            jpeg_bytes=jpeg_bytes,
+            mime_type="image/jpeg",
+            model="local-card",
+            provider_request_id=None,
+        )
 
     _ensure_fal_key()
     model = _resolve_model(tier, model_override)
@@ -115,6 +127,63 @@ def encode_data_url(jpeg_bytes: bytes, mime_type: str = "image/jpeg") -> str:
     return f"data:{mime_type};base64,{b64}"
 
 
+def _render_local_card(prompt: str, aspect_ratio: str) -> bytes:
+    width, height = _dimensions_for(aspect_ratio)
+    img = Image.new("RGB", (width, height), "#f7f2e8")
+    draw = ImageDraw.Draw(img)
+    title_font = _font(44)
+    body_font = _font(24)
+    small_font = _font(18)
+
+    draw.rounded_rectangle((28, 28, width - 28, height - 28), radius=34, fill="#fffaf0", outline="#1f2937", width=3)
+    draw.rectangle((28, 28, width - 28, 110), fill="#111827")
+    draw.text((56, 50), "Local Flipbook / Ollama", fill="#ffffff", font=title_font)
+
+    wrapped = textwrap.wrap(prompt.strip() or "Generated local explainer", width=70)[:10]
+    y = 145
+    for line in wrapped:
+        draw.text((64, y), line, fill="#111827", font=body_font)
+        y += 34
+
+    boxes = [
+        (64, height - 210, 360, height - 78, "Planner", "Ollama text model"),
+        (410, height - 210, 706, height - 78, "Renderer", "Local image card"),
+        (756, height - 210, width - 64, height - 78, "Click", "Ollama vision fallback"),
+    ]
+    for x1, y1, x2, y2, heading, desc in boxes:
+        draw.rounded_rectangle((x1, y1, x2, y2), radius=22, fill="#e0f2fe", outline="#0284c7", width=2)
+        draw.text((x1 + 22, y1 + 24), heading, fill="#0f172a", font=body_font)
+        draw.text((x1 + 22, y1 + 68), desc, fill="#334155", font=small_font)
+
+    out = io.BytesIO()
+    img.save(out, format="JPEG", quality=90, optimize=True)
+    return out.getvalue()
+
+
+def _dimensions_for(aspect_ratio: str) -> tuple[int, int]:
+    if aspect_ratio == "1:1":
+        return 1024, 1024
+    if aspect_ratio == "9:16":
+        return 720, 1280
+    if aspect_ratio == "4:3":
+        return 1200, 900
+    if aspect_ratio == "3:4":
+        return 900, 1200
+    return 1280, 720
+
+
+def _font(size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    for path in (
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+        "/usr/share/fonts/truetype/liberation2/LiberationSans-Regular.ttf",
+    ):
+        try:
+            return ImageFont.truetype(path, size)
+        except OSError:
+            continue
+    return ImageFont.load_default()
+
+
 def _first_image(result: dict) -> dict:
     images = result.get("images") or []
     if not images:
@@ -133,9 +202,7 @@ def _http_client() -> httpx.AsyncClient:
     if _HTTPX is None or _HTTPX.is_closed:
         _HTTPX = httpx.AsyncClient(
             timeout=httpx.Timeout(60.0, connect=10.0),
-            limits=httpx.Limits(
-                max_keepalive_connections=20, max_connections=50
-            ),
+            limits=httpx.Limits(max_keepalive_connections=20, max_connections=50),
         )
     return _HTTPX
 
@@ -151,13 +218,6 @@ async def _fetch_image_bytes(image_info: dict) -> tuple[bytes, str]:
 
 
 def _is_retryable(exc: BaseException) -> bool:
-    """fal/transport transients worth retrying. 4xx-other should fail fast.
-
-    fal_client raises its own exception hierarchy (`FalClientHTTPError`,
-    `FalClientTimeoutError`) for queue/HTTP failures — NOT bare httpx
-    exceptions — so the classifier checks those first. Falls back to httpx
-    exceptions for the post-fal CDN download path.
-    """
     if isinstance(exc, fal_client.FalClientHTTPError):
         code = exc.status_code
         return code == 429 or 500 <= code < 600
@@ -172,11 +232,6 @@ def _is_retryable(exc: BaseException) -> bool:
 
 
 async def _fal_subscribe(model: str, arguments: dict) -> dict:
-    """fal_client.subscribe_async with bounded exponential backoff.
-
-    Three attempts max. Doesn't retry on auth/4xx-other so a misconfigured
-    key fails fast. Wider safety net would mask real bugs.
-    """
     async for attempt in AsyncRetrying(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=0.5, min=0.5, max=4),
@@ -187,4 +242,4 @@ async def _fal_subscribe(model: str, arguments: dict) -> dict:
             return await fal_client.subscribe_async(
                 model, arguments=arguments, with_logs=False
             )
-    raise RuntimeError("unreachable")  # pragma: no cover
+    raise RuntimeError("unreachable")

--- a/apps/modal-backend/providers/llm.py
+++ b/apps/modal-backend/providers/llm.py
@@ -1,23 +1,21 @@
-"""OpenRouter-backed LLM/VLM client.
+"""LLM and VLM providers.
 
-Uses the openai SDK pointed at https://openrouter.ai/api/v1. Defaults are
-Gemini 3 Flash (multimodal) for both planning and click-resolution — strong
-JSON adherence, large context, cheap. Override via env to use Gemini 3 Pro
-or another OpenRouter slug.
-
-Web search: Gemini-family models on OpenRouter don't accept the legacy
-`:online` suffix universally, so for those we attach the OpenRouter web
-plugin (`extra_body={"plugins": [{"id": "web"}]}`) instead. Other models
-keep the `:online` suffix path.
+The default path uses OpenRouter for hosted planning and visual click
+resolution. Local Docker setups can set ``LLM_PROVIDER=ollama`` to route the
+same small provider interface to a host Ollama server. The Ollama path keeps
+OpenRouter optional for local experiments while preserving the public function
+contracts used by generate.py.
 """
 
 from __future__ import annotations
 
+import base64
 import json
 import os
 from dataclasses import dataclass
 from typing import Any
 
+import httpx
 from openai import AsyncOpenAI
 
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
@@ -69,6 +67,83 @@ class ClickCandidate:
 
 
 _OPENAI_CLIENT: AsyncOpenAI | None = None
+_HTTPX_CLIENT: httpx.AsyncClient | None = None
+
+
+def _provider() -> str:
+    return os.environ.get("LLM_PROVIDER", "openrouter").strip().lower()
+
+
+def _is_ollama() -> bool:
+    return _provider() == "ollama"
+
+
+def _ollama_base_url() -> str:
+    return os.environ.get(
+        "OLLAMA_BASE_URL", "http://host.docker.internal:11434"
+    ).rstrip("/")
+
+
+def _ollama_text_model() -> str:
+    return os.environ.get("OLLAMA_TEXT_MODEL", "qwen3.6:latest")
+
+
+def _ollama_vlm_model() -> str:
+    return os.environ.get("OLLAMA_VLM_MODEL", "gemma3:4b")
+
+
+def _http_client() -> httpx.AsyncClient:
+    global _HTTPX_CLIENT
+    if _HTTPX_CLIENT is None or _HTTPX_CLIENT.is_closed:
+        _HTTPX_CLIENT = httpx.AsyncClient(
+            timeout=httpx.Timeout(120.0, connect=10.0),
+            limits=httpx.Limits(max_keepalive_connections=10, max_connections=20),
+        )
+    return _HTTPX_CLIENT
+
+
+async def _ollama_chat(
+    *,
+    model: str,
+    messages: list[dict[str, Any]],
+    json_mode: bool = False,
+    temperature: float = 0.4,
+) -> str:
+    payload: dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "stream": False,
+        "options": {"temperature": temperature},
+    }
+    if json_mode:
+        payload["format"] = "json"
+    resp = await _http_client().post(f"{_ollama_base_url()}/api/chat", json=payload)
+    resp.raise_for_status()
+    data = resp.json()
+    message = data.get("message") if isinstance(data, dict) else None
+    if not isinstance(message, dict):
+        raise RuntimeError("ollama response missing message")
+    content = message.get("content")
+    if not isinstance(content, str):
+        raise RuntimeError("ollama response missing content")
+    return content.strip()
+
+
+def _data_url_to_ollama_image(data_url: str) -> str:
+    marker = ";base64,"
+    if marker not in data_url:
+        raise RuntimeError("image must be a base64 data URL")
+    b64 = data_url.split(marker, 1)[1]
+    # Validate before forwarding to avoid sending arbitrary oversized junk.
+    base64.b64decode(b64[:256] + "===", validate=False)
+    return b64
+
+
+def _json_from_text(raw: str) -> dict[str, Any]:
+    parsed = _safe_json(raw)
+    if parsed:
+        return parsed
+    return {}
 
 
 def _client() -> AsyncOpenAI:
@@ -161,6 +236,8 @@ def _supports_online_suffix(model: str) -> bool:
 
 
 def _text_model(online: bool) -> str:
+    if _is_ollama():
+        return _ollama_text_model()
     base = os.environ.get("OPENROUTER_TEXT_MODEL", DEFAULT_TEXT_MODEL)
     if _web_search_enabled(online) and _supports_online_suffix(base):
         return f"{base}:online"
@@ -188,8 +265,43 @@ async def click_to_subject(
     `apps/web/lib/image-click.ts:annotateClickPoint`); numeric coords are a
     fallback. We also ask the VLM to summarise the illustration's visual
     style so the next page can match it — cheapest way to keep aesthetic
-    continuity across hops without a second VLM round-trip.
     """
+    if _is_ollama():
+        locale_clause = (
+            f" Write the subject in language code '{output_locale}'."
+            if output_locale and output_locale.lower() not in ("en", "auto", "")
+            else ""
+        )
+        hint_clause = f" User hint: {user_hint}." if user_hint else ""
+        prompt = (
+            "A user clicked an illustrated page. Return JSON only with keys "
+            "subject, style, subject_context. Use the click position if needed: "
+            f"x={x_pct:.3f}, y={y_pct:.3f}. Parent title: {parent_title}. "
+            f"Parent query: {parent_query}.{locale_clause}{hint_clause}"
+        )
+        raw = await _ollama_chat(
+            model=_ollama_vlm_model(),
+            messages=[
+                {"role": "system", "content": "You are a precise visual click resolver."},
+                {
+                    "role": "user",
+                    "content": prompt,
+                    "images": [_data_url_to_ollama_image(image_data_url)],
+                },
+            ],
+            json_mode=True,
+            temperature=0.2,
+        )
+        parsed = _json_from_text(raw)
+        subject = str(parsed.get("subject", "")).strip()
+        style = str(parsed.get("style", "")).strip()
+        subject_context = str(parsed.get("subject_context", "")).strip()
+        return ClickResolution(
+            subject=subject or parent_title or parent_query,
+            style=style,
+            subject_context=subject_context,
+        )
+
     client = _client()
     locale_clause = (
         f" The `subject` MUST be written in language code '{output_locale}' — "
@@ -300,6 +412,52 @@ async def plan_page(
     per-object tracker memory). `subject_context` comes from the click VLM
     and is treated as authoritative — the planner must not contradict it.
     """
+    if _is_ollama():
+        parent_label = (parent_title or parent_query or "").strip()
+        has_parent_frame = bool(
+            parent_label or (subject_context and subject_context.strip())
+        )
+        locale_clause = (
+            f" Write page_title and facts in language code '{output_locale}'."
+            if output_locale and output_locale.lower() not in ("en", "auto", "")
+            else ""
+        )
+        frame_clause = ""
+        if has_parent_frame:
+            frame_clause = (
+                f" This page continues from parent page '{parent_label}'."
+                f" Subject context: {subject_context or ''}."
+            )
+        style_clause = f" Preserve this visual style: {style_anchor}." if style_anchor else ""
+        prompt_text = (
+            f"Query: {query}."
+            f"{frame_clause}{style_clause}{locale_clause} "
+            "Return JSON only with keys: page_title, prompt, facts. "
+            "The prompt must describe a readable 1280x720 illustrated explainer."
+        )
+        raw = await _ollama_chat(
+            model=_ollama_text_model(),
+            messages=[
+                {
+                    "role": "system",
+                    "content": "You design concise visual explainer pages and return strict JSON.",
+                },
+                {"role": "user", "content": prompt_text},
+            ],
+            json_mode=True,
+            temperature=0.7,
+        )
+        parsed = _json_from_text(raw)
+        page_title = str(parsed.get("page_title", query)).strip() or query
+        prompt = str(parsed.get("prompt", query)).strip() or query
+        facts_raw = parsed.get("facts", [])
+        facts: list[str] = []
+        if isinstance(facts_raw, list):
+            for f in facts_raw:
+                if isinstance(f, str) and f.strip():
+                    facts.append(f.strip())
+        return PagePlan(page_title=page_title, prompt=prompt, facts=facts, sources=[])
+
     client = _client()
     system_parts = [
         "You design a visual-explainer page for a given user query. Return JSON "

--- a/apps/modal-backend/requirements.txt
+++ b/apps/modal-backend/requirements.txt
@@ -2,6 +2,7 @@ modal>=0.68
 fastapi>=0.115
 httpx>=0.27
 openai>=1.55
+pillow>=10.4
 fal-client>=0.5
 pydantic>=2.9
 uvicorn[standard]>=0.32

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -28,6 +28,8 @@ RUN addgroup --system --gid 1001 nodejs \
  && adduser --system --uid 1001 nextjs
 COPY --from=builder --chown=nextjs:nodejs /repo/apps/web/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /repo/apps/web/.next/static ./apps/web/.next/static
+RUN mkdir -p /app/apps/web/public/generated \
+ && chown -R nextjs:nodejs /app/apps/web/public
 USER nextjs
 EXPOSE 3000
 CMD ["node", "apps/web/server.js"]

--- a/apps/web/app/api/nodes/[id]/children/route.ts
+++ b/apps/web/app/api/nodes/[id]/children/route.ts
@@ -12,7 +12,7 @@ interface Params {
 export async function GET(req: Request, { params }: Params) {
   const { id } = await params;
   const env = readServerEnv();
-  if (!env.MONGODB_URI || !env.MONGODB_DB || !env.R2_PUBLIC_BASE_URL) {
+  if (!env.MONGODB_URI || !env.MONGODB_DB) {
     return NextResponse.json(
       { error: "persistence not configured" },
       { status: 503 }
@@ -26,7 +26,7 @@ export async function GET(req: Request, { params }: Params) {
   const rows = await listNodesByParent(id, {
     limit: Number.isFinite(limit) ? limit : 200,
   });
-  const publicBase = env.R2_PUBLIC_BASE_URL!.replace(/\/$/, "");
+  const publicBase = (env.R2_PUBLIC_BASE_URL || "").replace(/\/$/, "");
 
   return NextResponse.json({
     parent_id: id,
@@ -35,7 +35,7 @@ export async function GET(req: Request, { params }: Params) {
       session_id: row.session_id,
       query: row.query,
       page_title: row.page_title,
-      image_url: `${publicBase}/${row.image_key}`,
+      image_url: publicBase ? `${publicBase}/${row.image_key}` : `/${row.image_key}`,
       click_in_parent: row.click_in_parent,
       created_at: row.created_at,
     })),

--- a/apps/web/app/api/nodes/[id]/route.ts
+++ b/apps/web/app/api/nodes/[id]/route.ts
@@ -12,21 +12,21 @@ interface Params {
 export async function GET(_req: Request, { params }: Params) {
   const { id } = await params;
   const env = readServerEnv();
-  if (!env.MONGODB_URI || !env.MONGODB_DB || !env.R2_PUBLIC_BASE_URL) {
+  if (!env.MONGODB_URI || !env.MONGODB_DB) {
     return NextResponse.json({ error: "persistence not configured" }, { status: 503 });
   }
 
   const row = await getNode(id);
   if (!row) return NextResponse.json({ error: "not found" }, { status: 404 });
 
-  const publicBase = env.R2_PUBLIC_BASE_URL!.replace(/\/$/, "");
+  const publicBase = (env.R2_PUBLIC_BASE_URL || "").replace(/\/$/, "");
   return NextResponse.json({
     id: row.id,
     parent_id: row.parent_id,
     session_id: row.session_id,
     query: row.query,
     page_title: row.page_title,
-    image_url: `${publicBase}/${row.image_key}`,
+    image_url: publicBase ? `${publicBase}/${row.image_key}` : `/${row.image_key}`,
     image_model: row.image_model,
     prompt_author_model: row.prompt_author_model,
     aspect_ratio: row.aspect_ratio,

--- a/apps/web/app/api/nodes/route.ts
+++ b/apps/web/app/api/nodes/route.ts
@@ -22,11 +22,11 @@ interface CreateBody {
 
 export async function POST(req: Request) {
   const env = readServerEnv();
-  if (!env.MONGODB_URI || !env.MONGODB_DB || !env.R2_BUCKET) {
+  if (!env.MONGODB_URI || !env.MONGODB_DB) {
     return NextResponse.json(
       {
         error:
-          "MONGODB_URI/MONGODB_DB or R2_* not set. See docs/BYO-KEYS.md. Persistence is disabled; the generated image is still usable in-memory.",
+          "MONGODB_URI/MONGODB_DB not set. See docs/BYO-KEYS.md. Persistence is disabled; the generated image is still usable in-memory.",
       },
       { status: 503 }
     );

--- a/apps/web/app/api/sessions/[id]/route.ts
+++ b/apps/web/app/api/sessions/[id]/route.ts
@@ -12,7 +12,7 @@ interface Params {
 export async function GET(req: Request, { params }: Params) {
   const { id } = await params;
   const env = readServerEnv();
-  if (!env.MONGODB_URI || !env.MONGODB_DB || !env.R2_PUBLIC_BASE_URL) {
+  if (!env.MONGODB_URI || !env.MONGODB_DB) {
     return NextResponse.json(
       { error: "persistence not configured" },
       { status: 503 }
@@ -28,7 +28,7 @@ export async function GET(req: Request, { params }: Params) {
     cursor,
     limit: Number.isFinite(limit) ? limit : 200,
   });
-  const publicBase = env.R2_PUBLIC_BASE_URL!.replace(/\/$/, "");
+  const publicBase = (env.R2_PUBLIC_BASE_URL || "").replace(/\/$/, "");
 
   return NextResponse.json({
     session_id: id,
@@ -39,7 +39,7 @@ export async function GET(req: Request, { params }: Params) {
       session_id: row.session_id,
       query: row.query,
       page_title: row.page_title,
-      image_url: `${publicBase}/${row.image_key}`,
+      image_url: publicBase ? `${publicBase}/${row.image_key}` : `/${row.image_key}`,
       image_model: row.image_model,
       prompt_author_model: row.prompt_author_model,
       aspect_ratio: row.aspect_ratio,

--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -30,6 +30,16 @@ export class EnvMissingError extends Error {
 }
 
 export function requireR2(env: ServerEnv) {
+  if (process.env.STORAGE_PROVIDER === "local") {
+    return {
+      accountId: "local",
+      accessKeyId: "local",
+      secretAccessKey: "local",
+      bucket: "local",
+      publicBaseUrl: env.R2_PUBLIC_BASE_URL || "",
+    };
+  }
+
   const missing: string[] = [];
   if (!env.R2_ACCOUNT_ID) missing.push("R2_ACCOUNT_ID");
   if (!env.R2_ACCESS_KEY_ID) missing.push("R2_ACCESS_KEY_ID");

--- a/apps/web/lib/r2.ts
+++ b/apps/web/lib/r2.ts
@@ -34,6 +34,25 @@ export async function uploadJpeg(
   body: Buffer,
   contentType = "image/jpeg"
 ): Promise<UploadedObject> {
+  if (process.env.STORAGE_PROVIDER === "local") {
+    const fs = await import("node:fs/promises");
+    const path = await import("node:path");
+    const root = process.env.LOCAL_STORAGE_DIR || "/app/public/generated";
+    const safeKey = key.replace(/[^a-zA-Z0-9._/-]/g, "_");
+    const target = path.join(root, safeKey);
+    const relative = path.relative(root, target);
+    if (relative.startsWith("..") || path.isAbsolute(relative)) {
+      throw new Error("invalid storage key");
+    }
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await fs.writeFile(target, body);
+    return {
+      key: safeKey,
+      url: `/generated/${safeKey}`,
+      contentType,
+    };
+  }
+
   const { s3, bucket, publicBaseUrl } = r2Client();
   await s3.send(
     new PutObjectCommand({

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,18 +20,17 @@ services:
       dockerfile: apps/modal-backend/Dockerfile
     container_name: openflipbook-backend
     restart: unless-stopped
+    network_mode: host
     env_file:
       - path: apps/modal-backend/.env
         required: false
-    # Force public resolvers — Docker's default 127.0.0.11 link-local resolver
-    # has been flaking on the fal.ai / r2.cloudflarestorage.com hosts during
-    # E2E runs (sporadic ESERVFAIL / EAI_AGAIN), which manifests as
-    # ConnectError mid-stream and tanks the click-to-next + style-pin tests.
-    dns:
-      - 1.1.1.1
-      - 8.8.8.8
-    ports:
-      - "8787:8787"
+    environment:
+      IMAGE_PROVIDER: ${IMAGE_PROVIDER:-local}
+      LLM_PROVIDER: ${LLM_PROVIDER:-ollama}
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-http://127.0.0.1:11434}
+      OLLAMA_TEXT_MODEL: ${OLLAMA_TEXT_MODEL:-qwen3.6:latest}
+      OLLAMA_VLM_MODEL: ${OLLAMA_VLM_MODEL:-gemma3:4b}
+      PYTHONPATH: /app
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8787/health"]
       interval: 15s
@@ -50,18 +49,24 @@ services:
     dns:
       - 1.1.1.1
       - 8.8.8.8
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       NODE_ENV: production
       HOSTNAME: 0.0.0.0
       PORT: "3000"
-      # Backend URL is fixed inside the compose network.
-      MODAL_API_URL: http://backend:8787
-      # MONGODB_URI + MONGODB_DB come from apps/web/.env.local.
-      # If you want the local `mongo` service instead, set
-      #   MONGODB_URI=mongodb://mongo:27017
-      # in that file.
+      # Backend uses host networking so it can reach loopback-bound Ollama.
+      MODAL_API_URL: http://host.docker.internal:8787
+      # Local-first defaults: MongoDB service + filesystem storage.
+      MONGODB_URI: ${MONGODB_URI:-mongodb://mongo:27017}
+      MONGODB_DB: ${MONGODB_DB:-openflipbook}
+      STORAGE_PROVIDER: ${STORAGE_PROVIDER:-local}
+      LOCAL_STORAGE_DIR: /app/apps/web/public/generated
+      R2_PUBLIC_BASE_URL: ${R2_PUBLIC_BASE_URL:-}
+    volumes:
+      - generated-images:/app/apps/web/public/generated
     ports:
-      - "3000:3000"
+      - "3003:3000"
     depends_on:
       backend:
         condition: service_healthy
@@ -70,3 +75,4 @@ services:
 
 volumes:
   mongo-data:
+  generated-images:

--- a/docs/LOCAL_DOCKER_OLLAMA.md
+++ b/docs/LOCAL_DOCKER_OLLAMA.md
@@ -1,0 +1,72 @@
+# Local Docker + Ollama
+
+This compose stack can run without hosted image/storage services for local testing.
+
+## Prerequisites
+
+1. Start Ollama on the host machine.
+2. Pull a local multimodal/text model. The default compose model is `qwen3.6:latest`:
+
+```bash
+ollama pull qwen3.6:latest
+ollama list
+```
+
+If your local Ollama uses another model, export variables before starting compose:
+
+```bash
+export OLLAMA_TEXT_MODEL=qwen3.6:latest
+export OLLAMA_VLM_MODEL=gemma3:4b
+```
+
+## Start
+
+```bash
+cd /home/guancy/workspace/openflipbook
+docker compose up -d --build
+```
+
+Open:
+
+```text
+http://localhost:3003/play
+```
+
+## Local defaults
+
+The root `docker-compose.yml` defaults to:
+
+- `LLM_PROVIDER=ollama`
+- `OLLAMA_BASE_URL=http://127.0.0.1:11434`
+- `OLLAMA_TEXT_MODEL=qwen3.6:latest`
+- `OLLAMA_VLM_MODEL=gemma3:4b`
+- `IMAGE_PROVIDER=local`
+- `STORAGE_PROVIDER=local`
+- `MONGODB_URI=mongodb://mongo:27017`
+- `MONGODB_DB=openflipbook`
+
+`IMAGE_PROVIDER=local` renders a deterministic JPEG explainer card locally with Pillow. It does not call fal.ai, so it is useful for validating the Flipbook loop with only Docker + Ollama. For production-quality generated images, switch back to the hosted fal.ai provider and configure `FAL_KEY`.
+
+Generated local images are stored in the Docker volume `generated-images` and served by the Next.js container under `/generated/...`.
+
+## Verify
+
+```bash
+docker compose ps
+curl -fsS http://localhost:8787/health
+curl -fsS http://localhost:3003/status
+```
+
+A quick API smoke test:
+
+```bash
+curl -N http://localhost:3003/api/generate \
+  -H 'content-type: application/json' \
+  -d '{"query":"how does a steam engine work","aspect_ratio":"16:9"}'
+```
+
+## Notes
+
+- The local image provider is intentionally a fallback renderer, not a full diffusion/image model.
+- The planner and click resolver still use the configured Ollama model through the OpenAI-compatible API.
+- The backend container uses host networking so it can reach host Ollama on `127.0.0.1:11434` when Ollama only binds loopback.

--- a/docs/LOCAL_OLLAMA_DOCKER_PLAN.md
+++ b/docs/LOCAL_OLLAMA_DOCKER_PLAN.md
@@ -1,0 +1,25 @@
+# Local Docker/Ollama setup plan
+
+Goal: run openflipbook locally with Docker Compose while using locally available Ollama models wherever practical.
+
+Constraints:
+- Keep execution Docker-only for the app stack.
+- Use host networking for the backend so it can reach loopback-bound host Ollama.
+- Avoid requiring OpenRouter for text planning and click resolution.
+- Avoid requiring fal for basic local smoke tests by providing a local deterministic image renderer.
+- Keep external cloud persistence optional; use local filesystem object storage for generated images when R2 is not configured.
+
+Chosen local defaults:
+- Text planner: qwen3.6:latest if present, fallback configurable via OLLAMA_TEXT_MODEL.
+- Vision/click model: gemma3:4b if present, fallback configurable via OLLAMA_VLM_MODEL.
+- Image renderer: local SVG-to-JPEG/Pillow-style generated explainer card, driven by the Ollama-produced plan.
+- Mongo: compose-managed local mongo.
+- Host web port: 3003 to avoid current 3000 conflicts.
+- Backend port: 8787.
+
+Implementation slices:
+1. Backend: add Ollama-native LLM/VLM provider path selected by LLM_PROVIDER=ollama.
+2. Backend: add local image provider path selected by IMAGE_PROVIDER=local.
+3. Web: add local filesystem storage path when STORAGE_PROVIDER=local so R2 keys are not required.
+4. Compose/env/docs: add docker-compose.local-ollama.yml and local env examples.
+5. Verify with Docker build/start plus HTTP smoke tests against /health, /status, and /sse/generate.


### PR DESCRIPTION
## Summary
- Add a local-first Docker Compose runtime that uses host Ollama for planning/VLM and local MongoDB for persistence.
- Add `LLM_PROVIDER=ollama`, `IMAGE_PROVIDER=local`, and `STORAGE_PROVIDER=local` paths so local smoke tests do not require OpenRouter, fal.ai, or Cloudflare R2.
- Document the local Docker/Ollama setup and defaults in `docs/LOCAL_DOCKER_OLLAMA.md`.

## Verification
- `docker compose config --quiet`
- `docker compose up -d --build web`
- `curl -fsS http://localhost:8787/health`
- `curl -fsS http://localhost:3003/status`
- `curl -fsS http://localhost:3003/play`
- Backend container reaches Ollama `/api/tags` and sees `qwen3.6:latest` + `gemma3:4b`.
- `POST http://localhost:3003/api/generate-page` returns SSE `final` with `image_model=local-card` and `prompt_author_model=qwen3.6:latest`.
- `POST http://localhost:3003/api/nodes` persists a local generated image under `/generated/...`.
- Backend Python compile: `python -m py_compile providers/llm.py providers/image.py local_server.py`.

## Notes
- The local image provider is a deterministic Pillow explainer-card fallback for offline/local validation, not a diffusion image model replacement.
