### PR TITLE
feat(atlas): scale-space world map — gradient layout + LOD zoom-reveal (M3 P2+P3)

### DIFF
--- a/apps/web/app/atlas/[sessionId]/page.tsx
+++ b/apps/web/app/atlas/[sessionId]/page.tsx
@@ -151,6 +151,8 @@ export default async function AtlasPage({ params }: AtlasPageProps) {
     createdAt: row.created_at,
     imageModel: row.image_model,
     promptAuthorModel: row.prompt_author_model,
+    relation: row.relation,
+    scale: row.scale,
   }));
 
   // Hydrate the world-memory registry for the entity-pin overlay. Best-

--- a/apps/web/components/atlas-view.lod.test.tsx
+++ b/apps/web/components/atlas-view.lod.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+
+import AtlasView, { type AtlasNode } from "./atlas-view";
+
+/**
+ * M3 phase 3 — LOD level composition. The atlas walks the tree assigning each
+ * node an absolute scale-level (parent's level + the child's scale step), which
+ * is what the zoom-reveal band maps onto. The band math itself lives in
+ * world-layout.lod.test.ts; this proves the per-node level is composed and
+ * threaded into the rendered tree. Camera-independent (happy-dom has no
+ * layout), so it's stable.
+ */
+
+function node(partial: Partial<AtlasNode> & { id: string }): AtlasNode {
+  return {
+    parentId: null,
+    title: partial.id,
+    query: partial.id,
+    imageUrl: "",
+    clickInParent: null,
+    createdAt: "2026-06-01T00:00:00.000Z",
+    imageModel: "test",
+    promptAuthorModel: "test",
+    ...partial,
+  } as AtlasNode;
+}
+
+function levelOf(container: HTMLElement, nodeId: string): number {
+  const el = container.querySelector<HTMLElement>(`[data-node-id="${nodeId}"]`);
+  if (!el) throw new Error(`no tile for ${nodeId}`);
+  return Number(el.dataset.scaleLevel);
+}
+
+describe("AtlasView LOD scale-levels (M3 phase 3)", () => {
+  it("composes absolute scale-levels down the tree (container +1, component -1 per hop)", () => {
+    const click = { xPct: 0.5, yPct: 0.5 };
+    const nodes: AtlasNode[] = [
+      node({ id: "root" }), // 0
+      node({ id: "down", parentId: "root", relation: "descend", scale: "component", clickInParent: { xPct: 0.3, yPct: 0.5 } }), // -1
+      node({ id: "out", parentId: "root", relation: "expand", scale: "container", clickInParent: { xPct: 0.7, yPct: 0.5 } }), // +1
+      node({ id: "deep", parentId: "down", relation: "descend", scale: "component", clickInParent: click }), // -2
+    ];
+    const { container } = render(
+      <AtlasView sessionId="s1" nodes={nodes} latestNodeId="deep" rootTitle="root" />,
+    );
+    expect(levelOf(container, "root")).toBe(0);
+    expect(levelOf(container, "down")).toBe(-1);
+    expect(levelOf(container, "out")).toBe(1);
+    expect(levelOf(container, "deep")).toBe(-2);
+  });
+
+  it("treats scale-less nodes as level 0 (back-compat)", () => {
+    const nodes: AtlasNode[] = [
+      node({ id: "root" }),
+      node({ id: "kid", parentId: "root", clickInParent: { xPct: 0.5, yPct: 0.5 } }),
+    ];
+    const { container } = render(
+      <AtlasView sessionId="s1" nodes={nodes} latestNodeId="kid" rootTitle="root" />,
+    );
+    expect(levelOf(container, "root")).toBe(0);
+    expect(levelOf(container, "kid")).toBe(0);
+  });
+});

--- a/apps/web/components/atlas-view.scale.test.tsx
+++ b/apps/web/components/atlas-view.scale.test.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+
+import AtlasView, { type AtlasNode } from "./atlas-view";
+
+/**
+ * M3 phase 2 — the scale-space data path through the atlas. These prove the
+ * threading NodeRow→AtlasNode→LayoutInput→render carries `relation`/`scale`
+ * end to end, and that an expand (breadth) edge renders distinctly from a
+ * descend (depth) edge. The layout *math* is covered by
+ * world-layout.scale.test.ts; this is the wiring + rendering contract.
+ */
+
+function node(partial: Partial<AtlasNode> & { id: string }): AtlasNode {
+  return {
+    parentId: null,
+    title: partial.id,
+    query: partial.id,
+    imageUrl: "",
+    clickInParent: null,
+    createdAt: "2026-06-01T00:00:00.000Z",
+    imageModel: "test",
+    promptAuthorModel: "test",
+    ...partial,
+  } as AtlasNode;
+}
+
+function tileWidth(container: HTMLElement, nodeId: string): number {
+  const el = container.querySelector<HTMLElement>(`[data-node-id="${nodeId}"]`);
+  if (!el) throw new Error(`no tile for ${nodeId}`);
+  return parseFloat(el.style.width);
+}
+
+describe("AtlasView scale-space rendering (M3 phase 2)", () => {
+  it("tags each connector with the child's relation so expand reads distinctly from descend", () => {
+    const nodes: AtlasNode[] = [
+      node({ id: "root" }),
+      node({
+        id: "down",
+        parentId: "root",
+        relation: "descend",
+        scale: "peer",
+        clickInParent: { xPct: 0.3, yPct: 0.5 },
+      }),
+      node({
+        id: "out",
+        parentId: "root",
+        relation: "expand",
+        scale: "container",
+        clickInParent: { xPct: 0.7, yPct: 0.5 },
+      }),
+    ];
+    const { container } = render(
+      <AtlasView sessionId="s1" nodes={nodes} latestNodeId="out" rootTitle="root" />,
+    );
+    expect(container.querySelector('[data-relation="expand"]')).not.toBeNull();
+    expect(container.querySelector('[data-relation="descend"]')).not.toBeNull();
+  });
+
+  it("sizes tiles by the node's scale — a container expand-neighbour looms larger than a peer", () => {
+    const nodes: AtlasNode[] = [
+      node({ id: "root" }),
+      node({
+        id: "peer",
+        parentId: "root",
+        relation: "expand",
+        scale: "peer",
+        clickInParent: { xPct: 0.3, yPct: 0.5 },
+      }),
+      node({
+        id: "big",
+        parentId: "root",
+        relation: "expand",
+        scale: "container",
+        clickInParent: { xPct: 0.7, yPct: 0.5 },
+      }),
+    ];
+    const { container } = render(
+      <AtlasView sessionId="s1" nodes={nodes} latestNodeId="big" rootTitle="root" />,
+    );
+    expect(tileWidth(container, "big")).toBeGreaterThan(tileWidth(container, "peer"));
+  });
+});

--- a/apps/web/components/atlas-view.tsx
+++ b/apps/web/components/atlas-view.tsx
@@ -20,6 +20,7 @@ import {
   type LayoutInput,
 } from "@/lib/world-layout";
 import HeatmapOverlay from "@/components/heatmap-overlay";
+import type { NodeRelation, ScaleKind } from "@openflipbook/config";
 
 export interface AtlasNode {
   id: string;
@@ -31,6 +32,11 @@ export interface AtlasNode {
   createdAt: string;
   imageModel: string;
   promptAuthorModel: string;
+  // M3 scale-space: "descend" = tapped-in child (depth), "expand" = bloomed
+  // neighbour (breadth); scale sizes the tile. Optional so pre-M3 sessions and
+  // the existing fixtures render unchanged (default descend/peer).
+  relation?: NodeRelation;
+  scale?: ScaleKind;
 }
 
 interface AtlasViewProps {
@@ -132,6 +138,8 @@ export default function AtlasView({
         imageDataUrl: n.imageUrl,
         title: n.title,
         ...(n.clickInParent ? { clickInParent: n.clickInParent } : {}),
+        ...(n.relation ? { relation: n.relation } : {}),
+        ...(n.scale ? { scale: n.scale } : {}),
       })),
     [nodes]
   );
@@ -431,20 +439,43 @@ export default function AtlasView({
                 >
                   <path d="M0,0 L10,5 L0,10 z" fill="rgba(15,15,15,0.55)" />
                 </marker>
+                <marker
+                  id="ofb-atlas-arrow-expand"
+                  viewBox="0 0 10 10"
+                  refX="9"
+                  refY="5"
+                  markerWidth="6"
+                  markerHeight="6"
+                  orient="auto-start-reverse"
+                >
+                  <path d="M0,0 L10,5 L0,10 z" fill="rgba(13,148,136,0.7)" />
+                </marker>
               </defs>
               {connectors.map((c) => {
                 const childDepth = depthById.get(c.toNodeId) ?? 0;
                 const delay = reduced ? 0 : childDepth * STAGGER_MS;
+                // Breadth (expand) edges read in teal with a hollow anchor —
+                // no tap happened, the world bloomed outward. Depth (descend)
+                // edges keep the ink line + red tap dot.
+                const isExpand =
+                  (byId.get(c.toNodeId)?.relation ?? "descend") === "expand";
                 return (
-                  <g key={c.fromNodeId + "->" + c.toNodeId}>
+                  <g
+                    key={c.fromNodeId + "->" + c.toNodeId}
+                    data-relation={isExpand ? "expand" : "descend"}
+                  >
                     <path
                       d={arcPath(c.from, c.to)}
                       fill="none"
-                      stroke="rgba(15,15,15,0.55)"
+                      stroke={isExpand ? "rgba(13,148,136,0.6)" : "rgba(15,15,15,0.55)"}
                       strokeWidth={8}
                       strokeLinecap="round"
                       strokeDasharray="2 22"
-                      markerEnd="url(#ofb-atlas-arrow)"
+                      markerEnd={
+                        isExpand
+                          ? "url(#ofb-atlas-arrow-expand)"
+                          : "url(#ofb-atlas-arrow)"
+                      }
                       className={reduced ? undefined : "ofb-edge-draw ofb-edge-flow"}
                       style={
                         reduced
@@ -456,8 +487,8 @@ export default function AtlasView({
                       cx={c.from.x}
                       cy={c.from.y}
                       r={14}
-                      fill="rgba(239,68,68,0.85)"
-                      stroke="white"
+                      fill={isExpand ? "none" : "rgba(239,68,68,0.85)"}
+                      stroke={isExpand ? "rgba(13,148,136,0.85)" : "white"}
                       strokeWidth={4}
                       className={reduced ? undefined : "ofb-edge-draw"}
                       style={
@@ -479,10 +510,13 @@ export default function AtlasView({
             const depth = depthById.get(p.nodeId) ?? 0;
             const delay = reduced ? 0 : depth * STAGGER_MS;
             const tint = depthTint(depth);
+            const isExpand = (p.relation ?? "descend") === "expand";
             return (
               <div
                 key={p.nodeId}
                 data-tile="1"
+                data-node-id={p.nodeId}
+                data-relation={isExpand ? "expand" : "descend"}
                 className={
                   "absolute overflow-visible " +
                   (reduced ? "" : "ofb-tile-in")
@@ -525,7 +559,9 @@ export default function AtlasView({
                   style={{
                     borderColor: isFocused
                       ? "rgba(239, 68, 68, 0.95)"
-                      : "rgba(0,0,0,0.2)",
+                      : isExpand
+                        ? "rgba(13,148,136,0.45)"
+                        : "rgba(0,0,0,0.2)",
                     borderWidth: isFocused ? 6 : 2,
                     filter: `saturate(${tint.saturation})`,
                     opacity: isFocused ? 1 : tint.opacity,
@@ -580,8 +616,9 @@ export default function AtlasView({
                     <div className="text-xs uppercase tracking-wide opacity-50">
                       depth {depth}
                       {p.parentId
-                        ? ` · child of ${truncate(byId.get(p.parentId)?.title ?? "?", 40)}`
+                        ? ` · ${isExpand ? "expanded from" : "child of"} ${truncate(byId.get(p.parentId)?.title ?? "?", 40)}`
                         : " · root"}
+                      {p.scale && p.scale !== "peer" ? ` · ${p.scale}` : ""}
                     </div>
                     <div className="mt-1 font-display text-base font-bold leading-tight">
                       {node.title}

--- a/apps/web/components/atlas-view.tsx
+++ b/apps/web/components/atlas-view.tsx
@@ -15,6 +15,8 @@ import {
   fitAllCamera,
   fitCamera,
   layoutPages,
+  lodOpacity,
+  scaleStep,
   type Connector,
   type LaidOutPage,
   type LayoutInput,
@@ -163,49 +165,77 @@ export default function AtlasView({
     return m;
   }, [entities]);
 
-  const { laid, connectors, depthById, byId } = useMemo<{
-    laid: LaidOutPage[];
-    connectors: Connector[];
-    depthById: Map<string, number>;
-    byId: Map<string, AtlasNode>;
-  }>(() => {
-    const result = layoutPages(layoutInputs);
-    const m = new Map<string, AtlasNode>();
-    for (const n of nodes) m.set(n.id, n);
-    // BFS depth from each root, used for stagger order on reveal.
-    const depth = new Map<string, number>();
-    const queue: { id: string; d: number }[] = [];
-    for (const n of nodes) if (n.parentId == null) queue.push({ id: n.id, d: 0 });
-    const childrenOf = new Map<string, string[]>();
-    for (const n of nodes) {
-      if (!n.parentId) continue;
-      const arr = childrenOf.get(n.parentId) ?? [];
-      arr.push(n.id);
-      childrenOf.set(n.parentId, arr);
-    }
-    while (queue.length) {
-      const { id, d } = queue.shift()!;
-      if (depth.has(id)) continue;
-      depth.set(id, d);
-      for (const child of childrenOf.get(id) ?? []) {
-        queue.push({ id: child, d: d + 1 });
+  const { laid, connectors, depthById, scaleLevelById, lodActive, byId } =
+    useMemo<{
+      laid: LaidOutPage[];
+      connectors: Connector[];
+      depthById: Map<string, number>;
+      scaleLevelById: Map<string, number>;
+      lodActive: boolean;
+      byId: Map<string, AtlasNode>;
+    }>(() => {
+      const result = layoutPages(layoutInputs);
+      const m = new Map<string, AtlasNode>();
+      for (const n of nodes) m.set(n.id, n);
+      // One BFS computes both depth (stagger order) and absolute scale-level
+      // (parent's level + this node's scale step) — the level the LOD band
+      // maps onto.
+      const depth = new Map<string, number>();
+      const level = new Map<string, number>();
+      const queue: { id: string; d: number; lvl: number }[] = [];
+      for (const n of nodes)
+        if (n.parentId == null) queue.push({ id: n.id, d: 0, lvl: 0 });
+      const childrenOf = new Map<string, string[]>();
+      for (const n of nodes) {
+        if (!n.parentId) continue;
+        const arr = childrenOf.get(n.parentId) ?? [];
+        arr.push(n.id);
+        childrenOf.set(n.parentId, arr);
       }
-    }
-    // Orphans (parent_id pointed outside this session) — give them their own
-    // depth bucket starting after the deepest known one.
-    let maxD = 0;
-    for (const v of depth.values()) if (v > maxD) maxD = v;
-    let orphanD = maxD + 1;
-    for (const n of nodes) {
-      if (!depth.has(n.id)) depth.set(n.id, orphanD++);
-    }
-    return {
-      laid: result.pages,
-      connectors: result.connectors,
-      depthById: depth,
-      byId: m,
-    };
-  }, [layoutInputs, nodes]);
+      while (queue.length) {
+        const { id, d, lvl } = queue.shift()!;
+        if (depth.has(id)) continue;
+        depth.set(id, d);
+        level.set(id, lvl);
+        for (const child of childrenOf.get(id) ?? []) {
+          queue.push({
+            id: child,
+            d: d + 1,
+            lvl: lvl + scaleStep(m.get(child)?.scale),
+          });
+        }
+      }
+      // Orphans (parent_id pointed outside this session) — give them their own
+      // depth bucket starting after the deepest known one, scale-level 0.
+      let maxD = 0;
+      for (const v of depth.values()) if (v > maxD) maxD = v;
+      let orphanD = maxD + 1;
+      for (const n of nodes) {
+        if (!depth.has(n.id)) {
+          depth.set(n.id, orphanD++);
+          level.set(n.id, 0);
+        }
+      }
+      // LOD only kicks in when the session actually spans multiple scale
+      // levels; an all-peer (pre-M3) session stays uniformly visible.
+      const active = new Set(level.values()).size > 1;
+      return {
+        laid: result.pages,
+        connectors: result.connectors,
+        depthById: depth,
+        scaleLevelById: level,
+        lodActive: active,
+        byId: m,
+      };
+    }, [layoutInputs, nodes]);
+
+  // Fit-all zoom is the reference the LOD bands are centred on (peers peak
+  // here). Recomputed when the map or viewport changes.
+  const fitZoom = useMemo(
+    () => fitAllCamera(laid, viewport.w, viewport.h).zoom,
+    [laid, viewport.w, viewport.h]
+  );
+  const lodOn = lodActive && fitZoom > 0 && Number.isFinite(fitZoom);
 
   useLayoutEffect(() => {
     const el = containerRef.current;
@@ -459,10 +489,20 @@ export default function AtlasView({
                 // edges keep the ink line + red tap dot.
                 const isExpand =
                   (byId.get(c.toNodeId)?.relation ?? "descend") === "expand";
+                // Fade an edge with the node it points at, so it reveals/hides
+                // in lockstep with the LOD band.
+                const lod = lodOn
+                  ? lodOpacity(
+                      scaleLevelById.get(c.toNodeId) ?? 0,
+                      camera.zoom,
+                      fitZoom
+                    )
+                  : 1;
                 return (
                   <g
                     key={c.fromNodeId + "->" + c.toNodeId}
                     data-relation={isExpand ? "expand" : "descend"}
+                    opacity={lod}
                   >
                     <path
                       d={arcPath(c.from, c.to)}
@@ -511,12 +551,17 @@ export default function AtlasView({
             const delay = reduced ? 0 : depth * STAGGER_MS;
             const tint = depthTint(depth);
             const isExpand = (p.relation ?? "descend") === "expand";
+            const scaleLevel = scaleLevelById.get(p.nodeId) ?? 0;
+            const lodFactor = lodOn
+              ? lodOpacity(scaleLevel, camera.zoom, fitZoom)
+              : 1;
             return (
               <div
                 key={p.nodeId}
                 data-tile="1"
                 data-node-id={p.nodeId}
                 data-relation={isExpand ? "expand" : "descend"}
+                data-scale-level={scaleLevel}
                 className={
                   "absolute overflow-visible " +
                   (reduced ? "" : "ofb-tile-in")
@@ -564,7 +609,7 @@ export default function AtlasView({
                         : "rgba(0,0,0,0.2)",
                     borderWidth: isFocused ? 6 : 2,
                     filter: `saturate(${tint.saturation})`,
-                    opacity: isFocused ? 1 : tint.opacity,
+                    opacity: isFocused ? 1 : tint.opacity * lodFactor,
                   }}
                   title={`${p.title} — click to open · shift-click to focus`}
                 >

--- a/apps/web/lib/world-layout.lod.test.ts
+++ b/apps/web/lib/world-layout.lod.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { lodOpacity, scaleStep } from "./world-layout";
+
+/**
+ * M3 phase 3 — level-of-detail zoom reveal. `scaleStep` composes the scale
+ * buckets into an integer ladder; `lodOpacity` maps (scale-level, camera zoom)
+ * to a visibility factor so small things reveal when you zoom in and big
+ * things when you zoom out. Pure functions so the band math is regression-
+ * tested without rendering the atlas.
+ */
+
+describe("scaleStep — scale buckets compose into an integer ladder", () => {
+  it("maps container/peer/component to +1/0/-1, defaulting to 0", () => {
+    expect(scaleStep("container")).toBe(1);
+    expect(scaleStep("peer")).toBe(0);
+    expect(scaleStep("component")).toBe(-1);
+    expect(scaleStep(undefined)).toBe(0); // scale-less = peer (back-compat)
+  });
+});
+
+describe("lodOpacity — zoom-reveal band", () => {
+  const FIT = 0.1; // arbitrary fit-all reference zoom
+
+  it("shows a peer (level 0) fully at the fit-all zoom", () => {
+    expect(lodOpacity(0, FIT, FIT)).toBe(1);
+  });
+
+  it("reveals containers (level +1) when zoomed OUT, fades them when zoomed IN", () => {
+    const zoomedOut = lodOpacity(1, FIT / 4, FIT);
+    const zoomedIn = lodOpacity(1, FIT * 4, FIT);
+    expect(zoomedOut).toBeGreaterThan(zoomedIn);
+  });
+
+  it("reveals components (level -1) when zoomed IN, fades them when zoomed OUT", () => {
+    const zoomedIn = lodOpacity(-1, FIT * 4, FIT);
+    const zoomedOut = lodOpacity(-1, FIT / 4, FIT);
+    expect(zoomedIn).toBeGreaterThan(zoomedOut);
+  });
+
+  it("never fully hides a node (keeps a legible floor) and never exceeds 1", () => {
+    const wayOutOfBand = lodOpacity(3, FIT * 64, FIT);
+    expect(wayOutOfBand).toBeGreaterThan(0);
+    expect(wayOutOfBand).toBeLessThan(0.3);
+    expect(lodOpacity(0, FIT, FIT)).toBeLessThanOrEqual(1);
+  });
+});

--- a/apps/web/lib/world-layout.scale.test.ts
+++ b/apps/web/lib/world-layout.scale.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { layoutPages, type LayoutInput } from "./world-layout";
+
+const PAGE_W = 1600;
+const PAGE_H = 900;
+
+type Rect = { x: number; y: number; w: number; h: number };
+
+function rectOf(pages: ReturnType<typeof layoutPages>["pages"], id: string): Rect {
+  const p = pages.find((q) => q.nodeId === id);
+  if (!p) throw new Error(`no node ${id}`);
+  return p.rect;
+}
+
+function distFromParent(parent: Rect, child: Rect): number {
+  return Math.hypot(
+    child.x + child.w / 2 - (parent.x + parent.w / 2),
+    child.y + child.h / 2 - (parent.y + parent.h / 2),
+  );
+}
+
+function kid(nodeId: string, scale?: "component" | "peer" | "container"): LayoutInput {
+  return {
+    nodeId,
+    parentId: "root",
+    imageDataUrl: null,
+    title: nodeId,
+    clickInParent: { xPct: 0.5, yPct: 0.5 },
+    ...(scale ? { scale } : {}),
+  };
+}
+
+const ROOT: LayoutInput = {
+  nodeId: "root",
+  parentId: null,
+  imageDataUrl: null,
+  title: "root",
+};
+
+describe("world-layout scale gradient (M3 phase 2)", () => {
+  it("sizes child rects by scale — container > peer > component, aspect preserved", () => {
+    const { pages } = layoutPages([
+      ROOT,
+      kid("big", "container"),
+      kid("mid", "peer"),
+      kid("small", "component"),
+    ]);
+    expect(rectOf(pages, "mid").w).toBe(PAGE_W); // peer = default
+    expect(rectOf(pages, "big").w).toBeGreaterThan(PAGE_W);
+    expect(rectOf(pages, "small").w).toBeLessThan(PAGE_W);
+    const b = rectOf(pages, "big");
+    expect(b.w / b.h).toBeCloseTo(PAGE_W / PAGE_H, 5); // aspect ratio kept
+  });
+
+  it("places bigger-scale children farther from the parent than smaller ones", () => {
+    const { pages } = layoutPages([
+      ROOT,
+      kid("big", "container"),
+      kid("small", "component"),
+    ]);
+    const root = rectOf(pages, "root");
+    expect(distFromParent(root, rectOf(pages, "big"))).toBeGreaterThan(
+      distFromParent(root, rectOf(pages, "small")),
+    );
+  });
+
+  it("leaves scale-less children at the exact default size (back-compat)", () => {
+    const { pages } = layoutPages([ROOT, kid("plain")]);
+    expect(rectOf(pages, "plain").w).toBe(PAGE_W);
+    expect(rectOf(pages, "plain").h).toBe(PAGE_H);
+  });
+});

--- a/apps/web/lib/world-layout.ts
+++ b/apps/web/lib/world-layout.ts
@@ -291,6 +291,44 @@ export function depthTint(depth: number): { saturation: number; opacity: number 
 }
 
 /**
+ * Scale bucket → integer step on the scale ladder, relative to the parent.
+ * A container is one level *up* (bigger / zoom-out), a component one level
+ * *down* (smaller / zoom-in), a peer/scale-less node stays level (0). BFS over
+ * the tree (parentLevel + scaleStep(child)) yields each node's absolute level.
+ */
+export function scaleStep(scale?: ScaleKind): number {
+  if (scale === "container") return 1;
+  if (scale === "component") return -1;
+  return 0;
+}
+
+/**
+ * Level-of-detail visibility for a node at absolute `scaleLevel`, given the
+ * camera `zoom` and the map's fit-all `fitZoom`. Each scale-level owns a band
+ * of zoom (measured in octaves = log2 zoom ratio): bigger things (higher
+ * level) are centred when zoomed *out*, smaller things (lower level) when
+ * zoomed *in*. Inside the band → fully visible (1); outside it fades linearly
+ * to a floor so a node never vanishes entirely (the map stays legible). Peers
+ * (level 0) peak at the fit-all zoom. This is the "small stuff reveals when
+ * you zoom in" payoff; callers gate it off when a session has no scale spread.
+ */
+export function lodOpacity(
+  scaleLevel: number,
+  zoom: number,
+  fitZoom: number
+): number {
+  const SPREAD = 1.4; // octaves of zoom per scale-level
+  const BAND = 1.2; // half-width of the full-opacity plateau (octaves)
+  const FEATHER = 1.6; // fade distance beyond the band (octaves)
+  const FLOOR = 0.12; // never fully hide — keep the map readable
+  const octave = Math.log2(Math.max(zoom, 1e-6) / Math.max(fitZoom, 1e-6));
+  const center = -SPREAD * scaleLevel;
+  const dist = Math.abs(octave - center);
+  if (dist <= BAND) return 1;
+  return Math.max(FLOOR, 1 - (dist - BAND) / FEATHER);
+}
+
+/**
  * Compute camera (cx, cy, zoom) that fits `rect` in a viewport of size
  * (vw, vh) with `padding` fraction of slack (0.1 = 10% margin around).
  */

--- a/apps/web/lib/world-layout.ts
+++ b/apps/web/lib/world-layout.ts
@@ -1,3 +1,5 @@
+import type { NodeRelation, ScaleKind } from "@openflipbook/config";
+
 export interface WorldRect {
   x: number;
   y: number;
@@ -13,6 +15,10 @@ export interface LaidOutPage {
   parentId: string | null;
   /** World-coord point on the parent's rect where the user clicked. Null for roots. */
   parentClickPoint: { x: number; y: number } | null;
+  /** M3 scale-space: how this node relates to its parent + its relative size,
+   *  so the atlas can render expand-neighbours / scale distinctly. */
+  relation?: NodeRelation;
+  scale?: ScaleKind;
 }
 
 export interface Connector {
@@ -30,6 +36,8 @@ export interface LayoutInput {
   imageDataUrl: string | null;
   title: string;
   clickInParent?: { xPct: number; yPct: number };
+  relation?: NodeRelation;
+  scale?: ScaleKind;
 }
 
 export interface LayoutResult {
@@ -41,6 +49,22 @@ const PAGE_W = 1600;
 const PAGE_H = 900;
 const GAP = 280;
 const ROOT_GAP = 600;
+
+/** Rect size relative to a peer/default node — containers loom larger, parts
+ *  shrink. `undefined`/`peer` returns 1.0 so scale-less nodes are unchanged. */
+function sizeFactor(scale?: ScaleKind): number {
+  if (scale === "container") return 1.5;
+  if (scale === "component") return 0.6;
+  return 1.0;
+}
+
+/** Multiplier on the parent→child radius — bigger things sit farther out
+ *  (pan out to reach), smaller things nearer (zoom in). 1.0 for peer/default. */
+function radiusBias(scale?: ScaleKind): number {
+  if (scale === "container") return 1.5;
+  if (scale === "component") return 0.85;
+  return 1.0;
+}
 
 /**
  * Lay pages out as a branching land. Each child sits outside its parent
@@ -85,12 +109,14 @@ export function layoutPages(pages: LayoutInput[]): LayoutResult {
               y: parentRect.y + page.clickInParent.yPct * parentRect.h,
             }
           : null,
+      ...(page.relation ? { relation: page.relation } : {}),
+      ...(page.scale ? { scale: page.scale } : {}),
     });
     placed.push(rect);
 
     const kids = childrenOf.get(page.nodeId) ?? [];
     for (const kid of kids) {
-      const kidRect = positionChild(rect, kid.clickInParent, placed);
+      const kidRect = positionChild(rect, kid.clickInParent, placed, kid.scale);
       if (kid.clickInParent) {
         const clickWorld = {
           x: rect.x + kid.clickInParent.xPct * rect.w,
@@ -127,7 +153,8 @@ export function layoutPages(pages: LayoutInput[]): LayoutResult {
 function positionChild(
   parent: WorldRect,
   click: { xPct: number; yPct: number } | undefined,
-  placed: WorldRect[]
+  placed: WorldRect[],
+  scale?: ScaleKind
 ): WorldRect {
   const cx = parent.x + parent.w / 2;
   const cy = parent.y + parent.h / 2;
@@ -146,9 +173,16 @@ function positionChild(
     baseAngle = 0;
   }
 
-  // Distance from parent center to child center: enough that bounding boxes
-  // don't overlap on either axis. Use the larger of the two needed offsets.
-  const radius = Math.hypot(PAGE_W, PAGE_H) * 0.55 + GAP;
+  // Child size from scale: containers loom larger, components shrink.
+  const childW = PAGE_W * sizeFactor(scale);
+  const childH = PAGE_H * sizeFactor(scale);
+  // Distance from parent center to child center. For a peer/default child this
+  // equals the original radius (back-compat); it grows with child size so a
+  // bigger child still clears, and is biased by scale so bigger things sit
+  // farther out and smaller things nearer — the scale gradient.
+  const radius =
+    (Math.hypot(PAGE_W, PAGE_H) + Math.hypot(childW, childH)) * 0.275 * radiusBias(scale) +
+    GAP;
 
   // Try base angle first, then nudge ±15° outward up to ±90° each side.
   const tries = [0, 15, -15, 30, -30, 45, -45, 60, -60, 90, -90, 135, -135, 180];
@@ -157,10 +191,10 @@ function positionChild(
     const ccx = cx + Math.cos(ang) * radius;
     const ccy = cy + Math.sin(ang) * radius;
     const rect: WorldRect = {
-      x: ccx - PAGE_W / 2,
-      y: ccy - PAGE_H / 2,
-      w: PAGE_W,
-      h: PAGE_H,
+      x: ccx - childW / 2,
+      y: ccy - childH / 2,
+      w: childW,
+      h: childH,
     };
     if (!collidesAny(rect, placed)) return rect;
   }
@@ -170,10 +204,10 @@ function positionChild(
   const ccx = cx + Math.cos(ang) * radius * 1.6;
   const ccy = cy + Math.sin(ang) * radius * 1.6;
   return {
-    x: ccx - PAGE_W / 2,
-    y: ccy - PAGE_H / 2,
-    w: PAGE_W,
-    h: PAGE_H,
+    x: ccx - childW / 2,
+    y: ccy - childH / 2,
+    w: childW,
+    h: childH,
   };
 }
 


### PR DESCRIPTION
Completes the **scale-space world map** (M3) — the visualization half, building on the P1 bloom that already ships scale-tagged neighbours (PR #5). Two phases, both **additive + back-compat**: pre-M3 (all-peer) sessions render exactly as before.

## P2 — scale-gradient atlas layout
The atlas becomes a scale-space, not just a tree.
- `world-layout.ts` sizes each child rect and biases its parent→child radius by the VLM-graded `scale`: **container** looms larger + sits farther out, **component** shrinks + sits nearer, **peer**/scale-less is byte-identical to before (the existing 17 layout tests pass untouched).
- `relation`/`scale` thread through the whole data path: `NodeRow → AtlasNode → LayoutInput → LaidOutPage`.
- **Breadth reads distinctly from depth:** expand edges render teal with a hollow anchor (no tap happened — the world bloomed outward); descend edges keep the ink line + red tap dot. Expand tiles get a faint teal ring; the hover popup says "expanded from X" vs "child of X" and surfaces non-peer scale.

## P3 — LOD zoom-reveal
The "small stuff reveals when you zoom in" payoff.
- One BFS composes each node's **absolute scale-level** (parent's level + `scaleStep`: container +1 / peer 0 / component −1) alongside the existing depth pass.
- `lodOpacity(level, zoom, fitZoom)` maps a node onto a **band of zoom** (octaves around the fit-all zoom): bigger things reveal zoomed out, smaller zoomed in, fading to a floor (never fully hidden) outside the band. Tiles + their connectors fade together; the focused node always stays full.
- **Gated:** LOD only engages when a session spans >1 scale-level (and fit-all zoom is finite/positive), so all-peer sessions stay uniformly visible.

## Tests
Pure band/layout math unit-tested without rendering; the atlas wiring tested structurally (camera-independent, so stable under happy-dom's no-layout).
- `world-layout.scale.test.ts` (3) — size gradient, radius gradient, scale-less back-compat
- `world-layout.lod.test.ts` (5) — step ladder, peer-at-fit, container-reveals-out, component-reveals-in, floor/clamp
- `atlas-view.scale.test.tsx` (2) — connector relation tagging, scale-driven tile sizing
- `atlas-view.lod.test.tsx` (2) — scale-level composition down the tree, scale-less = 0 back-compat

Full web suite **272 green**, `tsc --noEmit` clean, lint clean (no new warnings).

## Not in scope
Tap/query/edit/bloom backend untouched. Draft pending a manual atlas eyeball after a live bloom (zoom in/out to watch the LOD reveal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)