### PR TITLE
fix(play): don't overlap the coach chip with the Around tray

### DIFF
--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -2020,7 +2020,10 @@ export default function PlayPage() {
         onMutate={mutateWorldEntity}
       />
 
-      {phase === "ready" && !helpOpen && (
+      {/* Hide the coach while the Around tray is open — both are pinned to
+          bottom-centre, so they'd overlap; mid-bloom the hint is noise anyway.
+          It returns when the tray is closed. */}
+      {phase === "ready" && !helpOpen && !bloom && (
         <FirstRunCoach onShowHelp={() => setHelpOpen(true)} />
       )}
 


### PR DESCRIPTION
Reported on the live `make demo`: opening **Around** drew the neighbour tray on top of the coach ("help bar") — both are pinned to bottom-centre.

Fix: gate `FirstRunCoach` on `!bloom`, so the coach hides while the tray is open (mid-look-around the onboarding hint is redundant) and returns when the tray closes. One render condition; tap/Around behaviour otherwise unchanged.

typecheck + lint clean. Branches off main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)