### PR TITLE
feat(expand): scale-space world map — Phase 1 (expand-outward bloom)

### DIFF
--- a/apps/modal-backend/.env.example
+++ b/apps/modal-backend/.env.example
@@ -2,9 +2,12 @@
 FAL_KEY=
 OPENROUTER_API_KEY=
 
-# Optional overrides (defaults in providers/llm.py + providers/image.py)
-OPENROUTER_VLM_MODEL=qwen/qwen-2.5-vl-72b-instruct
-OPENROUTER_TEXT_MODEL=qwen/qwen-2.5-72b-instruct
+# Optional overrides (defaults in providers/llm.py + providers/image.py).
+# Gemini 3 Flash: cheap ($0.50/M in, $3/M out), fast, strong multimodal
+# grounding, and on your own credits — unlike the free Qwen tier that
+# rate-limits (429) under any real use.
+OPENROUTER_VLM_MODEL=google/gemini-3-flash-preview
+OPENROUTER_TEXT_MODEL=google/gemini-3-flash-preview
 OPENROUTER_ENABLE_WEB_SEARCH=true
 
 # --- Use a different LLM provider (advanced; default = OpenRouter above) ---

--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -292,6 +292,7 @@ async def _event_stream(
                             "page_title": plan.page_title,
                             "image_data_url": data_url,
                             "image_model": img.model,
+                            "prompt_author_model": llm._text_model(online=False),
                             "final_prompt": plan.prompt,
                             "session_id": body.session_id,
                             "index": idx,

--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -264,6 +264,9 @@ async def _event_stream(
                 )
                 return idx, neighbor, plan, img
 
+            # Last gate before we spend on ~4 concurrent fal jobs: if the client
+            # dropped during propose_neighbors, bail before launching any.
+            await _abort_if_disconnected("pre-bloom")
             tasks = [
                 _asyncio.create_task(_bloom_one(i, n)) for i, n in enumerate(neighbors)
             ]
@@ -273,15 +276,20 @@ async def _event_stream(
                     try:
                         idx, neighbor, plan, img = await fut
                     except Exception as exc:
-                        # One neighbour failing shouldn't sink the whole bloom.
+                        # One neighbour failing shouldn't sink the whole bloom,
+                        # but a systematic failure (quota, bad style lock) should
+                        # still surface in Sentry rather than vanish into a warn.
                         log(
                             "warn",
                             "expand.neighbor_failed",
                             error=f"{type(exc).__name__}: {exc}",
                         )
+                        record_error("expand_neighbor", exc)
                         continue
-                    data_url = image_provider.encode_data_url(
-                        img.jpeg_bytes, img.mime_type
+                    # Offload the sync base64 of a multi-MB JPEG so it doesn't
+                    # stall the event loop between yields (matches the tap path).
+                    data_url = await _asyncio.to_thread(
+                        image_provider.encode_data_url, img.jpeg_bytes, img.mime_type
                     )
                     emitted += 1
                     yield _sse(

--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -214,6 +214,100 @@ async def _event_stream(
             )
             return
 
+        # Expand mode blooms the world AROUND the focal subject: propose a few
+        # neighbouring subjects across scales (component/peer/container), then
+        # generate their pages concurrently and stream one `neighbor` event per
+        # page as it lands. Self-contained like edit — the tap/query single-
+        # `final` path below is untouched.
+        if body.mode == "expand":
+            if not body.image:
+                yield _sse(
+                    {"type": "error", "message": "expand mode requires an image"},
+                    trace_id,
+                )
+                return
+            expand_style_lock = (body.session_style_anchor or "").strip() or None
+            expand_world_context = [e.model_dump() for e in body.world_context]
+            yield _sse({"type": "status", "stage": "planning"}, trace_id)
+            await _abort_if_disconnected("pre-expand-plan")
+            neighbors = await llm.propose_neighbors(
+                image_data_url=body.image,
+                parent_title=body.parent_title or body.query,
+                parent_query=body.parent_query or body.query,
+                output_locale=body.output_locale,
+            )
+            total = len(neighbors)
+            if total == 0:
+                yield _sse({"type": "expand_done", "count": 0}, trace_id)
+                return
+
+            async def _bloom_one(idx, neighbor):
+                plan = await llm.plan_page(
+                    query=neighbor.subject,
+                    web_search=False,
+                    style_anchor=expand_style_lock,
+                    output_locale=body.output_locale,
+                    parent_title=body.parent_title,
+                    parent_query=body.parent_query,
+                    world_context=expand_world_context,
+                )
+                prompt = plan.prompt
+                if expand_style_lock:
+                    prompt = f"Style: {expand_style_lock}\n\n{prompt}"
+                if plan.facts:
+                    prompt += "\n\nLabels to include:\n- " + "\n- ".join(plan.facts)
+                img = await image_provider.generate_image(
+                    prompt=prompt,
+                    aspect_ratio=body.aspect_ratio,
+                    tier=body.image_tier,
+                    model_override=body.image_model,
+                )
+                return idx, neighbor, plan, img
+
+            tasks = [
+                _asyncio.create_task(_bloom_one(i, n)) for i, n in enumerate(neighbors)
+            ]
+            emitted = 0
+            try:
+                for fut in _asyncio.as_completed(tasks):
+                    try:
+                        idx, neighbor, plan, img = await fut
+                    except Exception as exc:
+                        # One neighbour failing shouldn't sink the whole bloom.
+                        log(
+                            "warn",
+                            "expand.neighbor_failed",
+                            error=f"{type(exc).__name__}: {exc}",
+                        )
+                        continue
+                    data_url = image_provider.encode_data_url(
+                        img.jpeg_bytes, img.mime_type
+                    )
+                    emitted += 1
+                    yield _sse(
+                        {
+                            "type": "neighbor",
+                            "subject": neighbor.subject,
+                            "scale": neighbor.scale,
+                            "page_title": plan.page_title,
+                            "image_data_url": data_url,
+                            "image_model": img.model,
+                            "final_prompt": plan.prompt,
+                            "session_id": body.session_id,
+                            "index": idx,
+                            "total": total,
+                        },
+                        trace_id,
+                    )
+            finally:
+                # Client disconnect / early exit cancels any in-flight pages so
+                # we don't keep burning fal credits with no one listening.
+                for t in tasks:
+                    if not t.done():
+                        t.cancel()
+            yield _sse({"type": "expand_done", "count": emitted}, trace_id)
+            return
+
         # 1. Resolve click → subject phrase + style anchor (style is empty for
         #    text-only queries; only set on tap mode). When the client has
         #    already prefetched on hover, skip the VLM round-trip entirely.

--- a/apps/modal-backend/providers/llm.py
+++ b/apps/modal-backend/providers/llm.py
@@ -77,6 +77,11 @@ class ClickResolution:
     # because not every VLM emits them; older payloads default to None.
     point: tuple[float, float] | None = None
     bbox: tuple[float, float, float, float] | None = None
+    # Scale of `subject` relative to the parent's focal subject: "component"
+    # (a part of it / smaller), "peer" (beside it / similar), or "container"
+    # (it is part of this / bigger). Powers the scale-space map + zoom
+    # level-of-detail. Default "peer" keeps older payloads valid.
+    scale: str = "peer"
 
 
 @dataclass
@@ -95,9 +100,35 @@ class ClickCandidate:
     salience: float
 
 
+@dataclass
+class Neighbor:
+    """One proposed neighbouring subject for the expand-outward bloom.
+
+    `scale` is relative to the page's focal subject (see SCALE_KINDS):
+    "component" (smaller / a part), "peer" (similar), "container" (bigger).
+    """
+
+    subject: str
+    scale: str = "peer"
+    note: str = ""
+
+
 # Allowed kinds match the EntityKind union in packages/config. Strings only —
 # wire format is JSON. Any other kind emitted by the VLM is dropped on parse.
 ENTITY_KINDS = ("person", "place", "item", "creature")
+
+# Relative scale buckets for the scale-space map (M3). Composed into an integer
+# scale-level (component=-1, peer=0, container=+1) for zoom level-of-detail.
+SCALE_KINDS = ("component", "peer", "container")
+
+
+def _coerce_scale(raw: Any) -> str:
+    """Coerce a VLM-emitted scale to one of SCALE_KINDS; default 'peer'."""
+    if isinstance(raw, str):
+        s = raw.strip().lower()
+        if s in SCALE_KINDS:
+            return s
+    return "peer"
 
 
 @dataclass
@@ -403,6 +434,7 @@ CLICK_SCHEMA: dict[str, Any] = {
                 "h": {"type": "number"},
             },
         },
+        "scale": {"type": "string", "enum": ["component", "peer", "container"]},
     },
     "required": ["subject"],
 }
@@ -436,6 +468,28 @@ CANDIDATES_SCHEMA: dict[str, Any] = {
         }
     },
     "required": ["candidates"],
+}
+
+NEIGHBORS_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "neighbors": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "subject": {"type": "string"},
+                    "scale": {
+                        "type": "string",
+                        "enum": ["component", "peer", "container"],
+                    },
+                    "note": {"type": "string"},
+                },
+                "required": ["subject"],
+            },
+        }
+    },
+    "required": ["neighbors"],
 }
 
 EXTRACTION_SCHEMA: dict[str, Any] = {
@@ -709,7 +763,11 @@ async def click_to_subject(
         "(0,0 top-left). Use the crosshair location as a strong prior. "
         "(7) `bbox` — optional axis-aligned bounding box around the "
         "subject as {\"x\": <0-1>, \"y\": <0-1>, \"w\": <0-1>, \"h\": <0-1>}. "
-        "Omit if you cannot give a tight box."
+        "Omit if you cannot give a tight box. "
+        "(8) `scale` — the subject's size relative to the page's overall focal "
+        "subject: \"component\" (a part of it / smaller), \"peer\" (a separate "
+        "thing of similar size), or \"container\" (a larger thing the focal "
+        "subject is part of). Default to \"peer\" when unsure."
         + locale_clause
     )
     hint_clause = ""
@@ -858,6 +916,7 @@ def _build_click_resolution(
             _coerce_unit(y_pct) or 0.0,
         )
     bbox = _parse_bbox(parsed.get("bbox"))
+    scale = _coerce_scale(parsed.get("scale"))
 
     return ClickResolution(
         subject=subject or fallback_subject,
@@ -867,6 +926,7 @@ def _build_click_resolution(
         confidence=confidence,
         point=point,
         bbox=bbox,
+        scale=scale,
     )
 
 
@@ -1379,6 +1439,107 @@ async def precompute_click_candidates(
         if len(out) >= max_candidates:
             break
     out.sort(key=lambda c: c.salience, reverse=True)
+    return out
+
+
+async def propose_neighbors(
+    image_data_url: str,
+    parent_title: str,
+    parent_query: str,
+    subject_context: str | None = None,
+    output_locale: str | None = None,
+    max_neighbors: int = 4,
+) -> list[Neighbor]:
+    """Survey the neighbourhood of a page's focal subject for "expand outward".
+
+    Returns up to ``max_neighbors`` notable neighbouring subjects across scales
+    (component / peer / container), each a good next page to bloom. Falls back
+    to an empty list on parse failure — the caller just blooms nothing.
+    """
+    locale_clause = (
+        f" Each `subject` MUST be written in language code '{output_locale}'."
+        if output_locale and output_locale.lower() not in ("en", "auto", "")
+        else ""
+    )
+    context_clause = (
+        f" The focal subject is: {subject_context.strip()}."
+        if subject_context and subject_context.strip()
+        else ""
+    )
+    system = (
+        f"You examine an illustrated page titled '{parent_title}' (user query: "
+        f"'{parent_query}'). The user wants to EXPAND OUTWARD — to see the "
+        f"wider world this page's focal subject sits in.{context_clause} "
+        f"Propose up to {max_neighbors} notable NEIGHBOURING subjects: things "
+        "adjacent to it, larger things that contain it, and notable things it "
+        "is composed of — each of which would make a good next page to explore. "
+        "Favour variety across scales and do NOT repeat the focal subject "
+        "itself. Return JSON: {\"neighbors\": [{\"subject\": \"2-8 word noun "
+        "phrase\", \"scale\": \"component|peer|container\", \"note\": \"<=15 "
+        "word reason it neighbours the focal subject\"}]}. `scale` is the "
+        "neighbour's size relative to the focal subject: \"component\" (a part "
+        "of it / smaller), \"peer\" (beside it / similar size), \"container\" "
+        "(a larger thing it is part of)."
+        + locale_clause
+    )
+    user_text = (
+        "List the most interesting neighbouring subjects to explore around "
+        f"this page. Return at most {max_neighbors}; fewer is fine."
+    )
+    from obs import span
+
+    async with span("vlm.propose_neighbors", model=_vlm_model()) as ctx:
+        parsed = await _complete_json(
+            model=_vlm_model(),
+            messages=[
+                _system_message(system),
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": user_text},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": image_data_url, "detail": "high"},
+                        },
+                    ],
+                },
+            ],
+            schema=NEIGHBORS_SCHEMA,
+            schema_name="neighbors",
+            temperature=0.4,
+            max_tokens=700,
+            span_ctx=ctx,
+        )
+    return _build_neighbors(parsed, max_neighbors)
+
+
+def _build_neighbors(parsed: dict[str, Any], max_neighbors: int) -> list[Neighbor]:
+    """Coerce the planner's JSON into typed Neighbors. Drops empty/duplicate
+    subjects, defaults bad scales to "peer", caps at ``max_neighbors``."""
+    items = parsed.get("neighbors", [])
+    out: list[Neighbor] = []
+    if not isinstance(items, list):
+        return out
+    seen: set[str] = set()
+    for entry in items:
+        if not isinstance(entry, dict):
+            continue
+        subject = str(entry.get("subject", "")).strip()[:120]
+        if not subject:
+            continue
+        key = subject.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(
+            Neighbor(
+                subject=subject,
+                scale=_coerce_scale(entry.get("scale")),
+                note=str(entry.get("note", "")).strip()[:200],
+            )
+        )
+        if len(out) >= max_neighbors:
+            break
     return out
 
 

--- a/apps/modal-backend/tests/test_generate_expand.py
+++ b/apps/modal-backend/tests/test_generate_expand.py
@@ -1,0 +1,183 @@
+"""Integration tests for the expand-outward bloom in generate.py.
+
+Drives the real `_event_stream` async generator end to end with the LLM/image
+providers mocked — zero API cost — and asserts the SSE event stream: the
+`neighbor` events (shape + scale + count), the terminal `expand_done`,
+per-neighbour failure isolation, and that the additive expand branch left the
+tap/query `final` path intact.
+
+generate.py imports `modal` at module level (deploy-only, not a test dep), so
+we inject a stub before importing it; `_event_stream` itself never touches it.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.modules.setdefault("modal", MagicMock())
+
+import providers.image as image_mod  # noqa: E402
+import providers.llm as llm_mod  # noqa: E402
+from generate import GenerateBody, _event_stream  # noqa: E402
+from providers.image import GeneratedImage  # noqa: E402
+from providers.llm import Neighbor, PagePlan  # noqa: E402
+
+
+async def _collect(agen: Any) -> list[dict[str, Any]]:
+    """Drain the SSE async generator into parsed event dicts."""
+    events: list[dict[str, Any]] = []
+    async for chunk in agen:
+        text = chunk.decode() if isinstance(chunk, bytes) else chunk
+        for block in text.strip().split("\n\n"):
+            block = block.strip()
+            if block.startswith("data:"):
+                events.append(json.loads(block[len("data:") :].strip()))
+    return events
+
+
+def _expand_body(**over: Any) -> GenerateBody:
+    base: dict[str, Any] = {
+        "query": "how a steam engine works",
+        "session_id": "s1",
+        "current_node_id": "n0",
+        "mode": "expand",
+        "image": "data:image/jpeg;base64,abc",
+        "parent_title": "Steam Engine",
+        "parent_query": "how a steam engine works",
+        "web_search": False,
+    }
+    base.update(over)
+    return GenerateBody(**base)
+
+
+def _mock_providers(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    neighbours: list[Neighbor],
+    generate_side_effect: Any = None,
+) -> None:
+    monkeypatch.setattr(
+        llm_mod, "propose_neighbors", AsyncMock(return_value=neighbours)
+    )
+    monkeypatch.setattr(
+        llm_mod,
+        "plan_page",
+        AsyncMock(return_value=PagePlan("A Page", "an illustrated page", [], [])),
+    )
+    img = GeneratedImage(b"jpegbytes", "image/jpeg", "fal-model", "req-1")
+    if generate_side_effect is not None:
+        monkeypatch.setattr(
+            image_mod, "generate_image", AsyncMock(side_effect=generate_side_effect)
+        )
+    else:
+        monkeypatch.setattr(image_mod, "generate_image", AsyncMock(return_value=img))
+
+
+async def test_expand_blooms_all_neighbours(monkeypatch: pytest.MonkeyPatch) -> None:
+    _mock_providers(
+        monkeypatch,
+        neighbours=[
+            Neighbor("The Factory", "container", "houses the boiler"),
+            Neighbor("Piston", "peer"),
+            Neighbor("Pressure Valve", "component"),
+        ],
+    )
+    events = await _collect(_event_stream(_expand_body(), "trace1"))
+    types = [e["type"] for e in events]
+    assert types[0] == "status"  # planning
+    neighbours = [e for e in events if e["type"] == "neighbor"]
+    assert len(neighbours) == 3
+    assert {n["subject"] for n in neighbours} == {"The Factory", "Piston", "Pressure Valve"}
+    assert {n["scale"] for n in neighbours} == {"container", "peer", "component"}
+    assert {n["total"] for n in neighbours} == {3}
+    assert events[-1]["type"] == "expand_done"
+    assert events[-1]["count"] == 3
+
+
+async def test_expand_neighbor_event_matches_wire_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The frontend GenerateNeighborEvent type + persistNode depend on exactly
+    # these keys — lock them so a backend rename can't silently break the tray.
+    _mock_providers(monkeypatch, neighbours=[Neighbor("The Factory", "container")])
+    events = await _collect(_event_stream(_expand_body(), "trace1"))
+    neighbour = next(e for e in events if e["type"] == "neighbor")
+    assert set(neighbour) == {
+        "type",
+        "subject",
+        "scale",
+        "page_title",
+        "image_data_url",
+        "image_model",
+        "prompt_author_model",
+        "final_prompt",
+        "session_id",
+        "index",
+        "total",
+        "trace_id",
+    }
+    assert neighbour["image_data_url"].startswith("data:image/jpeg;base64,")
+    assert neighbour["prompt_author_model"]  # non-empty
+
+
+async def test_expand_zero_neighbours_emits_done(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_providers(monkeypatch, neighbours=[])
+    events = await _collect(_event_stream(_expand_body(), "trace1"))
+    assert not [e for e in events if e["type"] == "neighbor"]
+    assert events[-1] == {"type": "expand_done", "count": 0, "trace_id": "trace1"}
+
+
+async def test_expand_isolates_one_neighbour_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Two neighbours; one image-gen throws. The bloom must still emit the other
+    # and report the true count — not sink the whole stream.
+    good = GeneratedImage(b"jpegbytes", "image/jpeg", "fal-model", "req-1")
+    _mock_providers(
+        monkeypatch,
+        neighbours=[Neighbor("The Factory", "container"), Neighbor("Piston", "peer")],
+        generate_side_effect=[RuntimeError("fal boom"), good],
+    )
+    events = await _collect(_event_stream(_expand_body(), "trace1"))
+    neighbours = [e for e in events if e["type"] == "neighbor"]
+    assert len(neighbours) == 1
+    assert events[-1]["type"] == "expand_done"
+    assert events[-1]["count"] == 1
+
+
+async def test_expand_requires_an_image(monkeypatch: pytest.MonkeyPatch) -> None:
+    _mock_providers(monkeypatch, neighbours=[Neighbor("X", "peer")])
+    events = await _collect(_event_stream(_expand_body(image=None), "trace1"))
+    assert events == [
+        {"type": "error", "message": "expand mode requires an image", "trace_id": "trace1"}
+    ]
+    llm_mod.propose_neighbors.assert_not_called()  # type: ignore[attr-defined]
+
+
+async def test_query_mode_still_emits_final(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression: the additive expand branch must not disturb the shared
+    # tap/query path — a plain query still streams a single `final`.
+    monkeypatch.setenv("PROGRESSIVE_DRAFT", "false")
+    monkeypatch.setattr(
+        llm_mod,
+        "plan_page",
+        AsyncMock(return_value=PagePlan("Boilers", "a boiler diagram", ["water boils"], [])),
+    )
+    monkeypatch.setattr(
+        image_mod,
+        "generate_image",
+        AsyncMock(return_value=GeneratedImage(b"jpeg", "image/jpeg", "fal-model", "r")),
+    )
+    body = GenerateBody(query="how do boilers work", session_id="s1")
+    events = await _collect(_event_stream(body, "trace1"))
+    finals = [e for e in events if e["type"] == "final"]
+    assert len(finals) == 1
+    assert finals[0]["page_title"] == "Boilers"
+    assert not [e for e in events if e["type"] in ("neighbor", "expand_done")]

--- a/apps/modal-backend/tests/test_llm_provider.py
+++ b/apps/modal-backend/tests/test_llm_provider.py
@@ -981,3 +981,114 @@ async def test_precompute_candidates_parses(monkeypatch: pytest.MonkeyPatch) -> 
     out = await llm.precompute_click_candidates("data:image/jpeg;base64,abc", "Engine", "q")
     assert len(out) == 1
     assert out[0].subject == "Valve"
+
+
+# ---------- scale tag on click resolution (M3) ---------------------------
+
+
+def test_build_click_resolution_parses_scale() -> None:
+    res = llm._build_click_resolution(
+        {"subject": "Factory", "scale": "container"},
+        x_pct=0.5,
+        y_pct=0.5,
+        fallback_subject="x",
+    )
+    assert res.scale == "container"
+
+
+def test_build_click_resolution_defaults_scale_to_peer() -> None:
+    res = llm._build_click_resolution(
+        {"subject": "X"}, x_pct=0.5, y_pct=0.5, fallback_subject="x"
+    )
+    assert res.scale == "peer"
+
+
+def test_build_click_resolution_rejects_unknown_scale() -> None:
+    res = llm._build_click_resolution(
+        {"subject": "X", "scale": "ginormous"},
+        x_pct=0.5,
+        y_pct=0.5,
+        fallback_subject="x",
+    )
+    assert res.scale == "peer"
+
+
+def test_build_click_resolution_scale_is_case_insensitive() -> None:
+    res = llm._build_click_resolution(
+        {"subject": "X", "scale": "Component"},
+        x_pct=0.5,
+        y_pct=0.5,
+        fallback_subject="x",
+    )
+    assert res.scale == "component"
+
+
+# ---------- propose_neighbors (M3 expand bloom) --------------------------
+
+
+def test_build_neighbors_parses_and_tags_scale() -> None:
+    parsed = {
+        "neighbors": [
+            {"subject": "The Factory", "scale": "container", "note": "houses the boiler"},
+            {"subject": "Piston", "scale": "peer"},
+            {"subject": "Valve", "scale": "component"},
+        ]
+    }
+    out = llm._build_neighbors(parsed, max_neighbors=4)
+    assert [n.subject for n in out] == ["The Factory", "Piston", "Valve"]
+    assert [n.scale for n in out] == ["container", "peer", "component"]
+    assert out[0].note == "houses the boiler"
+
+
+def test_build_neighbors_defaults_bad_scale_to_peer() -> None:
+    out = llm._build_neighbors(
+        {"neighbors": [{"subject": "X", "scale": "weird"}]}, max_neighbors=4
+    )
+    assert out[0].scale == "peer"
+
+
+def test_build_neighbors_drops_empty_subject() -> None:
+    out = llm._build_neighbors(
+        {"neighbors": [{"subject": "  "}, {"subject": "Real"}]}, max_neighbors=4
+    )
+    assert [n.subject for n in out] == ["Real"]
+
+
+def test_build_neighbors_caps_at_max() -> None:
+    parsed = {"neighbors": [{"subject": f"N{i}"} for i in range(10)]}
+    out = llm._build_neighbors(parsed, max_neighbors=4)
+    assert len(out) == 4
+
+
+def test_build_neighbors_dedupes_by_normalized_subject() -> None:
+    parsed = {
+        "neighbors": [
+            {"subject": "The Boiler"},
+            {"subject": "the boiler"},
+            {"subject": "Coal"},
+        ]
+    }
+    out = llm._build_neighbors(parsed, max_neighbors=4)
+    assert [n.subject for n in out] == ["The Boiler", "Coal"]
+
+
+def test_build_neighbors_tolerates_garbage() -> None:
+    assert llm._build_neighbors({}, max_neighbors=4) == []
+    assert llm._build_neighbors({"neighbors": "nope"}, max_neighbors=4) == []
+
+
+async def test_propose_neighbors_end_to_end(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        [
+            _fake_response(
+                content='{"neighbors": [{"subject": "Factory", "scale": "container"}]}'
+            )
+        ]
+    )
+    monkeypatch.setattr(llm, "_client", lambda: fake)
+    out = await llm.propose_neighbors(
+        "data:image/jpeg;base64,abc", "Boiler", "how a boiler works"
+    )
+    assert len(out) == 1
+    assert out[0].subject == "Factory"
+    assert out[0].scale == "container"

--- a/apps/web/app/api/nodes/route.ts
+++ b/apps/web/app/api/nodes/route.ts
@@ -18,6 +18,8 @@ interface CreateBody {
   final_prompt?: string | null;
   click_in_parent?: { x_pct: number; y_pct: number } | null;
   sources?: { url: string; title: string | null }[] | null;
+  relation?: "descend" | "expand";
+  scale?: "component" | "peer" | "container";
 }
 
 export async function POST(req: Request) {
@@ -59,6 +61,8 @@ export async function POST(req: Request) {
     final_prompt: body.final_prompt ?? null,
     click_in_parent: body.click_in_parent ?? null,
     sources: Array.isArray(body.sources) ? body.sources.slice(0, 3) : null,
+    relation: body.relation ?? "descend",
+    scale: body.scale ?? "peer",
   });
 
   return NextResponse.json({

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -261,6 +261,10 @@ export default function PlayPage() {
   const [bloom, setBloom] = useState<
     { items: NeighbourItem[]; total: number; done: boolean } | null
   >(null);
+  // Aborts the in-flight bloom stream when the tray closes or a new bloom
+  // starts, so late `neighbor` events can't resurrect a closed tray or mix
+  // two blooms into one tray.
+  const bloomAbortRef = useRef<AbortController | null>(null);
   const [statusMsg, setStatusMsg] = useState<string | null>(null);
   const [clickRipple, setClickRipple] = useState<{
     xPx: number;
@@ -644,6 +648,8 @@ export default function PlayPage() {
   // and persist as relation:"expand" children; `expand_done` ends the bloom.
   const runExpand = useCallback(async (body: GenerateRequestBody) => {
     const traceId = newTraceId();
+    const ac = new AbortController();
+    bloomAbortRef.current = ac;
     try {
       const response = await fetch("/api/generate-page", {
         method: "POST",
@@ -652,6 +658,7 @@ export default function PlayPage() {
           [TRACE_HEADER]: traceId,
         },
         body: JSON.stringify({ ...body, trace_id: traceId }),
+        signal: ac.signal,
       });
       if (!response.ok || !response.body) {
         throw new Error(`expand failed: HTTP ${response.status}`);
@@ -671,6 +678,9 @@ export default function PlayPage() {
           const payload = trimmed.slice(5).trim();
           if (!payload) continue;
           const evt = JSON.parse(payload) as GenerateEvent;
+          // Stop touching bloom state the moment this stream is superseded /
+          // closed, so a buffered late event can't revive a closed tray.
+          if (ac.signal.aborted) return;
           if (evt.type === "neighbor") {
             const item: NeighbourItem = {
               key: `${body.current_node_id}-${evt.index}-${evt.subject}`,
@@ -731,6 +741,7 @@ export default function PlayPage() {
   const triggerExpand = useCallback(() => {
     if (!page || !page.imageDataUrl || phase === "generating") return;
     if (bloom && !bloom.done) return;
+    bloomAbortRef.current?.abort();
     setBloom({ items: [], total: 0, done: false });
     void runExpand({
       query: page.query,
@@ -2135,7 +2146,10 @@ export default function PlayPage() {
           onPick={(item) => {
             if (item.nodeId) window.location.href = `/n/${item.nodeId}`;
           }}
-          onClose={() => setBloom(null)}
+          onClose={() => {
+            bloomAbortRef.current?.abort();
+            setBloom(null);
+          }}
         />
       )}
 

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -24,6 +24,7 @@ import WorldMap from "@/components/world-map";
 import DebugHud from "@/components/debug-hud";
 import SessionMinimap from "@/components/session-minimap";
 import WaterfallHUD from "@/components/waterfall-hud";
+import NeighbourTray, { type NeighbourItem } from "@/components/PlayPage/NeighbourTray";
 import CitationsChip from "@/components/citations-chip";
 import TimeScrubber from "@/components/time-scrubber";
 import {
@@ -110,6 +111,8 @@ interface PersistBody {
   final_prompt: string;
   click_in_parent?: { x_pct: number; y_pct: number } | null;
   sources?: { url: string; title: string | null }[] | null;
+  relation?: "descend" | "expand";
+  scale?: "component" | "peer" | "container";
 }
 
 function readFileAsDataUrl(file: File): Promise<string> {
@@ -253,6 +256,11 @@ export default function PlayPage() {
     trailIdx: -1,
   });
   const [viewMode, setViewMode] = useState<"page" | "map">("page");
+  // Expand-outward bloom: the neighbours streaming into the tray (null = no
+  // bloom). Independent of the main `phase` so the focal page stays put.
+  const [bloom, setBloom] = useState<
+    { items: NeighbourItem[]; total: number; done: boolean } | null
+  >(null);
   const [statusMsg, setStatusMsg] = useState<string | null>(null);
   const [clickRipple, setClickRipple] = useState<{
     xPx: number;
@@ -630,6 +638,116 @@ export default function PlayPage() {
     []
   );
 
+  // Expand outward: bloom the world AROUND the current page. Self-contained
+  // (its own fetch + SSE loop) so the tap/query/edit generate() path is
+  // untouched. Neighbour pages stream in as `neighbor` events, fill the tray,
+  // and persist as relation:"expand" children; `expand_done` ends the bloom.
+  const runExpand = useCallback(async (body: GenerateRequestBody) => {
+    const traceId = newTraceId();
+    try {
+      const response = await fetch("/api/generate-page", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          [TRACE_HEADER]: traceId,
+        },
+        body: JSON.stringify({ ...body, trace_id: traceId }),
+      });
+      if (!response.ok || !response.body) {
+        throw new Error(`expand failed: HTTP ${response.status}`);
+      }
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const chunks = buffer.split("\n\n");
+        buffer = chunks.pop() ?? "";
+        for (const chunk of chunks) {
+          const trimmed = chunk.trim();
+          if (!trimmed.startsWith("data:")) continue;
+          const payload = trimmed.slice(5).trim();
+          if (!payload) continue;
+          const evt = JSON.parse(payload) as GenerateEvent;
+          if (evt.type === "neighbor") {
+            const item: NeighbourItem = {
+              key: `${body.current_node_id}-${evt.index}-${evt.subject}`,
+              subject: evt.subject,
+              scale: evt.scale,
+              imageDataUrl: evt.image_data_url,
+              nodeId: null,
+            };
+            setBloom((prev) => ({
+              items: [...(prev?.items ?? []), item],
+              total: evt.total,
+              done: prev?.done ?? false,
+            }));
+            void persistNode(
+              {
+                parent_id: body.current_node_id || null,
+                session_id: evt.session_id,
+                query: evt.subject,
+                page_title: evt.page_title,
+                image_data_url: evt.image_data_url,
+                image_model: evt.image_model,
+                prompt_author_model: evt.prompt_author_model,
+                aspect_ratio: body.aspect_ratio,
+                final_prompt: evt.final_prompt,
+                relation: "expand",
+                scale: evt.scale,
+              },
+              traceId
+            ).then((saved) => {
+              if (saved) {
+                setBloom((prev) =>
+                  prev
+                    ? {
+                        ...prev,
+                        items: prev.items.map((it) =>
+                          it.key === item.key ? { ...it, nodeId: saved.id } : it
+                        ),
+                      }
+                    : prev
+                );
+              }
+            });
+          } else if (evt.type === "expand_done") {
+            setBloom((prev) => (prev ? { ...prev, done: true } : prev));
+          } else if (evt.type === "error") {
+            throw new Error(evt.message);
+          }
+        }
+      }
+    } catch (err) {
+      if ((err as Error).name === "AbortError") return;
+      // A failed bloom shouldn't disturb the focal page — just stop the
+      // tray's pending spinner and keep whatever neighbours arrived.
+      setBloom((prev) => (prev ? { ...prev, done: true } : prev));
+    }
+  }, []);
+
+  const triggerExpand = useCallback(() => {
+    if (!page || !page.imageDataUrl || phase === "generating") return;
+    if (bloom && !bloom.done) return;
+    setBloom({ items: [], total: 0, done: false });
+    void runExpand({
+      query: page.query,
+      aspect_ratio: "16:9",
+      web_search: false,
+      session_id: page.sessionId,
+      current_node_id: page.nodeId ?? "",
+      mode: "expand",
+      image: page.imageDataUrl,
+      parent_query: page.query,
+      parent_title: page.title,
+      image_tier: imageTier,
+      output_locale: resolveOutputLocale(outputLocale),
+      ...(styleAnchor ? { session_style_anchor: styleAnchor.style } : {}),
+    });
+  }, [page, phase, bloom, runExpand, imageTier, outputLocale, styleAnchor]);
+
   const acceptUploadedImage = useCallback(
     async (file: File) => {
       if (!file.type.startsWith("image/")) {
@@ -860,6 +978,7 @@ export default function PlayPage() {
     onOpenQuickbar: () => setQuickbarOpen(true),
     onToggleHelp: () => setHelpOpen((h) => !h),
     onToggleCodex: () => setCodexOpen((c) => !c),
+    onExpandOutward: triggerExpand,
     onCloseOverlays: () => {
       setHelpOpen(false);
       setQuickbarOpen(false);
@@ -1795,6 +1914,19 @@ export default function PlayPage() {
             <div className="absolute right-3 top-3 flex gap-2">
               <button
                 type="button"
+                onClick={triggerExpand}
+                disabled={
+                  phase === "generating" ||
+                  !page?.imageDataUrl ||
+                  (bloom !== null && !bloom.done)
+                }
+                className="rounded-full bg-black/60 px-3 py-1 text-xs text-white hover:bg-black/75 disabled:opacity-50"
+                title="Expand outward (E) — bloom the world around this page"
+              >
+                Expand
+              </button>
+              <button
+                type="button"
                 onClick={() => setCodexOpen((c) => !c)}
                 aria-pressed={codexOpen}
                 className={
@@ -1992,6 +2124,18 @@ export default function PlayPage() {
             );
           }}
           onClose={() => setScrubberOpen(false)}
+        />
+      )}
+
+      {bloom && (
+        <NeighbourTray
+          items={bloom.items}
+          total={bloom.total}
+          done={bloom.done}
+          onPick={(item) => {
+            if (item.nodeId) window.location.href = `/n/${item.nodeId}`;
+          }}
+          onClose={() => setBloom(null)}
         />
       )}
 

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -24,7 +24,7 @@ import WorldMap from "@/components/world-map";
 import DebugHud from "@/components/debug-hud";
 import SessionMinimap from "@/components/session-minimap";
 import WaterfallHUD from "@/components/waterfall-hud";
-import NeighbourTray, { type NeighbourItem } from "@/components/PlayPage/NeighbourTray";
+import NeighbourTray from "@/components/PlayPage/NeighbourTray";
 import CitationsChip from "@/components/citations-chip";
 import TimeScrubber from "@/components/time-scrubber";
 import {
@@ -35,6 +35,7 @@ import {
 } from "@/lib/trace";
 import { getStrings, resolveOutputLocale } from "@/lib/i18n";
 import { useImageTier, useVideoTier } from "@/hooks/usePersistedTier";
+import { useExpandBloom } from "@/hooks/useExpandBloom";
 import { usePersistedLocale } from "@/hooks/usePersistedLocale";
 import { usePersistedTheme } from "@/hooks/usePersistedTheme";
 import { useStyleAnchor } from "@/hooks/useStyleAnchor";
@@ -258,13 +259,12 @@ export default function PlayPage() {
   const [viewMode, setViewMode] = useState<"page" | "map">("page");
   // Expand-outward bloom: the neighbours streaming into the tray (null = no
   // bloom). Independent of the main `phase` so the focal page stays put.
-  const [bloom, setBloom] = useState<
-    { items: NeighbourItem[]; total: number; done: boolean } | null
-  >(null);
-  // Aborts the in-flight bloom stream when the tray closes or a new bloom
-  // starts, so late `neighbor` events can't resurrect a closed tray or mix
-  // two blooms into one tray.
-  const bloomAbortRef = useRef<AbortController | null>(null);
+  // Expand-outward bloom (own SSE loop, abort-on-close) — see useExpandBloom.
+  const {
+    bloom,
+    start: startBloom,
+    close: closeBloom,
+  } = useExpandBloom(persistNode);
   const [statusMsg, setStatusMsg] = useState<string | null>(null);
   const [clickRipple, setClickRipple] = useState<{
     xPx: number;
@@ -642,108 +642,12 @@ export default function PlayPage() {
     []
   );
 
-  // Expand outward: bloom the world AROUND the current page. Self-contained
-  // (its own fetch + SSE loop) so the tap/query/edit generate() path is
-  // untouched. Neighbour pages stream in as `neighbor` events, fill the tray,
-  // and persist as relation:"expand" children; `expand_done` ends the bloom.
-  const runExpand = useCallback(async (body: GenerateRequestBody) => {
-    const traceId = newTraceId();
-    const ac = new AbortController();
-    bloomAbortRef.current = ac;
-    try {
-      const response = await fetch("/api/generate-page", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          [TRACE_HEADER]: traceId,
-        },
-        body: JSON.stringify({ ...body, trace_id: traceId }),
-        signal: ac.signal,
-      });
-      if (!response.ok || !response.body) {
-        throw new Error(`expand failed: HTTP ${response.status}`);
-      }
-      const reader = response.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = "";
-      while (true) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        const chunks = buffer.split("\n\n");
-        buffer = chunks.pop() ?? "";
-        for (const chunk of chunks) {
-          const trimmed = chunk.trim();
-          if (!trimmed.startsWith("data:")) continue;
-          const payload = trimmed.slice(5).trim();
-          if (!payload) continue;
-          const evt = JSON.parse(payload) as GenerateEvent;
-          // Stop touching bloom state the moment this stream is superseded /
-          // closed, so a buffered late event can't revive a closed tray.
-          if (ac.signal.aborted) return;
-          if (evt.type === "neighbor") {
-            const item: NeighbourItem = {
-              key: `${body.current_node_id}-${evt.index}-${evt.subject}`,
-              subject: evt.subject,
-              scale: evt.scale,
-              imageDataUrl: evt.image_data_url,
-              nodeId: null,
-            };
-            setBloom((prev) => ({
-              items: [...(prev?.items ?? []), item],
-              total: evt.total,
-              done: prev?.done ?? false,
-            }));
-            void persistNode(
-              {
-                parent_id: body.current_node_id || null,
-                session_id: evt.session_id,
-                query: evt.subject,
-                page_title: evt.page_title,
-                image_data_url: evt.image_data_url,
-                image_model: evt.image_model,
-                prompt_author_model: evt.prompt_author_model,
-                aspect_ratio: body.aspect_ratio,
-                final_prompt: evt.final_prompt,
-                relation: "expand",
-                scale: evt.scale,
-              },
-              traceId
-            ).then((saved) => {
-              if (saved) {
-                setBloom((prev) =>
-                  prev
-                    ? {
-                        ...prev,
-                        items: prev.items.map((it) =>
-                          it.key === item.key ? { ...it, nodeId: saved.id } : it
-                        ),
-                      }
-                    : prev
-                );
-              }
-            });
-          } else if (evt.type === "expand_done") {
-            setBloom((prev) => (prev ? { ...prev, done: true } : prev));
-          } else if (evt.type === "error") {
-            throw new Error(evt.message);
-          }
-        }
-      }
-    } catch (err) {
-      if ((err as Error).name === "AbortError") return;
-      // A failed bloom shouldn't disturb the focal page — just stop the
-      // tray's pending spinner and keep whatever neighbours arrived.
-      setBloom((prev) => (prev ? { ...prev, done: true } : prev));
-    }
-  }, []);
-
+  // Build the expand body from the current page + session state and hand it to
+  // the bloom hook (which owns the SSE loop, tray state, persistence + abort).
   const triggerExpand = useCallback(() => {
     if (!page || !page.imageDataUrl || phase === "generating") return;
     if (bloom && !bloom.done) return;
-    bloomAbortRef.current?.abort();
-    setBloom({ items: [], total: 0, done: false });
-    void runExpand({
+    startBloom({
       query: page.query,
       aspect_ratio: "16:9",
       web_search: false,
@@ -757,7 +661,7 @@ export default function PlayPage() {
       output_locale: resolveOutputLocale(outputLocale),
       ...(styleAnchor ? { session_style_anchor: styleAnchor.style } : {}),
     });
-  }, [page, phase, bloom, runExpand, imageTier, outputLocale, styleAnchor]);
+  }, [page, phase, bloom, startBloom, imageTier, outputLocale, styleAnchor]);
 
   const acceptUploadedImage = useCallback(
     async (file: File) => {
@@ -2146,10 +2050,7 @@ export default function PlayPage() {
           onPick={(item) => {
             if (item.nodeId) window.location.href = `/n/${item.nodeId}`;
           }}
-          onClose={() => {
-            bloomAbortRef.current?.abort();
-            setBloom(null);
-          }}
+          onClose={closeBloom}
         />
       )}
 

--- a/apps/web/components/PlayPage/HelpOverlay.tsx
+++ b/apps/web/components/PlayPage/HelpOverlay.tsx
@@ -28,6 +28,7 @@ export function HelpOverlay({ onClose }: Props) {
           <Row k="M" v="Toggle map view" />
           <Row k="T" v="Toggle time-scrubber" />
           <Row k="K" v="Toggle codex" />
+          <Row k="E" v="Expand outward" />
           <Row k="/" v="Jump to page…" />
           <Row k="?" v="This help" />
           <Row k="Esc" v="Close overlay" />

--- a/apps/web/components/PlayPage/NeighbourTray.test.tsx
+++ b/apps/web/components/PlayPage/NeighbourTray.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import NeighbourTray, { type NeighbourItem } from "./NeighbourTray";
+
+function item(over: Partial<NeighbourItem> = {}): NeighbourItem {
+  return {
+    key: over.key ?? "k1",
+    subject: over.subject ?? "The Factory",
+    scale: over.scale ?? "peer",
+    imageDataUrl: over.imageDataUrl ?? "data:image/jpeg;base64,abc",
+    nodeId: over.nodeId ?? "n1",
+    ...over,
+  };
+}
+
+const noop = () => {};
+
+describe("NeighbourTray", () => {
+  it("renders nothing when there's no bloom", () => {
+    render(<NeighbourTray items={[]} total={0} done={false} onPick={noop} onClose={noop} />);
+    expect(screen.queryByRole("region")).toBeNull();
+  });
+
+  it("renders one card per neighbour with its subject + scale label", () => {
+    render(
+      <NeighbourTray
+        items={[
+          item({ key: "a", subject: "The Factory", scale: "container" }),
+          item({ key: "b", subject: "Piston", scale: "peer" }),
+          item({ key: "c", subject: "Valve", scale: "component" }),
+        ]}
+        total={3}
+        done
+        onPick={noop}
+        onClose={noop}
+      />
+    );
+    expect(screen.getByRole("button", { name: "Explore The Factory" })).toBeTruthy();
+    // Scale encodes to a chip label: container→around, peer→beside, component→part.
+    expect(screen.getByText("around")).toBeTruthy();
+    expect(screen.getByText("beside")).toBeTruthy();
+    expect(screen.getByText("part")).toBeTruthy();
+  });
+
+  it("shows an 'N of M' progress read while blooming, 'Expanded' when done", () => {
+    const items = [item({ key: "a" }), item({ key: "b", imageDataUrl: null })];
+    const { rerender } = render(
+      <NeighbourTray items={items} total={4} done={false} onPick={noop} onClose={noop} />
+    );
+    // 1 of 2 have images → "1 of 4".
+    expect(screen.getByText(/Expanding outward · 1 of 4/)).toBeTruthy();
+    rerender(
+      <NeighbourTray items={[item({ key: "a" })]} total={4} done onPick={noop} onClose={noop} />
+    );
+    expect(screen.getByText(/Expanded · 1 neighbour/)).toBeTruthy();
+  });
+
+  it("hides trailing pending slots once done (no perpetual shimmer on partial failure)", () => {
+    // total 4, only 2 arrived: while blooming there are pending slots; once
+    // done (a neighbour failed) they must disappear.
+    const items = [item({ key: "a" }), item({ key: "b" })];
+    const { container, rerender } = render(
+      <NeighbourTray items={items} total={4} done={false} onPick={noop} onClose={noop} />
+    );
+    expect(container.querySelectorAll("[aria-hidden]").length).toBe(2);
+    rerender(
+      <NeighbourTray items={items} total={4} done onPick={noop} onClose={noop} />
+    );
+    expect(container.querySelectorAll("[aria-hidden]").length).toBe(0);
+  });
+
+  it("fires onPick with the item when a saved card is clicked", () => {
+    const onPick = vi.fn();
+    const it1 = item({ key: "a", subject: "The Factory", nodeId: "node-42" });
+    render(
+      <NeighbourTray items={[it1]} total={1} done onPick={onPick} onClose={noop} />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Explore The Factory" }));
+    expect(onPick).toHaveBeenCalledTimes(1);
+    expect(onPick).toHaveBeenCalledWith(expect.objectContaining({ nodeId: "node-42" }));
+  });
+
+  it("disables a card until it's persisted (no dead clicks)", () => {
+    const onPick = vi.fn();
+    // Image arrived but not yet persisted (nodeId null) → not clickable.
+    const it1 = item({ subject: "Pending", imageDataUrl: "data:image/jpeg;base64,x", nodeId: null });
+    render(<NeighbourTray items={[it1]} total={1} done onPick={onPick} onClose={noop} />);
+    const btn = screen.getByRole("button", { name: "Explore Pending" }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    fireEvent.click(btn);
+    expect(onPick).not.toHaveBeenCalled();
+  });
+
+  it("disables a still-generating card (no image yet)", () => {
+    const it1 = item({ subject: "Loading", imageDataUrl: null, nodeId: null });
+    render(<NeighbourTray items={[it1]} total={1} done={false} onPick={noop} onClose={noop} />);
+    const btn = screen.getByRole("button", { name: "Explore Loading" }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it("fires onClose from the close button", () => {
+    const onClose = vi.fn();
+    render(<NeighbourTray items={[item()]} total={1} done onPick={noop} onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: "Close neighbours" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/components/PlayPage/NeighbourTray.tsx
+++ b/apps/web/components/PlayPage/NeighbourTray.tsx
@@ -64,11 +64,13 @@ export default function NeighbourTray({ items, total, done, onPick, onClose }: P
         {items.map((it) => {
           const meta = SCALE_META[it.scale];
           const loading = !it.imageDataUrl;
+          // Clickable only once persisted — onPick navigates to the node's
+          // permalink, so a not-yet-saved card would be a dead click.
           return (
             <button
               key={it.key}
               type="button"
-              disabled={loading}
+              disabled={loading || !it.nodeId}
               aria-label={`Explore ${it.subject}`}
               title={`${it.subject} · ${it.scale}`}
               onClick={() => onPick(it)}
@@ -104,13 +106,16 @@ export default function NeighbourTray({ items, total, done, onPick, onClose }: P
             </button>
           );
         })}
-        {Array.from({ length: pendingCount }).map((_, i) => (
-          <span
-            key={`pending-${i}`}
-            aria-hidden
-            className="h-16 w-24 shrink-0 animate-pulse rounded-lg border border-[var(--color-ink)]/15 bg-[var(--color-ink)]/10"
-          />
-        ))}
+        {/* Trailing "still proposing" slots — hidden once done, so a bloom
+            with a failed neighbour doesn't leave a slot shimmering forever. */}
+        {!done &&
+          Array.from({ length: pendingCount }).map((_, i) => (
+            <span
+              key={`pending-${i}`}
+              aria-hidden
+              className="h-16 w-24 shrink-0 animate-pulse rounded-lg border border-[var(--color-ink)]/15 bg-[var(--color-ink)]/10"
+            />
+          ))}
       </div>
     </div>
   );

--- a/apps/web/components/PlayPage/NeighbourTray.tsx
+++ b/apps/web/components/PlayPage/NeighbourTray.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import type { ScaleKind } from "@openflipbook/config";
+
+/** One bloomed neighbour. `imageDataUrl` is null while its page is still
+ *  generating (the slot shows a shimmer); `nodeId` is null until persisted. */
+export interface NeighbourItem {
+  key: string;
+  subject: string;
+  scale: ScaleKind;
+  imageDataUrl: string | null;
+  nodeId: string | null;
+}
+
+interface Props {
+  items: NeighbourItem[];
+  /** How many neighbours the bloom proposed — drives the "N of M" read and
+   *  the trailing pending slots before their pages arrive. */
+  total: number;
+  /** True once the `expand_done` event lands. */
+  done: boolean;
+  onPick: (item: NeighbourItem) => void;
+  onClose: () => void;
+}
+
+// Scale → visual encoding. Card width + chip colour make the scale legible at
+// a glance: a "container" reads bigger + warmer than a "component".
+const SCALE_META: Record<ScaleKind, { label: string; chip: string; width: string }> = {
+  component: { label: "part", chip: "bg-sky-500", width: "w-20" },
+  peer: { label: "beside", chip: "bg-slate-500", width: "w-24" },
+  container: { label: "around", chip: "bg-amber-500", width: "w-28" },
+};
+
+export default function NeighbourTray({ items, total, done, onPick, onClose }: Props) {
+  const ready = items.filter((i) => i.imageDataUrl).length;
+  const pendingCount = Math.max(0, total - items.length);
+  if (total === 0 && items.length === 0) return null;
+
+  return (
+    <div
+      role="region"
+      aria-label="Expanded neighbours"
+      className="pointer-events-auto fixed bottom-3 left-1/2 z-30 max-w-[min(960px,92vw)] -translate-x-1/2 rounded-2xl border border-[var(--color-ink)]/20 bg-[var(--color-paper)]/95 p-2 shadow-xl backdrop-blur"
+    >
+      <div className="flex items-center justify-between px-2 pb-1.5 text-[11px] opacity-70">
+        <span className="flex items-center gap-1.5">
+          {!done && (
+            <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-amber-500" />
+          )}
+          {done
+            ? `Expanded · ${ready} neighbour${ready === 1 ? "" : "s"} — tap one to explore`
+            : `Expanding outward · ${ready} of ${total}`}
+        </span>
+        <button
+          type="button"
+          aria-label="Close neighbours"
+          onClick={onClose}
+          className="rounded px-1.5 py-0.5 text-[11px] hover:bg-[var(--color-ink)]/10"
+        >
+          E · close
+        </button>
+      </div>
+      <div className="flex max-w-full items-end gap-1.5 overflow-x-auto pb-1">
+        {items.map((it) => {
+          const meta = SCALE_META[it.scale];
+          const loading = !it.imageDataUrl;
+          return (
+            <button
+              key={it.key}
+              type="button"
+              disabled={loading}
+              aria-label={`Explore ${it.subject}`}
+              title={`${it.subject} · ${it.scale}`}
+              onClick={() => onPick(it)}
+              className={
+                "relative h-16 shrink-0 overflow-hidden rounded-lg border transition disabled:cursor-default " +
+                meta.width +
+                " border-[var(--color-ink)]/20 enabled:hover:border-[var(--color-ink)]/60 enabled:hover:ring-2 enabled:hover:ring-amber-200"
+              }
+            >
+              {it.imageDataUrl ? (
+                <img
+                  src={it.imageDataUrl}
+                  alt=""
+                  className="block h-full w-full object-cover"
+                  draggable={false}
+                />
+              ) : (
+                <span className="flex h-full w-full animate-pulse items-center justify-center bg-[var(--color-ink)]/10 text-[11px] opacity-50">
+                  …
+                </span>
+              )}
+              <span
+                className={
+                  "absolute left-1 top-1 rounded px-1 py-0.5 text-[8px] font-medium uppercase tracking-wide text-white " +
+                  meta.chip
+                }
+              >
+                {meta.label}
+              </span>
+              <span className="absolute inset-x-0 bottom-0 truncate bg-black/55 px-1 py-0.5 text-[9px] text-white">
+                {it.subject}
+              </span>
+            </button>
+          );
+        })}
+        {Array.from({ length: pendingCount }).map((_, i) => (
+          <span
+            key={`pending-${i}`}
+            aria-hidden
+            className="h-16 w-24 shrink-0 animate-pulse rounded-lg border border-[var(--color-ink)]/15 bg-[var(--color-ink)]/10"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/hooks/useExpandBloom.test.tsx
+++ b/apps/web/hooks/useExpandBloom.test.tsx
@@ -1,0 +1,173 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { GenerateRequestBody } from "@openflipbook/config";
+
+import { useExpandBloom, type PersistNeighbour } from "./useExpandBloom";
+
+const BODY: GenerateRequestBody = {
+  query: "how a steam engine works",
+  aspect_ratio: "16:9",
+  web_search: false,
+  session_id: "s1",
+  current_node_id: "n0",
+  mode: "expand",
+  image: "data:image/jpeg;base64,abc",
+  parent_query: "how a steam engine works",
+  parent_title: "Steam Engine",
+};
+
+function neighbor(over: Record<string, unknown> = {}): object {
+  return {
+    type: "neighbor",
+    subject: "The Factory",
+    scale: "container",
+    page_title: "The Factory Floor",
+    image_data_url: "data:image/jpeg;base64,xxx",
+    image_model: "fal-model",
+    prompt_author_model: "google/gemini-3-flash-preview",
+    final_prompt: "an illustrated factory",
+    session_id: "s1",
+    index: 0,
+    total: 2,
+    ...over,
+  };
+}
+
+function cannedResponse(events: object[]): Response {
+  const enc = new TextEncoder();
+  const stream = new ReadableStream({
+    start(c) {
+      for (const e of events) c.enqueue(enc.encode(`data: ${JSON.stringify(e)}\n\n`));
+      c.close();
+    },
+  });
+  return new Response(stream, { status: 200 });
+}
+
+function manualResponse(): {
+  response: Response;
+  push: (e: object) => void;
+  finish: () => void;
+} {
+  const enc = new TextEncoder();
+  let ctrl!: ReadableStreamDefaultController;
+  const stream = new ReadableStream({
+    start(c) {
+      ctrl = c;
+    },
+  });
+  return {
+    response: new Response(stream, { status: 200 }),
+    push: (e) => ctrl.enqueue(enc.encode(`data: ${JSON.stringify(e)}\n\n`)),
+    finish: () => ctrl.close(),
+  };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("useExpandBloom", () => {
+  it("fills the tray + persists each neighbour as a relation:expand child", async () => {
+    const persist = vi.fn().mockResolvedValue({ id: "node-x" });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        cannedResponse([
+          { type: "status", stage: "planning" },
+          neighbor({ subject: "The Factory", scale: "container", index: 0 }),
+          neighbor({ subject: "Piston", scale: "peer", index: 1 }),
+          { type: "expand_done", count: 2 },
+        ]),
+      ),
+    );
+
+    const { result } = renderHook(() =>
+      useExpandBloom(persist as unknown as PersistNeighbour),
+    );
+    act(() => result.current.start(BODY));
+
+    await waitFor(() => expect(result.current.bloom?.done).toBe(true));
+    expect(result.current.bloom?.items.map((i) => i.subject)).toEqual([
+      "The Factory",
+      "Piston",
+    ]);
+    expect(result.current.bloom?.items.map((i) => i.scale)).toEqual(["container", "peer"]);
+    expect(result.current.bloom?.total).toBe(2);
+    expect(persist).toHaveBeenCalledTimes(2);
+    expect(persist).toHaveBeenCalledWith(
+      expect.objectContaining({ relation: "expand", scale: "container", query: "The Factory" }),
+      expect.anything(),
+    );
+    // nodeId back-patched once persist resolves.
+    await waitFor(() =>
+      expect(result.current.bloom?.items.every((i) => i.nodeId === "node-x")).toBe(true),
+    );
+  });
+
+  it("a stream error marks the bloom done instead of throwing", async () => {
+    const persist = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(cannedResponse([{ type: "error", message: "boom" }])),
+    );
+    const { result } = renderHook(() =>
+      useExpandBloom(persist as unknown as PersistNeighbour),
+    );
+    act(() => result.current.start(BODY));
+    await waitFor(() => expect(result.current.bloom?.done).toBe(true));
+    expect(result.current.bloom?.items).toEqual([]);
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  it("close() clears the tray and a late neighbour can't resurrect it", async () => {
+    const persist = vi.fn().mockResolvedValue({ id: "n" });
+    const m = manualResponse();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(m.response));
+    const { result } = renderHook(() =>
+      useExpandBloom(persist as unknown as PersistNeighbour),
+    );
+    act(() => result.current.start(BODY));
+    act(() => m.push(neighbor({ subject: "First", index: 0 })));
+    await waitFor(() => expect(result.current.bloom?.items.length).toBe(1));
+
+    act(() => result.current.close());
+    expect(result.current.bloom).toBeNull();
+
+    // Late event after close must be dropped (the abort + in-loop guard).
+    await act(async () => {
+      m.push(neighbor({ subject: "Late", index: 1 }));
+      m.finish();
+      await new Promise((r) => setTimeout(r, 20));
+    });
+    expect(result.current.bloom).toBeNull();
+  });
+
+  it("starting a new bloom replaces the prior tray", async () => {
+    const persist = vi.fn().mockResolvedValue({ id: "n" });
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          cannedResponse([
+            neighbor({ subject: "Old", index: 0, total: 1 }),
+            { type: "expand_done", count: 1 },
+          ]),
+        )
+        .mockResolvedValueOnce(
+          cannedResponse([
+            neighbor({ subject: "New", index: 0, total: 1 }),
+            { type: "expand_done", count: 1 },
+          ]),
+        ),
+    );
+    const { result } = renderHook(() =>
+      useExpandBloom(persist as unknown as PersistNeighbour),
+    );
+    act(() => result.current.start(BODY));
+    await waitFor(() => expect(result.current.bloom?.items[0]?.subject).toBe("Old"));
+    act(() => result.current.start(BODY));
+    await waitFor(() => expect(result.current.bloom?.items[0]?.subject).toBe("New"));
+    expect(result.current.bloom?.items.length).toBe(1);
+  });
+});

--- a/apps/web/hooks/useExpandBloom.ts
+++ b/apps/web/hooks/useExpandBloom.ts
@@ -1,0 +1,160 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+import type { GenerateEvent, GenerateRequestBody, ScaleKind } from "@openflipbook/config";
+
+import type { NeighbourItem } from "@/components/PlayPage/NeighbourTray";
+import { TRACE_HEADER, newTraceId } from "@/lib/trace";
+
+export interface BloomState {
+  items: NeighbourItem[];
+  /** How many neighbours the bloom proposed (drives "N of M" + pending slots). */
+  total: number;
+  /** True once `expand_done` lands (or the stream errored out). */
+  done: boolean;
+}
+
+/** Persists one bloomed neighbour as a relation:"expand" child and returns its
+ *  node id. `app/play/page.tsx`'s `persistNode` satisfies this. */
+export type PersistNeighbour = (
+  body: {
+    parent_id: string | null;
+    session_id: string;
+    query: string;
+    page_title: string;
+    image_data_url: string;
+    image_model: string;
+    prompt_author_model: string;
+    aspect_ratio: string;
+    final_prompt: string;
+    relation: "expand";
+    scale: ScaleKind;
+  },
+  traceId: string | null,
+) => Promise<{ id: string } | null>;
+
+/**
+ * The "expand outward" bloom: own fetch + SSE loop, independent of the page's
+ * main `generate()` so the tap/query/edit path is untouched. Neighbour pages
+ * stream in via `neighbor` events, fill the tray, and persist as
+ * relation:"expand" children; `expand_done` (or a stream error) ends it.
+ *
+ * `start(body)` aborts any prior bloom first, and `close()` aborts the live
+ * one — so a late `neighbor` event can never resurrect a closed tray or mix
+ * two blooms into one (the abort + the in-loop `aborted` guard both gate it).
+ */
+export function useExpandBloom(persist: PersistNeighbour): {
+  bloom: BloomState | null;
+  start: (body: GenerateRequestBody) => void;
+  close: () => void;
+} {
+  const [bloom, setBloom] = useState<BloomState | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const start = useCallback(
+    (body: GenerateRequestBody) => {
+      abortRef.current?.abort();
+      const ac = new AbortController();
+      abortRef.current = ac;
+      setBloom({ items: [], total: 0, done: false });
+
+      void (async () => {
+        const traceId = newTraceId();
+        try {
+          const response = await fetch("/api/generate-page", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              [TRACE_HEADER]: traceId,
+            },
+            body: JSON.stringify({ ...body, trace_id: traceId }),
+            signal: ac.signal,
+          });
+          if (!response.ok || !response.body) {
+            throw new Error(`expand failed: HTTP ${response.status}`);
+          }
+          const reader = response.body.getReader();
+          const decoder = new TextDecoder();
+          let buffer = "";
+          while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            const chunks = buffer.split("\n\n");
+            buffer = chunks.pop() ?? "";
+            for (const chunk of chunks) {
+              const trimmed = chunk.trim();
+              if (!trimmed.startsWith("data:")) continue;
+              const payload = trimmed.slice(5).trim();
+              if (!payload) continue;
+              const evt = JSON.parse(payload) as GenerateEvent;
+              // Stop touching bloom state the moment this stream is superseded
+              // / closed, so a buffered late event can't revive a closed tray.
+              if (ac.signal.aborted) return;
+              if (evt.type === "neighbor") {
+                const item: NeighbourItem = {
+                  key: `${body.current_node_id}-${evt.index}-${evt.subject}`,
+                  subject: evt.subject,
+                  scale: evt.scale,
+                  imageDataUrl: evt.image_data_url,
+                  nodeId: null,
+                };
+                setBloom((prev) => ({
+                  items: [...(prev?.items ?? []), item],
+                  total: evt.total,
+                  done: prev?.done ?? false,
+                }));
+                void persist(
+                  {
+                    parent_id: body.current_node_id || null,
+                    session_id: evt.session_id,
+                    query: evt.subject,
+                    page_title: evt.page_title,
+                    image_data_url: evt.image_data_url,
+                    image_model: evt.image_model,
+                    prompt_author_model: evt.prompt_author_model,
+                    aspect_ratio: body.aspect_ratio,
+                    final_prompt: evt.final_prompt,
+                    relation: "expand",
+                    scale: evt.scale,
+                  },
+                  traceId,
+                ).then((saved) => {
+                  if (!saved) return;
+                  setBloom((prev) =>
+                    prev
+                      ? {
+                          ...prev,
+                          items: prev.items.map((i) =>
+                            i.key === item.key ? { ...i, nodeId: saved.id } : i,
+                          ),
+                        }
+                      : prev,
+                  );
+                });
+              } else if (evt.type === "expand_done") {
+                setBloom((prev) => (prev ? { ...prev, done: true } : prev));
+              } else if (evt.type === "error") {
+                throw new Error(evt.message);
+              }
+            }
+          }
+        } catch (err) {
+          if ((err as Error).name === "AbortError") return;
+          // A failed bloom shouldn't disturb the focal page — just stop the
+          // tray's pending spinner and keep whatever neighbours arrived.
+          setBloom((prev) => (prev ? { ...prev, done: true } : prev));
+        }
+      })();
+    },
+    [persist],
+  );
+
+  const close = useCallback(() => {
+    abortRef.current?.abort();
+    setBloom(null);
+  }, []);
+
+  return { bloom, start, close };
+}

--- a/apps/web/hooks/useKeyboardShortcuts.test.tsx
+++ b/apps/web/hooks/useKeyboardShortcuts.test.tsx
@@ -12,6 +12,7 @@ function makeHandlers(overrides: Partial<KeyboardShortcutHandlers> = {}): Keyboa
     onOpenQuickbar: vi.fn(),
     onToggleHelp: vi.fn(),
     onToggleCodex: vi.fn(),
+    onExpandOutward: vi.fn(),
     onCloseOverlays: vi.fn(),
     anyOverlayOpen: false,
     ...overrides,
@@ -68,6 +69,14 @@ describe("useKeyboardShortcuts", () => {
     expect(handlers.onToggleScrubber).toHaveBeenCalledTimes(1);
     expect(handlers.onOpenQuickbar).toHaveBeenCalledTimes(1);
     expect(handlers.onToggleHelp).toHaveBeenCalledTimes(1);
+  });
+
+  it("E fires expand-outward (case-insensitive)", () => {
+    const handlers = makeHandlers();
+    cleanup = renderHook(() => useKeyboardShortcuts(handlers)).unmount;
+    press({ key: "E" });
+    press({ key: "e" });
+    expect(handlers.onExpandOutward).toHaveBeenCalledTimes(2);
   });
 
   it("Esc only fires close when an overlay is open", () => {

--- a/apps/web/hooks/useKeyboardShortcuts.ts
+++ b/apps/web/hooks/useKeyboardShortcuts.ts
@@ -10,6 +10,8 @@ export interface KeyboardShortcutHandlers {
   onOpenQuickbar: () => void;
   onToggleHelp: () => void;
   onToggleCodex: () => void;
+  /** Bloom the world around the current page (mode:"expand"). */
+  onExpandOutward: () => void;
   onCloseOverlays: () => void;
   /** True while at least one overlay (help / quickbar / context menu / codex) is open. */
   anyOverlayOpen: boolean;
@@ -32,6 +34,7 @@ export interface KeyboardShortcutHandlers {
  *   M / m    Toggle map view
  *   T / t    Toggle time-scrubber
  *   K / k    Toggle codex panel
+ *   E / e    Expand outward (bloom neighbours)
  *   /        Open quickbar
  *   ?        Toggle help overlay
  *   Esc      Close any open overlay
@@ -45,6 +48,7 @@ export function useKeyboardShortcuts(handlers: KeyboardShortcutHandlers): void {
     onOpenQuickbar,
     onToggleHelp,
     onToggleCodex,
+    onExpandOutward,
     onCloseOverlays,
     anyOverlayOpen,
   } = handlers;
@@ -89,6 +93,9 @@ export function useKeyboardShortcuts(handlers: KeyboardShortcutHandlers): void {
       } else if (e.key.toLowerCase() === "k") {
         e.preventDefault();
         onToggleCodex();
+      } else if (e.key.toLowerCase() === "e") {
+        e.preventDefault();
+        onExpandOutward();
       } else if (e.key === "/") {
         e.preventDefault();
         onOpenQuickbar();
@@ -109,6 +116,7 @@ export function useKeyboardShortcuts(handlers: KeyboardShortcutHandlers): void {
     onOpenQuickbar,
     onToggleHelp,
     onToggleCodex,
+    onExpandOutward,
     onCloseOverlays,
   ]);
 }

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -103,6 +103,11 @@ export interface NodeDoc extends Document {
   // Web-search citations the planner used. Backwards-compatible: missing on
   // pre-citations nodes and treated as []. Domain-deduped, max ~3.
   sources?: NodeSource[] | null;
+  // M3 scale-space: how this node relates to its parent ("descend" = tap-in /
+  // default, "expand" = bloomed neighbour) + its size vs the parent's focal
+  // subject. Optional + defaulted for back-compat with pre-M3 rows.
+  relation?: "descend" | "expand" | null;
+  scale?: "component" | "peer" | "container" | null;
   created_at: Date;
 }
 
@@ -118,6 +123,8 @@ export interface NodeInsert {
   final_prompt: string | null;
   click_in_parent?: ClickInParent | null;
   sources?: NodeSource[] | null;
+  relation?: "descend" | "expand" | null;
+  scale?: "component" | "peer" | "container" | null;
 }
 
 export interface NodeRow {
@@ -133,16 +140,20 @@ export interface NodeRow {
   final_prompt: string | null;
   click_in_parent: ClickInParent | null;
   sources: NodeSource[];
+  relation: "descend" | "expand";
+  scale: "component" | "peer" | "container";
   created_at: string;
 }
 
 function toRow(doc: NodeDoc): NodeRow {
-  const { _id, created_at, click_in_parent, sources, ...rest } = doc;
+  const { _id, created_at, click_in_parent, sources, relation, scale, ...rest } = doc;
   return {
     id: _id,
     ...rest,
     click_in_parent: click_in_parent ?? null,
     sources: Array.isArray(sources) ? sources : [],
+    relation: relation ?? "descend",
+    scale: scale ?? "peer",
     created_at: created_at.toISOString(),
   };
 }
@@ -162,6 +173,8 @@ export async function insertNode(n: NodeInsert): Promise<NodeRow> {
     final_prompt: n.final_prompt,
     click_in_parent: n.click_in_parent ?? null,
     sources: n.sources ?? null,
+    relation: n.relation ?? "descend",
+    scale: n.scale ?? "peer",
     created_at: new Date(),
   };
   await collection.insertOne(doc);

--- a/docs/BYO-KEYS.md
+++ b/docs/BYO-KEYS.md
@@ -10,7 +10,7 @@ Endless Canvas has no hosted backend. To actually generate pages you need to pro
 
 Optional for v1:
 
-- Custom `OPENROUTER_VLM_MODEL` / `OPENROUTER_TEXT_MODEL` if you want to swap off the Qwen 2.5 defaults.
+- Custom `OPENROUTER_VLM_MODEL` / `OPENROUTER_TEXT_MODEL` if you want to swap off the Gemini 3 Flash defaults (e.g. `google/gemini-3-pro-preview` for sharper click-grounding, or a direct/local provider via `LLM_PROVIDER` — see below).
 
 ## 1. Accounts & keys
 
@@ -31,8 +31,8 @@ Modal reads secrets at runtime from a named secret, not your local `.env`. Creat
 modal secret create openflipbook-secrets \
   FAL_KEY="$FAL_KEY" \
   OPENROUTER_API_KEY="$OPENROUTER_API_KEY" \
-  OPENROUTER_VLM_MODEL="qwen/qwen-2.5-vl-72b-instruct" \
-  OPENROUTER_TEXT_MODEL="qwen/qwen-2.5-72b-instruct" \
+  OPENROUTER_VLM_MODEL="google/gemini-3-flash-preview" \
+  OPENROUTER_TEXT_MODEL="google/gemini-3-flash-preview" \
   OPENROUTER_ENABLE_WEB_SEARCH=true
 ```
 
@@ -138,7 +138,7 @@ cost/lock-in lever — but image quality varies a lot by model.
 
 ## Cost notes
 
-- OpenRouter Qwen 2.5 72B Text ≈ $0.0005 / request; VLM 72B ≈ $0.0015 / click resolution.
+- OpenRouter Gemini 3 Flash ($0.50/M in, $3/M out): planner ≈ $0.0005 / request, VLM ≈ $0.0015 / click resolution.
 - fal nano-banana ≈ $0.02 / image (varies).
 - Modal CPU container (generate.py) idles at $0; wakes for a few seconds per request.
 - R2: storage is cheap, egress is free on the public dev URL.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,6 +1,11 @@
 export type AspectRatio = "16:9" | "9:16" | "1:1" | "4:3" | "3:4";
 
-export type GenerateMode = "query" | "tap" | "edit";
+export type GenerateMode = "query" | "tap" | "edit" | "expand";
+
+// Scale of a node's subject relative to its parent's focal subject, for the
+// scale-space world map + zoom level-of-detail (M3). Composes into an integer
+// scale-level: component = -1, peer = 0, container = +1.
+export type ScaleKind = "component" | "peer" | "container";
 
 export type ImageTier = "fast" | "balanced" | "pro";
 
@@ -165,11 +170,40 @@ export interface GenerateStatusEvent {
   trace_id?: string;
 }
 
+// One bloomed neighbour from an "expand outward" pass (mode: "expand").
+// Streamed as each neighbour's page finishes generating, so the tray fills in
+// progressively. The client persists each as a relation:"expand" child of the
+// node that was expanded.
+export interface GenerateNeighborEvent {
+  type: "neighbor";
+  subject: string;
+  scale: ScaleKind;
+  page_title: string;
+  image_data_url: string;
+  image_model: string;
+  final_prompt: string;
+  session_id: string;
+  // Position within this bloom + how many were proposed, for tray ordering
+  // and a "3 of 4" progress read.
+  index: number;
+  total: number;
+  trace_id?: string;
+}
+
+// Terminal event of an expand bloom — the tray stops showing pending slots.
+export interface GenerateExpandDoneEvent {
+  type: "expand_done";
+  count: number;
+  trace_id?: string;
+}
+
 export type GenerateEvent =
   | GenerateStatusEvent
   | GenerateProgressEvent
   | GenerateFinalEvent
-  | GenerateErrorEvent;
+  | GenerateErrorEvent
+  | GenerateNeighborEvent
+  | GenerateExpandDoneEvent;
 
 export interface NodeRecord {
   id: string;

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -7,6 +7,10 @@ export type GenerateMode = "query" | "tap" | "edit" | "expand";
 // scale-level: component = -1, peer = 0, container = +1.
 export type ScaleKind = "component" | "peer" | "container";
 
+// How a node relates to its parent: "descend" = went IN (a tap child, the
+// default), "expand" = bloomed OUT (a neighbour from mode:"expand").
+export type NodeRelation = "descend" | "expand";
+
 export type ImageTier = "fast" | "balanced" | "pro";
 
 export type VideoTier = "fast" | "balanced" | "pro";

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -185,6 +185,7 @@ export interface GenerateNeighborEvent {
   page_title: string;
   image_data_url: string;
   image_model: string;
+  prompt_author_model: string;
   final_prompt: string;
   session_id: string;
   // Position within this bloom + how many were proposed, for tray ordering


### PR DESCRIPTION
Draft — **Phase 1 of the scale-space world map** (M3): the *expand outward* bloom. Tap goes IN (deeper into a subject); expand blooms OUT — proposes ~4 neighbouring subjects across scales and generates their pages, so the session graph grows laterally, not just by descent. Every node now carries a VLM-graded `scale` (component/peer/container) so the atlas can become a level-of-detail map in Phases 2–3.

Branches off `main`. All additive, back-compat — **tap/query/edit behaviour is unchanged**.

## What's in it

**Backend**
- `scale` on `ClickResolution` — the click VLM tags every tap-child's size vs its parent (+ the prompt/schema for it), so the scale-space is complete, not just expand nodes.
- `propose_neighbors` planner — surveys a page's focal subject for up to ~4 neighbours across scales, each a good next page. Built on M1's `_complete_json` ladder, so it degrades gracefully on weak models for free. Typed `Neighbor`, schema, tolerant coercer (drops empties/dupes, defaults bad scale to `peer`, caps at N).
- `generate.py` `mode=="expand"` branch — propose → generate the neighbour pages **concurrently** → stream one `neighbor` event per page as it lands, then `expand_done`. Self-contained (returns like `edit`); per-neighbour failures are logged + skipped; client disconnect cancels in-flight pages so we don't burn fal credits.

**Frontend**
- Wire types: `"expand"` mode, `ScaleKind`, `NodeRelation`, `GenerateNeighborEvent` / `GenerateExpandDoneEvent`.
- `relation`/`scale` persisted on every node (`PersistBody → /api/nodes → db.ts`), additive + defaulted (`descend`/`peer`) so pre-M3 rows stay valid.
- `/play`: an Expand button (next to Edit/Codex) + the `E` hotkey fire a self-contained `runExpand` (its own fetch + SSE loop, so `generate()` is untouched). Neighbours stream into the scale-aware **NeighbourTray** (card width + chip colour encode scale), persist as `relation:"expand"` children, and click-to-open the permalink.

## Verification

- Backend: new unit tests for scale coercion + `propose_neighbors` parsing/dedupe/cap; `generate.py` py_compile + ruff + mypy clean; full backend suite green.
- Frontend: typecheck clean, **248** web tests (incl. the `E` binding), lint 0 errors; the tray was screenshot-checked against the dev server.
- **Not** live-smoked: the real bloom (VLM neighbours + N concurrent image-gens streaming) needs keys. Every unit is tested; the end-to-end stream is the manual check.

## Scope

Phase 1 of 3. **Phase 2** = the atlas sizes + places nodes by scale (the gradient). **Phase 3** = zoom-reveal level-of-detail (small stuff when you zoom in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
