### PR TITLE
fix(play): harden empty/slow blooms so the tray never goes dead

### DIFF
--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -266,6 +266,15 @@ export default function PlayPage() {
     start: startBloom,
     close: closeBloom,
   } = useExpandBloom(persistNode);
+  // An empty bloom (VLM proposed nothing usable) shows its brief "no neighbours
+  // found" message, then auto-dismisses — so the coach + Around return instead
+  // of a dead tray lingering at the bottom.
+  useEffect(() => {
+    if (bloom?.done && bloom.items.length === 0) {
+      const t = setTimeout(closeBloom, 2600);
+      return () => clearTimeout(t);
+    }
+  }, [bloom?.done, bloom?.items.length, closeBloom]);
   const [statusMsg, setStatusMsg] = useState<string | null>(null);
   const [clickRipple, setClickRipple] = useState<{
     xPx: number;

--- a/apps/web/components/PlayPage/NeighbourTray.test.tsx
+++ b/apps/web/components/PlayPage/NeighbourTray.test.tsx
@@ -17,9 +17,18 @@ function item(over: Partial<NeighbourItem> = {}): NeighbourItem {
 const noop = () => {};
 
 describe("NeighbourTray", () => {
-  it("renders nothing when there's no bloom", () => {
+  it("shows a proposing state before any neighbour arrives (not a blank bar)", () => {
     render(<NeighbourTray items={[]} total={0} done={false} onPick={noop} onClose={noop} />);
-    expect(screen.queryByRole("region")).toBeNull();
+    expect(screen.getByRole("region")).toBeTruthy();
+    expect(screen.getByText(/Looking around/)).toBeTruthy();
+  });
+
+  it("shows a 'no neighbours found' message + stays closeable when a bloom finishes empty", () => {
+    const onClose = vi.fn();
+    render(<NeighbourTray items={[]} total={0} done onPick={noop} onClose={onClose} />);
+    expect(screen.getByText(/no neighbours found/i)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Close neighbours" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it("renders one card per neighbour with its subject + scale label", () => {

--- a/apps/web/components/PlayPage/NeighbourTray.tsx
+++ b/apps/web/components/PlayPage/NeighbourTray.tsx
@@ -34,7 +34,20 @@ const SCALE_META: Record<ScaleKind, { label: string; chip: string; width: string
 export default function NeighbourTray({ items, total, done, onPick, onClose }: Props) {
   const ready = items.filter((i) => i.imageDataUrl).length;
   const pendingCount = Math.max(0, total - items.length);
-  if (total === 0 && items.length === 0) return null;
+  // The bloom finished but proposed nothing usable (e.g. a weak VLM whose
+  // neighbours got dropped). Show a brief message instead of a blank bar — the
+  // page auto-closes it shortly after.
+  const empty = done && items.length === 0;
+  // Bloom started but no neighbours known yet (the VLM is still surveying):
+  // show activity rather than nothing while it thinks.
+  const proposing = !done && total === 0 && items.length === 0;
+  const status = empty
+    ? "No neighbours found nearby"
+    : done
+      ? `Around this page · ${ready} neighbour${ready === 1 ? "" : "s"} — tap one`
+      : proposing
+        ? "Looking around…"
+        : `Looking around · ${ready} of ${total}`;
 
   return (
     <div
@@ -47,9 +60,7 @@ export default function NeighbourTray({ items, total, done, onPick, onClose }: P
           {!done && (
             <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-teal-500" />
           )}
-          {done
-            ? `Around this page · ${ready} neighbour${ready === 1 ? "" : "s"} — tap one`
-            : `Looking around · ${ready} of ${total}`}
+          {status}
         </span>
         <button
           type="button"
@@ -112,6 +123,16 @@ export default function NeighbourTray({ items, total, done, onPick, onClose }: P
           Array.from({ length: pendingCount }).map((_, i) => (
             <span
               key={`pending-${i}`}
+              aria-hidden
+              className="h-16 w-24 shrink-0 animate-pulse rounded-lg border border-[var(--color-ink)]/15 bg-[var(--color-ink)]/10"
+            />
+          ))}
+        {/* No total yet (still proposing) — a few placeholders so the survey
+            phase reads as "working", not a blank bar. */}
+        {proposing &&
+          Array.from({ length: 3 }).map((_, i) => (
+            <span
+              key={`proposing-${i}`}
               aria-hidden
               className="h-16 w-24 shrink-0 animate-pulse rounded-lg border border-[var(--color-ink)]/15 bg-[var(--color-ink)]/10"
             />

--- a/apps/web/hooks/useExpandBloom.test.tsx
+++ b/apps/web/hooks/useExpandBloom.test.tsx
@@ -104,6 +104,23 @@ describe("useExpandBloom", () => {
     );
   });
 
+  it("resolves the bloom (done) when the stream closes without an expand_done", async () => {
+    // Defensive: if the backend ever closes the stream without a terminal
+    // expand_done (e.g. an early bail), the bloom must still flip to done so
+    // Around re-enables and the tray shows its terminal state — not spin forever.
+    const persist = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(cannedResponse([{ type: "status", stage: "planning" }])),
+    );
+    const { result } = renderHook(() =>
+      useExpandBloom(persist as unknown as PersistNeighbour),
+    );
+    act(() => result.current.start(BODY));
+    await waitFor(() => expect(result.current.bloom?.done).toBe(true));
+    expect(result.current.bloom?.items).toEqual([]);
+  });
+
   it("a stream error marks the bloom done instead of throwing", async () => {
     const persist = vi.fn();
     vi.stubGlobal(

--- a/apps/web/hooks/useExpandBloom.ts
+++ b/apps/web/hooks/useExpandBloom.ts
@@ -140,6 +140,13 @@ export function useExpandBloom(persist: PersistNeighbour): {
               }
             }
           }
+          // Stream closed cleanly. Make sure the bloom resolves even if the
+          // backend never sent an explicit expand_done (e.g. an early bail) —
+          // otherwise `done` would stay false: Around stuck disabled, the tray
+          // stuck on its spinner. Idempotent when expand_done already landed.
+          if (!ac.signal.aborted) {
+            setBloom((prev) => (prev ? { ...prev, done: true } : prev));
+          }
         } catch (err) {
           if ((err as Error).name === "AbortError") return;
           // A failed bloom shouldn't disturb the focal page — just stop the


### PR DESCRIPTION
Follow-up to #9. On the live demo, a bloom returned **0 usable neighbours** (the qwen VLM's proposal got dropped). The backend correctly sends `expand_done(count:0)`, but the frontend left a **blank bottom with no feedback** — the tray returned `null` and the coach was gated off.

Give the tray a full lifecycle instead of the null guard:

| State | Before | After |
|---|---|---|
| proposing (started, no total yet) | blank (coach hidden) | **"Looking around…"** + placeholder shimmer |
| empty (done, 0 neighbours) | blank, dead tray | **"No neighbours found nearby"**, auto-dismisses after 2.6s → coach + Around return |
| streaming / done-with-neighbours | — | unchanged |

Also defensive in `useExpandBloom`: resolve the bloom (`done=true`) when the SSE stream closes even without an explicit `expand_done`, so it can't get stuck (Around disabled, spinner forever). Idempotent when `expand_done` already landed.

This makes #9's `!bloom` coach gate exactly right — there's always a tray to replace the coach, so no overlap *and* no blank.

> Note: the bloom returning 0 neighbours in the first place is a VLM-config thing — `OPENROUTER_VLM_MODEL=qwen/qwen-2.5-vl-72b` in your `.env`; the Gemini default proposes clean neighbours.

Tests: `NeighbourTray` proposing + empty-done states; `useExpandBloom` stream-closes-without-`expand_done`. **282 web green**, tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)