### PR TITLE
Trace dashboard, eval benches, click groundability

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -123,12 +123,29 @@ async def _event_stream(
         client `AbortController.abort()` actually halts the planner / image-gen
         path instead of letting it run to completion (and burn fal credits)
         with no one listening.
+
+        Each abort is recorded in obs so /trace/abort-stats can show how
+        much wall-time (and $) we save by polling here.
         """
         if is_disconnected is None:
             return
         try:
             if await is_disconnected():
-                log("info", "sse.generate.client_disconnect", stage=stage)
+                from obs import record_abort
+
+                elapsed_ms = (_time.perf_counter() - started) * 1000.0
+                log(
+                    "info",
+                    "sse.generate.client_disconnect",
+                    stage=stage,
+                    elapsed_ms=round(elapsed_ms, 2),
+                )
+                record_abort(
+                    stage,
+                    elapsed_ms,
+                    trace_id=trace_id,
+                    extra={"mode": body.mode},
+                )
                 raise _asyncio.CancelledError()
         except _asyncio.CancelledError:
             raise
@@ -765,6 +782,34 @@ async def status() -> dict:
     from obs import status_payload
 
     return await status_payload(APP_NAME)
+
+
+@fastapi_app.get("/trace/recent")
+async def trace_recent(limit: int = 50) -> dict:
+    """Return the in-memory ring buffer of recent completed traces.
+
+    Powers the /admin/trace dashboard. Buffer is bounded (TRACE_BUFFER_MAX,
+    default 200) and process-local, so this is for ops/dev visibility, not
+    a long-term store.
+    """
+    from obs import recent_traces
+
+    clamped = max(1, min(int(limit), 200))
+    return {"ok": True, "service": APP_NAME, "traces": recent_traces(clamped)}
+
+
+@fastapi_app.get("/trace/abort-stats")
+async def trace_abort_stats(limit: int = 100) -> dict:
+    """Return aggregated stale-click stats: counts + wasted ms + $ per stage.
+
+    The bench/audit deliverable from the Bet E plan — confirms or refutes
+    the $200-400/month stale-click waste estimate by tracking every
+    client-disconnect during the SSE pipeline.
+    """
+    from obs import abort_stats
+
+    clamped = max(0, min(int(limit), 500))
+    return {"ok": True, "service": APP_NAME, **abort_stats(clamped)}
 
 
 @app.function(secrets=secrets, min_containers=0, timeout=600)

--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -80,6 +80,10 @@ class GenerateBody(BaseModel):
     prefetched_subject: str | None = None
     prefetched_style: str | None = None
     prefetched_subject_context: str | None = None
+    # Multi-turn refer (SAMA / MM-Conv pattern): when the user rejects a
+    # resolved subject and taps again nearby, the client forwards the
+    # rejected phrase so the VLM picks something different.
+    prior_rejected_subject: str | None = None
     session_style_anchor: str | None = None
     # Phase 3 — world-memory continuity. Web proxy resolves a slim slice
     # of the session's registry before forwarding; planner injects each
@@ -267,6 +271,7 @@ async def _event_stream(
                     parent_query=body.parent_query or body.query,
                     output_locale=body.output_locale,
                     user_hint=cleaned_user_hint or None,
+                    prior_rejected_subject=body.prior_rejected_subject,
                 )
                 if resolution.subject:
                     effective_query = resolution.subject
@@ -275,6 +280,23 @@ async def _event_stream(
                             "type": "status",
                             "stage": "click_resolved",
                             "subject": resolution.subject,
+                            "groundable": resolution.groundable,
+                            "confidence": resolution.confidence,
+                            "point": (
+                                {"x": resolution.point[0], "y": resolution.point[1]}
+                                if resolution.point is not None
+                                else None
+                            ),
+                            "bbox": (
+                                {
+                                    "x": resolution.bbox[0],
+                                    "y": resolution.bbox[1],
+                                    "w": resolution.bbox[2],
+                                    "h": resolution.bbox[3],
+                                }
+                                if resolution.bbox is not None
+                                else None
+                            ),
                         },
                         trace_id,
                     )
@@ -574,6 +596,7 @@ class ResolveClickBody(BaseModel):
     parent_title: str | None = None
     parent_query: str | None = None
     output_locale: str | None = None
+    prior_rejected_subject: str | None = None
     trace_id: str | None = None
 
 
@@ -581,9 +604,10 @@ class ResolveClickBody(BaseModel):
 async def resolve_click(req: Request, body: ResolveClickBody):
     """Hover-prefetch endpoint.
 
-    Returns just the click→subject+style mapping so the frontend can warm a
-    tap before the user commits, then forward `prefetched_subject` /
-    `prefetched_style` into `/sse/generate` to skip the VLM step there.
+    Returns the click→subject+style mapping plus groundability + bounding
+    box so the frontend can: (a) warm a tap before the user commits, (b)
+    render the "we think you tapped this — yes / try again" overlay, and
+    (c) suppress page generation when ``groundable`` is false.
     """
     from obs import TRACE_HEADER, bind_trace, record_error
     from providers import llm as llm_provider
@@ -597,6 +621,7 @@ async def resolve_click(req: Request, body: ResolveClickBody):
             parent_title=body.parent_title or "",
             parent_query=body.parent_query or "",
             output_locale=body.output_locale,
+            prior_rejected_subject=body.prior_rejected_subject,
         )
     except Exception as exc:
         record_error("resolve_click", exc)
@@ -610,6 +635,23 @@ async def resolve_click(req: Request, body: ResolveClickBody):
             "subject": resolution.subject,
             "style": resolution.style,
             "subject_context": resolution.subject_context,
+            "groundable": resolution.groundable,
+            "confidence": resolution.confidence,
+            "point": (
+                {"x": resolution.point[0], "y": resolution.point[1]}
+                if resolution.point is not None
+                else None
+            ),
+            "bbox": (
+                {
+                    "x": resolution.bbox[0],
+                    "y": resolution.bbox[1],
+                    "w": resolution.bbox[2],
+                    "h": resolution.bbox[3],
+                }
+                if resolution.bbox is not None
+                else None
+            ),
             "trace_id": trace_id,
         },
         headers={"X-Trace-Id": trace_id},

--- a/apps/modal-backend/obs.py
+++ b/apps/modal-backend/obs.py
@@ -15,6 +15,7 @@ import os
 import sys
 import time
 import uuid
+from collections import OrderedDict
 from collections.abc import AsyncIterator
 from contextvars import ContextVar
 from typing import Any
@@ -30,6 +31,194 @@ _last_error_ts: float | None = None
 _in_flight = 0
 _provider_health_cache: dict[str, tuple[float, bool]] = {}
 _PROVIDER_TTL_SEC = 30.0
+
+# Bounded in-memory trace ring buffer for the /trace/recent dashboard.
+# trace_id -> list of completed span records. Eviction is LRU on the trace.
+_TRACE_BUFFER_MAX = int(os.environ.get("TRACE_BUFFER_MAX", "200"))
+_SPANS_PER_TRACE_MAX = int(os.environ.get("TRACE_SPANS_PER_TRACE_MAX", "200"))
+_trace_buffer: OrderedDict[str, list[dict[str, Any]]] = OrderedDict()
+
+# Abort ring buffer + per-stage counters. Powers /trace/abort-stats so we can
+# confirm or refute the "stale-click cost" estimate empirically. Each entry
+# records which stage was running when the client dropped the SSE socket,
+# how much wall-time had already been spent, and a coarse $-cost estimate.
+_ABORT_BUFFER_MAX = int(os.environ.get("ABORT_BUFFER_MAX", "500"))
+_abort_buffer: list[dict[str, Any]] = []
+_abort_stage_counts: dict[str, int] = {}
+_abort_stage_wasted_ms: dict[str, float] = {}
+_abort_total_count = 0
+
+# Coarse per-second cost rate ($/sec) used to estimate wasted spend. These
+# are rough — image-gen via fal-ai/nano-banana is the dominant per-call
+# cost (~$0.039 for a ~2s render), so $0.02/sec is a useful order-of-
+# magnitude rate. Override via env if you have firmer numbers.
+_DEFAULT_STAGE_COST_PER_SEC: dict[str, float] = {
+    "pre-click-resolve": 0.005,
+    "pre-plan": 0.020,
+    "pre-image-gen": 0.020,
+}
+
+
+def _stage_cost_per_sec(stage: str) -> float:
+    env_key = "ABORT_COST_PER_SEC_" + stage.upper().replace("-", "_")
+    raw = os.environ.get(env_key)
+    if raw:
+        try:
+            return float(raw)
+        except ValueError:
+            pass
+    return _DEFAULT_STAGE_COST_PER_SEC.get(stage, 0.005)
+
+
+def record_abort(
+    stage: str,
+    elapsed_ms: float,
+    *,
+    trace_id: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """Record a client-disconnect at a specific stage of the SSE pipeline.
+
+    Cost estimate is ``elapsed_ms`` * ``$/sec`` for the stage; this is
+    intentionally simple — the dashboard reads stage_cost_per_sec from env
+    and can recompute against firmer pricing later.
+    """
+    global _abort_total_count
+
+    if not stage:
+        return
+    cost_per_sec = _stage_cost_per_sec(stage)
+    wasted_usd = (elapsed_ms / 1000.0) * cost_per_sec
+
+    entry: dict[str, Any] = {
+        "ts_ms": round(time.time() * 1000.0, 2),
+        "stage": stage,
+        "elapsed_ms": round(elapsed_ms, 2),
+        "wasted_usd": round(wasted_usd, 5),
+        "cost_per_sec": cost_per_sec,
+        "trace_id": trace_id or trace_var.get(),
+    }
+    if extra:
+        for k, v in extra.items():
+            try:
+                json.dumps(v)
+                entry[k] = v
+            except (TypeError, ValueError):
+                entry[k] = repr(v)
+
+    _abort_buffer.append(entry)
+    if len(_abort_buffer) > _ABORT_BUFFER_MAX:
+        del _abort_buffer[: len(_abort_buffer) - _ABORT_BUFFER_MAX]
+
+    _abort_stage_counts[stage] = _abort_stage_counts.get(stage, 0) + 1
+    _abort_stage_wasted_ms[stage] = _abort_stage_wasted_ms.get(stage, 0.0) + elapsed_ms
+    _abort_total_count += 1
+
+
+def abort_stats(limit: int = 100) -> dict[str, Any]:
+    """Return aggregated abort counts + recent abort entries."""
+    if limit <= 0:
+        return {
+            "total": _abort_total_count,
+            "by_stage": [],
+            "recent": [],
+        }
+    by_stage: list[dict[str, Any]] = []
+    for stage, count in _abort_stage_counts.items():
+        wasted_ms = _abort_stage_wasted_ms.get(stage, 0.0)
+        cost_per_sec = _stage_cost_per_sec(stage)
+        by_stage.append(
+            {
+                "stage": stage,
+                "count": count,
+                "wasted_ms": round(wasted_ms, 2),
+                "wasted_usd": round((wasted_ms / 1000.0) * cost_per_sec, 5),
+                "cost_per_sec": cost_per_sec,
+            }
+        )
+    by_stage.sort(key=lambda r: r["wasted_usd"], reverse=True)
+
+    recent = list(reversed(_abort_buffer[-limit:]))
+    return {
+        "total": _abort_total_count,
+        "by_stage": by_stage,
+        "recent": recent,
+    }
+
+
+def _record_span(
+    trace_id: str | None,
+    *,
+    name: str,
+    start_epoch_ms: float,
+    end_epoch_ms: float,
+    duration_ms: float,
+    level: str,
+    error: str | None,
+    kv: dict[str, Any],
+) -> None:
+    if not trace_id:
+        return
+    record: dict[str, Any] = {
+        "name": name,
+        "start_ms": round(start_epoch_ms, 2),
+        "end_ms": round(end_epoch_ms, 2),
+        "duration_ms": duration_ms,
+        "level": level,
+    }
+    if error:
+        record["error"] = error
+    if kv:
+        safe: dict[str, Any] = {}
+        for k, v in kv.items():
+            try:
+                json.dumps(v)
+                safe[k] = v
+            except (TypeError, ValueError):
+                safe[k] = repr(v)
+        record["kv"] = safe
+    bucket = _trace_buffer.get(trace_id)
+    if bucket is None:
+        if len(_trace_buffer) >= _TRACE_BUFFER_MAX:
+            _trace_buffer.popitem(last=False)
+        bucket = []
+        _trace_buffer[trace_id] = bucket
+    else:
+        _trace_buffer.move_to_end(trace_id)
+    bucket.append(record)
+    if len(bucket) > _SPANS_PER_TRACE_MAX:
+        del bucket[: len(bucket) - _SPANS_PER_TRACE_MAX]
+
+
+def recent_traces(limit: int = 50) -> list[dict[str, Any]]:
+    """Return up to ``limit`` most-recent traces, newest first.
+
+    Each entry is a self-contained summary: trace_id, spans, wall-clock
+    duration (max end - min start), span count, and whether any span
+    errored. The dashboard renders this directly.
+    """
+    if limit <= 0:
+        return []
+    items = list(_trace_buffer.items())[-limit:]
+    items.reverse()
+    summaries: list[dict[str, Any]] = []
+    for trace_id, spans in items:
+        if not spans:
+            continue
+        start_ms = min(s["start_ms"] for s in spans)
+        end_ms = max(s["end_ms"] for s in spans)
+        summaries.append(
+            {
+                "trace_id": trace_id,
+                "start_ms": start_ms,
+                "end_ms": end_ms,
+                "wall_ms": round(end_ms - start_ms, 2),
+                "span_count": len(spans),
+                "errored": any(s.get("level") == "error" for s in spans),
+                "spans": spans,
+            }
+        )
+    return summaries
 
 
 def _init_sentry() -> bool:
@@ -90,6 +279,7 @@ async def span(name: str, **kv: Any) -> AsyncIterator[dict[str, Any]]:
     """
     global _in_flight, _last_error_ts
     started = time.perf_counter()
+    start_epoch_ms = time.time() * 1000.0
     extra: dict[str, Any] = {}
     _in_flight += 1
     log("info", f"{name}.start", **kv)
@@ -106,10 +296,30 @@ async def span(name: str, **kv: Any) -> AsyncIterator[dict[str, Any]]:
             **kv,
             **extra,
         )
+        _record_span(
+            trace_var.get(),
+            name=name,
+            start_epoch_ms=start_epoch_ms,
+            end_epoch_ms=time.time() * 1000.0,
+            duration_ms=duration_ms,
+            level="error",
+            error=f"{type(exc).__name__}: {exc}",
+            kv={**kv, **extra},
+        )
         raise
     else:
         duration_ms = round((time.perf_counter() - started) * 1000, 2)
         log("info", f"{name}.end", duration_ms=duration_ms, **kv, **extra)
+        _record_span(
+            trace_var.get(),
+            name=name,
+            start_epoch_ms=start_epoch_ms,
+            end_epoch_ms=time.time() * 1000.0,
+            duration_ms=duration_ms,
+            level="info",
+            error=None,
+            kv={**kv, **extra},
+        )
     finally:
         _in_flight = max(0, _in_flight - 1)
 

--- a/apps/modal-backend/providers/llm.py
+++ b/apps/modal-backend/providers/llm.py
@@ -50,6 +50,20 @@ class ClickResolution:
     # Threaded into plan_page as ground truth so the planner can't drift
     # domains even when web search surfaces a more popular meaning.
     subject_context: str = ""
+    # Groundability: did the VLM actually see something meaningful under the
+    # crosshair, or is it confabulating? GroundingME (arXiv:2512.17495)
+    # reports ~0% rejection rate on current VLMs, so we ask explicitly.
+    # ``confidence`` is 0..1; the client can render a "tap something
+    # specific?" hint when low. Default True/1.0 keeps the field backward-
+    # compatible when older callers / models omit it.
+    groundable: bool = True
+    confidence: float = 1.0
+    # VLM's own best-estimate centroid + bounding box of the resolved
+    # subject (0..1 normalised in the image's own frame). Powers the
+    # "we think you tapped this — yes/try again" overlay UX. Both optional
+    # because not every VLM emits them; older payloads default to None.
+    point: tuple[float, float] | None = None
+    bbox: tuple[float, float, float, float] | None = None
 
 
 @dataclass
@@ -270,6 +284,7 @@ async def click_to_subject(
     parent_query: str,
     output_locale: str | None = None,
     user_hint: str | None = None,
+    prior_rejected_subject: str | None = None,
 ) -> ClickResolution:
     """Resolve the click region to a subject phrase AND a style descriptor.
 
@@ -278,6 +293,16 @@ async def click_to_subject(
     fallback. We also ask the VLM to summarise the illustration's visual
     style so the next page can match it — cheapest way to keep aesthetic
     continuity across hops without a second VLM round-trip.
+
+    Also asks the VLM to self-report ``groundable`` + ``confidence`` and
+    its best-estimate ``point``/``bbox`` of the resolved subject. The
+    client uses these for the "we think you tapped this — yes/try again"
+    UX and to suppress page-generation on empty-region taps.
+
+    ``prior_rejected_subject`` lets the caller signal that the user just
+    rejected a previous resolution near this tap, which gives the VLM a
+    multi-turn conversational refer signal ("you said X — what else
+    could this be?"). Inspired by SAMA / MM-Conv dialog grounding.
     """
     client = _client()
     locale_clause = (
@@ -291,7 +316,7 @@ async def click_to_subject(
         "You examine a generated illustration of the page titled "
         f"'{parent_title}' (user query: '{parent_query}'). A red crosshair with "
         "a white halo has been drawn on the image to mark where the user "
-        "clicked. Do THREE things and return them as JSON: "
+        "clicked. Return ONE JSON object with these fields: "
         "(1) `subject` — a 2-8 word noun phrase naming the specific thing "
         "under the crosshair (ignore the crosshair itself); should make a "
         "good next query for a visual explainer. "
@@ -305,11 +330,21 @@ async def click_to_subject(
         "why it's there. This is the disambiguation. If `subject` is "
         "\"Memory Bank\" inside a video-segmentation architecture, the context "
         "is \"per-object memory store the tracker uses to keep object "
-        "identity across frames\" — NOT a generic definition. If the click "
-        "is on something purely decorative, give the most specific concrete "
-        "reading you can. "
-        "Return JSON: {\"subject\": \"...\", \"style\": \"...\", "
-        "\"subject_context\": \"...\"}."
+        "identity across frames\" — NOT a generic definition. "
+        "(4) `groundable` — boolean. true when the crosshair is on a "
+        "concrete, depicted object/label/region that you can name with "
+        "confidence; false when it is on empty background, decorative "
+        "stippling, or otherwise non-meaningful. Be honest: it is "
+        "better to return groundable=false with a best-guess subject "
+        "than to confabulate. "
+        "(5) `confidence` — number in [0,1]; how sure you are that the "
+        "subject you named is what the user intended to tap. "
+        "(6) `point` — your best-estimate centroid of the resolved "
+        "subject as {\"x\": <0-1>, \"y\": <0-1>} in the image's own frame "
+        "(0,0 top-left). Use the crosshair location as a strong prior. "
+        "(7) `bbox` — optional axis-aligned bounding box around the "
+        "subject as {\"x\": <0-1>, \"y\": <0-1>, \"w\": <0-1>, \"h\": <0-1>}. "
+        "Omit if you cannot give a tight box."
         + locale_clause
     )
     hint_clause = ""
@@ -321,6 +356,15 @@ async def click_to_subject(
             "keep the subject concrete and grounded in what's actually under "
             "the crosshair."
         )
+    refer_clause = ""
+    if prior_rejected_subject:
+        refer_clause = (
+            "\n\nMulti-turn refer: the user just rejected the previous "
+            f"resolution \"{prior_rejected_subject}\" near this tap. Pick a "
+            "DIFFERENT plausible subject under the crosshair — favour a "
+            "neighbouring element, a sibling label, or a part-of-X if the "
+            "previous reading was an X. Do NOT return the same subject again."
+        )
     user_text = (
         "Look at the red crosshair marker on the image and tell me the "
         "specific subject beneath it. Also describe the visual style of "
@@ -329,6 +373,7 @@ async def click_to_subject(
         f"numeric position x={x_pct:.3f}, y={y_pct:.3f} "
         "(0-1 normalized, origin top-left)."
         + hint_clause
+        + refer_clause
     )
     from obs import span
 
@@ -350,18 +395,114 @@ async def click_to_subject(
             ],
             **_maybe_response_format(_vlm_model()),
             temperature=0.2,
-            max_tokens=300,
+            max_tokens=400,
         )
         _log_cache_usage(ctx, response)
     raw = (response.choices[0].message.content or "{}").strip()
     parsed = _safe_json(raw)
+    return _build_click_resolution(parsed, x_pct=x_pct, y_pct=y_pct, fallback_subject=parent_title)
+
+
+def _coerce_unit(value: Any) -> float | None:
+    """Coerce a JSON value to a clamped [0,1] float, or None if non-numeric."""
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    if f != f:  # NaN
+        return None
+    if f < 0.0:
+        return 0.0
+    if f > 1.0:
+        return 1.0
+    return f
+
+
+def _parse_point(raw: Any) -> tuple[float, float] | None:
+    """Accept {"x": .., "y": ..} or [x, y] or null. Out-of-range → clamped."""
+    if isinstance(raw, dict):
+        x = _coerce_unit(raw.get("x"))
+        y = _coerce_unit(raw.get("y"))
+    elif isinstance(raw, (list, tuple)) and len(raw) >= 2:
+        x = _coerce_unit(raw[0])
+        y = _coerce_unit(raw[1])
+    else:
+        return None
+    if x is None or y is None:
+        return None
+    return (x, y)
+
+
+def _parse_bbox(raw: Any) -> tuple[float, float, float, float] | None:
+    """Accept {x,y,w,h} or [x,y,w,h]. Returns None if any component invalid."""
+    if isinstance(raw, dict):
+        x = _coerce_unit(raw.get("x"))
+        y = _coerce_unit(raw.get("y"))
+        w = _coerce_unit(raw.get("w") or raw.get("width"))
+        h = _coerce_unit(raw.get("h") or raw.get("height"))
+    elif isinstance(raw, (list, tuple)) and len(raw) >= 4:
+        x = _coerce_unit(raw[0])
+        y = _coerce_unit(raw[1])
+        w = _coerce_unit(raw[2])
+        h = _coerce_unit(raw[3])
+    else:
+        return None
+    if x is None or y is None or w is None or h is None:
+        return None
+    if w == 0.0 or h == 0.0:
+        return None
+    return (x, y, w, h)
+
+
+def _build_click_resolution(
+    parsed: dict[str, Any],
+    *,
+    x_pct: float,
+    y_pct: float,
+    fallback_subject: str,
+) -> ClickResolution:
+    """Map the VLM's JSON payload onto a ClickResolution with safe defaults.
+
+    Older models / out-of-distribution prompts may omit the groundability /
+    point / bbox fields entirely. We fill them in with conservative
+    defaults (groundable=True, confidence=1.0, point=crosshair) so the
+    upstream UX never breaks; downstream code can still inspect for
+    explicit ``False`` to render the low-confidence warning.
+    """
     subject = str(parsed.get("subject", "")).strip()
     style = str(parsed.get("style", "")).strip()
     subject_context = str(parsed.get("subject_context", "")).strip()
+
+    groundable_raw = parsed.get("groundable")
+    if isinstance(groundable_raw, bool):
+        groundable = groundable_raw
+    elif isinstance(groundable_raw, str):
+        groundable = groundable_raw.lower() not in ("false", "no", "0")
+    else:
+        groundable = True
+
+    confidence = _coerce_unit(parsed.get("confidence"))
+    if confidence is None:
+        confidence = 1.0
+
+    point = _parse_point(parsed.get("point"))
+    if point is None:
+        # Crosshair location is the strongest fallback — that's where the
+        # user actually tapped, even if the VLM didn't echo it back.
+        point = (
+            _coerce_unit(x_pct) or 0.0,
+            _coerce_unit(y_pct) or 0.0,
+        )
+    bbox = _parse_bbox(parsed.get("bbox"))
+
     return ClickResolution(
-        subject=subject or parent_title,
+        subject=subject or fallback_subject,
         style=style,
         subject_context=subject_context,
+        groundable=groundable,
+        confidence=confidence,
+        point=point,
+        bbox=bbox,
     )
 
 

--- a/apps/modal-backend/requirements-dev.txt
+++ b/apps/modal-backend/requirements-dev.txt
@@ -3,3 +3,4 @@ ruff>=0.7
 mypy>=1.13
 pytest>=8.3
 pytest-asyncio>=0.24
+Pillow>=10.0

--- a/apps/modal-backend/tests/click_bench/__init__.py
+++ b/apps/modal-backend/tests/click_bench/__init__.py
@@ -1,0 +1,11 @@
+"""Click-resolver micro-benchmark for openflipbook.
+
+Runs ``providers.llm.click_to_subject`` against a frozen fixture set of
+``(image_path, tap_xy, expected_subject)`` tuples and scores phrase
+similarity. The fixture format is JSON; PIL annotates each image with the
+same crosshair the web client draws (``apps/web/lib/image-click.ts``).
+
+Designed to gate VLM swaps: confirm a new resolver model ≥ the current one
+on accuracy before shipping. Run via pytest with CLICK_BENCH_RUN=1 + a
+real OPENROUTER_API_KEY, or via the CLI in runner.py.
+"""

--- a/apps/modal-backend/tests/click_bench/_annotate.py
+++ b/apps/modal-backend/tests/click_bench/_annotate.py
@@ -1,0 +1,67 @@
+"""Python replica of ``apps/web/lib/image-click.ts:annotateClickPoint``.
+
+The web client draws a red crosshair + white halo at the click point and
+sends the annotated JPEG to the VLM. The bench needs the same annotation
+applied server-side so resolver accuracy is measured under production
+conditions.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+from PIL import Image, ImageDraw
+
+
+def annotate_click_point(
+    image_bytes: bytes,
+    x_pct: float,
+    y_pct: float,
+    *,
+    output_format: str = "JPEG",
+    quality: int = 92,
+) -> bytes:
+    """Draw a red crosshair with white halo at (x_pct, y_pct) on the image.
+
+    Matches the geometry of ``annotateClickPoint`` in image-click.ts:
+      - circle radius r = max(24, round(width * 0.02))
+      - crosshair reach = r * 1.8
+      - white halo stroke width 8, red overlay stroke width 4
+      - red filled center dot, radius max(3, r * 0.18)
+    """
+    if not 0.0 <= x_pct <= 1.0 or not 0.0 <= y_pct <= 1.0:
+        raise ValueError(f"x_pct/y_pct must be in [0,1]; got {x_pct}, {y_pct}")
+
+    img = Image.open(BytesIO(image_bytes)).convert("RGB")
+    w, h = img.size
+    cx = round(x_pct * w)
+    cy = round(y_pct * h)
+    r = max(24, round(w * 0.02))
+    reach = round(r * 1.8)
+
+    draw = ImageDraw.Draw(img, "RGBA")
+
+    halo = (255, 255, 255, 242)
+    red = (239, 68, 68, 255)
+
+    draw.ellipse((cx - r, cy - r, cx + r, cy + r), outline=halo, width=8)
+    draw.line((cx - reach, cy, cx + reach, cy), fill=halo, width=8)
+    draw.line((cx, cy - reach, cx, cy + reach), fill=halo, width=8)
+
+    draw.ellipse((cx - r, cy - r, cx + r, cy + r), outline=red, width=4)
+    draw.line((cx - reach, cy, cx + reach, cy), fill=red, width=4)
+    draw.line((cx, cy - reach, cx, cy + reach), fill=red, width=4)
+
+    dot = max(3, round(r * 0.18))
+    draw.ellipse((cx - dot, cy - dot, cx + dot, cy + dot), fill=red)
+
+    buf = BytesIO()
+    img.save(buf, format=output_format, quality=quality)
+    return buf.getvalue()
+
+
+def to_data_url(image_bytes: bytes, mime: str = "image/jpeg") -> str:
+    """Encode image bytes as a base64 data URL ready for the VLM payload."""
+    import base64
+
+    return f"data:{mime};base64,{base64.b64encode(image_bytes).decode('ascii')}"

--- a/apps/modal-backend/tests/click_bench/_score.py
+++ b/apps/modal-backend/tests/click_bench/_score.py
@@ -1,0 +1,102 @@
+"""Phrase similarity scoring for the click bench.
+
+v1 uses cheap string-similarity heuristics so the bench runs without
+extra ML deps. v2 can swap in embedding cosine (sentence-transformers,
+OpenAI ada, or any small open model) behind the same interface.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+
+_STOPWORDS = frozenset(
+    {"the", "a", "an", "of", "and", "in", "on", "at", "to", "with", "for"}
+)
+_PUNCT_RE = re.compile(r"[^\w\s]", re.UNICODE)
+
+
+def normalize(phrase: str) -> str:
+    """Lowercase, strip punctuation, drop articles + small stop words."""
+    s = _PUNCT_RE.sub(" ", phrase.lower()).strip()
+    tokens = [t for t in s.split() if t and t not in _STOPWORDS]
+    return " ".join(tokens)
+
+
+def token_set(phrase: str) -> set[str]:
+    return set(normalize(phrase).split())
+
+
+@dataclass(frozen=True)
+class PhraseScore:
+    exact: bool
+    fuzzy: float
+    jaccard: float
+    composite: float
+    matched_against: str
+
+    def passed(self, threshold: float = 0.6) -> bool:
+        return self.composite >= threshold
+
+
+def _score_one(predicted_norm: str, expected_norm: str) -> tuple[float, float]:
+    fuzzy = SequenceMatcher(None, predicted_norm, expected_norm).ratio()
+    p_tokens = set(predicted_norm.split())
+    e_tokens = set(expected_norm.split())
+    if not p_tokens and not e_tokens:
+        jaccard = 1.0
+    elif not p_tokens or not e_tokens:
+        jaccard = 0.0
+    else:
+        jaccard = len(p_tokens & e_tokens) / len(p_tokens | e_tokens)
+    return fuzzy, jaccard
+
+
+def score_subject(
+    predicted: str,
+    expected: str,
+    alternates: list[str] | None = None,
+) -> PhraseScore:
+    """Score a predicted subject phrase against an expected + alternates.
+
+    Best score wins. Composite is 0.6 * fuzzy + 0.4 * jaccard — fuzzy
+    handles spelling/inflection drift, jaccard handles reorderings and
+    missing function words.
+    """
+    predicted_norm = normalize(predicted)
+    candidates = [expected, *(alternates or [])]
+
+    best_fuzzy = 0.0
+    best_jaccard = 0.0
+    best_match = expected
+    best_exact = False
+
+    for cand in candidates:
+        cand_norm = normalize(cand)
+        if not cand_norm:
+            continue
+        if predicted_norm == cand_norm:
+            return PhraseScore(
+                exact=True,
+                fuzzy=1.0,
+                jaccard=1.0,
+                composite=1.0,
+                matched_against=cand,
+            )
+        fuzzy, jaccard = _score_one(predicted_norm, cand_norm)
+        composite = 0.6 * fuzzy + 0.4 * jaccard
+        if composite > 0.6 * best_fuzzy + 0.4 * best_jaccard:
+            best_fuzzy = fuzzy
+            best_jaccard = jaccard
+            best_match = cand
+            best_exact = False
+
+    composite = round(0.6 * best_fuzzy + 0.4 * best_jaccard, 4)
+    return PhraseScore(
+        exact=best_exact,
+        fuzzy=round(best_fuzzy, 4),
+        jaccard=round(best_jaccard, 4),
+        composite=composite,
+        matched_against=best_match,
+    )

--- a/apps/modal-backend/tests/click_bench/fixtures/v1.json
+++ b/apps/modal-backend/tests/click_bench/fixtures/v1.json
@@ -1,0 +1,27 @@
+{
+  "_meta": {
+    "bench_version": 1,
+    "description": "Seed fixtures for the click-resolver micro-bench. Each case needs an image checked into fixtures/images/ and a labelled tap target. The harness annotates with the same crosshair the web client draws and calls providers.llm.click_to_subject against it.",
+    "field_reference": {
+      "case_id": "stable id, used in reports",
+      "image_path": "relative to this JSON file's directory",
+      "x_pct": "0..1, normalized X of click point (origin top-left)",
+      "y_pct": "0..1, normalized Y of click point",
+      "parent_title": "title of the page being clicked on (passed to VLM as context)",
+      "parent_query": "the original user query that produced the parent page",
+      "expected_subject": "human-labelled ground-truth subject phrase",
+      "alternates": "optional list of acceptable phrasings",
+      "groundable": "false when the tap point is on a non-meaningful region (sky, decoration); used for the rejection-rate metric",
+      "output_locale": "optional locale code for non-English bench cases",
+      "notes": "free-text human notes about the case"
+    },
+    "how_to_add_cases": [
+      "1. Save the source illustration to fixtures/images/{case_id}.jpg",
+      "2. Pick a click point, record x_pct and y_pct",
+      "3. Write the expected subject phrase as a human reader would name it",
+      "4. Add alternate phrasings if there's reasonable ambiguity",
+      "5. Re-run: .venv/bin/python -m tests.click_bench.runner --fixtures tests/click_bench/fixtures/v1.json --out tests/click_bench/reports/$(date +%F).json"
+    ]
+  },
+  "cases": []
+}

--- a/apps/modal-backend/tests/click_bench/runner.py
+++ b/apps/modal-backend/tests/click_bench/runner.py
@@ -1,0 +1,231 @@
+"""Bench runner: load fixtures, call click_to_subject, score, report.
+
+CLI usage::
+
+    cd apps/modal-backend
+    .venv/bin/python -m tests.click_bench.runner \
+        --fixtures tests/click_bench/fixtures/v1.json \
+        --out tests/click_bench/reports/latest.json
+
+Set ``CLICK_BENCH_MODEL=qwen/qwen3-vl-8b-instruct`` (or any OpenRouter VLM)
+to A/B against the default ``OPENROUTER_VLM_MODEL``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import statistics
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from . import _annotate, _score
+
+_BENCH_VERSION = 1
+
+
+@dataclass(frozen=True)
+class BenchCase:
+    case_id: str
+    image_path: str
+    x_pct: float
+    y_pct: float
+    parent_title: str
+    parent_query: str
+    expected_subject: str
+    alternates: list[str] = field(default_factory=list)
+    groundable: bool = True
+    output_locale: str | None = None
+    notes: str = ""
+
+
+@dataclass
+class CaseResult:
+    case_id: str
+    predicted_subject: str
+    predicted_style: str
+    predicted_context: str
+    expected_subject: str
+    score: dict[str, Any]
+    latency_ms: float
+    ok: bool
+    error: str | None = None
+
+
+@dataclass
+class BenchReport:
+    bench_version: int
+    model: str
+    started_at: str
+    cases: list[CaseResult]
+    summary: dict[str, Any]
+
+
+def load_fixtures(path: Path) -> list[BenchCase]:
+    raw = json.loads(path.read_text())
+    cases_raw = raw.get("cases", [])
+    return [BenchCase(**case) for case in cases_raw]
+
+
+async def _run_case(
+    case: BenchCase, fixture_dir: Path, *, model_override: str | None
+) -> CaseResult:
+    from providers import llm
+
+    image_bytes = (fixture_dir / case.image_path).read_bytes()
+    annotated = _annotate.annotate_click_point(image_bytes, case.x_pct, case.y_pct)
+    data_url = _annotate.to_data_url(annotated)
+
+    if model_override:
+        os.environ["OPENROUTER_VLM_MODEL"] = model_override
+
+    started = time.perf_counter()
+    try:
+        resolution = await llm.click_to_subject(
+            image_data_url=data_url,
+            x_pct=case.x_pct,
+            y_pct=case.y_pct,
+            parent_title=case.parent_title,
+            parent_query=case.parent_query,
+            output_locale=case.output_locale,
+        )
+    except Exception as exc:
+        latency_ms = round((time.perf_counter() - started) * 1000, 2)
+        return CaseResult(
+            case_id=case.case_id,
+            predicted_subject="",
+            predicted_style="",
+            predicted_context="",
+            expected_subject=case.expected_subject,
+            score={},
+            latency_ms=latency_ms,
+            ok=False,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+    latency_ms = round((time.perf_counter() - started) * 1000, 2)
+
+    score = _score.score_subject(
+        resolution.subject, case.expected_subject, case.alternates
+    )
+    return CaseResult(
+        case_id=case.case_id,
+        predicted_subject=resolution.subject,
+        predicted_style=resolution.style,
+        predicted_context=resolution.subject_context,
+        expected_subject=case.expected_subject,
+        score=asdict(score),
+        latency_ms=latency_ms,
+        ok=score.passed(),
+    )
+
+
+def _summarize(results: list[CaseResult]) -> dict[str, Any]:
+    if not results:
+        return {"n": 0}
+    completed = [r for r in results if r.error is None]
+    composites = [r.score.get("composite", 0.0) for r in completed]
+    latencies = [r.latency_ms for r in completed]
+    summary: dict[str, Any] = {
+        "n": len(results),
+        "n_completed": len(completed),
+        "n_errored": len(results) - len(completed),
+        "n_passed": sum(1 for r in results if r.ok),
+        "pass_rate": (
+            round(sum(1 for r in results if r.ok) / len(results), 4)
+            if results
+            else 0.0
+        ),
+    }
+    if composites:
+        summary["composite_mean"] = round(statistics.mean(composites), 4)
+        summary["composite_median"] = round(statistics.median(composites), 4)
+    if latencies:
+        summary["latency_p50_ms"] = round(statistics.median(latencies), 2)
+        summary["latency_p95_ms"] = round(
+            statistics.quantiles(latencies, n=20)[18] if len(latencies) >= 5 else max(latencies),
+            2,
+        )
+        summary["latency_mean_ms"] = round(statistics.mean(latencies), 2)
+    return summary
+
+
+async def run_bench(
+    fixtures_path: Path,
+    *,
+    model_override: str | None = None,
+    out_path: Path | None = None,
+) -> BenchReport:
+    cases = load_fixtures(fixtures_path)
+    fixture_dir = fixtures_path.parent
+
+    results: list[CaseResult] = []
+    for case in cases:
+        result = await _run_case(case, fixture_dir, model_override=model_override)
+        results.append(result)
+
+    model = model_override or os.environ.get("OPENROUTER_VLM_MODEL", "default")
+    report = BenchReport(
+        bench_version=_BENCH_VERSION,
+        model=model,
+        started_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        cases=results,
+        summary=_summarize(results),
+    )
+
+    if out_path is not None:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(
+            json.dumps(
+                {
+                    "bench_version": report.bench_version,
+                    "model": report.model,
+                    "started_at": report.started_at,
+                    "cases": [asdict(c) for c in report.cases],
+                    "summary": report.summary,
+                },
+                indent=2,
+            )
+        )
+    return report
+
+
+def _cli() -> None:
+    parser = argparse.ArgumentParser(description="click resolver micro-bench")
+    parser.add_argument(
+        "--fixtures",
+        type=Path,
+        default=Path(__file__).parent / "fixtures" / "v1.json",
+        help="path to fixtures JSON",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="write JSON report to this path",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=None,
+        help="OpenRouter VLM slug to A/B against the default",
+    )
+    args = parser.parse_args()
+
+    if not os.environ.get("OPENROUTER_API_KEY"):
+        raise SystemExit(
+            "OPENROUTER_API_KEY is required to run the bench against a real VLM."
+        )
+
+    report = asyncio.run(
+        run_bench(args.fixtures, model_override=args.model, out_path=args.out)
+    )
+
+    print(json.dumps({"model": report.model, "summary": report.summary}, indent=2))
+
+
+if __name__ == "__main__":
+    _cli()

--- a/apps/modal-backend/tests/continuity_bench/__init__.py
+++ b/apps/modal-backend/tests/continuity_bench/__init__.py
@@ -1,0 +1,12 @@
+"""Continuity bench (ViStoryBench-lite) for openflipbook.
+
+Scores a multi-hop session for visual style coherence, entity-identity
+consistency, and prompt-image alignment. Inspired by ViStoryBench
+(arXiv:2505.24862), with three of its twelve metrics implemented for v1
+via a VLM judge — keeps the surface tiny and avoids a CLIP install.
+
+A session is a list of pages, each with the image bytes, the prompt the
+image was rendered from, and the entity manifest at that point. The
+bench accepts pre-recorded sessions; capture is orthogonal (replay from
+Mongo, replay from disk, or feed in a freshly-run scripted scenario).
+"""

--- a/apps/modal-backend/tests/continuity_bench/_replay.py
+++ b/apps/modal-backend/tests/continuity_bench/_replay.py
@@ -1,0 +1,93 @@
+"""Load a recorded session from disk for scoring.
+
+Session-on-disk layout (simplest path)::
+
+    sessions/<session_id>/
+      manifest.json              # ordered list of page entries
+      images/page-0.jpg
+      images/page-1.jpg
+      ...
+
+manifest.json schema::
+
+    {
+      "session_id": "...",
+      "started_at": "...",
+      "pages": [
+        {
+          "page_id": "...",
+          "page_title": "...",
+          "image_path": "images/page-0.jpg",
+          "prompt": "...",              # the prompt the image-gen received
+          "subject": "...",
+          "parent_page_id": null,
+          "entities": [
+            {"entity_id": "boiler", "name": "Boiler",
+             "appearance": "iron, soot-streaked, rivets visible"}
+          ]
+        }
+      ]
+    }
+
+Capture-from-Mongo is intentionally left out of v1; that adapter belongs
+in a separate module so the bench stays decoupled from Mongo schema.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class EntityRef:
+    entity_id: str
+    name: str
+    appearance: str = ""
+
+
+@dataclass(frozen=True)
+class PageRecord:
+    page_id: str
+    page_title: str
+    image_path: Path
+    prompt: str
+    subject: str
+    parent_page_id: str | None = None
+    entities: list[EntityRef] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class SessionRecord:
+    session_id: str
+    pages: list[PageRecord]
+
+
+def load_session(manifest_path: Path) -> SessionRecord:
+    """Load a session record from a manifest.json on disk."""
+    raw = json.loads(manifest_path.read_text())
+    base = manifest_path.parent
+
+    pages: list[PageRecord] = []
+    for entry in raw.get("pages", []):
+        entities = [
+            EntityRef(
+                entity_id=e["entity_id"],
+                name=e["name"],
+                appearance=e.get("appearance", ""),
+            )
+            for e in entry.get("entities", [])
+        ]
+        page = PageRecord(
+            page_id=entry["page_id"],
+            page_title=entry["page_title"],
+            image_path=base / entry["image_path"],
+            prompt=entry["prompt"],
+            subject=entry.get("subject", ""),
+            parent_page_id=entry.get("parent_page_id"),
+            entities=entities,
+        )
+        pages.append(page)
+
+    return SessionRecord(session_id=raw["session_id"], pages=pages)

--- a/apps/modal-backend/tests/continuity_bench/_score.py
+++ b/apps/modal-backend/tests/continuity_bench/_score.py
@@ -1,0 +1,134 @@
+"""VLM-judge scoring for the continuity bench.
+
+Three metrics, all rendered through a VLM-as-judge against pairs/triples
+of (image, image) or (image, text):
+
+  - style_drift: 0..10, "are these two images in the same visual style?"
+  - entity_consistency: 0..10, "do these crops depict the same X?"
+  - prompt_alignment: 0..10, "does this image render this prompt?"
+
+The judge VLM is configurable via CONTINUITY_BENCH_JUDGE_MODEL (defaults
+to the same VLM the resolver uses). Each judgement returns a score plus
+a short free-text rationale so the bench output is human-readable.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import re
+from dataclasses import dataclass
+
+_SCORE_RE = re.compile(r"\"score\"\s*:\s*(\d+(?:\.\d+)?)")
+
+
+@dataclass(frozen=True)
+class JudgeResult:
+    score: float
+    rationale: str
+    raw: str
+
+
+def _judge_model() -> str:
+    return os.environ.get(
+        "CONTINUITY_BENCH_JUDGE_MODEL",
+        os.environ.get("OPENROUTER_VLM_MODEL", "google/gemini-3-flash-preview"),
+    )
+
+
+def _image_block(image_bytes: bytes) -> dict[str, object]:
+    b64 = base64.b64encode(image_bytes).decode("ascii")
+    return {
+        "type": "image_url",
+        "image_url": {"url": f"data:image/jpeg;base64,{b64}", "detail": "low"},
+    }
+
+
+def _parse_judgement(raw: str) -> JudgeResult:
+    cleaned = raw.strip()
+    match = _SCORE_RE.search(cleaned)
+    score = float(match.group(1)) if match else 0.0
+    rationale = ""
+    try:
+        parsed = json.loads(cleaned[cleaned.find("{") : cleaned.rfind("}") + 1])
+        rationale = str(parsed.get("rationale", ""))[:300]
+        if "score" in parsed:
+            score = float(parsed["score"])
+    except Exception:
+        rationale = cleaned[:300]
+    return JudgeResult(score=score, rationale=rationale, raw=cleaned[:500])
+
+
+async def _ask_judge(
+    system: str, user_text: str, image_blocks: list[dict[str, object]]
+) -> JudgeResult:
+    from providers import llm
+
+    client = llm._client()
+    response = await client.chat.completions.create(
+        model=_judge_model(),
+        messages=[
+            {"role": "system", "content": system},
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": user_text}, *image_blocks],
+            },
+        ],
+        temperature=0.0,
+        max_tokens=200,
+    )
+    raw = response.choices[0].message.content or ""
+    return _parse_judgement(raw)
+
+
+async def score_style_pair(image_a: bytes, image_b: bytes) -> JudgeResult:
+    system = (
+        "You are a strict visual-style judge. Compare two illustrations and "
+        "score how well the SECOND image matches the FIRST image's visual "
+        "style: medium (flat infographic, watercolor, photoreal, line "
+        "drawing, etc.), palette, line work, level of stylization, "
+        "perspective. Ignore subject matter — score style only."
+        ' Return JSON exactly: {"score": <0-10 number>, "rationale": "<one short sentence>"}.'
+    )
+    user_text = (
+        "Image 1 is the reference style. Image 2 is the candidate. Score "
+        "how well image 2 matches image 1's style on a 0-10 scale (10 = "
+        "indistinguishable, 0 = completely different medium/palette)."
+    )
+    return await _ask_judge(
+        system, user_text, [_image_block(image_a), _image_block(image_b)]
+    )
+
+
+async def score_entity_consistency(
+    entity_name: str, appearance: str, image_a: bytes, image_b: bytes
+) -> JudgeResult:
+    system = (
+        "You are an identity-consistency judge. You are shown two pages of "
+        "an illustrated explorable. Both pages should contain the same "
+        f"entity: \"{entity_name}\". Stated appearance: \"{appearance}\". "
+        "Score 0-10 how confidently the entity in image 2 is visually the "
+        "same instance as in image 1: shape, color, proportions, "
+        "distinctive features. Score 0 if the entity is absent in image 2."
+        ' Return JSON exactly: {"score": <0-10 number>, "rationale": "<one short sentence>"}.'
+    )
+    user_text = (
+        f"Both pages should depict \"{entity_name}\". Score the visual "
+        "identity match on a 0-10 scale."
+    )
+    return await _ask_judge(
+        system, user_text, [_image_block(image_a), _image_block(image_b)]
+    )
+
+
+async def score_prompt_alignment(prompt: str, image: bytes) -> JudgeResult:
+    system = (
+        "You are a prompt-alignment judge. Score on a 0-10 scale how "
+        "faithfully the image renders the given prompt. 10 = every "
+        "explicit element is present and visually correct, 0 = the image "
+        "ignores the prompt. Mention any missing or misrendered elements."
+        ' Return JSON exactly: {"score": <0-10 number>, "rationale": "<one short sentence>"}.'
+    )
+    user_text = f"Prompt:\n{prompt}\n\nScore the rendering on a 0-10 scale."
+    return await _ask_judge(system, user_text, [_image_block(image)])

--- a/apps/modal-backend/tests/continuity_bench/fixtures/example_session/manifest.json
+++ b/apps/modal-backend/tests/continuity_bench/fixtures/example_session/manifest.json
@@ -1,0 +1,13 @@
+{
+  "_meta": {
+    "bench_version": 1,
+    "description": "Schema example for a captured openflipbook session. Drop real session pages here (or load from Mongo via a separate adapter). The runner scores style drift across consecutive pages, entity-identity consistency across an entity's appearances, and prompt→image alignment per page.",
+    "how_to_capture": [
+      "Option A — disk replay: after a session, dump each page's image to images/page-N.jpg and append an entry to manifest.pages with the prompt and entity manifest at that moment.",
+      "Option B — Mongo loader: TODO. Mongo schema lives in apps/web/lib/* and the modal backend; build a separate _mongo.py loader that produces the same SessionRecord shape."
+    ]
+  },
+  "session_id": "example-empty",
+  "started_at": "2026-05-27T00:00:00Z",
+  "pages": []
+}

--- a/apps/modal-backend/tests/continuity_bench/runner.py
+++ b/apps/modal-backend/tests/continuity_bench/runner.py
@@ -1,0 +1,262 @@
+"""Continuity-bench runner: load session → score → report.
+
+CLI usage::
+
+    cd apps/modal-backend
+    .venv/bin/python -m tests.continuity_bench.runner \
+        --session tests/continuity_bench/fixtures/example_session/manifest.json \
+        --out tests/continuity_bench/reports/latest.json
+
+The judge VLM is whatever OPENROUTER_VLM_MODEL points to (override via
+CONTINUITY_BENCH_JUDGE_MODEL).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import statistics
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from ._replay import PageRecord, SessionRecord, load_session
+from ._score import score_entity_consistency, score_prompt_alignment, score_style_pair
+
+_BENCH_VERSION = 1
+
+
+@dataclass
+class PairwiseScore:
+    from_page_id: str
+    to_page_id: str
+    score: float
+    rationale: str
+
+
+@dataclass
+class EntityScore:
+    entity_id: str
+    entity_name: str
+    pair_scores: list[PairwiseScore] = field(default_factory=list)
+    mean_score: float = 0.0
+
+
+@dataclass
+class PageScore:
+    page_id: str
+    prompt_alignment: float
+    rationale: str
+
+
+@dataclass
+class ContinuityReport:
+    bench_version: int
+    judge_model: str
+    session_id: str
+    started_at: str
+    style_drift_pairs: list[PairwiseScore]
+    style_drift_mean: float
+    entity_scores: list[EntityScore]
+    page_alignment_scores: list[PageScore]
+    summary: dict[str, Any]
+
+
+def _load_image(page: PageRecord) -> bytes:
+    return page.image_path.read_bytes()
+
+
+async def _score_style_drift(session: SessionRecord) -> list[PairwiseScore]:
+    out: list[PairwiseScore] = []
+    if len(session.pages) < 2:
+        return out
+    for prev, cur in zip(session.pages, session.pages[1:], strict=False):
+        result = await score_style_pair(_load_image(prev), _load_image(cur))
+        out.append(
+            PairwiseScore(
+                from_page_id=prev.page_id,
+                to_page_id=cur.page_id,
+                score=result.score,
+                rationale=result.rationale,
+            )
+        )
+    return out
+
+
+def _collect_entity_appearances(
+    session: SessionRecord,
+) -> dict[str, list[PageRecord]]:
+    out: dict[str, list[PageRecord]] = {}
+    for page in session.pages:
+        for entity in page.entities:
+            out.setdefault(entity.entity_id, []).append(page)
+    return out
+
+
+async def _score_entity_consistency(
+    session: SessionRecord,
+) -> list[EntityScore]:
+    appearances = _collect_entity_appearances(session)
+    out: list[EntityScore] = []
+    for entity_id, pages in appearances.items():
+        if len(pages) < 2:
+            continue
+        canonical = next(
+            (e for p in pages for e in p.entities if e.entity_id == entity_id),
+            None,
+        )
+        if canonical is None:
+            continue
+
+        pair_scores: list[PairwiseScore] = []
+        first = pages[0]
+        for later in pages[1:]:
+            result = await score_entity_consistency(
+                canonical.name, canonical.appearance, _load_image(first), _load_image(later)
+            )
+            pair_scores.append(
+                PairwiseScore(
+                    from_page_id=first.page_id,
+                    to_page_id=later.page_id,
+                    score=result.score,
+                    rationale=result.rationale,
+                )
+            )
+        mean_score = (
+            round(statistics.mean(p.score for p in pair_scores), 4)
+            if pair_scores
+            else 0.0
+        )
+        out.append(
+            EntityScore(
+                entity_id=entity_id,
+                entity_name=canonical.name,
+                pair_scores=pair_scores,
+                mean_score=mean_score,
+            )
+        )
+    return out
+
+
+async def _score_prompt_alignment(session: SessionRecord) -> list[PageScore]:
+    out: list[PageScore] = []
+    for page in session.pages:
+        result = await score_prompt_alignment(page.prompt, _load_image(page))
+        out.append(
+            PageScore(
+                page_id=page.page_id,
+                prompt_alignment=result.score,
+                rationale=result.rationale,
+            )
+        )
+    return out
+
+
+def _summarize(report_parts: dict[str, Any]) -> dict[str, Any]:
+    style_scores = [p.score for p in report_parts["style_drift_pairs"]]
+    entity_means = [e.mean_score for e in report_parts["entity_scores"]]
+    page_scores = [p.prompt_alignment for p in report_parts["page_alignment_scores"]]
+
+    return {
+        "n_pages": report_parts["n_pages"],
+        "n_style_pairs": len(style_scores),
+        "style_drift_mean": (
+            round(statistics.mean(style_scores), 4) if style_scores else 0.0
+        ),
+        "style_drift_min": min(style_scores) if style_scores else 0.0,
+        "n_entities_tracked": len(entity_means),
+        "entity_consistency_mean": (
+            round(statistics.mean(entity_means), 4) if entity_means else 0.0
+        ),
+        "entity_consistency_min": min(entity_means) if entity_means else 0.0,
+        "prompt_alignment_mean": (
+            round(statistics.mean(page_scores), 4) if page_scores else 0.0
+        ),
+        "prompt_alignment_min": min(page_scores) if page_scores else 0.0,
+    }
+
+
+async def run_bench(
+    session_manifest: Path,
+    *,
+    out_path: Path | None = None,
+) -> ContinuityReport:
+    session = load_session(session_manifest)
+
+    style_drift = await _score_style_drift(session)
+    entity_scores = await _score_entity_consistency(session)
+    page_alignment = await _score_prompt_alignment(session)
+
+    summary = _summarize(
+        {
+            "n_pages": len(session.pages),
+            "style_drift_pairs": style_drift,
+            "entity_scores": entity_scores,
+            "page_alignment_scores": page_alignment,
+        }
+    )
+
+    from ._score import _judge_model
+
+    report = ContinuityReport(
+        bench_version=_BENCH_VERSION,
+        judge_model=_judge_model(),
+        session_id=session.session_id,
+        started_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        style_drift_pairs=style_drift,
+        style_drift_mean=summary["style_drift_mean"],
+        entity_scores=entity_scores,
+        page_alignment_scores=page_alignment,
+        summary=summary,
+    )
+
+    if out_path is not None:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(
+            json.dumps(
+                {
+                    "bench_version": report.bench_version,
+                    "judge_model": report.judge_model,
+                    "session_id": report.session_id,
+                    "started_at": report.started_at,
+                    "style_drift_pairs": [asdict(p) for p in report.style_drift_pairs],
+                    "entity_scores": [asdict(e) for e in report.entity_scores],
+                    "page_alignment_scores": [
+                        asdict(p) for p in report.page_alignment_scores
+                    ],
+                    "summary": report.summary,
+                },
+                indent=2,
+            )
+        )
+
+    return report
+
+
+def _cli() -> None:
+    parser = argparse.ArgumentParser(description="continuity bench (ViStoryBench-lite)")
+    parser.add_argument("--session", type=Path, required=True, help="path to manifest.json")
+    parser.add_argument("--out", type=Path, default=None, help="optional report path")
+    args = parser.parse_args()
+
+    if not os.environ.get("OPENROUTER_API_KEY"):
+        raise SystemExit("OPENROUTER_API_KEY is required to run the bench.")
+
+    report = asyncio.run(run_bench(args.session, out_path=args.out))
+    print(
+        json.dumps(
+            {
+                "judge_model": report.judge_model,
+                "session_id": report.session_id,
+                "summary": report.summary,
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    _cli()

--- a/apps/modal-backend/tests/test_click_bench.py
+++ b/apps/modal-backend/tests/test_click_bench.py
@@ -1,0 +1,132 @@
+"""Pytest gate for the click-resolver bench.
+
+Two layers run here:
+
+1. ``test_score_*`` — unit tests for the phrase-similarity scorer; no
+   network, no API key, runs on every commit.
+2. ``test_run_bench_against_vlm`` — integration test that calls the real
+   click resolver against the fixture set. Skipped unless
+   CLICK_BENCH_RUN=1 AND OPENROUTER_API_KEY is set. Also skipped when the
+   fixtures file is empty so a default ``pytest`` run never burns API
+   credits.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from tests.click_bench import _score
+from tests.click_bench.runner import load_fixtures, run_bench
+
+_FIXTURES = Path(__file__).parent / "click_bench" / "fixtures" / "v1.json"
+
+
+# ---------- scoring unit tests ------------------------------------------
+
+
+def test_score_exact_match() -> None:
+    s = _score.score_subject("steam engine piston rod", "steam engine piston rod")
+    assert s.exact is True
+    assert s.composite == 1.0
+
+
+def test_score_case_and_punctuation_normalization() -> None:
+    s = _score.score_subject("The Steam-Engine, Piston rod.", "steam engine piston rod")
+    assert s.exact is True
+
+
+def test_score_article_dropping() -> None:
+    s = _score.score_subject("the boiler", "boiler")
+    assert s.exact is True
+
+
+def test_score_partial_match() -> None:
+    s = _score.score_subject("engine piston", "steam engine piston rod")
+    assert s.exact is False
+    assert 0.4 <= s.composite < 1.0
+
+
+def test_score_alternates_pick_best() -> None:
+    s = _score.score_subject(
+        "valve", expected="cylinder", alternates=["valve", "piston"]
+    )
+    assert s.exact is True
+    assert s.matched_against == "valve"
+
+
+def test_score_completely_wrong_fails_threshold() -> None:
+    s = _score.score_subject("clouds", "steam engine piston rod")
+    assert s.composite < 0.4
+    assert s.passed() is False
+
+
+def test_score_jaccard_handles_reordering() -> None:
+    s = _score.score_subject("piston rod of engine", "engine piston rod")
+    # Same tokens, different order — should pass.
+    assert s.passed() is True
+
+
+# ---------- fixtures validation -----------------------------------------
+
+
+def test_fixture_file_parseable() -> None:
+    assert _FIXTURES.exists(), f"missing fixture file: {_FIXTURES}"
+    raw = json.loads(_FIXTURES.read_text())
+    assert "cases" in raw
+    assert isinstance(raw["cases"], list)
+
+
+def test_fixture_cases_have_required_fields() -> None:
+    cases = load_fixtures(_FIXTURES)
+    for case in cases:
+        assert case.case_id, f"case missing case_id: {case}"
+        assert case.image_path, f"case {case.case_id} missing image_path"
+        assert 0.0 <= case.x_pct <= 1.0
+        assert 0.0 <= case.y_pct <= 1.0
+        assert case.expected_subject, f"case {case.case_id} missing expected_subject"
+
+
+# ---------- annotation smoke test ---------------------------------------
+
+
+def test_annotate_runs_on_tiny_image() -> None:
+    pytest.importorskip("PIL", reason="Pillow not installed; skipping annotation test")
+
+    from io import BytesIO
+
+    from PIL import Image
+
+    from tests.click_bench._annotate import annotate_click_point
+
+    img = Image.new("RGB", (256, 256), color=(128, 128, 128))
+    buf = BytesIO()
+    img.save(buf, format="JPEG")
+    annotated = annotate_click_point(buf.getvalue(), 0.5, 0.5)
+    assert isinstance(annotated, bytes)
+    assert len(annotated) > 0
+    # Verify it's still a valid JPEG.
+    Image.open(BytesIO(annotated)).verify()
+
+
+# ---------- live VLM bench (gated) --------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_bench_against_vlm() -> None:
+    if os.environ.get("CLICK_BENCH_RUN", "").lower() not in ("1", "true", "yes"):
+        pytest.skip("set CLICK_BENCH_RUN=1 to run the live bench")
+    if not os.environ.get("OPENROUTER_API_KEY"):
+        pytest.skip("OPENROUTER_API_KEY required for live bench")
+
+    cases = load_fixtures(_FIXTURES)
+    if not cases:
+        pytest.skip("fixture file has no cases — see fixtures/v1.json _meta")
+
+    report = await run_bench(_FIXTURES)
+    assert report.summary["n"] == len(cases)
+    # Loose floor; tighten as fixtures grow + baseline is established.
+    assert report.summary["pass_rate"] >= 0.0

--- a/apps/modal-backend/tests/test_click_resolution.py
+++ b/apps/modal-backend/tests/test_click_resolution.py
@@ -1,0 +1,201 @@
+"""Tests for ClickResolution parsing helpers + groundability fields.
+
+These are pure unit tests on the JSON → ClickResolution mapping; no
+network. The live click_to_subject call is covered by the click bench
+under tests/click_bench (gated behind CLICK_BENCH_RUN=1).
+"""
+
+from __future__ import annotations
+
+from providers import llm
+
+# ---------- _coerce_unit --------------------------------------------------
+
+
+def test_coerce_unit_passes_through_in_range() -> None:
+    assert llm._coerce_unit(0.0) == 0.0
+    assert llm._coerce_unit(0.42) == 0.42
+    assert llm._coerce_unit(1.0) == 1.0
+
+
+def test_coerce_unit_clamps_below_zero() -> None:
+    assert llm._coerce_unit(-0.5) == 0.0
+
+
+def test_coerce_unit_clamps_above_one() -> None:
+    assert llm._coerce_unit(1.7) == 1.0
+
+
+def test_coerce_unit_handles_string_numerics() -> None:
+    assert llm._coerce_unit("0.25") == 0.25
+
+
+def test_coerce_unit_rejects_non_numeric() -> None:
+    assert llm._coerce_unit("nope") is None
+    assert llm._coerce_unit(None) is None
+    assert llm._coerce_unit({}) is None
+
+
+# ---------- _parse_point / _parse_bbox ------------------------------------
+
+
+def test_parse_point_dict_form() -> None:
+    assert llm._parse_point({"x": 0.4, "y": 0.6}) == (0.4, 0.6)
+
+
+def test_parse_point_list_form() -> None:
+    assert llm._parse_point([0.1, 0.9]) == (0.1, 0.9)
+
+
+def test_parse_point_clamps_out_of_range() -> None:
+    assert llm._parse_point({"x": 1.5, "y": -0.2}) == (1.0, 0.0)
+
+
+def test_parse_point_returns_none_when_invalid() -> None:
+    assert llm._parse_point(None) is None
+    assert llm._parse_point("not a point") is None
+    assert llm._parse_point({"x": 0.4}) is None  # missing y
+
+
+def test_parse_bbox_dict_form() -> None:
+    bbox = llm._parse_bbox({"x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4})
+    assert bbox == (0.1, 0.2, 0.3, 0.4)
+
+
+def test_parse_bbox_accepts_width_height_keys() -> None:
+    bbox = llm._parse_bbox({"x": 0.1, "y": 0.2, "width": 0.3, "height": 0.4})
+    assert bbox == (0.1, 0.2, 0.3, 0.4)
+
+
+def test_parse_bbox_rejects_zero_dimension() -> None:
+    assert llm._parse_bbox({"x": 0.1, "y": 0.2, "w": 0.0, "h": 0.4}) is None
+
+
+def test_parse_bbox_list_form() -> None:
+    assert llm._parse_bbox([0.1, 0.2, 0.3, 0.4]) == (0.1, 0.2, 0.3, 0.4)
+
+
+# ---------- _build_click_resolution ---------------------------------------
+
+
+def test_build_full_payload_round_trip() -> None:
+    payload = {
+        "subject": "Boiler",
+        "style": "flat infographic, blue accents",
+        "subject_context": "steam generator at the heart of the engine",
+        "groundable": True,
+        "confidence": 0.85,
+        "point": {"x": 0.42, "y": 0.61},
+        "bbox": {"x": 0.30, "y": 0.50, "w": 0.30, "h": 0.30},
+    }
+    res = llm._build_click_resolution(
+        payload, x_pct=0.42, y_pct=0.61, fallback_subject="Steam Engine"
+    )
+    assert res.subject == "Boiler"
+    assert res.style.startswith("flat infographic")
+    assert res.groundable is True
+    assert res.confidence == 0.85
+    assert res.point == (0.42, 0.61)
+    assert res.bbox == (0.30, 0.50, 0.30, 0.30)
+
+
+def test_build_missing_groundability_defaults_to_true() -> None:
+    payload = {"subject": "Boiler", "style": "", "subject_context": ""}
+    res = llm._build_click_resolution(
+        payload, x_pct=0.5, y_pct=0.5, fallback_subject="X"
+    )
+    assert res.groundable is True
+    assert res.confidence == 1.0
+
+
+def test_build_groundable_false_preserved() -> None:
+    payload = {
+        "subject": "background sky",
+        "style": "",
+        "subject_context": "",
+        "groundable": False,
+        "confidence": 0.1,
+    }
+    res = llm._build_click_resolution(
+        payload, x_pct=0.5, y_pct=0.5, fallback_subject="X"
+    )
+    assert res.groundable is False
+    assert res.confidence == 0.1
+
+
+def test_build_groundable_string_false_treated_as_false() -> None:
+    payload = {"subject": "x", "style": "", "subject_context": "", "groundable": "false"}
+    res = llm._build_click_resolution(
+        payload, x_pct=0.0, y_pct=0.0, fallback_subject="X"
+    )
+    assert res.groundable is False
+
+
+def test_build_missing_point_uses_crosshair_position() -> None:
+    payload = {"subject": "Boiler", "style": "", "subject_context": ""}
+    res = llm._build_click_resolution(
+        payload, x_pct=0.33, y_pct=0.77, fallback_subject="X"
+    )
+    assert res.point == (0.33, 0.77)
+
+
+def test_build_invalid_point_falls_back_to_crosshair() -> None:
+    payload = {
+        "subject": "x",
+        "style": "",
+        "subject_context": "",
+        "point": "not a point",
+    }
+    res = llm._build_click_resolution(
+        payload, x_pct=0.1, y_pct=0.2, fallback_subject="X"
+    )
+    assert res.point == (0.1, 0.2)
+
+
+def test_build_invalid_bbox_drops_to_none() -> None:
+    payload = {
+        "subject": "x",
+        "style": "",
+        "subject_context": "",
+        "bbox": [0.0, 0.0, 0.0, 0.0],  # zero-size
+    }
+    res = llm._build_click_resolution(
+        payload, x_pct=0.0, y_pct=0.0, fallback_subject="X"
+    )
+    assert res.bbox is None
+
+
+def test_build_uses_fallback_subject_when_payload_empty() -> None:
+    res = llm._build_click_resolution(
+        {}, x_pct=0.5, y_pct=0.5, fallback_subject="Parent Title"
+    )
+    assert res.subject == "Parent Title"
+
+
+def test_build_oob_confidence_clamps_to_unit_range() -> None:
+    payload = {"subject": "x", "style": "", "subject_context": "", "confidence": 5.0}
+    res = llm._build_click_resolution(
+        payload, x_pct=0.0, y_pct=0.0, fallback_subject="X"
+    )
+    assert res.confidence == 1.0
+
+
+def test_build_negative_confidence_clamps_to_zero() -> None:
+    payload = {"subject": "x", "style": "", "subject_context": "", "confidence": -0.5}
+    res = llm._build_click_resolution(
+        payload, x_pct=0.0, y_pct=0.0, fallback_subject="X"
+    )
+    assert res.confidence == 0.0
+
+
+def test_build_garbage_confidence_falls_back_to_one() -> None:
+    payload = {
+        "subject": "x",
+        "style": "",
+        "subject_context": "",
+        "confidence": "very sure",
+    }
+    res = llm._build_click_resolution(
+        payload, x_pct=0.0, y_pct=0.0, fallback_subject="X"
+    )
+    assert res.confidence == 1.0

--- a/apps/modal-backend/tests/test_continuity_bench.py
+++ b/apps/modal-backend/tests/test_continuity_bench.py
@@ -1,0 +1,134 @@
+"""Pytest gate for the continuity bench.
+
+Layer 1 — pure unit tests:
+  - ``_score._parse_judgement`` resilience against malformed JSON
+  - ``_replay.load_session`` round-trip on the example fixture
+
+Layer 2 — live VLM judge (skipped unless CONTINUITY_BENCH_RUN=1):
+  - run_bench against a captured session manifest, with at least 2 pages
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from tests.continuity_bench import _replay, _score
+from tests.continuity_bench.runner import run_bench
+
+_FIXTURE = (
+    Path(__file__).parent
+    / "continuity_bench"
+    / "fixtures"
+    / "example_session"
+    / "manifest.json"
+)
+
+
+# ---------- parse robustness --------------------------------------------
+
+
+def test_parse_judgement_strict_json() -> None:
+    raw = '{"score": 7.5, "rationale": "warm palette but flatter lines"}'
+    out = _score._parse_judgement(raw)
+    assert out.score == 7.5
+    assert "warm palette" in out.rationale
+
+
+def test_parse_judgement_score_only_via_regex() -> None:
+    raw = 'some prose then "score": 3 here'
+    out = _score._parse_judgement(raw)
+    assert out.score == 3.0
+
+
+def test_parse_judgement_garbage_defaults_to_zero() -> None:
+    out = _score._parse_judgement("no score anywhere in this string")
+    assert out.score == 0.0
+
+
+def test_parse_judgement_handles_extra_keys() -> None:
+    raw = '{"score": 9, "rationale": "good", "extra": true}'
+    out = _score._parse_judgement(raw)
+    assert out.score == 9.0
+    assert out.rationale == "good"
+
+
+# ---------- replay round-trip -------------------------------------------
+
+
+def test_load_example_session_manifest() -> None:
+    assert _FIXTURE.exists(), f"missing fixture: {_FIXTURE}"
+    session = _replay.load_session(_FIXTURE)
+    assert session.session_id == "example-empty"
+    assert session.pages == []
+
+
+def test_load_session_with_synthetic_manifest(tmp_path: Path) -> None:
+    images_dir = tmp_path / "images"
+    images_dir.mkdir()
+    (images_dir / "p0.jpg").write_bytes(b"\xff\xd8\xff")
+    (images_dir / "p1.jpg").write_bytes(b"\xff\xd8\xff")
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "session_id": "test-2",
+                "pages": [
+                    {
+                        "page_id": "p0",
+                        "page_title": "Boilers",
+                        "image_path": "images/p0.jpg",
+                        "prompt": "an illustrated boiler",
+                        "subject": "boiler",
+                        "entities": [
+                            {
+                                "entity_id": "boiler",
+                                "name": "Boiler",
+                                "appearance": "iron, riveted",
+                            }
+                        ],
+                    },
+                    {
+                        "page_id": "p1",
+                        "page_title": "Pistons",
+                        "image_path": "images/p1.jpg",
+                        "prompt": "an illustrated piston",
+                        "subject": "piston",
+                        "parent_page_id": "p0",
+                        "entities": [
+                            {
+                                "entity_id": "boiler",
+                                "name": "Boiler",
+                                "appearance": "iron, riveted",
+                            }
+                        ],
+                    },
+                ],
+            }
+        )
+    )
+    session = _replay.load_session(manifest)
+    assert len(session.pages) == 2
+    assert session.pages[0].entities[0].entity_id == "boiler"
+    assert session.pages[1].parent_page_id == "p0"
+
+
+# ---------- live judge (gated) ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_continuity_bench_live() -> None:
+    if os.environ.get("CONTINUITY_BENCH_RUN", "").lower() not in ("1", "true", "yes"):
+        pytest.skip("set CONTINUITY_BENCH_RUN=1 to run the live judge")
+    if not os.environ.get("OPENROUTER_API_KEY"):
+        pytest.skip("OPENROUTER_API_KEY required for live bench")
+
+    session = _replay.load_session(_FIXTURE)
+    if len(session.pages) < 2:
+        pytest.skip("fixture has fewer than 2 pages — see manifest.json _meta")
+
+    report = await run_bench(_FIXTURE)
+    assert report.summary["n_pages"] >= 2

--- a/apps/modal-backend/tests/test_obs_abort_stats.py
+++ b/apps/modal-backend/tests/test_obs_abort_stats.py
@@ -1,0 +1,100 @@
+"""Tests for the abort-stats accumulator in obs.py."""
+
+from __future__ import annotations
+
+import pytest
+
+import obs
+
+
+@pytest.fixture(autouse=True)
+def _reset_abort_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    obs._abort_buffer.clear()
+    obs._abort_stage_counts.clear()
+    obs._abort_stage_wasted_ms.clear()
+    obs._abort_total_count = 0
+
+
+def test_record_abort_increments_total_and_per_stage() -> None:
+    obs.record_abort("pre-plan", 850.0, trace_id="t-1")
+    obs.record_abort("pre-plan", 200.0, trace_id="t-2")
+    obs.record_abort("pre-image-gen", 2400.0, trace_id="t-3")
+
+    stats = obs.abort_stats()
+    assert stats["total"] == 3
+    by_stage = {row["stage"]: row for row in stats["by_stage"]}
+    assert by_stage["pre-plan"]["count"] == 2
+    assert by_stage["pre-plan"]["wasted_ms"] == 1050.0
+    assert by_stage["pre-image-gen"]["count"] == 1
+    assert by_stage["pre-image-gen"]["wasted_ms"] == 2400.0
+
+
+def test_record_abort_estimates_dollars_by_stage_cost_rate() -> None:
+    obs.record_abort("pre-image-gen", 1000.0, trace_id="t")
+    stats = obs.abort_stats()
+    row = next(r for r in stats["by_stage"] if r["stage"] == "pre-image-gen")
+    # default $0.02/sec * 1.0s = $0.02
+    assert row["wasted_usd"] == pytest.approx(0.02, abs=1e-4)
+
+
+def test_env_override_changes_cost_per_sec(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ABORT_COST_PER_SEC_PRE_IMAGE_GEN", "0.05")
+    obs.record_abort("pre-image-gen", 1000.0)
+    stats = obs.abort_stats()
+    row = next(r for r in stats["by_stage"] if r["stage"] == "pre-image-gen")
+    assert row["wasted_usd"] == pytest.approx(0.05, abs=1e-4)
+
+
+def test_recent_entries_returned_newest_first() -> None:
+    obs.record_abort("pre-plan", 100.0, trace_id="t-1")
+    obs.record_abort("pre-plan", 200.0, trace_id="t-2")
+    obs.record_abort("pre-image-gen", 300.0, trace_id="t-3")
+
+    recent = obs.abort_stats()["recent"]
+    assert [r["trace_id"] for r in recent] == ["t-3", "t-2", "t-1"]
+
+
+def test_recent_buffer_caps_at_max(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(obs, "_ABORT_BUFFER_MAX", 3)
+    for i in range(5):
+        obs.record_abort("pre-plan", float(i * 100), trace_id=f"t-{i}")
+    # Buffer is also pruned in the recorder, so only 3 remain.
+    assert len(obs._abort_buffer) == 3
+    recent = obs.abort_stats()["recent"]
+    assert [r["trace_id"] for r in recent] == ["t-4", "t-3", "t-2"]
+
+
+def test_extra_kv_recorded_and_passes_through() -> None:
+    obs.record_abort("pre-plan", 100.0, trace_id="t", extra={"mode": "tap"})
+    entry = obs.abort_stats()["recent"][0]
+    assert entry["mode"] == "tap"
+    assert entry["stage"] == "pre-plan"
+
+
+def test_empty_stats_when_no_aborts() -> None:
+    stats = obs.abort_stats()
+    assert stats["total"] == 0
+    assert stats["by_stage"] == []
+    assert stats["recent"] == []
+
+
+def test_limit_zero_returns_empty_recent_only() -> None:
+    obs.record_abort("pre-plan", 100.0, trace_id="t")
+    stats = obs.abort_stats(limit=0)
+    # Per-stage aggregates still meaningful at limit=0, recent suppressed.
+    assert stats["recent"] == []
+    assert stats["total"] == 1
+
+
+def test_unknown_stage_uses_fallback_cost() -> None:
+    obs.record_abort("custom-stage", 1000.0, trace_id="t")
+    stats = obs.abort_stats()
+    row = next(r for r in stats["by_stage"] if r["stage"] == "custom-stage")
+    # Fallback $0.005/sec * 1s
+    assert row["cost_per_sec"] == 0.005
+    assert row["wasted_usd"] == pytest.approx(0.005, abs=1e-4)
+
+
+def test_empty_stage_string_skipped() -> None:
+    obs.record_abort("", 100.0, trace_id="t")
+    assert obs.abort_stats()["total"] == 0

--- a/apps/modal-backend/tests/test_obs_trace_buffer.py
+++ b/apps/modal-backend/tests/test_obs_trace_buffer.py
@@ -1,0 +1,132 @@
+"""Tests for the in-memory trace ring buffer in obs.py.
+
+The buffer powers the /admin/trace dashboard. These tests verify:
+  - completed spans land in the buffer keyed by trace_id
+  - errored spans are recorded with level="error"
+  - traces beyond TRACE_BUFFER_MAX evict oldest
+  - per-trace spans beyond _SPANS_PER_TRACE_MAX evict oldest
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import obs
+
+
+@pytest.fixture(autouse=True)
+def _clear_buffer() -> None:
+    obs._trace_buffer.clear()
+    obs.trace_var.set(None)
+
+
+async def test_span_records_when_trace_bound() -> None:
+    obs.bind_trace("trace-A")
+    async with obs.span("test.simple"):
+        pass
+
+    traces = obs.recent_traces()
+    assert len(traces) == 1
+    assert traces[0]["trace_id"] == "trace-A"
+    assert traces[0]["span_count"] == 1
+    assert traces[0]["spans"][0]["name"] == "test.simple"
+    assert traces[0]["spans"][0]["level"] == "info"
+    assert traces[0]["wall_ms"] >= 0
+
+
+async def test_span_skipped_when_no_trace_bound() -> None:
+    obs.trace_var.set(None)
+    async with obs.span("test.untraced"):
+        pass
+
+    assert obs.recent_traces() == []
+
+
+async def test_errored_span_recorded_with_error_level() -> None:
+    obs.bind_trace("trace-error")
+    with pytest.raises(RuntimeError):
+        async with obs.span("test.boom"):
+            raise RuntimeError("nope")
+
+    traces = obs.recent_traces()
+    assert len(traces) == 1
+    assert traces[0]["errored"] is True
+    span = traces[0]["spans"][0]
+    assert span["level"] == "error"
+    assert "RuntimeError" in span["error"]
+
+
+async def test_multiple_spans_within_one_trace_accumulate() -> None:
+    obs.bind_trace("trace-multi")
+    async with obs.span("step.1"):
+        pass
+    async with obs.span("step.2"):
+        pass
+    async with obs.span("step.3"):
+        pass
+
+    traces = obs.recent_traces()
+    assert len(traces) == 1
+    assert traces[0]["span_count"] == 3
+    names = [s["name"] for s in traces[0]["spans"]]
+    assert names == ["step.1", "step.2", "step.3"]
+
+
+async def test_recent_traces_returns_newest_first() -> None:
+    obs.bind_trace("first")
+    async with obs.span("a"):
+        pass
+    obs.bind_trace("second")
+    async with obs.span("b"):
+        pass
+    obs.bind_trace("third")
+    async with obs.span("c"):
+        pass
+
+    traces = obs.recent_traces()
+    assert [t["trace_id"] for t in traces] == ["third", "second", "first"]
+
+
+async def test_trace_buffer_evicts_oldest_when_full(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(obs, "_TRACE_BUFFER_MAX", 3)
+
+    for i in range(5):
+        obs.bind_trace(f"trace-{i}")
+        async with obs.span("x"):
+            pass
+
+    traces = obs.recent_traces()
+    ids = [t["trace_id"] for t in traces]
+    # Oldest two (trace-0, trace-1) evicted; newest three remain.
+    assert ids == ["trace-4", "trace-3", "trace-2"]
+
+
+async def test_recent_traces_limit_clamps_to_available() -> None:
+    for i in range(3):
+        obs.bind_trace(f"t-{i}")
+        async with obs.span("x"):
+            pass
+
+    assert len(obs.recent_traces(limit=2)) == 2
+    assert len(obs.recent_traces(limit=10)) == 3
+
+
+async def test_recent_traces_zero_limit_returns_empty() -> None:
+    obs.bind_trace("t")
+    async with obs.span("x"):
+        pass
+    assert obs.recent_traces(limit=0) == []
+
+
+async def test_kv_payload_preserved_on_record() -> None:
+    obs.bind_trace("t-kv")
+    async with obs.span("vlm.click", model="qwen-vl-72b", x=0.5) as ctx:
+        ctx["tokens"] = 132
+
+    traces = obs.recent_traces()
+    span = traces[0]["spans"][0]
+    assert span["kv"]["model"] == "qwen-vl-72b"
+    assert span["kv"]["x"] == 0.5
+    assert span["kv"]["tokens"] == 132

--- a/apps/web/app/admin/trace/abort-panel.tsx
+++ b/apps/web/app/admin/trace/abort-panel.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import type { AbortStatsResponse } from "@/lib/trace-types";
+
+const POLL_INTERVAL_MS = 10_000;
+
+export default function AbortPanel({ initial }: { initial: AbortStatsResponse | null }) {
+  const [data, setData] = useState<AbortStatsResponse | null>(initial);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const res = await fetch("/api/trace/abort-stats?limit=20", { cache: "no-store" });
+        const parsed = (await res.json()) as AbortStatsResponse;
+        if (!cancelled) {
+          setData(parsed);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) setError((err as Error).message);
+      }
+    };
+    const id = setInterval(tick, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  if (!data) return null;
+  if (data.error) {
+    return (
+      <div className="rounded-md border border-red-700 bg-red-900/30 px-3 py-2 text-sm text-red-200">
+        abort-stats unavailable: {data.error}
+      </div>
+    );
+  }
+
+  const total = data.total ?? 0;
+  const byStage = data.by_stage ?? [];
+  const totalWastedUsd = byStage.reduce((sum, row) => sum + row.wasted_usd, 0);
+  const totalWastedMs = byStage.reduce((sum, row) => sum + row.wasted_ms, 0);
+
+  return (
+    <section className="rounded-lg border border-zinc-800 bg-zinc-950/60 p-4">
+      <div className="mb-3 flex items-baseline justify-between">
+        <h2 className="text-sm font-semibold text-zinc-200">stale-click audit</h2>
+        <span className="text-xs text-zinc-500">
+          {total} aborts • {(totalWastedMs / 1000).toFixed(1)}s wasted • ~$
+          {totalWastedUsd.toFixed(4)} estimated
+        </span>
+      </div>
+
+      {error ? (
+        <div className="mb-2 text-xs text-zinc-500">last poll error: {error}</div>
+      ) : null}
+
+      {byStage.length === 0 ? (
+        <p className="text-xs text-zinc-500">
+          No aborts recorded yet. Aborts are tallied per stage when{" "}
+          <code className="text-zinc-300">Request.is_disconnected()</code> trips
+          during page generation.
+        </p>
+      ) : (
+        <table className="w-full text-left text-xs text-zinc-300">
+          <thead className="text-[10px] uppercase tracking-wide text-zinc-500">
+            <tr>
+              <th className="py-1 pr-3">stage</th>
+              <th className="py-1 pr-3 text-right">count</th>
+              <th className="py-1 pr-3 text-right">wasted s</th>
+              <th className="py-1 pr-3 text-right">est $</th>
+              <th className="py-1 text-right">$/sec</th>
+            </tr>
+          </thead>
+          <tbody>
+            {byStage.map((row) => (
+              <tr key={row.stage} className="border-t border-zinc-900">
+                <td className="py-1 pr-3">
+                  <code className="text-zinc-200">{row.stage}</code>
+                </td>
+                <td className="py-1 pr-3 text-right">{row.count}</td>
+                <td className="py-1 pr-3 text-right">
+                  {(row.wasted_ms / 1000).toFixed(2)}
+                </td>
+                <td className="py-1 pr-3 text-right">${row.wasted_usd.toFixed(5)}</td>
+                <td className="py-1 text-right text-zinc-500">
+                  ${row.cost_per_sec.toFixed(4)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      <p className="mt-3 text-[10px] text-zinc-500">
+        Cost rates default to:{" "}
+        <code>$0.005/s</code> click-resolve, <code>$0.020/s</code> planner +
+        image-gen. Override per stage via{" "}
+        <code>ABORT_COST_PER_SEC_&lt;STAGE&gt;</code> env on the backend.
+      </p>
+    </section>
+  );
+}

--- a/apps/web/app/admin/trace/page.tsx
+++ b/apps/web/app/admin/trace/page.tsx
@@ -1,0 +1,60 @@
+import type { Metadata } from "next";
+
+import AbortPanel from "./abort-panel";
+import TraceList from "./trace-list";
+import type { AbortStatsResponse, TraceRecentResponse } from "@/lib/trace-types";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "openflipbook — trace dashboard",
+};
+
+async function fetchBackend<T>(path: string): Promise<T | null> {
+  const modalUrl = process.env.MODAL_API_URL;
+  if (!modalUrl) {
+    return { ok: false, error: "MODAL_API_URL not set" } as unknown as T;
+  }
+  try {
+    const res = await fetch(`${modalUrl.replace(/\/$/, "")}${path}`, {
+      cache: "no-store",
+      signal: AbortSignal.timeout(4000),
+    });
+    if (!res.ok) {
+      return { ok: false, error: `HTTP ${res.status}` } as unknown as T;
+    }
+    return (await res.json()) as T;
+  } catch (err) {
+    return { ok: false, error: (err as Error).message } as unknown as T;
+  }
+}
+
+export default async function TracePage() {
+  const [initialTraces, initialAborts] = await Promise.all([
+    fetchBackend<TraceRecentResponse>("/trace/recent?limit=50"),
+    fetchBackend<AbortStatsResponse>("/trace/abort-stats?limit=20"),
+  ]);
+  return (
+    <main className="mx-auto max-w-6xl space-y-6 px-6 py-10 text-zinc-100">
+      <header className="flex items-baseline justify-between">
+        <h1 className="text-xl font-semibold">trace dashboard</h1>
+        <span className="text-xs text-zinc-500">
+          in-memory ring buffer (TRACE_BUFFER_MAX, default 200) • process-local
+        </span>
+      </header>
+
+      <AbortPanel initial={initialAborts} />
+
+      <section className="space-y-2">
+        <h2 className="text-sm font-semibold text-zinc-200">recent traces</h2>
+        <p className="max-w-3xl text-sm text-zinc-400">
+          Recent completed traces grouped by{" "}
+          <code className="text-zinc-300">x-trace-id</code>. Click a row to expand
+          its flamegraph. Categories are coloured by span-name prefix (vlm,
+          planner, image, video, world, prefetch, persist, network).
+        </p>
+        <TraceList initial={initialTraces} />
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/admin/trace/trace-list.tsx
+++ b/apps/web/app/admin/trace/trace-list.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import type { BackendTrace, TraceRecentResponse } from "@/lib/trace-types";
+import { packSpansIntoRows, spanCategory, summarizeCategories } from "@/lib/trace-types";
+
+const POLL_INTERVAL_MS = 5_000;
+const ROW_HEIGHT = 22;
+const ROW_GAP = 4;
+const SPAN_VPAD = 4;
+const SIDEBAR_WIDTH = 160;
+const MIN_BAR_WIDTH = 2;
+
+interface FetchState {
+  loading: boolean;
+  error: string | null;
+  data: TraceRecentResponse | null;
+  lastUpdate: number;
+}
+
+export default function TraceList({ initial }: { initial: TraceRecentResponse | null }) {
+  const [state, setState] = useState<FetchState>({
+    loading: false,
+    error: null,
+    data: initial,
+    lastUpdate: Date.now(),
+  });
+  const [autoRefresh, setAutoRefresh] = useState(true);
+  const [openTraceId, setOpenTraceId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!autoRefresh) return;
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const res = await fetch("/api/trace/recent?limit=50", { cache: "no-store" });
+        const parsed = (await res.json()) as TraceRecentResponse;
+        if (!cancelled) {
+          setState({ loading: false, error: null, data: parsed, lastUpdate: Date.now() });
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setState((prev) => ({
+            ...prev,
+            loading: false,
+            error: (err as Error).message,
+            lastUpdate: Date.now(),
+          }));
+        }
+      }
+    };
+    const id = setInterval(tick, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [autoRefresh]);
+
+  const traces = state.data?.traces ?? [];
+
+  return (
+    <div className="space-y-4">
+      <Header
+        state={state}
+        autoRefresh={autoRefresh}
+        onToggleAutoRefresh={() => setAutoRefresh((v) => !v)}
+        traceCount={traces.length}
+      />
+
+      {state.data?.error ? (
+        <Banner kind="error">backend error: {state.data.error}</Banner>
+      ) : null}
+
+      {traces.length === 0 ? (
+        <Banner kind="info">
+          No traces in the ring buffer yet. Trigger a click or page generation to populate.
+        </Banner>
+      ) : null}
+
+      <div className="space-y-3">
+        {traces.map((trace) => (
+          <TraceRow
+            key={trace.trace_id}
+            trace={trace}
+            open={openTraceId === trace.trace_id}
+            onToggle={() =>
+              setOpenTraceId((current) => (current === trace.trace_id ? null : trace.trace_id))
+            }
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Header({
+  state,
+  autoRefresh,
+  onToggleAutoRefresh,
+  traceCount,
+}: {
+  state: FetchState;
+  autoRefresh: boolean;
+  onToggleAutoRefresh: () => void;
+  traceCount: number;
+}) {
+  return (
+    <div className="flex items-center justify-between text-sm text-zinc-400">
+      <div>
+        {traceCount} trace{traceCount === 1 ? "" : "s"} • last refresh{" "}
+        {formatClock(state.lastUpdate)}
+      </div>
+      <button
+        type="button"
+        onClick={onToggleAutoRefresh}
+        className={`rounded-md border px-2 py-1 text-xs ${
+          autoRefresh
+            ? "border-zinc-600 bg-zinc-800 text-zinc-200"
+            : "border-zinc-700 text-zinc-500 hover:text-zinc-300"
+        }`}
+        aria-pressed={autoRefresh}
+      >
+        {autoRefresh ? "auto-refresh on" : "auto-refresh off"}
+      </button>
+    </div>
+  );
+}
+
+function Banner({
+  children,
+  kind,
+}: {
+  children: React.ReactNode;
+  kind: "error" | "info";
+}) {
+  const color =
+    kind === "error"
+      ? "border-red-700 bg-red-900/30 text-red-200"
+      : "border-zinc-700 bg-zinc-900/40 text-zinc-300";
+  return <div className={`rounded-md border px-3 py-2 text-sm ${color}`}>{children}</div>;
+}
+
+function TraceRow({
+  trace,
+  open,
+  onToggle,
+}: {
+  trace: BackendTrace;
+  open: boolean;
+  onToggle: () => void;
+}) {
+  const summary = useMemo(() => summarizeCategories(trace.spans), [trace.spans]);
+  const wallSec = (trace.wall_ms / 1000).toFixed(2);
+
+  return (
+    <div className="rounded-md border border-zinc-800 bg-zinc-950/60">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-zinc-900/40"
+        aria-expanded={open}
+      >
+        <div className="flex items-center gap-3">
+          <span className={`h-2 w-2 rounded-full ${trace.errored ? "bg-red-500" : "bg-emerald-500"}`} />
+          <code className="text-zinc-300">{trace.trace_id}</code>
+          <span className="text-zinc-500">{trace.span_count} spans</span>
+        </div>
+        <div className="flex items-center gap-3 text-zinc-400">
+          <span>{wallSec}s</span>
+          <span className="text-zinc-600">{formatClock(trace.start_ms)}</span>
+        </div>
+      </button>
+      <div className="border-t border-zinc-900 px-3 py-2 text-xs text-zinc-500">
+        {summary.map(({ label, color, totalMs }) => (
+          <span key={label} className="mr-3 inline-flex items-center gap-1.5">
+            <span className="h-2 w-2 rounded-sm" style={{ background: color }} />
+            <span className="text-zinc-300">{label}</span>
+            <span>{Math.round(totalMs)}ms</span>
+          </span>
+        ))}
+      </div>
+      {open ? <Flamegraph trace={trace} /> : null}
+    </div>
+  );
+}
+
+function Flamegraph({ trace }: { trace: BackendTrace }) {
+  const packed = useMemo(() => packSpansIntoRows(trace.spans), [trace.spans]);
+  const rowCount = packed.reduce((max, span) => Math.max(max, span.row + 1), 1);
+  const height = rowCount * (ROW_HEIGHT + ROW_GAP) + SPAN_VPAD * 2;
+  const span = Math.max(trace.wall_ms, 1);
+
+  return (
+    <div className="overflow-x-auto border-t border-zinc-900 bg-zinc-950 px-3 py-3">
+      <div
+        className="relative font-mono text-[11px]"
+        style={{ minWidth: 640, height, paddingLeft: SIDEBAR_WIDTH }}
+      >
+        {packed.map((s, i) => {
+          const { color } = spanCategory(s.name);
+          const left =
+            SIDEBAR_WIDTH +
+            Math.max(0, ((s.start_ms - trace.start_ms) / span) * (100 * 8));
+          const width = Math.max(
+            MIN_BAR_WIDTH,
+            ((s.end_ms - s.start_ms) / span) * (100 * 8)
+          );
+          const top = SPAN_VPAD + s.row * (ROW_HEIGHT + ROW_GAP);
+          return (
+            <div
+              key={`${s.name}-${i}`}
+              className="absolute rounded-sm border border-black/40 text-white"
+              style={{
+                left,
+                top,
+                width,
+                height: ROW_HEIGHT,
+                background: s.level === "error" ? "#dc2626" : color,
+                opacity: s.level === "error" ? 1 : 0.85,
+              }}
+              title={`${s.name} • ${s.duration_ms.toFixed(1)}ms${
+                s.error ? `\n${s.error}` : ""
+              }${kvSummary(s.kv)}`}
+            >
+              <div className="overflow-hidden whitespace-nowrap px-1 leading-[22px]">
+                {s.name}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function kvSummary(kv: Record<string, unknown> | undefined): string {
+  if (!kv) return "";
+  const entries = Object.entries(kv).slice(0, 6);
+  if (entries.length === 0) return "";
+  return (
+    "\n" + entries.map(([k, v]) => `${k}=${truncate(String(v), 40)}`).join(" ")
+  );
+}
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(0, n - 1) + "…";
+}
+
+function formatClock(epochMs: number): string {
+  const d = new Date(epochMs);
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}

--- a/apps/web/app/api/trace/abort-stats/route.ts
+++ b/apps/web/app/api/trace/abort-stats/route.ts
@@ -1,0 +1,44 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const modalUrl = process.env.MODAL_API_URL;
+  if (!modalUrl) {
+    return NextResponse.json(
+      { ok: false, error: "MODAL_API_URL not set" },
+      { status: 503 }
+    );
+  }
+
+  const rawLimit = req.nextUrl.searchParams.get("limit");
+  const limit = rawLimit ? Math.max(0, Math.min(500, Number(rawLimit) || 100)) : 100;
+
+  try {
+    const upstream = await fetch(
+      `${modalUrl.replace(/\/$/, "")}/trace/abort-stats?limit=${limit}`,
+      {
+        method: "GET",
+        cache: "no-store",
+        signal: AbortSignal.timeout(6000),
+      }
+    );
+    const text = await upstream.text();
+    return new Response(text, {
+      status: upstream.status,
+      headers: {
+        "Content-Type":
+          upstream.headers.get("content-type") ?? "application/json",
+      },
+    });
+  } catch (err) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: `abort_stats_unreachable: ${(err as Error).message}`,
+      },
+      { status: 502 }
+    );
+  }
+}

--- a/apps/web/app/api/trace/recent/route.ts
+++ b/apps/web/app/api/trace/recent/route.ts
@@ -1,0 +1,44 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const modalUrl = process.env.MODAL_API_URL;
+  if (!modalUrl) {
+    return NextResponse.json(
+      { ok: false, error: "MODAL_API_URL not set" },
+      { status: 503 }
+    );
+  }
+
+  const rawLimit = req.nextUrl.searchParams.get("limit");
+  const limit = rawLimit ? Math.max(1, Math.min(200, Number(rawLimit) || 50)) : 50;
+
+  try {
+    const upstream = await fetch(
+      `${modalUrl.replace(/\/$/, "")}/trace/recent?limit=${limit}`,
+      {
+        method: "GET",
+        cache: "no-store",
+        signal: AbortSignal.timeout(6000),
+      }
+    );
+    const text = await upstream.text();
+    return new Response(text, {
+      status: upstream.status,
+      headers: {
+        "Content-Type":
+          upstream.headers.get("content-type") ?? "application/json",
+      },
+    });
+  } catch (err) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: `trace_unreachable: ${(err as Error).message}`,
+      },
+      { status: 502 }
+    );
+  }
+}

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -1072,12 +1072,24 @@ export default function PlayPage() {
             subject?: string;
             style?: string;
             subject_context?: string;
+            groundable?: boolean;
+            confidence?: number;
+            point?: { x: number; y: number } | null;
+            bbox?: { x: number; y: number; w: number; h: number } | null;
           };
           if (data.subject) {
             cache.set(key, {
               subject: data.subject,
               style: data.style ?? "",
               subject_context: data.subject_context ?? "",
+              ...(typeof data.groundable === "boolean"
+                ? { groundable: data.groundable }
+                : {}),
+              ...(typeof data.confidence === "number"
+                ? { confidence: data.confidence }
+                : {}),
+              ...(data.point ? { point: data.point } : {}),
+              ...(data.bbox ? { bbox: data.bbox } : {}),
             });
             // Bound the cache so a long session doesn't grow Map<> forever.
             // FIFO eviction is fine — cache entries are independent.

--- a/apps/web/hooks/usePrefetchCache.test.tsx
+++ b/apps/web/hooks/usePrefetchCache.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
+import type { PrefetchEntry } from "./usePrefetchCache";
 import { PREFETCH_LRU_MAX, PREFETCH_PER_PAGE, usePrefetchCache } from "./usePrefetchCache";
 
 describe("usePrefetchCache constants", () => {
@@ -61,5 +62,43 @@ describe("clearTimer / reset", () => {
     expect(abortSpy1).toHaveBeenCalledTimes(1);
     expect(abortSpy2).toHaveBeenCalledTimes(1);
     expect(result.current.inflightRef.current.size).toBe(0);
+  });
+});
+
+describe("PrefetchEntry shape", () => {
+  it("accepts the legacy minimal shape (backward compat)", () => {
+    const legacy: PrefetchEntry = { subject: "boiler", style: "" };
+    expect(legacy.groundable).toBeUndefined();
+    expect(legacy.confidence).toBeUndefined();
+    expect(legacy.point).toBeUndefined();
+    expect(legacy.bbox).toBeUndefined();
+  });
+
+  it("accepts the full groundability payload", () => {
+    const full: PrefetchEntry = {
+      subject: "boiler",
+      style: "flat infographic",
+      subject_context: "the steam generator",
+      groundable: true,
+      confidence: 0.92,
+      point: { x: 0.42, y: 0.61 },
+      bbox: { x: 0.3, y: 0.5, w: 0.25, h: 0.3 },
+    };
+    expect(full.groundable).toBe(true);
+    expect(full.confidence).toBe(0.92);
+    expect(full.point?.x).toBe(0.42);
+    expect(full.bbox?.w).toBe(0.25);
+  });
+
+  it("treats groundable=false as a low-confidence flag", () => {
+    const blocked: PrefetchEntry = {
+      subject: "background sky",
+      style: "",
+      groundable: false,
+      confidence: 0.1,
+    };
+    expect(blocked.groundable).toBe(false);
+    // Consumers should suppress page-gen on this entry.
+    expect(blocked.groundable === false && (blocked.confidence ?? 1) < 0.5).toBe(true);
   });
 });

--- a/apps/web/hooks/usePrefetchCache.ts
+++ b/apps/web/hooks/usePrefetchCache.ts
@@ -2,10 +2,30 @@
 
 import { useCallback, useRef } from "react";
 
+export interface PrefetchPoint {
+  x: number;
+  y: number;
+}
+
+export interface PrefetchBBox {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
 export interface PrefetchEntry {
   subject: string;
   style: string;
   subject_context?: string;
+  /**
+   * Resolver self-reported groundability + confidence. Default ``true`` /
+   * ``1.0`` keeps older cached entries backward-compatible.
+   */
+  groundable?: boolean;
+  confidence?: number;
+  point?: PrefetchPoint | null;
+  bbox?: PrefetchBBox | null;
 }
 
 export const PREFETCH_PER_PAGE = 6;

--- a/apps/web/lib/trace-types.test.ts
+++ b/apps/web/lib/trace-types.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "vitest";
+
+import type { BackendSpan } from "./trace-types";
+import {
+  packSpansIntoRows,
+  spanCategory,
+  summarizeCategories,
+} from "./trace-types";
+
+function makeSpan(
+  name: string,
+  start_ms: number,
+  end_ms: number,
+  level: BackendSpan["level"] = "info"
+): BackendSpan {
+  return {
+    name,
+    start_ms,
+    end_ms,
+    duration_ms: end_ms - start_ms,
+    level,
+  };
+}
+
+describe("spanCategory", () => {
+  test("vlm prefix → blue", () => {
+    expect(spanCategory("vlm.click_to_subject").label).toBe("vlm");
+    expect(spanCategory("vlm.click_to_subject").color).toBe("#3b82f6");
+  });
+
+  test("plan and planner both match planner", () => {
+    expect(spanCategory("plan.page").label).toBe("planner");
+    expect(spanCategory("planner.compose").label).toBe("planner");
+  });
+
+  test("image-gen prefixes", () => {
+    expect(spanCategory("image.generate").label).toBe("image-gen");
+    expect(spanCategory("image_gen.fast_tier").label).toBe("image-gen");
+  });
+
+  test("persist family covers r2, mongo, save, store", () => {
+    for (const name of ["r2.upload", "mongo.insert", "save.node", "store.entity"]) {
+      expect(spanCategory(name).label).toBe("persist");
+    }
+  });
+
+  test("unknown prefix falls back to other", () => {
+    expect(spanCategory("mystery.span").label).toBe("other");
+    expect(spanCategory("").label).toBe("other");
+  });
+});
+
+describe("packSpansIntoRows", () => {
+  test("non-overlapping spans share row 0", () => {
+    const packed = packSpansIntoRows([
+      makeSpan("a", 0, 10),
+      makeSpan("b", 10, 20),
+      makeSpan("c", 25, 30),
+    ]);
+    expect(packed.map((p) => p.row)).toEqual([0, 0, 0]);
+  });
+
+  test("overlapping spans stack onto separate rows", () => {
+    const packed = packSpansIntoRows([
+      makeSpan("a", 0, 50),
+      makeSpan("b", 10, 30),
+      makeSpan("c", 20, 40),
+    ]);
+    const rowOf = (n: string) => packed.find((p) => p.name === n)!.row;
+    expect(rowOf("a")).toBe(0);
+    expect(rowOf("b")).toBe(1);
+    expect(rowOf("c")).toBe(2);
+  });
+
+  test("freed row is reused once span ends", () => {
+    const packed = packSpansIntoRows([
+      makeSpan("a", 0, 10),
+      makeSpan("b", 5, 20),
+      makeSpan("c", 11, 25),
+    ]);
+    const rowOf = (n: string) => packed.find((p) => p.name === n)!.row;
+    expect(rowOf("a")).toBe(0);
+    expect(rowOf("b")).toBe(1);
+    // c starts at 11 — row 0 is free since a ended at 10
+    expect(rowOf("c")).toBe(0);
+  });
+
+  test("preserves input span data on the packed span", () => {
+    const [first] = packSpansIntoRows([makeSpan("x", 0, 10, "error")]);
+    expect(first).toBeDefined();
+    expect(first?.level).toBe("error");
+    expect(first?.duration_ms).toBe(10);
+  });
+
+  test("empty input → empty output", () => {
+    expect(packSpansIntoRows([])).toEqual([]);
+  });
+});
+
+describe("summarizeCategories", () => {
+  test("groups by label and sums duration_ms", () => {
+    const spans = [
+      makeSpan("vlm.click", 0, 100),
+      makeSpan("vlm.precompute", 100, 250),
+      makeSpan("plan.page", 250, 400),
+      makeSpan("image.gen", 400, 1500),
+    ];
+    const [first, second, third, ...rest] = summarizeCategories(spans);
+    expect(rest).toEqual([]);
+    // sorted descending by totalMs
+    expect(first).toMatchObject({ label: "image-gen", totalMs: 1100 });
+    expect(second).toMatchObject({ label: "vlm", totalMs: 250 });
+    expect(third).toMatchObject({ label: "planner", totalMs: 150 });
+  });
+
+  test("empty input → empty array", () => {
+    expect(summarizeCategories([])).toEqual([]);
+  });
+});

--- a/apps/web/lib/trace-types.ts
+++ b/apps/web/lib/trace-types.ts
@@ -1,0 +1,119 @@
+export interface BackendSpan {
+  name: string;
+  start_ms: number;
+  end_ms: number;
+  duration_ms: number;
+  level: "info" | "error";
+  error?: string;
+  kv?: Record<string, unknown>;
+}
+
+export interface BackendTrace {
+  trace_id: string;
+  start_ms: number;
+  end_ms: number;
+  wall_ms: number;
+  span_count: number;
+  errored: boolean;
+  spans: BackendSpan[];
+}
+
+export interface TraceRecentResponse {
+  ok: boolean;
+  service?: string;
+  traces?: BackendTrace[];
+  error?: string;
+}
+
+export interface AbortStageRow {
+  stage: string;
+  count: number;
+  wasted_ms: number;
+  wasted_usd: number;
+  cost_per_sec: number;
+}
+
+export interface AbortEntry {
+  ts_ms: number;
+  stage: string;
+  elapsed_ms: number;
+  wasted_usd: number;
+  cost_per_sec: number;
+  trace_id?: string | null;
+  mode?: string;
+  [key: string]: unknown;
+}
+
+export interface AbortStatsResponse {
+  ok: boolean;
+  service?: string;
+  total?: number;
+  by_stage?: AbortStageRow[];
+  recent?: AbortEntry[];
+  error?: string;
+}
+
+const SPAN_COLORS: Array<{ match: RegExp; color: string; label: string }> = [
+  { match: /^vlm\./, color: "#3b82f6", label: "vlm" },
+  { match: /^plan(ner)?\./, color: "#22c55e", label: "planner" },
+  { match: /^image[._]/, color: "#ea580c", label: "image-gen" },
+  { match: /^video\./, color: "#a855f7", label: "video" },
+  { match: /^world\./, color: "#14b8a6", label: "world-mem" },
+  { match: /^(prefetch|precompute)\./, color: "#94a3b8", label: "prefetch" },
+  { match: /^(save|r2|mongo|store)\./, color: "#ec4899", label: "persist" },
+  { match: /^(http|fetch|net)\./, color: "#0ea5e9", label: "network" },
+];
+
+const FALLBACK_COLOR = "#64748b";
+
+export function spanCategory(name: string): { color: string; label: string } {
+  for (const rule of SPAN_COLORS) {
+    if (rule.match.test(name)) return { color: rule.color, label: rule.label };
+  }
+  return { color: FALLBACK_COLOR, label: "other" };
+}
+
+export interface PackedSpan extends BackendSpan {
+  row: number;
+}
+
+/**
+ * Greedy row-packing: assign each span the lowest row whose previous span
+ * ended before this span starts. Produces a Gantt where concurrent spans
+ * occupy stacked rows.
+ */
+export function packSpansIntoRows(spans: BackendSpan[]): PackedSpan[] {
+  const sorted = [...spans].sort((a, b) => a.start_ms - b.start_ms);
+  const rows: number[] = [];
+  const packed: PackedSpan[] = [];
+  for (const span of sorted) {
+    let row = rows.findIndex((endMs) => endMs <= span.start_ms);
+    if (row === -1) {
+      row = rows.length;
+      rows.push(span.end_ms);
+    } else {
+      rows[row] = span.end_ms;
+    }
+    packed.push({ ...span, row });
+  }
+  return packed;
+}
+
+export interface CategorySummary {
+  label: string;
+  color: string;
+  totalMs: number;
+}
+
+export function summarizeCategories(spans: BackendSpan[]): CategorySummary[] {
+  const map = new Map<string, { color: string; totalMs: number }>();
+  for (const s of spans) {
+    const { color, label } = spanCategory(s.name);
+    const cur = map.get(label) ?? { color, totalMs: 0 };
+    cur.totalMs += s.duration_ms;
+    map.set(label, cur);
+  }
+  return [...map.entries()]
+    .map(([label, v]) => ({ label, ...v }))
+    .sort((a, b) => b.totalMs - a.totalMs);
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -37,6 +37,10 @@ export interface GenerateRequestBody {
   // frames"). Backend feeds this to plan_page as authoritative meaning so
   // ambiguous phrases stay in the parent's domain.
   prefetched_subject_context?: string;
+  // Multi-turn refer (SAMA / MM-Conv): when the user rejects a resolved
+  // subject and taps again nearby, the client forwards the rejected
+  // phrase so the VLM picks something different next time.
+  prior_rejected_subject?: string;
   // Session-level style lock. When set, the planner uses this as the
   // visual style for ALL pages in the session, overriding the per-hop
   // style derived from the parent. Pin a page in the UI to populate.
@@ -72,7 +76,24 @@ export interface ResolveClickRequestBody {
   parent_title?: string;
   parent_query?: string;
   output_locale?: string;
+  prior_rejected_subject?: string;
   trace_id?: string;
+}
+
+// VLM's best-estimate centroid of the resolved subject (0..1 in image
+// frame). Powers the "we think you tapped this — yes/try again" overlay.
+export interface ResolveClickPoint {
+  x: number;
+  y: number;
+}
+
+// Optional bounding box around the resolved subject. Omitted when the
+// VLM cannot give a tight box (cf. GroundingME findings on rejection).
+export interface ResolveClickBBox {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
 }
 
 export interface ResolveClickResponse {
@@ -83,6 +104,12 @@ export interface ResolveClickResponse {
   // so an ambiguous phrase like "Memory Bank" doesn't drift to the
   // popular web meaning when the parent is a video-segmentation diagram.
   subject_context?: string;
+  // VLM's self-reported groundability + confidence + best-estimate region.
+  // Default behaviour when omitted: treat as groundable=true, confidence=1.
+  groundable?: boolean;
+  confidence?: number;
+  point?: ResolveClickPoint | null;
+  bbox?: ResolveClickBBox | null;
 }
 
 export interface GenerateProgressEvent {
@@ -128,6 +155,13 @@ export interface GenerateStatusEvent {
   stage: GenerateStage;
   page_title?: string;
   subject?: string;
+  // Resolver self-report when stage === "click_resolved". Web client can
+  // render the bounding-box overlay or a "tap something specific?" toast
+  // when groundable is false / confidence is low.
+  groundable?: boolean;
+  confidence?: number;
+  point?: ResolveClickPoint | null;
+  bbox?: ResolveClickBBox | null;
   trace_id?: string;
 }
 


### PR DESCRIPTION
## Summary

Two themed commits from the post-research roadmap, each independently usable.

- **`feat(obs): trace dashboard + stale-click audit + bench harnesses`** — eval-infra deliverable so any future swap (VLM, image model, planner) lands with measurable before/after numbers. In-memory trace ring buffer keyed by `x-trace-id`, abort-stats accumulator with per-stage `$/sec` cost rates, two new endpoints (`/trace/recent`, `/trace/abort-stats`), and a `/admin/trace` dashboard with a Gantt flamegraph + abort panel. Plus two bench harnesses: click-resolver micro-bench (PIL crosshair replica, phrase-similarity scoring) and continuity bench (ViStoryBench-lite VLM-judge for style drift / entity consistency / prompt alignment).
- **`feat(click): groundability gate + multi-turn refer on click resolver`** — `ClickResolution` gains `groundable`/`confidence`/`point`/`bbox` with safe defaults, `click_to_subject` accepts `prior_rejected_subject` for SAMA/MM-Conv-style multi-turn refer. Threaded through the SSE `click_resolved` event, `/resolve-click` response, and the prefetch cache. Wire types in `packages/config` all-optional → fully backwards-compatible; existing flows unchanged.

Background sources: GroundingME (arXiv:2512.17495) on VLM hallucination on empty regions; ViStoryBench (arXiv:2505.24862) on the metric framework; SAMA / MM-Conv on multi-turn visual refer.

## Test plan

- [x] `cd apps/modal-backend && .venv/bin/pytest` → 143 pass, 2 skipped (live VLM benches gated behind `CLICK_BENCH_RUN=1` / `CONTINUITY_BENCH_RUN=1`)
- [x] `cd apps/web && pnpm test` → 251 pass
- [x] `cd apps/web && pnpm typecheck` → clean
- [x] `cd apps/modal-backend && .venv/bin/ruff check .` → clean
- [ ] Live: open `/admin/trace`, trigger a tap on `/play`, watch the trace land in the flamegraph and abort-stats panel populate as expected.
- [ ] Live: confirm existing click → next-page flow is unchanged (additive only; no UI surface added in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)