### PR TITLE
feat(providers): native multi-provider LLM + image backends (M1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,27 @@ OPENROUTER_TEXT_MODEL=google/gemini-3-flash-preview
 # other models append ":online" (Exa-backed). Disable to skip both.
 OPENROUTER_ENABLE_WEB_SEARCH=true
 
+# Use a different LLM provider (advanced). Leave LLM_PROVIDER unset to keep the
+# OpenRouter defaults above unchanged. Set it to run the planner + click VLM on
+# a direct vendor API or any OpenAI-compatible local server (Ollama/LM Studio/
+# vLLM). Web search is OpenRouter-only and is skipped on other providers.
+#   openrouter (default) | openai | anthropic | google | custom
+# LLM_PROVIDER=custom
+# LLM_BASE_URL=http://localhost:11434/v1   # required for `custom` (Ollama shown)
+# LLM_API_KEY=                              # blank is fine for keyless local servers
+# LLM_VLM_MODEL=qwen2.5vl
+# LLM_TEXT_MODEL=qwen2.5
+# LLM_STRUCTURED_OUTPUT=auto                # auto | json_object | tool | prompt
+
+# Swap the image backend off fal (advanced). Leave IMAGE_PROVIDER unset to keep
+# fal + its quality tiers. `openai` / `custom` use the OpenAI Images API shape;
+# tiers collapse to one IMAGE_MODEL there, and edit-mode stays on fal.
+#   fal (default) | openai | custom
+# IMAGE_PROVIDER=openai
+# IMAGE_API_KEY=
+# IMAGE_MODEL=gpt-image-1
+# IMAGE_BASE_URL=http://localhost:8080/v1   # required for `custom`
+
 # --- Image generation tier (fast | balanced | pro) ---
 # Per-request override available in body.image_tier from the frontend.
 FAL_IMAGE_TIER=balanced

--- a/apps/modal-backend/.env.example
+++ b/apps/modal-backend/.env.example
@@ -6,6 +6,38 @@ OPENROUTER_API_KEY=
 OPENROUTER_VLM_MODEL=qwen/qwen-2.5-vl-72b-instruct
 OPENROUTER_TEXT_MODEL=qwen/qwen-2.5-72b-instruct
 OPENROUTER_ENABLE_WEB_SEARCH=true
+
+# --- Use a different LLM provider (advanced; default = OpenRouter above) ---
+# Leave LLM_PROVIDER unset to keep OpenRouter byte-for-byte. Set it to point the
+# planner + click VLM at a direct vendor API or any OpenAI-compatible local
+# server (Ollama / LM Studio / vLLM) — every target speaks the OpenAI wire format.
+#   openrouter (default) | openai | anthropic | google | custom
+# LLM_PROVIDER=openai
+# LLM_API_KEY=
+# LLM_VLM_MODEL=gpt-4o
+# LLM_TEXT_MODEL=gpt-4o-mini
+# `custom` = any OpenAI-compatible base URL (Ollama shown; no key needed locally):
+# LLM_PROVIDER=custom
+# LLM_BASE_URL=http://localhost:11434/v1
+# LLM_VLM_MODEL=qwen2.5vl
+# LLM_TEXT_MODEL=qwen2.5
+# Structured-output strategy: auto (default) | json_object | tool | prompt.
+# Weak local models that ignore JSON mode fall to prompt+repair automatically;
+# pin a stronger tier if you know your model supports it.
+# LLM_STRUCTURED_OUTPUT=auto
+
+# --- Use a different image provider (advanced; default = fal above) ---
+# Leave IMAGE_PROVIDER unset to keep fal (with its quality tiers). Set it to
+# generate via the OpenAI Images API or any OpenAI-images-compatible server.
+# Tiers collapse to a single IMAGE_MODEL on non-fal backends; edit-mode stays fal.
+#   fal (default) | openai | custom
+# IMAGE_PROVIDER=openai
+# IMAGE_API_KEY=
+# IMAGE_MODEL=gpt-image-1
+# IMAGE_SIZE=1024x1024          # optional; default maps from aspect ratio
+# custom = any OpenAI-images-compatible base URL:
+# IMAGE_PROVIDER=custom
+# IMAGE_BASE_URL=http://localhost:8080/v1
 FAL_IMAGE_MODEL=fal-ai/nano-banana
 FAL_ANIMATE_MODEL=fal-ai/ltx-video/image-to-video
 

--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -380,6 +380,11 @@ async def _event_stream(
             progressive_enabled
             and target_tier != "fast"
             and not body.image_model  # honour explicit model_override
+            # The draft race is a fal tier optimisation (cheap fast-tier model
+            # in parallel with the requested tier). Non-fal backends collapse
+            # tiers to one model, so a draft would just regenerate the same
+            # image — skip it.
+            and image_provider.active_provider() == "fal"
         )
         draft_task: _asyncio.Task | None = None
         if wants_draft:

--- a/apps/modal-backend/providers/image.py
+++ b/apps/modal-backend/providers/image.py
@@ -57,9 +57,18 @@ IMAGE_BASE_URLS: dict[str, str] = {
 }
 DEFAULT_OPENAI_IMAGE_MODEL = "gpt-image-1"
 
-# Aspect → OpenAI image size. Defaults target dall-e-3 / gpt-image landscape +
-# portrait; override wholesale with IMAGE_SIZE for models with other valid sizes.
-OPENAI_SIZE_MAP: dict[str, str] = {
+# Aspect → image size. gpt-image-1 and dall-e-3 accept DIFFERENT size sets
+# (the only common one is 1024x1024), so pick per model family — otherwise the
+# default IMAGE_MODEL=gpt-image-1 would 400 on a 16:9 request (1792x1024 is a
+# dall-e size gpt-image rejects). Override wholesale with IMAGE_SIZE.
+GPT_IMAGE_SIZE_MAP: dict[str, str] = {
+    "16:9": "1536x1024",
+    "9:16": "1024x1536",
+    "1:1":  "1024x1024",
+    "4:3":  "1536x1024",
+    "3:4":  "1024x1536",
+}
+DALLE_SIZE_MAP: dict[str, str] = {
     "16:9": "1792x1024",
     "9:16": "1024x1792",
     "1:1":  "1024x1024",
@@ -147,10 +156,13 @@ def _image_model() -> str:
     return os.environ.get("IMAGE_MODEL", "").strip() or DEFAULT_OPENAI_IMAGE_MODEL
 
 
-def _openai_size(aspect_ratio: str) -> str:
-    return os.environ.get("IMAGE_SIZE", "").strip() or OPENAI_SIZE_MAP.get(
-        aspect_ratio, "1024x1024"
-    )
+def _openai_size(aspect_ratio: str, model: str) -> str:
+    override = os.environ.get("IMAGE_SIZE", "").strip()
+    if override:
+        return override
+    m = model.lower()
+    table = DALLE_SIZE_MAP if ("dall-e" in m or "dalle" in m) else GPT_IMAGE_SIZE_MAP
+    return table.get(aspect_ratio, "1024x1024")
 
 
 async def generate_image(
@@ -273,7 +285,7 @@ async def _openai_compatible_image(
     payload: dict[str, Any] = {
         "model": model,
         "prompt": prompt,
-        "size": _openai_size(aspect_ratio),
+        "size": _openai_size(aspect_ratio, model),
         "n": 1,
     }
     data = await _post_image_json(url, headers, payload)

--- a/apps/modal-backend/providers/image.py
+++ b/apps/modal-backend/providers/image.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import base64
 import os
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 import fal_client
 import httpx
@@ -45,6 +45,26 @@ SEEDREAM_SIZE_MAP: dict[str, str] = {
     "1:1":  "square_hd",
     "4:3":  "landscape_4_3",
     "3:4":  "portrait_4_3",
+}
+
+# Non-fal image backends. Every target speaks the OpenAI Images wire format
+# (`POST {base}/images/generations`), so the only thing that varies is the base
+# URL + key — data, not a registry. `custom` (or unknown) must supply
+# IMAGE_BASE_URL, covering OpenAI-compatible local servers (LocalAI, vLLM-image,
+# SD wrappers). fal stays the default and is handled separately.
+IMAGE_BASE_URLS: dict[str, str] = {
+    "openai": "https://api.openai.com/v1",
+}
+DEFAULT_OPENAI_IMAGE_MODEL = "gpt-image-1"
+
+# Aspect → OpenAI image size. Defaults target dall-e-3 / gpt-image landscape +
+# portrait; override wholesale with IMAGE_SIZE for models with other valid sizes.
+OPENAI_SIZE_MAP: dict[str, str] = {
+    "16:9": "1792x1024",
+    "9:16": "1024x1792",
+    "1:1":  "1024x1024",
+    "4:3":  "1792x1024",
+    "3:4":  "1024x1792",
 }
 
 
@@ -87,6 +107,52 @@ def _args_for(model: str, prompt: str, aspect_ratio: str) -> dict[str, Any]:
     return {"prompt": prompt, "aspect_ratio": aspect_ratio}
 
 
+def _image_provider() -> str:
+    """The active image provider, normalised. Defaults to `fal`."""
+    return (os.environ.get("IMAGE_PROVIDER", "") or "fal").strip().lower() or "fal"
+
+
+def active_provider() -> str:
+    """Public accessor so callers (e.g. generate.py) can gate fal-only paths
+    such as the draft/final tier race without reaching into a private."""
+    return _image_provider()
+
+
+def _resolve_image_provider() -> tuple[str, str, str]:
+    """Resolve (provider, base_url, api_key) for a non-fal image backend.
+
+    fal is the default and is handled separately in `generate_image`; this only
+    runs for OpenAI-images-compatible targets. Mirrors the LLM provider seam:
+    env-var only, `custom` (or unknown) needs IMAGE_BASE_URL, and a keyless
+    local server defaults to a placeholder key.
+    """
+    provider = _image_provider()
+    base_url = os.environ.get("IMAGE_BASE_URL", "").strip() or IMAGE_BASE_URLS.get(
+        provider, ""
+    )
+    if not base_url:
+        raise RuntimeError(
+            f"IMAGE_BASE_URL must be set for IMAGE_PROVIDER={provider!r}"
+        )
+    api_key = os.environ.get("IMAGE_API_KEY", "").strip()
+    if not api_key:
+        if provider == "custom":
+            api_key = "sk-noauth"
+        else:
+            raise RuntimeError(f"IMAGE_API_KEY is not set for IMAGE_PROVIDER={provider!r}")
+    return provider, base_url, api_key
+
+
+def _image_model() -> str:
+    return os.environ.get("IMAGE_MODEL", "").strip() or DEFAULT_OPENAI_IMAGE_MODEL
+
+
+def _openai_size(aspect_ratio: str) -> str:
+    return os.environ.get("IMAGE_SIZE", "").strip() or OPENAI_SIZE_MAP.get(
+        aspect_ratio, "1024x1024"
+    )
+
+
 async def generate_image(
     prompt: str,
     aspect_ratio: str,
@@ -95,9 +161,23 @@ async def generate_image(
 ) -> GeneratedImage:
     from obs import span
 
+    if _image_provider() != "fal":
+        prov, base_url, api_key = _resolve_image_provider()
+        model = model_override or _image_model()
+        async with span(
+            "image.generate", model=model, prompt_len=len(prompt), provider=prov
+        ) as ctx:
+            generated = await _openai_compatible_image(
+                base_url, api_key, model, prompt, aspect_ratio
+            )
+            ctx["bytes"] = len(generated.jpeg_bytes)
+        return generated
+
     _ensure_fal_key()
     model = _resolve_model(tier, model_override)
-    async with span("image.generate", model=model, prompt_len=len(prompt)) as ctx:
+    async with span(
+        "image.generate", model=model, prompt_len=len(prompt), provider="fal"
+    ) as ctx:
         result = await _fal_subscribe(model, _args_for(model, prompt, aspect_ratio))
         image_info = _first_image(result)
         jpeg_bytes, mime = await _fetch_image_bytes(image_info)
@@ -148,6 +228,74 @@ async def _fetch_image_bytes(image_info: dict) -> tuple[bytes, str]:
     resp = await _http_client().get(url)
     resp.raise_for_status()
     return resp.content, mime
+
+
+async def _fetch_url_bytes(url: str) -> tuple[bytes, str]:
+    """Download an image URL (the dall-e-style response path)."""
+    resp = await _http_client().get(url)
+    resp.raise_for_status()
+    mime = (resp.headers.get("content-type") or "image/jpeg").split(";")[0].strip()
+    return resp.content, mime or "image/jpeg"
+
+
+async def _post_image_json(
+    url: str, headers: dict[str, str], payload: dict[str, Any]
+) -> dict[str, Any]:
+    """POST to an OpenAI-images-compatible endpoint with bounded retry,
+    reusing the same transient classifier as the fal path."""
+    async for attempt in AsyncRetrying(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=0.5, min=0.5, max=4),
+        retry=retry_if_exception(_is_retryable),
+        reraise=True,
+    ):
+        with attempt:
+            resp = await _http_client().post(url, headers=headers, json=payload)
+            resp.raise_for_status()
+            return cast(dict[str, Any], resp.json())
+    raise RuntimeError("unreachable")  # pragma: no cover
+
+
+async def _openai_compatible_image(
+    base_url: str, api_key: str, model: str, prompt: str, aspect_ratio: str
+) -> GeneratedImage:
+    """Generate one image via the OpenAI Images API (or any compatible server).
+
+    Handles both response shapes: gpt-image-1 returns inline `b64_json`,
+    dall-e-style returns a `url` we then fetch. `response_format` is NOT sent —
+    gpt-image-1 rejects it — so we accept whichever shape the server emits.
+    """
+    url = f"{base_url.rstrip('/')}/images/generations"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    payload: dict[str, Any] = {
+        "model": model,
+        "prompt": prompt,
+        "size": _openai_size(aspect_ratio),
+        "n": 1,
+    }
+    data = await _post_image_json(url, headers, payload)
+    items = data.get("data") or []
+    if not items or not isinstance(items[0], dict):
+        raise RuntimeError("image provider returned no images")
+    item = items[0]
+    b64 = item.get("b64_json")
+    if isinstance(b64, str) and b64:
+        return GeneratedImage(
+            jpeg_bytes=base64.b64decode(b64),
+            mime_type="image/png",
+            model=model,
+            provider_request_id=None,
+        )
+    img_url = item.get("url")
+    if isinstance(img_url, str) and img_url:
+        raw, mime = await _fetch_url_bytes(img_url)
+        return GeneratedImage(
+            jpeg_bytes=raw, mime_type=mime, model=model, provider_request_id=None
+        )
+    raise RuntimeError("image provider returned neither b64_json nor url")
 
 
 def _is_retryable(exc: BaseException) -> bool:

--- a/apps/modal-backend/providers/llm.py
+++ b/apps/modal-backend/providers/llm.py
@@ -18,11 +18,24 @@ import os
 from dataclasses import dataclass
 from typing import Any, cast
 
-from openai import AsyncOpenAI
+from openai import AsyncOpenAI, BadRequestError
 
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 DEFAULT_VLM_MODEL = "google/gemini-3-flash-preview"
 DEFAULT_TEXT_MODEL = "google/gemini-3-flash-preview"
+
+# Built-in base URLs per provider. This is DATA, not a behavior registry —
+# every target speaks the OpenAI wire protocol, so the only thing that varies
+# is the endpoint + key. `custom` (or any unknown value) must supply
+# LLM_BASE_URL, which covers OpenAI-compatible local servers (Ollama,
+# LM Studio, vLLM) and self-hosted proxies. Anthropic/Google entries are their
+# OpenAI-compatibility endpoints so the single AsyncOpenAI code path is reused.
+_LLM_BASE_URLS = {
+    "openrouter": OPENROUTER_BASE_URL,
+    "openai": "https://api.openai.com/v1",
+    "anthropic": "https://api.anthropic.com/v1",
+    "google": "https://generativelanguage.googleapis.com/v1beta/openai/",
+}
 
 
 @dataclass
@@ -115,6 +128,51 @@ class EntityExtractionResult:
 _OPENAI_CLIENT: AsyncOpenAI | None = None
 
 
+def _llm_provider() -> str:
+    """The active LLM provider, normalised. Defaults to `openrouter`."""
+    return (os.environ.get("LLM_PROVIDER", "") or "openrouter").strip().lower() or "openrouter"
+
+
+def _resolve_provider() -> tuple[str, str, str, dict[str, str]]:
+    """Resolve (provider, base_url, api_key, default_headers) from env.
+
+    Selection is env-var only — no registry, no YAML. `LLM_PROVIDER` unset (or
+    `openrouter`) reproduces today's request byte-for-byte: OPENROUTER_API_KEY,
+    the OpenRouter base URL, and the HTTP-Referer/X-Title attribution headers.
+    Any other provider speaks the same OpenAI wire protocol at a different base
+    URL with LLM_API_KEY. `custom` (or an unknown value) targets an
+    OpenAI-compatible server (Ollama/LM Studio/vLLM) via LLM_BASE_URL.
+    """
+    provider = _llm_provider()
+    base_override = os.environ.get("LLM_BASE_URL", "").strip()
+    if provider == "openrouter":
+        api_key = os.environ.get("OPENROUTER_API_KEY")
+        if not api_key:
+            raise RuntimeError("OPENROUTER_API_KEY is not set")
+        headers = {
+            "HTTP-Referer": os.environ.get(
+                "OPENROUTER_REFERER", "https://github.com/eren23/openflipbook"
+            ),
+            "X-Title": "Endless Canvas",
+        }
+        return provider, base_override or OPENROUTER_BASE_URL, api_key, headers
+    base_url = base_override or _LLM_BASE_URLS.get(provider, "")
+    if not base_url:
+        raise RuntimeError(
+            f"LLM_BASE_URL must be set for LLM_PROVIDER={provider!r} "
+            "(e.g. http://localhost:11434/v1 for Ollama)"
+        )
+    api_key = os.environ.get("LLM_API_KEY", "").strip()
+    if not api_key:
+        if provider == "custom":
+            # Local OpenAI-compatible servers usually need no auth, but the
+            # SDK requires a non-empty string.
+            api_key = "sk-noauth"
+        else:
+            raise RuntimeError(f"LLM_API_KEY is not set for LLM_PROVIDER={provider!r}")
+    return provider, base_url, api_key, {}
+
+
 def _client() -> AsyncOpenAI:
     """Module-level singleton AsyncOpenAI client.
 
@@ -124,23 +182,16 @@ def _client() -> AsyncOpenAI:
     """
     global _OPENAI_CLIENT
     if _OPENAI_CLIENT is None:
-        api_key = os.environ.get("OPENROUTER_API_KEY")
-        if not api_key:
-            raise RuntimeError("OPENROUTER_API_KEY is not set")
+        provider, base_url, api_key, headers = _resolve_provider()
         _OPENAI_CLIENT = AsyncOpenAI(
             api_key=api_key,
-            base_url=OPENROUTER_BASE_URL,
-            default_headers={
-                "HTTP-Referer": os.environ.get(
-                    "OPENROUTER_REFERER", "https://github.com/eren23/openflipbook"
-                ),
-                "X-Title": "Endless Canvas",
-            },
+            base_url=base_url,
+            default_headers=headers or None,
         )
-        # Phase 7d — surface model capability posture on cold start so a
-        # deployer who swapped to a non-structured-output model sees the
-        # silent downgrade in the logs rather than discovering it through
-        # degraded extraction quality weeks later.
+        # Surface the resolved provider + structured-output tier on cold start
+        # so a deployer who swapped providers/models sees a weak model fall to
+        # the prompt+repair tier in the logs, rather than discovering degraded
+        # click-grounding / extraction quality weeks later.
         try:
             from obs import log
 
@@ -149,25 +200,24 @@ def _client() -> AsyncOpenAI:
             log(
                 "info",
                 "llm.startup",
+                provider=provider,
+                base_url=base_url,
                 vlm_model=vlm,
                 text_model=txt,
-                vlm_structured=_supports_structured_output(vlm),
-                text_structured=_supports_structured_output(txt),
+                vlm_tier=_resolve_structured_tier(provider, vlm),
+                text_tier=_resolve_structured_tier(provider, txt),
             )
-            if not _supports_structured_output(vlm):
-                log(
-                    "warn",
-                    "llm.no_structured_output_vlm",
-                    model=vlm,
-                    note="Falling back to freeform parsing — _safe_json recovers best-effort but extraction quality may degrade.",
-                )
-            if not _supports_structured_output(txt):
-                log(
-                    "warn",
-                    "llm.no_structured_output_text",
-                    model=txt,
-                    note="Falling back to freeform parsing for the planner.",
-                )
+            for role, model in (("vlm", vlm), ("text", txt)):
+                if _resolve_structured_tier(provider, model) == "prompt":
+                    log(
+                        "warn",
+                        "llm.weak_structured_output",
+                        role=role,
+                        model=model,
+                        note="No JSON mode / tool-calling detected — using prompt+repair. "
+                        "Structured quality (click grounding, extraction) may degrade. "
+                        "Set LLM_STRUCTURED_OUTPUT to override.",
+                    )
         except Exception:
             # `obs` import or log call should never block client init.
             pass
@@ -219,11 +269,23 @@ def _log_cache_usage(span_ctx: dict[str, Any], response: Any) -> None:
 
 
 def _vlm_model() -> str:
-    return os.environ.get("OPENROUTER_VLM_MODEL", DEFAULT_VLM_MODEL)
+    # LLM_VLM_MODEL (provider-native slug) wins; OPENROUTER_VLM_MODEL is the
+    # back-compat path; then the built-in default.
+    return (
+        os.environ.get("LLM_VLM_MODEL")
+        or os.environ.get("OPENROUTER_VLM_MODEL")
+        or DEFAULT_VLM_MODEL
+    )
 
 
 def _web_search_enabled(online: bool) -> bool:
     if not online:
+        return False
+    # Web search here is OpenRouter's :online / web-plugin brokering, which
+    # only exists on the openrouter provider. On direct providers there is no
+    # equivalent on this path, so report disabled (the planner still works,
+    # just without OpenRouter-brokered grounding).
+    if _llm_provider() != "openrouter":
         return False
     return os.environ.get("OPENROUTER_ENABLE_WEB_SEARCH", "true").lower() in (
         "1",
@@ -247,10 +309,46 @@ def _supports_online_suffix(model: str) -> bool:
 # losing structured output.
 _STRUCTURED_OUTPUT_FAMILIES = ("gemini", "gpt", "claude", "qwen")
 
+# Instruct tunes that follow forced tool-calls more reliably than JSON mode.
+# Used only on direct/custom providers (e.g. a local Ollama/vLLM server); the
+# openrouter path never selects the tool rung, preserving today's behavior.
+_TOOL_CALL_FAMILIES = ("llama", "mistral", "mixtral", "hermes", "command")
+
 
 def _supports_structured_output(model: str) -> bool:
     m = model.lower()
     return any(family in m for family in _STRUCTURED_OUTPUT_FAMILIES)
+
+
+def _resolve_structured_tier(provider: str, model: str) -> str:
+    """Pick how to coax structured JSON out of (provider, model).
+
+    Returns one of ``json_object`` | ``tool`` | ``prompt`` (descending
+    fidelity). `LLM_STRUCTURED_OUTPUT` (default ``auto``) lets an operator pin
+    a tier explicitly. This is a pure substring ladder — data, not a registry.
+
+    Back-compat is load-bearing: on the **openrouter** provider a known-good
+    family resolves to ``json_object`` exactly as today, and everything else
+    falls to ``prompt`` (which today already happens via the empty
+    response_format, just without the repair pass). The ``tool`` rung is
+    reserved for direct/custom providers so the default deployment is byte
+    unchanged.
+    """
+    override = os.environ.get("LLM_STRUCTURED_OUTPUT", "auto").strip().lower()
+    if override and override != "auto":
+        return override
+    m = model.lower()
+    if provider in ("openai", "google", "anthropic"):
+        # All three honour json_object on their OpenAI-compatible endpoints.
+        return "json_object"
+    if provider == "openrouter":
+        return "json_object" if _supports_structured_output(model) else "prompt"
+    # custom / unknown (local OpenAI-compatible servers): decide by family.
+    if any(fam in m for fam in _STRUCTURED_OUTPUT_FAMILIES):
+        return "json_object"
+    if any(fam in m for fam in _TOOL_CALL_FAMILIES):
+        return "tool"
+    return "prompt"
 
 
 def _maybe_response_format(model: str) -> dict[str, Any]:
@@ -264,7 +362,11 @@ def _maybe_response_format(model: str) -> dict[str, Any]:
 
 
 def _text_model(online: bool) -> str:
-    base = os.environ.get("OPENROUTER_TEXT_MODEL", DEFAULT_TEXT_MODEL)
+    base = (
+        os.environ.get("LLM_TEXT_MODEL")
+        or os.environ.get("OPENROUTER_TEXT_MODEL")
+        or DEFAULT_TEXT_MODEL
+    )
     if _web_search_enabled(online) and _supports_online_suffix(base):
         return f"{base}:online"
     return base
@@ -273,6 +375,270 @@ def _text_model(online: bool) -> str:
 def _web_plugin_extra(model: str, online: bool) -> dict[str, Any]:
     if _web_search_enabled(online) and not _supports_online_suffix(model):
         return {"plugins": [{"id": "web"}]}
+    return {}
+
+
+# JSON Schemas for the structured-output ladder. Used as the `tool` rung's
+# function parameters and as a shape hint for the `prompt` rung. They are an
+# upstream nudge only — the `_build_*` / `_parse_*` coercers below remain the
+# source of truth, which is why a weak model degrades to "thinner but valid".
+CLICK_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "subject": {"type": "string"},
+        "style": {"type": "string"},
+        "subject_context": {"type": "string"},
+        "groundable": {"type": "boolean"},
+        "confidence": {"type": "number"},
+        "point": {
+            "type": "object",
+            "properties": {"x": {"type": "number"}, "y": {"type": "number"}},
+        },
+        "bbox": {
+            "type": "object",
+            "properties": {
+                "x": {"type": "number"},
+                "y": {"type": "number"},
+                "w": {"type": "number"},
+                "h": {"type": "number"},
+            },
+        },
+    },
+    "required": ["subject"],
+}
+
+PLAN_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "page_title": {"type": "string"},
+        "prompt": {"type": "string"},
+        "facts": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["page_title", "prompt"],
+}
+
+CANDIDATES_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "candidates": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "x_pct": {"type": "number"},
+                    "y_pct": {"type": "number"},
+                    "subject": {"type": "string"},
+                    "style": {"type": "string"},
+                    "salience": {"type": "number"},
+                },
+                "required": ["x_pct", "y_pct", "subject"],
+            },
+        }
+    },
+    "required": ["candidates"],
+}
+
+EXTRACTION_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "added": {"type": "array", "items": {"type": "object"}},
+        "updated": {"type": "array", "items": {"type": "object"}},
+    },
+    "required": ["added", "updated"],
+}
+
+_TIER_LADDER = ("json_object", "tool", "prompt")
+
+_JSON_ONLY_HINT = (
+    "IMPORTANT: Respond with ONLY a single JSON object matching the shape "
+    "described above. No prose, no explanation, no markdown code fences."
+)
+_JSON_REPAIR_HINT = (
+    "Your previous reply was not valid JSON. Output ONLY the JSON object — "
+    "no prose, no code fences, nothing else."
+)
+
+
+def _safe_log(level: str, event: str, **kv: Any) -> None:
+    """Best-effort structured log that never raises into the request path."""
+    try:
+        from obs import log
+
+        log(level, event, **kv)
+    except Exception:
+        pass
+
+
+def _tier_attempts(tier: str) -> list[str]:
+    """The ordered rungs to try for a starting tier (degrade-on-error path).
+
+    `json_schema` is not implemented yet, so it maps to `json_object` (the
+    closest structured rung); an unknown override starts at the top so it still
+    walks the full ladder.
+    """
+    start = "json_object" if tier == "json_schema" else tier
+    if start not in _TIER_LADDER:
+        start = "json_object"
+    idx = _TIER_LADDER.index(start)
+    return list(_TIER_LADDER[idx:])
+
+
+def _rung_kwargs(rung: str, schema: dict[str, Any] | None, schema_name: str) -> dict[str, Any]:
+    """The create() kwargs specific to a rung. Spread by the caller so the
+    structured params bypass the SDK's strict per-arg typing, matching the
+    existing `**_maybe_response_format(...)` pattern."""
+    if rung == "json_object":
+        return {"response_format": {"type": "json_object"}}
+    if rung == "tool":
+        return {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": schema_name,
+                        "parameters": schema or {"type": "object"},
+                    },
+                }
+            ],
+            "tool_choice": {"type": "function", "function": {"name": schema_name}},
+        }
+    return {}
+
+
+def _with_json_hint(messages: list[Any], hint: str) -> list[Any]:
+    """Append a JSON-only instruction to the last user turn.
+
+    Weak local models often ignore a trailing system message, so the hint
+    rides on the user turn. Handles both string content and the multimodal
+    block-list shape (text + image_url).
+    """
+    out: list[Any] = [dict(m) for m in messages]
+    for m in reversed(out):
+        if m.get("role") == "user":
+            content = m.get("content")
+            if isinstance(content, str):
+                m["content"] = f"{content}\n\n{hint}"
+            elif isinstance(content, list):
+                m["content"] = [*content, {"type": "text", "text": hint}]
+            return out
+    out.append({"role": "system", "content": hint})
+    return out
+
+
+def _choice_content(response: Any) -> str:
+    try:
+        if not response.choices:
+            return ""
+        return response.choices[0].message.content or ""
+    except Exception:
+        return ""
+
+
+def _parse_choice_json(response: Any) -> dict[str, Any]:
+    return _safe_json(_choice_content(response).strip() or "{}")
+
+
+def _parse_tool_json(response: Any) -> dict[str, Any]:
+    try:
+        if not response.choices:
+            return {}
+        msg = response.choices[0].message
+        tool_calls = getattr(msg, "tool_calls", None)
+        if tool_calls:
+            args = tool_calls[0].function.arguments
+            if args:
+                return _safe_json(args)
+        # Some servers ignore tool_choice and answer in content instead.
+        return _safe_json((msg.content or "{}").strip())
+    except Exception:
+        return {}
+
+
+async def _complete_json(
+    *,
+    model: str,
+    messages: list[Any],
+    max_tokens: int,
+    temperature: float,
+    schema: dict[str, Any] | None = None,
+    schema_name: str = "result",
+    extra_body: dict[str, Any] | None = None,
+    span_ctx: dict[str, Any] | None = None,
+    response_sink: list[Any] | None = None,
+) -> dict[str, Any]:
+    """Issue a chat completion and return parsed JSON, degrading gracefully.
+
+    Picks a structured-output strategy via `_resolve_structured_tier`, then
+    walks DOWN the ladder (json_object -> tool -> prompt) if a provider rejects
+    the chosen mechanism with a 400. The prompt rung adds a JSON-only hint and
+    one repair retry. The caller's existing `_build_*` / `_parse_*` coercers
+    stay the source of truth, so a weak model degrades to "thinner but valid"
+    rather than crashing. On the default OpenRouter path this issues the exact
+    same json_object request as before.
+
+    `response_sink`, when provided, receives the final raw response object so a
+    caller that needs more than the parsed JSON (e.g. the planner reading
+    OpenRouter citation annotations) can reach it without changing the return.
+    """
+    client = _client()
+    provider = _llm_provider()
+    tier = _resolve_structured_tier(provider, model)
+    if span_ctx is not None:
+        span_ctx["structured_tier"] = tier
+    attempts = _tier_attempts(tier)
+    eb = extra_body or None
+    last_error: BadRequestError | None = None
+
+    for i, rung in enumerate(attempts):
+        kw = _rung_kwargs(rung, schema, schema_name)
+        call_messages = (
+            _with_json_hint(messages, _JSON_ONLY_HINT) if rung == "prompt" else messages
+        )
+        try:
+            response = await client.chat.completions.create(
+                model=model,
+                messages=call_messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                extra_body=eb,
+                **kw,
+            )
+            parsed = _parse_tool_json(response) if rung == "tool" else _parse_choice_json(response)
+            if rung == "prompt" and not parsed and _choice_content(response).strip():
+                # ONE repair retry — the model emitted prose, nudge harder.
+                response = await client.chat.completions.create(
+                    model=model,
+                    messages=_with_json_hint(messages, _JSON_REPAIR_HINT),
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    extra_body=eb,
+                )
+                parsed = _parse_choice_json(response)
+            if span_ctx is not None:
+                _log_cache_usage(span_ctx, response)
+                finish_reason = (
+                    getattr(response.choices[0], "finish_reason", None)
+                    if response.choices
+                    else None
+                )
+                if finish_reason:
+                    span_ctx["finish_reason"] = finish_reason
+            if response_sink is not None:
+                response_sink.append(response)
+            return parsed
+        except BadRequestError as err:
+            last_error = err
+            next_tier = attempts[i + 1] if i + 1 < len(attempts) else None
+            _safe_log(
+                "warn",
+                "llm.tier_downgrade",
+                model=model,
+                from_tier=rung,
+                next_tier=next_tier,
+            )
+            continue
+    if last_error is not None:
+        raise last_error
     return {}
 
 
@@ -304,7 +670,6 @@ async def click_to_subject(
     multi-turn conversational refer signal ("you said X — what else
     could this be?"). Inspired by SAMA / MM-Conv dialog grounding.
     """
-    client = _client()
     locale_clause = (
         f" The `subject` MUST be written in language code '{output_locale}' — "
         "the next page is being generated in that language and the subject "
@@ -378,7 +743,7 @@ async def click_to_subject(
     from obs import span
 
     async with span("vlm.click_to_subject", model=_vlm_model()) as ctx:
-        response = await client.chat.completions.create(
+        parsed = await _complete_json(
             model=_vlm_model(),
             messages=[
                 _system_message(system),
@@ -393,13 +758,12 @@ async def click_to_subject(
                     ],
                 },
             ],
-            **_maybe_response_format(_vlm_model()),
+            schema=CLICK_SCHEMA,
+            schema_name="click_resolution",
             temperature=0.2,
             max_tokens=400,
+            span_ctx=ctx,
         )
-        _log_cache_usage(ctx, response)
-    raw = (response.choices[0].message.content or "{}").strip()
-    parsed = _safe_json(raw)
     return _build_click_resolution(parsed, x_pct=x_pct, y_pct=y_pct, fallback_subject=parent_title)
 
 
@@ -531,7 +895,6 @@ async def plan_page(
     per-object tracker memory). `subject_context` comes from the click VLM
     and is treated as authoritative — the planner must not contradict it.
     """
-    client = _client()
     system_parts = [
         "You design a visual-explainer page for a given user query. Return JSON "
         "with keys: page_title (<=8 words, title case), prompt (<=120 words, a "
@@ -623,21 +986,22 @@ async def plan_page(
     from obs import span
 
     text_model = _text_model(online=web_search)
+    response_sink: list[Any] = []
     async with span("planner.plan_page", model=text_model, web_search=web_search) as ctx:
-        response = await client.chat.completions.create(
+        parsed = await _complete_json(
             model=text_model,
             messages=[
                 _system_message(system),
                 {"role": "user", "content": user},
             ],
-            **_maybe_response_format(text_model),
+            schema=PLAN_SCHEMA,
+            schema_name="page_plan",
             temperature=0.7,
             max_tokens=900,
             extra_body=_web_plugin_extra(text_model, online=web_search) or None,
+            span_ctx=ctx,
+            response_sink=response_sink,
         )
-        _log_cache_usage(ctx, response)
-    raw = (response.choices[0].message.content or "{}").strip()
-    parsed = _safe_json(raw)
     page_title = str(parsed.get("page_title", query)).strip() or query
     prompt = str(parsed.get("prompt", query)).strip() or query
     facts_raw = parsed.get("facts", [])
@@ -646,7 +1010,7 @@ async def plan_page(
         for f in facts_raw:
             if isinstance(f, str) and f.strip():
                 facts.append(f.strip())
-    sources = _extract_citations(response)
+    sources = _extract_citations(response_sink[0]) if response_sink else []
     return PagePlan(page_title=page_title, prompt=prompt, facts=facts, sources=sources)
 
 
@@ -936,7 +1300,6 @@ async def precompute_click_candidates(
     Coordinates are 0..1 in the image's frame. Falls back to an empty list on
     parse failure — the click handler still works via on-demand resolution.
     """
-    client = _client()
     locale_clause = (
         f" Each `subject` MUST be written in language code '{output_locale}'."
         if output_locale and output_locale.lower() not in ("en", "auto", "")
@@ -964,7 +1327,7 @@ async def precompute_click_candidates(
     from obs import span
 
     async with span("vlm.precompute_candidates", model=_vlm_model()) as ctx:
-        response = await client.chat.completions.create(
+        parsed = await _complete_json(
             model=_vlm_model(),
             messages=[
                 _system_message(system),
@@ -979,13 +1342,12 @@ async def precompute_click_candidates(
                     ],
                 },
             ],
-            **_maybe_response_format(_vlm_model()),
+            schema=CANDIDATES_SCHEMA,
+            schema_name="click_candidates",
             temperature=0.2,
             max_tokens=600,
+            span_ctx=ctx,
         )
-        _log_cache_usage(ctx, response)
-    raw = (response.choices[0].message.content or "{}").strip()
-    parsed = _safe_json(raw)
     items = parsed.get("candidates", [])
     out: list[ClickCandidate] = []
     if not isinstance(items, list):
@@ -1040,7 +1402,6 @@ async def extract_entities(
     or "the obsidian dagger" is. This filtering happens in the prompt
     rather than post-hoc because the VLM has the whole scene in view.
     """
-    client = _client()
     prior_blob = ""
     if prior_entities:
         # Compact rendering — the VLM only needs name/kind/appearance to
@@ -1168,7 +1529,13 @@ async def extract_entities(
     from obs import span
 
     async with span("vlm.extract_entities", model=_vlm_model()) as ctx:
-        response = await client.chat.completions.create(
+        # max_tokens is generous: a busy scene with ~30 prior entities easily
+        # crosses 1.5k tokens (appearance + facts + state + bbox each). A
+        # tighter cap truncates mid-JSON and the parse collapses to empty.
+        # `_complete_json` stamps finish_reason into the span and returns {}
+        # on the empty-choices stub OpenRouter sometimes relays as HTTP 200,
+        # so the merge layer just sees an empty diff and keeps moving.
+        parsed = await _complete_json(
             model=_vlm_model(),
             messages=[
                 _system_message(system),
@@ -1183,41 +1550,26 @@ async def extract_entities(
                     ],
                 },
             ],
-            **_maybe_response_format(_vlm_model()),
+            schema=EXTRACTION_SCHEMA,
+            schema_name="entity_extraction",
             temperature=0.2,
-            # Real responses for a busy scene with 30 prior entities easily
-            # cross 1.5k tokens (each entity is appearance sentence + facts
-            # list + state + bbox). The earlier 1100 cap truncated mid-JSON
-            # and `_safe_json` silently swallowed the whole turn as `{}`.
             max_tokens=2200,
+            span_ctx=ctx,
         )
-        _log_cache_usage(ctx, response)
-        # Surface truncations so they're observable in traces instead of
-        # silently dropping the entire extraction.
-        try:
-            choice = response.choices[0] if response.choices else None
-            finish_reason = getattr(choice, "finish_reason", None) if choice else None
-            if finish_reason:
-                ctx["finish_reason"] = finish_reason
-        except Exception:
-            pass
-    # Defensive: OpenRouter occasionally relays upstream errors as HTTP 200
-    # with an empty `choices` list (rate-limit stub, content filter, etc.).
-    # Return an empty diff in that case so the merge layer keeps moving;
-    # the next page's extraction will retry naturally.
-    if not response.choices:
-        return EntityExtractionResult(added=[], updated=[])
-    raw = (response.choices[0].message.content or "{}").strip()
-    return _parse_extraction(raw)
+    return _build_extraction(parsed)
 
 
 def _parse_extraction(raw: str) -> EntityExtractionResult:
-    """Tolerantly parse the extraction VLM's JSON output into typed records.
+    """Tolerantly parse the extraction VLM's raw JSON text into typed records."""
+    return _build_extraction(_safe_json(raw))
+
+
+def _build_extraction(parsed: dict[str, Any]) -> EntityExtractionResult:
+    """Map an already-parsed extraction payload onto typed records.
 
     Garbage entries are dropped, not raised — the extractor is permitted to
     miss things; the worst case is a thinner codex this turn.
     """
-    parsed = _safe_json(raw)
     added_raw = parsed.get("added", [])
     updated_raw = parsed.get("updated", [])
     added: list[ExtractedEntity] = []

--- a/apps/modal-backend/tests/conftest.py
+++ b/apps/modal-backend/tests/conftest.py
@@ -25,11 +25,25 @@ _SCRUB = (
     "OPENROUTER_TEXT_MODEL",
     "OPENROUTER_ENABLE_WEB_SEARCH",
     "OPENROUTER_CACHE",
+    # Multi-provider LLM selection (PR1) — scrub so a host-set provider can't
+    # make provider/model/tier resolution tests non-hermetic.
+    "LLM_PROVIDER",
+    "LLM_BASE_URL",
+    "LLM_API_KEY",
+    "LLM_VLM_MODEL",
+    "LLM_TEXT_MODEL",
+    "LLM_STRUCTURED_OUTPUT",
     "FAL_IMAGE_TIER",
     "FAL_IMAGE_MODEL",
     "FAL_IMAGE_MODEL_FAST",
     "FAL_IMAGE_MODEL_BALANCED",
     "FAL_IMAGE_MODEL_PRO",
+    # Multi-provider image backend (PR2).
+    "IMAGE_PROVIDER",
+    "IMAGE_BASE_URL",
+    "IMAGE_API_KEY",
+    "IMAGE_MODEL",
+    "IMAGE_SIZE",
     "SENTRY_DSN",
 )
 

--- a/apps/modal-backend/tests/test_image_provider.py
+++ b/apps/modal-backend/tests/test_image_provider.py
@@ -227,14 +227,28 @@ def test_image_model_override(monkeypatch: pytest.MonkeyPatch) -> None:
     assert image._image_model() == "dall-e-3"
 
 
-def test_openai_size_maps_aspect() -> None:
-    assert image._openai_size("1:1") == "1024x1024"
-    assert image._openai_size("16:9") == "1792x1024"
+def test_openai_size_maps_aspect_for_gpt_image() -> None:
+    # gpt-image-1 valid sizes: 1024x1024 / 1536x1024 / 1024x1536 / auto.
+    assert image._openai_size("1:1", "gpt-image-1") == "1024x1024"
+    assert image._openai_size("16:9", "gpt-image-1") == "1536x1024"
+    assert image._openai_size("9:16", "gpt-image-1") == "1024x1536"
 
 
-def test_openai_size_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_openai_size_maps_aspect_for_dalle() -> None:
+    assert image._openai_size("16:9", "dall-e-3") == "1792x1024"
+    assert image._openai_size("1:1", "dall-e-3") == "1024x1024"
+
+
+def test_openai_size_default_model_is_gpt_image_valid() -> None:
+    # Regression: the documented default (IMAGE_MODEL=gpt-image-1) + the default
+    # 16:9 aspect must NOT emit a dall-e-only size that gpt-image rejects (400).
+    size = image._openai_size("16:9", image.DEFAULT_OPENAI_IMAGE_MODEL)
+    assert size in {"1024x1024", "1536x1024", "1024x1536", "auto"}
+
+
+def test_openai_size_env_override_beats_model(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("IMAGE_SIZE", "1536x1024")
-    assert image._openai_size("16:9") == "1536x1024"
+    assert image._openai_size("16:9", "dall-e-3") == "1536x1024"
 
 
 async def test_openai_compatible_image_b64(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/apps/modal-backend/tests/test_image_provider.py
+++ b/apps/modal-backend/tests/test_image_provider.py
@@ -7,6 +7,8 @@ mocking fal_client at the module level so no network hits are made.
 
 from __future__ import annotations
 
+import base64
+
 import fal_client
 import httpx
 import pytest
@@ -158,3 +160,150 @@ def test_not_retryable_httpx_status_400() -> None:
 
 def test_not_retryable_random_value_error() -> None:
     assert image._is_retryable(ValueError("unrelated")) is False
+
+
+# ---------- multi-provider image backend (PR2) --------------------------
+
+
+def test_image_provider_defaults_to_fal() -> None:
+    assert image._image_provider() == "fal"
+    assert image.active_provider() == "fal"
+
+
+def test_image_provider_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("IMAGE_PROVIDER", "openai")
+    assert image._image_provider() == "openai"
+
+
+def test_resolve_image_provider_openai(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("IMAGE_PROVIDER", "openai")
+    monkeypatch.setenv("IMAGE_API_KEY", "sk-img")
+    prov, base, key = image._resolve_image_provider()
+    assert prov == "openai"
+    assert base == "https://api.openai.com/v1"
+    assert key == "sk-img"
+
+
+def test_resolve_image_provider_custom_requires_base(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("IMAGE_PROVIDER", "custom")
+    monkeypatch.setenv("IMAGE_API_KEY", "x")
+    with pytest.raises(RuntimeError):
+        image._resolve_image_provider()
+
+
+def test_resolve_image_provider_custom_noauth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("IMAGE_PROVIDER", "custom")
+    monkeypatch.setenv("IMAGE_BASE_URL", "http://localhost:8080/v1")
+    prov, base, key = image._resolve_image_provider()
+    assert prov == "custom"
+    assert base == "http://localhost:8080/v1"
+    assert key == "sk-noauth"
+
+
+def test_resolve_image_provider_openai_missing_key_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("IMAGE_PROVIDER", "openai")
+    with pytest.raises(RuntimeError):
+        image._resolve_image_provider()
+
+
+def test_resolve_image_provider_base_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("IMAGE_PROVIDER", "openai")
+    monkeypatch.setenv("IMAGE_API_KEY", "k")
+    monkeypatch.setenv("IMAGE_BASE_URL", "http://proxy/v1")
+    _, base, _ = image._resolve_image_provider()
+    assert base == "http://proxy/v1"
+
+
+def test_image_model_default() -> None:
+    assert image._image_model() == "gpt-image-1"
+
+
+def test_image_model_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("IMAGE_MODEL", "dall-e-3")
+    assert image._image_model() == "dall-e-3"
+
+
+def test_openai_size_maps_aspect() -> None:
+    assert image._openai_size("1:1") == "1024x1024"
+    assert image._openai_size("16:9") == "1792x1024"
+
+
+def test_openai_size_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("IMAGE_SIZE", "1536x1024")
+    assert image._openai_size("16:9") == "1536x1024"
+
+
+async def test_openai_compatible_image_b64(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_post(url: str, headers: dict, payload: dict) -> dict:
+        return {"data": [{"b64_json": base64.b64encode(b"PNGDATA").decode("ascii")}]}
+
+    monkeypatch.setattr(image, "_post_image_json", fake_post)
+    out = await image._openai_compatible_image(
+        "http://x/v1", "k", "gpt-image-1", "a cat", "1:1"
+    )
+    assert out.jpeg_bytes == b"PNGDATA"
+    assert out.mime_type == "image/png"
+    assert out.model == "gpt-image-1"
+
+
+async def test_openai_compatible_image_url_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_post(url: str, headers: dict, payload: dict) -> dict:
+        return {"data": [{"url": "http://cdn/img.jpg"}]}
+
+    async def fake_fetch(url: str) -> tuple[bytes, str]:
+        return b"JPEGDATA", "image/jpeg"
+
+    monkeypatch.setattr(image, "_post_image_json", fake_post)
+    monkeypatch.setattr(image, "_fetch_url_bytes", fake_fetch)
+    out = await image._openai_compatible_image(
+        "http://x/v1", "k", "dall-e-3", "a dog", "16:9"
+    )
+    assert out.jpeg_bytes == b"JPEGDATA"
+    assert out.mime_type == "image/jpeg"
+
+
+async def test_generate_image_routes_to_openai(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("IMAGE_PROVIDER", "openai")
+    monkeypatch.setenv("IMAGE_API_KEY", "k")
+    sentinel = image.GeneratedImage(
+        jpeg_bytes=b"x", mime_type="image/png", model="gpt-image-1", provider_request_id=None
+    )
+    seen: dict[str, str] = {}
+
+    async def fake_openai(
+        base: str, key: str, model: str, prompt: str, aspect: str
+    ) -> image.GeneratedImage:
+        seen["base"] = base
+        seen["model"] = model
+        return sentinel
+
+    monkeypatch.setattr(image, "_openai_compatible_image", fake_openai)
+    out = await image.generate_image("a cat", "1:1")
+    assert out is sentinel
+    assert seen["base"] == "https://api.openai.com/v1"
+    assert seen["model"] == "gpt-image-1"
+
+
+async def test_generate_image_stays_on_fal_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FAL_KEY", "fk")
+
+    async def fake_sub(model: str, args: dict) -> dict:
+        return {"images": [{"url": "http://x"}], "requestId": "r1"}
+
+    async def fake_fetch(info: dict) -> tuple[bytes, str]:
+        return b"jpeg", "image/jpeg"
+
+    monkeypatch.setattr(image, "_fal_subscribe", fake_sub)
+    monkeypatch.setattr(image, "_fetch_image_bytes", fake_fetch)
+    out = await image.generate_image("a cat", "16:9")
+    assert out.jpeg_bytes == b"jpeg"
+    assert out.model == image.TIER_MODELS["balanced"]
+    assert out.provider_request_id == "r1"

--- a/apps/modal-backend/tests/test_llm_provider.py
+++ b/apps/modal-backend/tests/test_llm_provider.py
@@ -824,6 +824,68 @@ async def test_complete_json_empty_choices_returns_empty(
     assert parsed == {}
 
 
+# ---------- _with_json_hint + multi-step downgrade -----------------------
+
+
+def test_with_json_hint_appends_to_string_user_turn() -> None:
+    msgs = [{"role": "system", "content": "sys"}, {"role": "user", "content": "hello"}]
+    out = llm._with_json_hint(msgs, "HINTX")
+    assert out[-1]["content"].endswith("HINTX")
+    # The caller's original message is not mutated.
+    assert msgs[1]["content"] == "hello"
+
+
+def test_with_json_hint_appends_text_block_to_multimodal_user_turn() -> None:
+    # The click/extract/candidates hot path: content is [text, image_url]. The
+    # hint must ride as a trailing text block, preserve the image block, and not
+    # mutate the caller's list.
+    img_block = {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,abc"}}
+    msgs = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": [{"type": "text", "text": "q"}, img_block]},
+    ]
+    out = llm._with_json_hint(msgs, "HINTX")
+    last = out[-1]["content"]
+    assert isinstance(last, list)
+    assert last[-1] == {"type": "text", "text": "HINTX"}
+    assert img_block in last
+    assert len(msgs[1]["content"]) == 2
+
+
+async def test_complete_json_two_step_downgrade(monkeypatch: pytest.MonkeyPatch) -> None:
+    # gemini starts at json_object; json_object 400 -> tool 400 -> prompt succeeds.
+    fake = _FakeClient(
+        [_bad_request(), _bad_request(), _fake_response(content='{"subject": "Z"}')]
+    )
+    monkeypatch.setattr(llm, "_client", lambda: fake)
+    parsed = await llm._complete_json(
+        model="google/gemini-3-flash-preview",
+        messages=[{"role": "user", "content": "x"}],
+        max_tokens=100,
+        temperature=0.2,
+        schema=llm.CLICK_SCHEMA,
+    )
+    assert parsed == {"subject": "Z"}
+    assert len(fake.chat.completions.calls) == 3
+
+
+async def test_complete_json_reraises_when_all_rungs_400(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from openai import BadRequestError
+
+    fake = _FakeClient([_bad_request(), _bad_request(), _bad_request()])
+    monkeypatch.setattr(llm, "_client", lambda: fake)
+    with pytest.raises(BadRequestError):
+        await llm._complete_json(
+            model="google/gemini-3-flash-preview",
+            messages=[{"role": "user", "content": "x"}],
+            max_tokens=100,
+            temperature=0.2,
+            schema=llm.CLICK_SCHEMA,
+        )
+
+
 # ---------- contract-function integration (fake client end-to-end) --------
 
 

--- a/apps/modal-backend/tests/test_llm_provider.py
+++ b/apps/modal-backend/tests/test_llm_provider.py
@@ -7,6 +7,9 @@ is never invoked.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from typing import Any
+
 import pytest
 
 from providers import llm
@@ -475,3 +478,444 @@ def test_world_context_clause_state_survives_for_multiple_entities() -> None:
     assert "wounded=True" in out
     assert "lantern=lit" in out
     assert "defeated=True" in out
+
+
+# ---------- provider resolution (multi-provider, PR1) --------------------
+
+
+def test_resolve_provider_defaults_to_openrouter(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    provider, base_url, api_key, headers = llm._resolve_provider()
+    assert provider == "openrouter"
+    assert base_url == llm.OPENROUTER_BASE_URL
+    assert api_key == "or-key"
+    # OpenRouter attribution headers preserved exactly as today.
+    assert headers["HTTP-Referer"]
+    assert headers["X-Title"] == "Endless Canvas"
+
+
+def test_resolve_provider_openrouter_missing_key_raises() -> None:
+    # OPENROUTER_API_KEY scrubbed by conftest; the default path must raise
+    # rather than build a keyless client.
+    with pytest.raises(RuntimeError):
+        llm._resolve_provider()
+
+
+def test_resolve_provider_openai(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_API_KEY", "sk-openai")
+    provider, base_url, api_key, headers = llm._resolve_provider()
+    assert provider == "openai"
+    assert base_url == "https://api.openai.com/v1"
+    assert api_key == "sk-openai"
+    # No OpenRouter-specific headers leak onto direct providers.
+    assert "HTTP-Referer" not in headers
+
+
+def test_resolve_provider_anthropic_compat_base(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+    monkeypatch.setenv("LLM_API_KEY", "sk-ant")
+    _, base_url, _, _ = llm._resolve_provider()
+    assert base_url == "https://api.anthropic.com/v1"
+
+
+def test_resolve_provider_google_compat_base(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "google")
+    monkeypatch.setenv("LLM_API_KEY", "g-key")
+    _, base_url, _, _ = llm._resolve_provider()
+    assert base_url == "https://generativelanguage.googleapis.com/v1beta/openai/"
+
+
+def test_resolve_provider_custom_requires_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "custom")
+    monkeypatch.setenv("LLM_API_KEY", "x")
+    with pytest.raises(RuntimeError):
+        llm._resolve_provider()
+
+
+def test_resolve_provider_custom_local_defaults_noauth_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "custom")
+    monkeypatch.setenv("LLM_BASE_URL", "http://localhost:11434/v1")
+    # No LLM_API_KEY — local servers (Ollama/LM Studio) usually need none, but
+    # the OpenAI SDK requires a non-empty string, so we default it.
+    provider, base_url, api_key, _ = llm._resolve_provider()
+    assert provider == "custom"
+    assert base_url == "http://localhost:11434/v1"
+    assert api_key == "sk-noauth"
+
+
+def test_resolve_provider_base_url_override_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_API_KEY", "k")
+    monkeypatch.setenv("LLM_BASE_URL", "http://proxy.local/v1")
+    _, base_url, _, _ = llm._resolve_provider()
+    assert base_url == "http://proxy.local/v1"
+
+
+def test_resolve_provider_direct_missing_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    with pytest.raises(RuntimeError):
+        llm._resolve_provider()
+
+
+# ---------- model resolution: LLM_* overrides, OPENROUTER_* back-compat ----
+
+
+def test_vlm_model_prefers_llm_vlm_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENROUTER_VLM_MODEL", "or/vlm")
+    monkeypatch.setenv("LLM_VLM_MODEL", "direct/vlm")
+    assert llm._vlm_model() == "direct/vlm"
+
+
+def test_vlm_model_falls_back_to_openrouter_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Back-compat: when LLM_VLM_MODEL is unset the old var still drives it.
+    monkeypatch.setenv("OPENROUTER_VLM_MODEL", "or/vlm")
+    assert llm._vlm_model() == "or/vlm"
+
+
+def test_text_model_prefers_llm_text_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENROUTER_TEXT_MODEL", "or/text")
+    monkeypatch.setenv("LLM_TEXT_MODEL", "direct/text")
+    assert llm._text_model(online=False) == "direct/text"
+
+
+def test_web_search_disabled_on_direct_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    # OpenRouter brokers web search via :online / the web plugin; that only
+    # exists on the openrouter provider, so direct providers report disabled.
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    assert llm._web_search_enabled(True) is False
+
+
+def test_text_model_no_online_suffix_on_direct_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "custom")
+    monkeypatch.setenv("LLM_BASE_URL", "http://localhost:11434/v1")
+    monkeypatch.setenv("LLM_TEXT_MODEL", "qwen2.5")
+    # qwen takes the :online suffix on openrouter, but we're not on openrouter.
+    assert llm._text_model(online=True) == "qwen2.5"
+
+
+# ---------- structured-output capability ladder: tier resolver -----------
+
+
+def test_tier_openrouter_supported_family_is_json_object() -> None:
+    # Back-compat: the default OpenRouter path keeps today's json_object call.
+    assert (
+        llm._resolve_structured_tier("openrouter", "google/gemini-3-flash-preview")
+        == "json_object"
+    )
+    assert llm._resolve_structured_tier("openrouter", "qwen/qwen-2.5-72b") == "json_object"
+
+
+def test_tier_openrouter_unsupported_family_is_prompt() -> None:
+    # Today these silently strip response_format; the prompt rung recovers
+    # best-effort instead of returning empty.
+    assert llm._resolve_structured_tier("openrouter", "mistralai/mistral-large") == "prompt"
+    assert llm._resolve_structured_tier("openrouter", "x-ai/grok-3") == "prompt"
+
+
+def test_tier_cloud_direct_providers_are_json_object() -> None:
+    assert llm._resolve_structured_tier("openai", "gpt-4o") == "json_object"
+    assert llm._resolve_structured_tier("google", "gemini-2.5-flash") == "json_object"
+    assert llm._resolve_structured_tier("anthropic", "claude-3.5-sonnet") == "json_object"
+
+
+def test_tier_custom_tool_family_is_tool() -> None:
+    assert llm._resolve_structured_tier("custom", "llama-3.1-8b-instruct") == "tool"
+    assert llm._resolve_structured_tier("custom", "mistral-7b-instruct") == "tool"
+
+
+def test_tier_custom_json_family_is_json_object() -> None:
+    assert llm._resolve_structured_tier("custom", "qwen2.5vl") == "json_object"
+
+
+def test_tier_custom_unknown_small_model_is_prompt() -> None:
+    assert llm._resolve_structured_tier("custom", "phi-3-mini") == "prompt"
+
+
+def test_tier_override_forces_tier(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLM_STRUCTURED_OUTPUT", "tool")
+    # Operator override beats the auto table, even for a gemini default.
+    assert (
+        llm._resolve_structured_tier("openrouter", "google/gemini-3-flash-preview") == "tool"
+    )
+
+
+def test_tier_override_auto_uses_table(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLM_STRUCTURED_OUTPUT", "auto")
+    assert llm._resolve_structured_tier("openai", "gpt-4o") == "json_object"
+
+
+# ---------- _complete_json capability ladder (mock client, no network) ----
+
+
+def _fake_response(content: str | None = None, tool_args: str | None = None) -> Any:
+    msg = SimpleNamespace(content=content, tool_calls=None)
+    if tool_args is not None:
+        msg.tool_calls = [SimpleNamespace(function=SimpleNamespace(arguments=tool_args))]
+    choice = SimpleNamespace(message=msg, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], usage=None)
+
+
+class _FakeCompletions:
+    def __init__(self, script: list[Any]) -> None:
+        self.script = list(script)
+        self.calls: list[dict[str, Any]] = []
+
+    async def create(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        action = self.script.pop(0)
+        if isinstance(action, Exception):
+            raise action
+        return action
+
+
+class _FakeClient:
+    def __init__(self, script: list[Any]) -> None:
+        self.chat = SimpleNamespace(completions=_FakeCompletions(script))
+
+
+def _bad_request() -> Exception:
+    import httpx
+    from openai import BadRequestError
+
+    req = httpx.Request("POST", "http://test/v1/chat/completions")
+    return BadRequestError("bad", response=httpx.Response(400, request=req), body=None)
+
+
+async def test_complete_json_json_object_rung_parses(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient([_fake_response(content='{"subject": "Boiler"}')])
+    monkeypatch.setattr(llm, "_client", lambda: fake)
+    parsed = await llm._complete_json(
+        model="google/gemini-3-flash-preview",
+        messages=[{"role": "user", "content": "x"}],
+        max_tokens=100,
+        temperature=0.2,
+        schema=llm.CLICK_SCHEMA,
+        schema_name="click",
+    )
+    assert parsed == {"subject": "Boiler"}
+    call = fake.chat.completions.calls[0]
+    assert call["response_format"] == {"type": "json_object"}
+
+
+async def test_complete_json_tool_rung_reads_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "custom")
+    monkeypatch.setenv("LLM_BASE_URL", "http://localhost:11434/v1")
+    fake = _FakeClient([_fake_response(tool_args='{"subject": "Valve"}')])
+    monkeypatch.setattr(llm, "_client", lambda: fake)
+    parsed = await llm._complete_json(
+        model="llama-3.1-8b-instruct",
+        messages=[{"role": "user", "content": "x"}],
+        max_tokens=100,
+        temperature=0.2,
+        schema=llm.CLICK_SCHEMA,
+        schema_name="click",
+    )
+    assert parsed == {"subject": "Valve"}
+    call = fake.chat.completions.calls[0]
+    assert call["tool_choice"]["function"]["name"] == "click"
+    assert "response_format" not in call
+
+
+async def test_complete_json_prompt_rung_recovers_fenced_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "custom")
+    monkeypatch.setenv("LLM_BASE_URL", "http://x/v1")
+    fake = _FakeClient([_fake_response(content='Sure!\n```json\n{"subject": "Sky"}\n```')])
+    monkeypatch.setattr(llm, "_client", lambda: fake)
+    parsed = await llm._complete_json(
+        model="phi-3-mini",
+        messages=[{"role": "user", "content": "x"}],
+        max_tokens=100,
+        temperature=0.2,
+        schema=llm.CLICK_SCHEMA,
+    )
+    assert parsed == {"subject": "Sky"}
+    call = fake.chat.completions.calls[0]
+    assert "response_format" not in call
+    assert "tools" not in call
+
+
+async def test_complete_json_prompt_rung_repair_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "custom")
+    monkeypatch.setenv("LLM_BASE_URL", "http://x/v1")
+    fake = _FakeClient(
+        [
+            _fake_response(content="I cannot comply."),
+            _fake_response(content='{"subject": "Door"}'),
+        ]
+    )
+    monkeypatch.setattr(llm, "_client", lambda: fake)
+    parsed = await llm._complete_json(
+        model="phi-3-mini",
+        messages=[{"role": "user", "content": "x"}],
+        max_tokens=100,
+        temperature=0.2,
+        schema=llm.CLICK_SCHEMA,
+    )
+    assert parsed == {"subject": "Door"}
+    # The repair pass fires exactly once when the first reply isn't JSON.
+    assert len(fake.chat.completions.calls) == 2
+
+
+async def test_complete_json_prompt_rung_no_retry_when_valid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "custom")
+    monkeypatch.setenv("LLM_BASE_URL", "http://x/v1")
+    fake = _FakeClient([_fake_response(content='{"subject": "X"}')])
+    monkeypatch.setattr(llm, "_client", lambda: fake)
+    parsed = await llm._complete_json(
+        model="phi-3-mini",
+        messages=[{"role": "user", "content": "x"}],
+        max_tokens=100,
+        temperature=0.2,
+        schema=llm.CLICK_SCHEMA,
+    )
+    assert parsed == {"subject": "X"}
+    assert len(fake.chat.completions.calls) == 1
+
+
+async def test_complete_json_downgrades_on_bad_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(
+        llm, "_safe_log", lambda level, event, **kv: events.append((event, kv))
+    )
+    # gemini on openrouter starts at json_object; a 400 must drop a rung and the
+    # next rung (tool) succeeds within the same call.
+    fake = _FakeClient([_bad_request(), _fake_response(tool_args='{"subject": "Y"}')])
+    monkeypatch.setattr(llm, "_client", lambda: fake)
+    parsed = await llm._complete_json(
+        model="google/gemini-3-flash-preview",
+        messages=[{"role": "user", "content": "x"}],
+        max_tokens=100,
+        temperature=0.2,
+        schema=llm.CLICK_SCHEMA,
+        schema_name="click",
+    )
+    assert parsed == {"subject": "Y"}
+    assert len(fake.chat.completions.calls) == 2
+    assert any(name == "llm.tier_downgrade" for name, _ in events)
+
+
+async def test_complete_json_empty_choices_returns_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeClient([SimpleNamespace(choices=[], usage=None)])
+    monkeypatch.setattr(llm, "_client", lambda: fake)
+    parsed = await llm._complete_json(
+        model="google/gemini-3-flash-preview",
+        messages=[{"role": "user", "content": "x"}],
+        max_tokens=100,
+        temperature=0.2,
+        schema=llm.CLICK_SCHEMA,
+    )
+    assert parsed == {}
+
+
+# ---------- contract-function integration (fake client end-to-end) --------
+
+
+async def test_click_to_subject_builds_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        [
+            _fake_response(
+                content=(
+                    '{"subject": "Boiler", "style": "flat infographic", '
+                    '"groundable": true, "confidence": 0.9, '
+                    '"point": {"x": 0.5, "y": 0.4}}'
+                )
+            )
+        ]
+    )
+    monkeypatch.setattr(llm, "_client", lambda: fake)
+    res = await llm.click_to_subject(
+        "data:image/jpeg;base64,abc",
+        0.5,
+        0.4,
+        "Steam Engine",
+        "how does a steam engine work",
+    )
+    assert isinstance(res, llm.ClickResolution)
+    assert res.subject == "Boiler"
+    assert res.groundable is True
+    assert res.confidence == 0.9
+    assert res.point == (0.5, 0.4)
+
+
+async def test_click_to_subject_falls_back_to_parent_on_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # An empty/garbage model reply must not crash — subject falls back to the
+    # parent title and the crosshair becomes the point.
+    fake = _FakeClient([_fake_response(content="no json here")])
+    monkeypatch.setattr(llm, "_client", lambda: fake)
+    res = await llm.click_to_subject(
+        "data:image/jpeg;base64,abc", 0.25, 0.75, "Steam Engine", "q"
+    )
+    assert res.subject == "Steam Engine"
+    assert res.point == (0.25, 0.75)
+
+
+async def test_extract_entities_returns_added(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        [
+            _fake_response(
+                content=(
+                    '{"added": [{"kind": "person", "name": "Mira", '
+                    '"appearance": "tall keeper in navy coat"}], "updated": []}'
+                )
+            )
+        ]
+    )
+    monkeypatch.setattr(llm, "_client", lambda: fake)
+    res = await llm.extract_entities("data:image/jpeg;base64,abc", "The Lighthouse")
+    assert len(res.added) == 1
+    assert res.added[0].name == "Mira"
+
+
+async def test_plan_page_builds_plan(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        [
+            _fake_response(
+                content=(
+                    '{"page_title": "How Boilers Work", '
+                    '"prompt": "A flat infographic of a boiler", '
+                    '"facts": ["Water boils", "Steam rises"]}'
+                )
+            )
+        ]
+    )
+    monkeypatch.setattr(llm, "_client", lambda: fake)
+    plan = await llm.plan_page("how do boilers work", web_search=False)
+    assert plan.page_title == "How Boilers Work"
+    assert "boiler" in plan.prompt.lower()
+    assert plan.facts == ["Water boils", "Steam rises"]
+
+
+async def test_precompute_candidates_parses(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        [
+            _fake_response(
+                content=(
+                    '{"candidates": [{"x_pct": 0.3, "y_pct": 0.4, '
+                    '"subject": "Valve", "style": "flat", "salience": 0.8}]}'
+                )
+            )
+        ]
+    )
+    monkeypatch.setattr(llm, "_client", lambda: fake)
+    out = await llm.precompute_click_candidates("data:image/jpeg;base64,abc", "Engine", "q")
+    assert len(out) == 1
+    assert out[0].subject == "Valve"

--- a/docs/BYO-KEYS.md
+++ b/docs/BYO-KEYS.md
@@ -80,6 +80,62 @@ pnpm dev
 # open http://localhost:3000/play
 ```
 
+## Use a different LLM provider (OpenAI / Anthropic / Google / local)
+
+By default everything routes through OpenRouter. If you'd rather use a direct
+vendor key or run the models locally, set `LLM_PROVIDER` (and friends) in the
+Modal secret — no code changes, no YAML. Leave it unset and nothing changes.
+
+Every target speaks the OpenAI wire protocol, so the only things that vary are
+the base URL and the key:
+
+| `LLM_PROVIDER` | Base URL | Models to set |
+|---|---|---|
+| `openrouter` (default) | OpenRouter | `OPENROUTER_VLM_MODEL` / `OPENROUTER_TEXT_MODEL` |
+| `openai` | `api.openai.com` | `LLM_VLM_MODEL=gpt-4o`, `LLM_TEXT_MODEL=gpt-4o-mini` |
+| `google` | Gemini OpenAI-compat | `LLM_VLM_MODEL=gemini-2.5-flash` |
+| `anthropic` | Anthropic OpenAI-compat | `LLM_VLM_MODEL=claude-3.5-sonnet` (runs at the `json_object` tier) |
+| `custom` | your `LLM_BASE_URL` | Ollama / LM Studio / vLLM — see below |
+
+Direct OpenAI, for example:
+
+```bash
+modal secret create openflipbook-secrets \
+  FAL_KEY="$FAL_KEY" \
+  LLM_PROVIDER=openai \
+  LLM_API_KEY="$OPENAI_API_KEY" \
+  LLM_VLM_MODEL=gpt-4o \
+  LLM_TEXT_MODEL=gpt-4o-mini
+```
+
+Local via Ollama (or LM Studio on `:1234`, vLLM on `:8000`):
+
+```bash
+LLM_PROVIDER=custom
+LLM_BASE_URL=http://localhost:11434/v1   # LLM_API_KEY can be blank for local
+LLM_VLM_MODEL=qwen2.5vl
+LLM_TEXT_MODEL=qwen2.5
+```
+
+**Honest caveat:** the whole UX rides on the click VLM grounding a tap into the
+right subject, and small local VLMs are weak at structured output. The backend
+detects this and walks a fallback ladder — `json_object` → forced tool-call →
+prompt-with-repair — so a weak model degrades to *thinner but valid* grounding
+instead of crashing. It does **not** make a 7B model ground like Gemini. Want to
+know which models actually hold up? That's what the click-bench (next milestone)
+is for. If your model supports JSON mode but isn't auto-detected, pin it with
+`LLM_STRUCTURED_OUTPUT=json_object`.
+
+Web search is OpenRouter-only; it's skipped on direct/local providers (the
+planner still runs, just without OpenRouter-brokered grounding).
+
+**Images** swap the same way with `IMAGE_PROVIDER` (default `fal`). Set it to
+`openai` (or `custom` + `IMAGE_BASE_URL` for an OpenAI-images-compatible local
+server) plus `IMAGE_API_KEY` / `IMAGE_MODEL`. fal keeps its fast/balanced/pro
+tiers; non-fal backends collapse to a single `IMAGE_MODEL`, and edit-mode stays
+on fal. Note fal is the expensive part of a page, so this is the bigger
+cost/lock-in lever — but image quality varies a lot by model.
+
 ## Cost notes
 
 - OpenRouter Qwen 2.5 72B Text ≈ $0.0005 / request; VLM 72B ≈ $0.0015 / click resolution.


### PR DESCRIPTION
Draft — first milestone of the "support more stuff natively" roadmap: run openflipbook's planner + click VLM (and optionally image gen) on providers other than OpenRouter + fal, without touching the env-var-driven config the way the earlier Ollama PR did.

## What this does

**LLM/VLM provider freedom.** Point the planner + click VLM at OpenAI, Anthropic, Google, or any OpenAI-compatible local server (Ollama / LM Studio / vLLM) via env vars — `LLM_PROVIDER` + `LLM_BASE_URL` / `LLM_API_KEY` / `LLM_VLM_MODEL` / `LLM_TEXT_MODEL`. No registry, no YAML, no factory: every target speaks the OpenAI wire protocol, so it's the existing one-file-per-provider pattern with a base-URL switch.

**The capability ladder** (the part that matters). The 4 structured-output callers now route through one `_complete_json()` helper that picks `json_object → tool → prompt` based on (provider, model), drops a rung on a 400, and does a repair-retry on the prompt rung. A weak local model degrades to *thinner-but-valid* grounding instead of the silent-`{}` garbage a naive base-URL swap would ship. The `_build_*` / `_parse_*` coercers stay the source of truth.

**Pluggable image backend.** `IMAGE_PROVIDER` swaps fal for the OpenAI Images API (or a custom compatible server). fal stays the default with its quality tiers; the draft/final race is gated fal-only so non-fal backends don't double-generate.

## Back-compat

Leave everything unset → **byte-identical** to today's OpenRouter + fal path. Existing `OPENROUTER_*` / `FAL_*` env vars unchanged, wire types unchanged, no UX change.

## Deferred (called out, not forgotten)

- Strict `json_schema` rung (buys little over the tolerant coercers; needs all-required schemas)
- Per-role provider *mixing* (cloud VLM + local planner)
- Web search on direct providers (OpenRouter-only today)

## Testing

- +49 unit tests: provider/model/tier resolution, every ladder rung + degrade + repair, end-to-end contract functions, and the image backend
- `ruff` + `mypy --strict` (on `providers.*`) clean
- **Not yet** live-smoked against a real OpenAI/Ollama endpoint — that's a manual check with keys

Docs: provider recipes in `docs/BYO-KEYS.md` + commented blocks in both `.env.example`s, with an honest note that small local models hit the prompt tier and grounding quality drops — which is exactly what the next roadmap milestone (a click-grounding eval + "which models actually ground" leaderboard) will measure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
