### PR TITLE
feat(play): clarify in-vs-around — rename Expand → Around + teach the pair

### DIFF
--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -44,6 +44,7 @@ import { useTraceEmitter } from "@/hooks/useTraceEmitter";
 import { QueryToolbar } from "@/components/PlayPage/QueryToolbar";
 import { StyleGallery } from "@/components/PlayPage/StyleGallery";
 import { FirstRunCoach } from "@/components/PlayPage/FirstRunCoach";
+import { BloomGlyph } from "@/components/PlayPage/BloomGlyph";
 import { MorphImagePair } from "@/components/PlayPage/MorphImagePair";
 import { StrokeOverlay } from "@/components/PlayPage/StrokeOverlay";
 import { ClickRipple } from "@/components/PlayPage/ClickRipple";
@@ -1835,10 +1836,11 @@ export default function PlayPage() {
                   !page?.imageDataUrl ||
                   (bloom !== null && !bloom.done)
                 }
-                className="rounded-full bg-black/60 px-3 py-1 text-xs text-white hover:bg-black/75 disabled:opacity-50"
-                title="Expand outward (E) — bloom the world around this page"
+                className="flex items-center gap-1.5 rounded-full bg-teal-600/85 px-3 py-1 text-xs text-white hover:bg-teal-600 disabled:opacity-50"
+                title="Look around (E) — bloom the world around this page (vs tap a region to go in)"
               >
-                Expand
+                <BloomGlyph className="h-3.5 w-3.5" />
+                Around
               </button>
               <button
                 type="button"

--- a/apps/web/components/PlayPage/BloomGlyph.tsx
+++ b/apps/web/components/PlayPage/BloomGlyph.tsx
@@ -1,0 +1,22 @@
+/**
+ * The "around" mark: a focal dot ringed by four neighbours — a tiny picture of
+ * what the Around action does (bloom the world around the current page). Shared
+ * by the /play Around button and the coach chip so the breadth move reads the
+ * same everywhere. Inherits `currentColor`.
+ */
+export function BloomGlyph({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      aria-hidden="true"
+      className={className}
+      fill="currentColor"
+    >
+      <circle cx="8" cy="8" r="2.2" />
+      <circle cx="8" cy="2.6" r="1.4" />
+      <circle cx="13.4" cy="8" r="1.4" />
+      <circle cx="8" cy="13.4" r="1.4" />
+      <circle cx="2.6" cy="8" r="1.4" />
+    </svg>
+  );
+}

--- a/apps/web/components/PlayPage/BloomGlyph.tsx
+++ b/apps/web/components/PlayPage/BloomGlyph.tsx
@@ -1,22 +1,14 @@
 /**
- * The "around" mark: a focal dot ringed by four neighbours — a tiny picture of
- * what the Around action does (bloom the world around the current page). Shared
+ * The "around" mark: a focal dot inside a ring — the current page and the world
+ * around it. Reads cleanly at ~14px (a cross of dots looked like a "+"). Shared
  * by the /play Around button and the coach chip so the breadth move reads the
  * same everywhere. Inherits `currentColor`.
  */
 export function BloomGlyph({ className }: { className?: string }) {
   return (
-    <svg
-      viewBox="0 0 16 16"
-      aria-hidden="true"
-      className={className}
-      fill="currentColor"
-    >
-      <circle cx="8" cy="8" r="2.2" />
-      <circle cx="8" cy="2.6" r="1.4" />
-      <circle cx="13.4" cy="8" r="1.4" />
-      <circle cx="8" cy="13.4" r="1.4" />
-      <circle cx="2.6" cy="8" r="1.4" />
+    <svg viewBox="0 0 16 16" aria-hidden="true" className={className} fill="none">
+      <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.4" />
+      <circle cx="8" cy="8" r="2.4" fill="currentColor" />
     </svg>
   );
 }

--- a/apps/web/components/PlayPage/FirstRunCoach.test.tsx
+++ b/apps/web/components/PlayPage/FirstRunCoach.test.tsx
@@ -1,0 +1,26 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { FirstRunCoach } from "./FirstRunCoach";
+
+/**
+ * The coach chip is where a first-timer learns the two generative moves. It
+ * must teach the *pair* — tap goes in (depth), Around blooms outward (breadth)
+ * — not just tapping, which is the gap that made "what does Expand do" unclear.
+ */
+describe("FirstRunCoach", () => {
+  it("teaches both moves: go in (tap) and around (the breadth action)", () => {
+    render(<FirstRunCoach onShowHelp={() => {}} />);
+    const text = document.body.textContent ?? "";
+    expect(/go in/i.test(text)).toBe(true); // the depth move (tap)
+    expect(/around/i.test(text)).toBe(true); // the breadth move
+    expect(screen.getByText("E")).toBeTruthy(); // the Around hotkey is surfaced
+  });
+
+  it("opens help from the ? button", () => {
+    const onShowHelp = vi.fn();
+    render(<FirstRunCoach onShowHelp={onShowHelp} />);
+    fireEvent.click(screen.getByRole("button", { name: /shortcut/i }));
+    expect(onShowHelp).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/components/PlayPage/FirstRunCoach.tsx
+++ b/apps/web/components/PlayPage/FirstRunCoach.tsx
@@ -1,13 +1,16 @@
 "use client";
 
+import { BloomGlyph } from "./BloomGlyph";
+
 interface Props {
   onShowHelp: () => void;
 }
 
 /**
- * Persistent bottom-of-page hint chip. Surfaces the two shortcut keys most
- * people miss without reading docs (`?` for the full help overlay, `T` for
- * the time-scrubber). Stays out of the visual centre — the rendered
+ * Persistent bottom-of-page hint chip. Its job is to teach the two generative
+ * moves as a *pair* — tap a region to go IN (depth), or bloom the world AROUND
+ * the page (breadth, the `E` / Around action). Without this pairing, "what does
+ * Expand do" was a mystery. Stays out of the visual centre — the rendered
  * illustration is what matters.
  */
 export function FirstRunCoach({ onShowHelp }: Props) {
@@ -17,18 +20,28 @@ export function FirstRunCoach({ onShowHelp }: Props) {
       aria-live="polite"
       className="pointer-events-none fixed inset-x-0 bottom-6 z-40 flex justify-center px-4"
     >
-      <div className="pointer-events-auto flex items-center gap-3 rounded-full border border-[var(--color-edge)] bg-[var(--color-canvas)]/95 px-4 py-2 text-sm shadow-lg backdrop-blur">
-        <span className="opacity-80">Tap any region to explore.</span>
+      <div className="pointer-events-auto flex max-w-full items-center gap-2.5 overflow-x-auto rounded-full border border-[var(--color-edge)] bg-[var(--color-canvas)]/95 px-4 py-2 text-sm shadow-lg backdrop-blur">
+        {/* The two moves, side by side, so the in/around duality is obvious. */}
+        <span className="whitespace-nowrap opacity-80">Tap to go in</span>
+        <span className="opacity-40">·</span>
+        <span className="flex items-center gap-1.5 whitespace-nowrap opacity-80">
+          <BloomGlyph className="h-3.5 w-3.5 text-teal-600" />
+          around
+          <kbd className="rounded border border-[var(--color-edge)] px-1 font-mono text-[10px]">
+            E
+          </kbd>
+        </span>
         <span className="opacity-40">·</span>
         <button
           type="button"
+          aria-label="shortcuts"
           onClick={onShowHelp}
           className="rounded-full border border-[var(--color-edge)] px-2 py-0.5 font-mono text-xs hover:bg-[var(--color-ink)]/10"
           title="Show all shortcuts"
         >
           ?
         </button>
-        <span className="opacity-80">shortcuts</span>
+        <span className="whitespace-nowrap opacity-80">shortcuts</span>
         <span className="opacity-40">·</span>
         <span className="font-mono text-xs opacity-80">T</span>
         <span className="opacity-80">scrubber</span>

--- a/apps/web/components/PlayPage/HelpOverlay.tsx
+++ b/apps/web/components/PlayPage/HelpOverlay.tsx
@@ -28,7 +28,7 @@ export function HelpOverlay({ onClose }: Props) {
           <Row k="M" v="Toggle map view" />
           <Row k="T" v="Toggle time-scrubber" />
           <Row k="K" v="Toggle codex" />
-          <Row k="E" v="Expand outward" />
+          <Row k="E" v="Look around (bloom neighbours)" />
           <Row k="/" v="Jump to page…" />
           <Row k="?" v="This help" />
           <Row k="Esc" v="Close overlay" />

--- a/apps/web/components/PlayPage/NeighbourTray.test.tsx
+++ b/apps/web/components/PlayPage/NeighbourTray.test.tsx
@@ -43,17 +43,17 @@ describe("NeighbourTray", () => {
     expect(screen.getByText("part")).toBeTruthy();
   });
 
-  it("shows an 'N of M' progress read while blooming, 'Expanded' when done", () => {
+  it("shows an 'N of M' progress read while blooming, 'Around this page' when done", () => {
     const items = [item({ key: "a" }), item({ key: "b", imageDataUrl: null })];
     const { rerender } = render(
       <NeighbourTray items={items} total={4} done={false} onPick={noop} onClose={noop} />
     );
     // 1 of 2 have images → "1 of 4".
-    expect(screen.getByText(/Expanding outward · 1 of 4/)).toBeTruthy();
+    expect(screen.getByText(/Looking around · 1 of 4/)).toBeTruthy();
     rerender(
       <NeighbourTray items={[item({ key: "a" })]} total={4} done onPick={noop} onClose={noop} />
     );
-    expect(screen.getByText(/Expanded · 1 neighbour/)).toBeTruthy();
+    expect(screen.getByText(/Around this page · 1 neighbour/)).toBeTruthy();
   });
 
   it("hides trailing pending slots once done (no perpetual shimmer on partial failure)", () => {

--- a/apps/web/components/PlayPage/NeighbourTray.tsx
+++ b/apps/web/components/PlayPage/NeighbourTray.tsx
@@ -39,17 +39,17 @@ export default function NeighbourTray({ items, total, done, onPick, onClose }: P
   return (
     <div
       role="region"
-      aria-label="Expanded neighbours"
+      aria-label="Neighbours around this page"
       className="pointer-events-auto fixed bottom-3 left-1/2 z-30 max-w-[min(960px,92vw)] -translate-x-1/2 rounded-2xl border border-[var(--color-ink)]/20 bg-[var(--color-paper)]/95 p-2 shadow-xl backdrop-blur"
     >
       <div className="flex items-center justify-between px-2 pb-1.5 text-[11px] opacity-70">
         <span className="flex items-center gap-1.5">
           {!done && (
-            <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-amber-500" />
+            <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-teal-500" />
           )}
           {done
-            ? `Expanded · ${ready} neighbour${ready === 1 ? "" : "s"} — tap one to explore`
-            : `Expanding outward · ${ready} of ${total}`}
+            ? `Around this page · ${ready} neighbour${ready === 1 ? "" : "s"} — tap one`
+            : `Looking around · ${ready} of ${total}`}
         </span>
         <button
           type="button"
@@ -77,7 +77,7 @@ export default function NeighbourTray({ items, total, done, onPick, onClose }: P
               className={
                 "relative h-16 shrink-0 overflow-hidden rounded-lg border transition disabled:cursor-default " +
                 meta.width +
-                " border-[var(--color-ink)]/20 enabled:hover:border-[var(--color-ink)]/60 enabled:hover:ring-2 enabled:hover:ring-amber-200"
+                " border-[var(--color-ink)]/20 enabled:hover:border-teal-500/70 enabled:hover:ring-2 enabled:hover:ring-teal-300/60"
               }
             >
               {it.imageDataUrl ? (


### PR DESCRIPTION
"What does Expand do" was unclear: the `Expand` pill looked identical to the Codex/Edit utility buttons, "outward" only lived in a tooltip, and the coach chip only taught tapping — so the core idea (**tap goes IN, Around blooms OUT**) was never stated.

Light, additive fix — **tap is untouched**:

| Surface | Before | After |
|---|---|---|
| Top-right button | `Expand` (black, = Codex/Edit) | **`◌ Around`** — teal + bloom glyph, reads as the breadth twin of tapping |
| Coach chip | "Tap any region to explore" | **"Tap to go in · ◌ around (E) · ? shortcuts · T scrubber"** |
| Tray header | "Expanding outward · N of M" / "Expanded · …" | **"Looking around · N of M"** / **"Around this page · N — tap one"** |
| Help (`?`) | `E — Expand outward` | `E — Look around (bloom neighbours)` |

- Teal accent matches the atlas's expand edges (PR #6), so **around = teal** across /play and the map.
- New shared `BloomGlyph` (focal dot ringed by neighbours) on the button + coach.
- Per-card `part/beside/around` scale chips unchanged (they teach scale).

Tests: `NeighbourTray` copy assertions updated; new `FirstRunCoach.test.tsx` locks the pair-teaching so it can't silently regress. **262 web green**, tsc + lint clean.

Branches off main, independent of #6/#7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)