### PR TITLE
feat(local): one-command no-cloud demo stack — Minio + Ollama (M4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,29 @@
 # ------------------------------------------------------------------
-# Endless Canvas — BYO keys
-# Copy to .env.local inside apps/web and apps/modal-backend as needed.
+# Endless Canvas — configuration
+#
+# QUICK START (local docker stack): copy this file to `.env`, fill in the two
+# keys below, then `make demo` (or `docker compose up --build`). Everything
+# else — Mongo, blob storage (Minio), URLs — is wired to local containers with
+# working defaults; you don't need to touch it. For a no-cloud LLM too, run
+# `make demo-local` (adds Ollama; then only FAL_KEY is needed). The detailed
+# reference further down is for the non-Docker / hosted (Modal + R2) path —
+# copy those into apps/web/.env.local and apps/modal-backend/.env as needed.
 # ------------------------------------------------------------------
 
 # --- Modal backend ---
+# `make demo` needs FAL_KEY (images) + OPENROUTER_API_KEY (planner/VLM).
+# `make demo-local` runs the LLM on Ollama, so only FAL_KEY is required.
 FAL_KEY=
 OPENROUTER_API_KEY=
+
+# --- Local docker stack (compose) — optional overrides ---
+# Minio (local S3) credentials; also used as the web app's R2 access key/secret.
+# MINIO_ROOT_USER=openflipbook
+# MINIO_ROOT_PASSWORD=openflipbook-local
+# R2_BUCKET=openflipbook
+# Ollama models for `make demo-local` (pulled on first run; multi-GB, CPU-slow).
+# LLM_VLM_MODEL=qwen2.5vl
+# LLM_TEXT_MODEL=qwen2.5
 
 # Planner + click-resolution VLM. Defaults to Gemini 3 Flash (multimodal,
 # 1M ctx, cheap). Override with google/gemini-3-pro-preview for frontier

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+# openflipbook — local demo stack shortcuts.
+#
+#   cp .env.example .env   # add FAL_KEY (+ OPENROUTER_API_KEY)
+#   make demo              # → http://localhost:3000/play
+#
+.PHONY: demo demo-local demo-down demo-clean demo-logs
+
+# Local stores (Mongo + Minio) + backend + web, with cloud AI.
+# Needs FAL_KEY + OPENROUTER_API_KEY in .env (see .env.example).
+demo:
+	docker compose up --build
+
+# Adds Ollama so the planner + click VLM run locally too — only FAL_KEY needed
+# (images stay on fal). First run pulls multi-GB models; CPU-slow.
+demo-local:
+	docker compose -f docker-compose.yml -f docker-compose.local.yml up --build
+
+# Stop + remove containers (keeps the mongo / minio / ollama data volumes).
+demo-down:
+	docker compose -f docker-compose.yml -f docker-compose.local.yml down
+
+# Stop + wipe volumes too — fresh slate (empty DB + blob store + models).
+demo-clean:
+	docker compose -f docker-compose.yml -f docker-compose.local.yml down -v
+
+# Tail logs from the running stack.
+demo-logs:
+	docker compose logs -f --tail=100

--- a/apps/web/lib/env.test.ts
+++ b/apps/web/lib/env.test.ts
@@ -28,6 +28,7 @@ function stubAllEmpty(): void {
 describe("readServerEnv", () => {
   it("returns all configured values when every var is set", () => {
     stubAll("x");
+    vi.stubEnv("R2_ENDPOINT", "x");
     const env = readServerEnv();
     expect(env).toEqual({
       MODAL_API_URL: "x",
@@ -38,6 +39,7 @@ describe("readServerEnv", () => {
       R2_SECRET_ACCESS_KEY: "x",
       R2_BUCKET: "x",
       R2_PUBLIC_BASE_URL: "x",
+      R2_ENDPOINT: "x",
     });
   });
 
@@ -69,6 +71,7 @@ describe("requireR2", () => {
       secretAccessKey: "present",
       bucket: "present",
       publicBaseUrl: "present",
+      endpoint: null,
     });
   });
 
@@ -96,6 +99,42 @@ describe("requireR2", () => {
       }
     });
   }
+});
+
+describe("R2_ENDPOINT seam (M4 local / Minio)", () => {
+  it("readServerEnv surfaces R2_ENDPOINT", () => {
+    vi.stubEnv("R2_ENDPOINT", "http://minio:9000");
+    expect(readServerEnv().R2_ENDPOINT).toBe("http://minio:9000");
+  });
+
+  it("readServerEnv R2_ENDPOINT is null when empty/unset", () => {
+    vi.stubEnv("R2_ENDPOINT", "");
+    expect(readServerEnv().R2_ENDPOINT).toBeNull();
+  });
+
+  it("requireR2 drops the R2_ACCOUNT_ID requirement when an explicit endpoint is set", () => {
+    stubAll("present");
+    vi.stubEnv("R2_ACCOUNT_ID", "");
+    vi.stubEnv("R2_ENDPOINT", "http://minio:9000");
+    const r2 = requireR2(readServerEnv());
+    expect(r2.endpoint).toBe("http://minio:9000");
+    expect(r2.accountId).toBeNull();
+  });
+
+  it("requireR2 still requires R2_ACCOUNT_ID when no endpoint is given", () => {
+    stubAll("present");
+    vi.stubEnv("R2_ACCOUNT_ID", "");
+    vi.stubEnv("R2_ENDPOINT", "");
+    try {
+      requireR2(readServerEnv());
+      throw new Error("expected requireR2 to throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(EnvMissingError);
+      expect((e as Error).message).toBe(
+        "Missing required env vars: R2_ACCOUNT_ID"
+      );
+    }
+  });
 });
 
 describe("requireMongo", () => {

--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -7,6 +7,10 @@ export interface ServerEnv {
   R2_SECRET_ACCESS_KEY: string | null;
   R2_BUCKET: string | null;
   R2_PUBLIC_BASE_URL: string | null;
+  // Explicit S3 endpoint override. Set it to point at a self-hosted, S3-
+  // compatible store (e.g. a local Minio container) instead of Cloudflare R2.
+  // Unset = derive the Cloudflare endpoint from R2_ACCOUNT_ID (today's path).
+  R2_ENDPOINT: string | null;
 }
 
 export function readServerEnv(): ServerEnv {
@@ -19,6 +23,7 @@ export function readServerEnv(): ServerEnv {
     R2_SECRET_ACCESS_KEY: process.env.R2_SECRET_ACCESS_KEY || null,
     R2_BUCKET: process.env.R2_BUCKET || null,
     R2_PUBLIC_BASE_URL: process.env.R2_PUBLIC_BASE_URL || null,
+    R2_ENDPOINT: process.env.R2_ENDPOINT || null,
   };
 }
 
@@ -31,18 +36,21 @@ export class EnvMissingError extends Error {
 
 export function requireR2(env: ServerEnv) {
   const missing: string[] = [];
-  if (!env.R2_ACCOUNT_ID) missing.push("R2_ACCOUNT_ID");
+  // With an explicit endpoint (Minio etc.) the account-id-derived Cloudflare
+  // URL is unused, so the account id is optional; otherwise it's required.
+  if (!env.R2_ENDPOINT && !env.R2_ACCOUNT_ID) missing.push("R2_ACCOUNT_ID");
   if (!env.R2_ACCESS_KEY_ID) missing.push("R2_ACCESS_KEY_ID");
   if (!env.R2_SECRET_ACCESS_KEY) missing.push("R2_SECRET_ACCESS_KEY");
   if (!env.R2_BUCKET) missing.push("R2_BUCKET");
   if (!env.R2_PUBLIC_BASE_URL) missing.push("R2_PUBLIC_BASE_URL");
   if (missing.length) throw new EnvMissingError(missing);
   return {
-    accountId: env.R2_ACCOUNT_ID!,
+    accountId: env.R2_ACCOUNT_ID, // may be null when an endpoint is set
     accessKeyId: env.R2_ACCESS_KEY_ID!,
     secretAccessKey: env.R2_SECRET_ACCESS_KEY!,
     bucket: env.R2_BUCKET!,
     publicBaseUrl: env.R2_PUBLIC_BASE_URL!,
+    endpoint: env.R2_ENDPOINT, // null = derive from accountId
   };
 }
 

--- a/apps/web/lib/r2.test.ts
+++ b/apps/web/lib/r2.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { r2ClientConfig } from "./r2";
+
+/**
+ * M4 — the blob endpoint seam. With no override the client derives the
+ * Cloudflare R2 endpoint from the account id (virtual-host style, today's
+ * behavior). With an explicit endpoint (e.g. a Minio container) it uses that
+ * verbatim and switches to path-style, which Minio requires. Pure config so
+ * it's tested without constructing a network client.
+ */
+
+const creds = { accessKeyId: "ak", secretAccessKey: "sk" };
+
+describe("r2ClientConfig", () => {
+  it("derives the Cloudflare endpoint + virtual-host style when no override is set", () => {
+    const cfg = r2ClientConfig({ ...creds, accountId: "acct123", endpoint: null });
+    expect(cfg.endpoint).toBe("https://acct123.r2.cloudflarestorage.com");
+    expect(cfg.forcePathStyle).toBe(false);
+    expect(cfg.credentials).toEqual(creds);
+    expect(cfg.region).toBe("auto");
+  });
+
+  it("uses the explicit endpoint + path-style (Minio) when one is set", () => {
+    const cfg = r2ClientConfig({
+      ...creds,
+      accountId: null,
+      endpoint: "http://minio:9000",
+    });
+    expect(cfg.endpoint).toBe("http://minio:9000");
+    expect(cfg.forcePathStyle).toBe(true);
+  });
+});

--- a/apps/web/lib/r2.ts
+++ b/apps/web/lib/r2.ts
@@ -3,18 +3,42 @@ import { readServerEnv, requireR2 } from "./env";
 
 let cachedClient: S3Client | null = null;
 
+export interface R2ClientConfig {
+  region: "auto";
+  endpoint: string;
+  forcePathStyle: boolean;
+  credentials: { accessKeyId: string; secretAccessKey: string };
+}
+
+/**
+ * S3Client config from resolved R2 settings. With no `endpoint` override we
+ * derive Cloudflare R2's account-scoped URL and use virtual-host addressing
+ * (today's behavior). With an explicit `endpoint` (e.g. a Minio container) we
+ * use it verbatim and switch to path-style addressing, which Minio needs.
+ * Pure so the endpoint/style decision is unit-tested without a live client.
+ */
+export function r2ClientConfig(r2: {
+  accountId: string | null;
+  accessKeyId: string;
+  secretAccessKey: string;
+  endpoint: string | null;
+}): R2ClientConfig {
+  return {
+    region: "auto",
+    endpoint: r2.endpoint ?? `https://${r2.accountId}.r2.cloudflarestorage.com`,
+    forcePathStyle: Boolean(r2.endpoint),
+    credentials: {
+      accessKeyId: r2.accessKeyId,
+      secretAccessKey: r2.secretAccessKey,
+    },
+  };
+}
+
 function r2Client(): { s3: S3Client; bucket: string; publicBaseUrl: string } {
   const env = readServerEnv();
   const r2 = requireR2(env);
   if (!cachedClient) {
-    cachedClient = new S3Client({
-      region: "auto",
-      endpoint: `https://${r2.accountId}.r2.cloudflarestorage.com`,
-      credentials: {
-        accessKeyId: r2.accessKeyId,
-        secretAccessKey: r2.secretAccessKey,
-      },
-    });
+    cachedClient = new S3Client(r2ClientConfig(r2));
   }
   return {
     s3: cachedClient,

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,63 @@
+# No-cloud LLM override — layer on top of docker-compose.yml to run the
+# planner + click VLM locally via Ollama instead of OpenRouter:
+#
+#   make demo-local
+#   # = docker compose -f docker-compose.yml -f docker-compose.local.yml up --build
+#
+# Only a FAL_KEY is still needed (images stay on fal — there's no local
+# nano-banana equivalent; point IMAGE_PROVIDER at a local OpenAI-images server
+# if you want fully offline, with a quality drop). Honest caveat: small local
+# VLMs ground clicks far worse than Gemini — the backend's capability ladder
+# degrades them to thinner-but-valid output rather than crashing. Fine for a
+# kick-the-tyres demo. Ollama here runs on CPU (slow); add GPU reservations if
+# you have them.
+services:
+  ollama:
+    image: ollama/ollama:latest
+    container_name: openflipbook-ollama
+    restart: unless-stopped
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama-data:/root/.ollama
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # One-shot: pull the VLM + text models, then exit. `backend` waits on it so
+  # the first request doesn't race a cold model download (multi-GB; cached in
+  # the ollama-data volume after the first run).
+  ollama-pull:
+    image: ollama/ollama:latest
+    container_name: openflipbook-ollama-pull
+    depends_on:
+      - ollama
+    environment:
+      OLLAMA_HOST: http://ollama:11434
+      LLM_VLM_MODEL: ${LLM_VLM_MODEL:-qwen2.5vl}
+      LLM_TEXT_MODEL: ${LLM_TEXT_MODEL:-qwen2.5}
+    entrypoint: |
+      /bin/sh -c '
+      until ollama list >/dev/null 2>&1; do echo "waiting for ollama..."; sleep 1; done;
+      ollama pull "$${LLM_VLM_MODEL}";
+      ollama pull "$${LLM_TEXT_MODEL}";
+      echo "ollama models ready";
+      '
+    restart: "no"
+
+  backend:
+    environment:
+      # M1 provider seam: point the OpenAI-compatible client at Ollama.
+      LLM_PROVIDER: custom
+      LLM_BASE_URL: http://ollama:11434/v1
+      LLM_API_KEY: ollama
+      LLM_VLM_MODEL: ${LLM_VLM_MODEL:-qwen2.5vl}
+      LLM_TEXT_MODEL: ${LLM_TEXT_MODEL:-qwen2.5}
+    depends_on:
+      ollama-pull:
+        condition: service_completed_successfully
+
+volumes:
+  ollama-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,15 @@
+# openflipbook — one-command local stack.
+#
+#   cp .env.example .env          # drop in FAL_KEY (+ OPENROUTER_API_KEY)
+#   docker compose up --build     # → http://localhost:3000/play
+#
+# Stores run fully local: Mongo for metadata, Minio (S3-compatible) for image
+# blobs — so no Cloudflare R2 / hosted Mongo to provision. The AI still calls
+# out (OpenRouter for the planner/VLM, fal for images). For a no-cloud LLM too,
+# add the Ollama override:  make demo-local  (see docker-compose.local.yml).
+#
+# Overridable defaults are read from `.env` (compose auto-loads it); the values
+# below are the local-stack fallbacks, so a bare `docker compose up` just works.
 services:
   mongo:
     image: mongo:7
@@ -14,13 +26,58 @@ services:
       timeout: 5s
       retries: 5
 
+  # S3-compatible blob store — the local stand-in for Cloudflare R2. The web
+  # app writes here (R2_ENDPOINT=http://minio:9000) and the browser reads image
+  # URLs from the published port (R2_PUBLIC_BASE_URL=http://localhost:9000/...).
+  minio:
+    image: minio/minio:latest
+    container_name: openflipbook-minio
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-openflipbook}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-openflipbook-local}
+    ports:
+      - "9000:9000" # S3 API (also the browser's image origin)
+      - "9001:9001" # web console
+    volumes:
+      - minio-data:/data
+
+  # One-shot: create the bucket and make it anonymously readable, so the
+  # browser's <img src> GETs aren't 403'd. Retries until Minio answers, then
+  # exits — `web` waits on it completing.
+  minio-setup:
+    image: minio/mc:latest
+    container_name: openflipbook-minio-setup
+    depends_on:
+      - minio
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-openflipbook}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-openflipbook-local}
+      R2_BUCKET: ${R2_BUCKET:-openflipbook}
+    entrypoint: |
+      /bin/sh -c '
+      until mc alias set local http://minio:9000 "$${MINIO_ROOT_USER}" "$${MINIO_ROOT_PASSWORD}"; do
+        echo "waiting for minio..."; sleep 1;
+      done;
+      mc mb --ignore-existing "local/$${R2_BUCKET}";
+      mc anonymous set download "local/$${R2_BUCKET}";
+      echo "minio bucket $${R2_BUCKET} ready";
+      '
+    restart: "no"
+
   backend:
     build:
       context: .
       dockerfile: apps/modal-backend/Dockerfile
     container_name: openflipbook-backend
     restart: unless-stopped
+    # Keys come from the root .env (single-file demo) or, for power users, the
+    # backend's own .env which overrides it. Both optional; neither clobbers
+    # unset keys.
     env_file:
+      - path: .env
+        required: false
       - path: apps/modal-backend/.env
         required: false
     # Force public resolvers — Docker's default 127.0.0.11 link-local resolver
@@ -56,10 +113,16 @@ services:
       PORT: "3000"
       # Backend URL is fixed inside the compose network.
       MODAL_API_URL: http://backend:8787
-      # MONGODB_URI + MONGODB_DB come from apps/web/.env.local.
-      # If you want the local `mongo` service instead, set
-      #   MONGODB_URI=mongodb://mongo:27017
-      # in that file.
+      # Metadata → local Mongo by default.
+      MONGODB_URI: ${MONGODB_URI:-mongodb://mongo:27017}
+      MONGODB_DB: ${MONGODB_DB:-openflipbook}
+      # Blobs → local Minio by default. R2_ENDPOINT makes the S3 client target
+      # Minio (path-style); the public base URL is what the browser fetches.
+      R2_ENDPOINT: ${R2_ENDPOINT:-http://minio:9000}
+      R2_BUCKET: ${R2_BUCKET:-openflipbook}
+      R2_ACCESS_KEY_ID: ${MINIO_ROOT_USER:-openflipbook}
+      R2_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:-openflipbook-local}
+      R2_PUBLIC_BASE_URL: ${R2_PUBLIC_BASE_URL:-http://localhost:9000/openflipbook}
     ports:
       - "3000:3000"
     depends_on:
@@ -67,6 +130,9 @@ services:
         condition: service_healthy
       mongo:
         condition: service_healthy
+      minio-setup:
+        condition: service_completed_successfully
 
 volumes:
   mongo-data:
+  minio-data:

--- a/docs/BYO-KEYS.md
+++ b/docs/BYO-KEYS.md
@@ -1,5 +1,10 @@
 # BYO Keys — running Endless Canvas yourself
 
+> Just want to try it locally? Skip all of this — `cp .env.example .env`, add a
+> `FAL_KEY` (+ `OPENROUTER_API_KEY`), and `make demo`. The Docker stack runs
+> Mongo + blob storage locally so you don't provision R2/Mongo/Modal. See
+> [DOCKER.md](./DOCKER.md). This page is the hosted-production path.
+
 Endless Canvas has no hosted backend. To actually generate pages you need to provide:
 
 1. **OpenRouter API key** — planning + VLM click interpretation + web search.

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,86 +1,108 @@
-# Docker end-to-end
+# Run it locally with Docker
 
-Three-container stack for full local E2E testing.
-
-| Service | Container name | Port | Purpose |
-|---|---|---|---|
-| `mongo` | `openflipbook-mongo` | 27017 | Node metadata (replaces Railway Mongo locally) |
-| `backend` | `openflipbook-backend` | 8787 | Python FastAPI (OpenRouter + fal orchestration) |
-| `web` | `openflipbook-web` | 3000 | Next.js |
-
-The web container reaches the backend via Docker's internal DNS
-(`http://backend:8787`), and reaches mongo via `mongodb://mongo:27017`.
-R2 stays external — keys passed through via `apps/web/.env.local`.
-
-## Prereqs
-
-- Docker 25+ with Compose v2.
-- `apps/modal-backend/.env` with `FAL_KEY` + `OPENROUTER_API_KEY` (copy from `.env.example`).
-- `apps/web/.env.local` with the `R2_*` vars. `MONGODB_*` and `MODAL_API_URL`
-  are injected by compose so you can leave them out (or override).
-
-Both env files are loaded as `required: false`, so compose won't bark if
-they are missing — you'll just get 503s when the app tries to call fal /
-R2.
-
-## Run
+One command brings up the whole stack — web, the Python backend, and **local
+stores** (Mongo for metadata, Minio for image blobs). No Cloudflare R2, no
+hosted Mongo, no Modal deploy to provision.
 
 ```bash
-# one shot: build + up, detached
-docker compose up -d --build
+cp .env.example .env     # add FAL_KEY  (+ OPENROUTER_API_KEY)
+make demo                # → http://localhost:3000/play
+```
 
-# watch logs
-docker compose logs -f
+(`make demo` is just `docker compose up --build`.)
 
-# tear down (keeps mongo volume)
-docker compose down
+## What you need
 
-# nuke everything including mongo data
-docker compose down -v
+| Path | Keys | What runs in the cloud |
+|---|---|---|
+| `make demo` | `FAL_KEY` + `OPENROUTER_API_KEY` | planner/click-VLM (OpenRouter), images (fal) |
+| `make demo-local` | `FAL_KEY` only | images (fal) — the LLM runs locally on Ollama |
+
+Put the keys in the repo-root `.env` (copy `.env.example`). Everything else —
+Mongo URI, Minio credentials, bucket, public URLs — is wired to the local
+containers with working defaults, so you don't have to set anything else.
+
+**The images caveat.** fal is the one piece that stays in the cloud even with
+`make demo-local`: there's no local model that matches nano-banana, so a
+`FAL_KEY` is needed for image generation. Want fully offline? Point the M1 image
+seam at a local OpenAI-Images-compatible server (`IMAGE_PROVIDER=custom` +
+`IMAGE_BASE_URL`, see `docs/BYO-KEYS.md`) — expect a quality drop. And small
+local VLMs ground clicks noticeably worse than Gemini; the backend's capability
+ladder degrades them to thinner-but-valid output instead of crashing. Both are
+fine for kicking the tyres, weaker than the hosted path.
+
+## Services
+
+| Service | Container | Port | Purpose |
+|---|---|---|---|
+| `mongo` | `openflipbook-mongo` | 27017 | node metadata |
+| `minio` | `openflipbook-minio` | 9000 / 9001 | S3-compatible blob store (local R2); 9001 = console |
+| `minio-setup` | `openflipbook-minio-setup` | — | one-shot: creates the bucket + makes it public-readable, then exits |
+| `backend` | `openflipbook-backend` | 8787 | Python FastAPI (off Modal, via `local_server.py`) |
+| `web` | `openflipbook-web` | 3000 | Next.js |
+| `ollama` | `openflipbook-ollama` | 11434 | local LLM/VLM — **only with `make demo-local`** |
+
+The web container writes blobs to Minio over the internal network
+(`R2_ENDPOINT=http://minio:9000`, path-style) and the browser loads image URLs
+from the published port (`R2_PUBLIC_BASE_URL=http://localhost:9000/openflipbook`,
+served anonymously). Both hostnames are intentional: server-write vs
+browser-read.
+
+## Commands
+
+```bash
+make demo          # cloud AI + local stores
+make demo-local    # + Ollama (local LLM), first run pulls multi-GB models (CPU-slow)
+make demo-down     # stop + remove containers (keeps data volumes)
+make demo-clean    # + wipe volumes (fresh DB, blob store, models)
+make demo-logs     # tail logs
 ```
 
 Then open <http://localhost:3000>:
 
-- `/` — landing
-- `/play` — search bar
+- `/play` — start a session
 - `/status` — live env check (green/red per var)
+- Minio console at <http://localhost:9001> (login = `MINIO_ROOT_USER` /
+  `MINIO_ROOT_PASSWORD`, default `openflipbook` / `openflipbook-local`).
 
 ## Overrides
 
-Pass a different image backend or WS URL at `docker compose up` time:
+Everything overridable lives in `.env` (compose auto-loads it). A few examples:
 
 ```bash
-# point web at a Modal-deployed streaming worker instead of the cheap path
-NEXT_PUBLIC_LTX_WS_URL=wss://... docker compose up -d --build
+# different bucket / Minio creds
+R2_BUCKET=demo MINIO_ROOT_PASSWORD=hunter2 make demo
 
-# different mongo db name
-MONGODB_DB=ec_staging docker compose up -d
+# pin different Ollama models
+LLM_VLM_MODEL=llama3.2-vision LLM_TEXT_MODEL=llama3.2 make demo-local
+
+# use a real cloud store instead of Minio: set R2_ENDPOINT to your S3 endpoint
+# (or unset it + provide R2_ACCOUNT_ID for Cloudflare) in .env
 ```
 
-## Rebuild just one service
+Rebuild a single service:
 
 ```bash
-docker compose build web
-docker compose up -d --no-deps web
+docker compose build web && docker compose up -d --no-deps web
 ```
 
 ## Notes
 
-- Next.js uses `output: "standalone"` with `outputFileTracingRoot` pointing
-  at the repo root so pnpm workspace symlinks resolve cleanly inside the
-  image.
-- The backend image is Python 3.12 slim + the same `requirements.txt` used
-  by `local_server.py`.
-- Mongo runs unauthenticated on the internal network. Do NOT expose port
-  27017 publicly.
-- Web container runs as an unprivileged `nextjs` user (uid 1001); backend
-  runs as `backend` (uid 1001) — both have no sudo.
+- Next.js uses `output: "standalone"` with `outputFileTracingRoot` at the repo
+  root so pnpm workspace symlinks resolve inside the image.
+- The backend image is Python 3.12 slim running the same `requirements.txt` as
+  `local_server.py` — the standalone `fastapi_app` from `generate.py`, no Modal.
+- Mongo and Minio run unauthenticated / with demo credentials on the internal
+  network. This is a local demo — don't expose 27017 / 9000 publicly.
+- The Modal deploy stays the production path (`docs/BYO-KEYS.md`); nothing here
+  changes it.
 
 ## Debug
 
 | Symptom | Check |
 |---|---|
-| `docker compose up` hangs at `web Waiting` | Backend or mongo healthcheck failing. `docker compose ps` to see which. |
-| `/play` returns 503 from `/api/generate-page` | Backend can't reach fal/OpenRouter. `docker compose logs backend`. |
-| `/api/nodes` 503 | R2 creds not in `apps/web/.env.local`. |
-| Web container exits immediately | Next.js crash. `docker compose logs web`. |
+| `up` hangs at `web Waiting` | a dependency healthcheck is failing — `docker compose ps`. |
+| images 403 / don't load | `minio-setup` didn't run — `docker compose logs minio-setup`; it must print "bucket … ready". |
+| `/play` 503 from generate | backend can't reach fal/OpenRouter (or Ollama) — `docker compose logs backend`. |
+| `make demo-local` slow / times out first request | models still downloading — `docker compose logs ollama-pull`. |
+| `/api/nodes` 500 | blob upload failed — check `R2_*` in the web service + `docker compose logs minio`. |


### PR DESCRIPTION
**M4 — kill setup friction.** First-run drops from "provision OpenRouter + fal + Modal + R2 + Mongo" to:

```bash
cp .env.example .env   # add FAL_KEY (+ OPENROUTER_API_KEY)
make demo              # → http://localhost:3000/play
```

The compose stack already ran web + local Mongo + the backend off Modal (`local_server.py`). This adds the two missing local pieces so **blobs and the LLM can run locally too** — additive throughout (every new env var unset ⇒ today's behavior; Modal deploy stays the production path).

## Blob storage (additive seam)
- `env.ts`: new `R2_ENDPOINT`; `requireR2` drops the `R2_ACCOUNT_ID` requirement when an explicit endpoint is set (Minio has no account id).
- `r2.ts`: extracted pure `r2ClientConfig` — uses `R2_ENDPOINT` + path-style when set (Minio), else derives today's Cloudflare R2 URL + virtual-host. **Unset ⇒ byte-identical to before.**

## Compose
- `docker-compose.yml`: adds a `minio` (S3-compatible) service + a `minio-setup` one-shot that creates the bucket and makes it anonymously readable (so the browser's `<img src>` GETs work). Web writes to `minio:9000`; the browser reads from the published port. Local-stack defaults via `${VAR:-default}` so a bare `up` works; backend also reads the root `.env` (single-file keys).
- `docker-compose.local.yml`: override adding `ollama` + a model-pull one-shot, pointing the backend at it via M1's `LLM_PROVIDER=custom` seam — so `make demo-local` needs only a `FAL_KEY`.
- `Makefile`: `demo` / `demo-local` / `demo-down` / `demo-clean` / `demo-logs`.
- Docs: `.env.example` quick-start header; `docs/DOCKER.md` rewritten for both flows + the honest images caveat; `BYO-KEYS` cross-link.

## What's local vs cloud
| Path | Keys | Cloud |
|---|---|---|
| `make demo` | FAL_KEY + OPENROUTER_API_KEY | planner/VLM (OpenRouter) + images (fal) |
| `make demo-local` | FAL_KEY only | images (fal) — LLM runs on Ollama |

**Images are the honest holdout:** no local nano-banana equivalent, so a `FAL_KEY` stays unless you point `IMAGE_PROVIDER` at a local OpenAI-Images server (quality drop). Small local VLMs also ground clicks worse than Gemini — the M1 capability ladder degrades them to thinner-but-valid rather than crashing.

## Verification
- Tests: `env.test.ts` (R2_ENDPOINT threading + account-id-optional-with-endpoint + still-required-without) and new `r2.test.ts` (Cloudflare-vs-Minio endpoint + path-style). **266 web green**, `tsc --noEmit` clean, lint clean.
- Both compose files validate + resolve to the intended wiring.
- **Storage layer smoke-booted:** `minio-setup` creates + publicizes the bucket; authenticated upload → anonymous fetch returns 200 + content. (Full web/backend image build + a live generated page not run here — draft pending that end-to-end eyeball.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)