### PR TITLE
expand = map-pan: outpaint the world outward (flag-gated)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ ec-*.png
 
 # Demo recorder intermediates
 scripts/record-demo/artifacts/
+scripts/record-demo/artifacts-mappan/
 scripts/record-demo/node_modules/
 
 # Playwright artifacts (committing reports = noisy + binary churn).

--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -231,6 +231,84 @@ async def _event_stream(
                     trace_id,
                 )
                 return
+
+            # Map-pan (flag-gated): instead of blooming neighbour SUBJECTS,
+            # outpaint the parent OUTWARD in four directions so "expand" pans the
+            # same continuous world — like moving across a map (BRIA, bakeoff
+            # winner). Reuses the neighbor/expand_done stream + abort handling;
+            # flag off → the subject bloom below, unchanged.
+            if os.environ.get("EXPAND_MAP_PAN", "false").lower() in (
+                "1", "true", "yes"
+            ):
+                yield _sse({"type": "status", "stage": "planning"}, trace_id)
+                _dirs = [
+                    ("west", "Westward"),
+                    ("east", "Eastward"),
+                    ("north", "Northward"),
+                    ("south", "Southward"),
+                ]
+                _dims = {
+                    "16:9": (1600, 900),
+                    "9:16": (900, 1600),
+                    "1:1": (1024, 1024),
+                    "4:3": (1280, 960),
+                    "3:4": (960, 1280),
+                }
+                pw, ph = _dims.get(body.aspect_ratio, (1600, 900))
+                total = len(_dirs)
+                parent_image = body.image  # non-None (checked above); narrows for the closure
+
+                async def _pan_one(idx: int, direction: str):
+                    img = await image_edit_provider.expand_image(
+                        parent_image, direction, pw, ph
+                    )
+                    return idx, direction, img
+
+                await _abort_if_disconnected("pre-pan")
+                pan_tasks = [
+                    _asyncio.create_task(_pan_one(i, d[0]))
+                    for i, d in enumerate(_dirs)
+                ]
+                emitted = 0
+                try:
+                    for fut in _asyncio.as_completed(pan_tasks):
+                        try:
+                            idx, direction, img = await fut
+                        except Exception as exc:
+                            log(
+                                "warn",
+                                "expand.pan_failed",
+                                error=f"{type(exc).__name__}: {exc}",
+                            )
+                            record_error("expand_pan", exc)
+                            continue
+                        data_url = await _asyncio.to_thread(
+                            image_provider.encode_data_url, img.jpeg_bytes, img.mime_type
+                        )
+                        emitted += 1
+                        yield _sse(
+                            {
+                                "type": "neighbor",
+                                "subject": _dirs[idx][1],
+                                "scale": "peer",
+                                "page_title": _dirs[idx][1],
+                                "image_data_url": data_url,
+                                "image_model": img.model,
+                                "prompt_author_model": "",
+                                "final_prompt": f"map-pan {direction}",
+                                "session_id": body.session_id,
+                                "index": idx,
+                                "total": total,
+                            },
+                            trace_id,
+                        )
+                finally:
+                    for t in pan_tasks:
+                        if not t.done():
+                            t.cancel()
+                yield _sse({"type": "expand_done", "count": emitted}, trace_id)
+                return
+
             expand_style_lock = (body.session_style_anchor or "").strip() or None
             expand_world_context = [e.model_dump() for e in body.world_context]
             yield _sse({"type": "status", "stage": "planning"}, trace_id)

--- a/apps/modal-backend/providers/image_edit.py
+++ b/apps/modal-backend/providers/image_edit.py
@@ -88,3 +88,66 @@ async def edit_image(
         model=model,
         provider_request_id=str(result.get("requestId") or "") or None,
     )
+
+
+# --- Map-pan (expand outward) -------------------------------------------------
+
+# BRIA Expand: seamless, pixel-preserving outpaint — the parent keeps its pixels,
+# the new margin is painted to match. A bakeoff picked it over nano-banana /
+# Kontext for "pan the world outward". Override with FAL_EXPAND_MODEL.
+EXPAND_MODEL_DEFAULT = "fal-ai/bria/expand"
+_EXPAND_GROW = 0.5  # extend by 50% of the parent in the chosen direction
+
+
+def _expand_args_for(
+    image_url: str, direction: str, width: int, height: int
+) -> dict[str, Any]:
+    """BRIA places the original on a larger canvas and paints the empty margin.
+    `original_image_location` is the parent's top-left on that canvas."""
+    gw, gh = int(width * _EXPAND_GROW), int(height * _EXPAND_GROW)
+    if direction in ("east", "west"):
+        canvas = [width + gw, height]
+        loc = [0, 0] if direction == "east" else [gw, 0]
+    else:  # north / south
+        canvas = [width, height + gh]
+        loc = [0, 0] if direction == "south" else [0, gh]
+    return {
+        "image_url": image_url,
+        "canvas_size": canvas,
+        "original_image_size": [width, height],
+        "original_image_location": loc,
+    }
+
+
+async def expand_image(
+    image_data_url: str,
+    direction: str,
+    width: int = 1600,
+    height: int = 900,
+    model_override: str | None = None,
+) -> GeneratedImage:
+    """Map-pan: outpaint the parent OUTWARD in `direction` (west/east/north/
+    south) so 'expand' extends the same place seamlessly rather than blooming
+    new subjects. Default BRIA Expand (bakeoff winner); FAL_EXPAND_MODEL override."""
+    from obs import span
+
+    _ensure_fal_key()
+    model = (
+        model_override
+        or os.environ.get("FAL_EXPAND_MODEL")
+        or EXPAND_MODEL_DEFAULT
+    )
+    image_url = await to_fal_url(image_data_url)
+    async with span("image.expand", model=model, direction=direction) as ctx:
+        result = await _fal_subscribe(
+            model, _expand_args_for(image_url, direction, width, height)
+        )
+        image_info = _first_image(result)
+        jpeg_bytes, mime = await _fetch_image_bytes(image_info)
+        ctx["bytes"] = len(jpeg_bytes)
+    return GeneratedImage(
+        jpeg_bytes=jpeg_bytes,
+        mime_type=mime,
+        model=model,
+        provider_request_id=str(result.get("requestId") or "") or None,
+    )

--- a/apps/modal-backend/providers/image_edit.py
+++ b/apps/modal-backend/providers/image_edit.py
@@ -12,7 +12,9 @@ nano-banana-pro which handles both gen and edit on the same endpoint.
 
 from __future__ import annotations
 
+import base64
 import os
+import struct
 from typing import Any
 
 from ._common import to_fal_url
@@ -119,6 +121,50 @@ def _expand_args_for(
     }
 
 
+def _img_dims(data: bytes) -> tuple[int, int] | None:
+    """Read (width, height) straight from PNG/JPEG headers — Pillow isn't in the
+    runtime, and BRIA needs the parent's REAL pixel size or it rescales (and
+    seams) the original. Returns None for anything we can't measure."""
+    if data[:8] == b"\x89PNG\r\n\x1a\n" and data[12:16] == b"IHDR":
+        w, h = struct.unpack(">II", data[16:24])
+        return int(w), int(h)
+    if data[:2] == b"\xff\xd8":  # JPEG: scan to the first SOF marker.
+        i, n = 2, len(data)
+        while i + 9 < n:
+            if data[i] != 0xFF:
+                i += 1
+                continue
+            marker = data[i + 1]
+            if 0xC0 <= marker <= 0xCF and marker not in (0xC4, 0xC8, 0xCC):
+                h, w = struct.unpack(">HH", data[i + 5 : i + 9])
+                return int(w), int(h)
+            if marker == 0xD8 or marker == 0xD9 or 0xD0 <= marker <= 0xD7:
+                i += 2
+                continue
+            i += 2 + struct.unpack(">H", data[i + 2 : i + 4])[0]
+    return None
+
+
+def _dims_from_data_url(data_url: str) -> tuple[int, int] | None:
+    """Parent dims from a `data:` URL (the fresh in-session path). http(s) URLs
+    fall back to the caller's width/height."""
+    if not data_url.startswith("data:") or "," not in data_url:
+        return None
+    try:
+        return _img_dims(base64.b64decode(data_url.split(",", 1)[1]))
+    except Exception:
+        return None
+
+
+def _expand_first_image(result: dict[str, Any]) -> dict[str, Any]:
+    """BRIA Expand answers with a singular `image` object; nano-banana-style
+    models use `images: [...]`. Accept either."""
+    image = result.get("image")
+    if isinstance(image, dict):
+        return image
+    return _first_image(result)
+
+
 async def expand_image(
     image_data_url: str,
     direction: str,
@@ -137,12 +183,15 @@ async def expand_image(
         or os.environ.get("FAL_EXPAND_MODEL")
         or EXPAND_MODEL_DEFAULT
     )
+    # BRIA places the parent at its true size on the bigger canvas; a wrong size
+    # rescales/seams it, so measure rather than trust the aspect-ratio default.
+    w, h = _dims_from_data_url(image_data_url) or (width, height)
     image_url = await to_fal_url(image_data_url)
-    async with span("image.expand", model=model, direction=direction) as ctx:
+    async with span("image.expand", model=model, direction=direction, w=w, h=h) as ctx:
         result = await _fal_subscribe(
-            model, _expand_args_for(image_url, direction, width, height)
+            model, _expand_args_for(image_url, direction, w, h)
         )
-        image_info = _first_image(result)
+        image_info = _expand_first_image(result)
         jpeg_bytes, mime = await _fetch_image_bytes(image_info)
         ctx["bytes"] = len(jpeg_bytes)
     return GeneratedImage(

--- a/apps/modal-backend/tests/conftest.py
+++ b/apps/modal-backend/tests/conftest.py
@@ -44,6 +44,9 @@ _SCRUB = (
     "IMAGE_API_KEY",
     "IMAGE_MODEL",
     "IMAGE_SIZE",
+    # Map-pan expand (outpaint the world outward).
+    "EXPAND_MAP_PAN",
+    "FAL_EXPAND_MODEL",
     "SENTRY_DSN",
 )
 

--- a/apps/modal-backend/tests/test_image_edit_provider.py
+++ b/apps/modal-backend/tests/test_image_edit_provider.py
@@ -1,0 +1,54 @@
+"""Tests for the edit/expand provider (providers/image_edit.py)."""
+from __future__ import annotations
+
+import pytest
+
+from providers import image_edit
+
+
+def test_expand_args_east_keeps_parent_left_and_grows_width() -> None:
+    args = image_edit._expand_args_for("u", "east", 1600, 900)
+    assert args["canvas_size"] == [2400, 900]  # +50% width
+    assert args["original_image_location"] == [0, 0]  # parent at the left, new on right
+    assert args["original_image_size"] == [1600, 900]
+
+
+def test_expand_args_west_shifts_parent_right() -> None:
+    args = image_edit._expand_args_for("u", "west", 1600, 900)
+    assert args["canvas_size"] == [2400, 900]
+    assert args["original_image_location"] == [800, 0]  # parent right, new on left
+
+
+def test_expand_args_north_south_grow_height() -> None:
+    south = image_edit._expand_args_for("u", "south", 1600, 900)
+    assert south["canvas_size"] == [1600, 1350]
+    assert south["original_image_location"] == [0, 0]
+    north = image_edit._expand_args_for("u", "north", 1600, 900)
+    assert north["original_image_location"] == [0, 450]  # parent bottom, new above
+
+
+async def test_expand_image_defaults_to_bria(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+
+    async def fake_to_fal(data_url: str) -> str:
+        return "fal://parent"
+
+    async def fake_sub(model: str, args: dict) -> dict:
+        captured["model"] = model
+        captured["args"] = args
+        return {"images": [{"url": "http://x"}], "requestId": "r1"}
+
+    async def fake_fetch(info: dict) -> tuple[bytes, str]:
+        return b"jpeg", "image/jpeg"
+
+    monkeypatch.setenv("FAL_KEY", "fk")
+    monkeypatch.setattr(image_edit, "to_fal_url", fake_to_fal)
+    monkeypatch.setattr(image_edit, "_fal_subscribe", fake_sub)
+    monkeypatch.setattr(image_edit, "_fetch_image_bytes", fake_fetch)
+
+    out = await image_edit.expand_image("data:image/jpeg;base64,x", "east", 1600, 900)
+
+    assert out.jpeg_bytes == b"jpeg"
+    assert "bria" in captured["model"]
+    assert captured["args"]["image_url"] == "fal://parent"
+    assert captured["args"]["canvas_size"] == [2400, 900]

--- a/apps/modal-backend/tests/test_image_edit_provider.py
+++ b/apps/modal-backend/tests/test_image_edit_provider.py
@@ -1,9 +1,34 @@
 """Tests for the edit/expand provider (providers/image_edit.py)."""
 from __future__ import annotations
 
+import base64
+import struct
+import zlib
+
 import pytest
 
 from providers import image_edit
+
+
+def _png(w: int, h: int) -> bytes:
+    """A minimal valid solid-colour PNG — enough for the header parser."""
+    raw = (b"\x00" + b"\x7f\x40\x30" * w) * h
+
+    def chunk(typ: bytes, data: bytes) -> bytes:
+        body = typ + data
+        return struct.pack(">I", len(data)) + body + struct.pack(
+            ">I", zlib.crc32(body) & 0xFFFFFFFF
+        )
+
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 2, 0, 0, 0))
+        + chunk(b"IDAT", zlib.compress(raw))
+        + chunk(b"IEND", b"")
+    )
+
+
+# --- outpaint geometry --------------------------------------------------------
 
 
 def test_expand_args_east_keeps_parent_left_and_grows_width() -> None:
@@ -27,7 +52,42 @@ def test_expand_args_north_south_grow_height() -> None:
     assert north["original_image_location"] == [0, 450]  # parent bottom, new above
 
 
-async def test_expand_image_defaults_to_bria(monkeypatch: pytest.MonkeyPatch) -> None:
+# --- dimension probing (Pillow-free) ------------------------------------------
+
+
+def test_img_dims_reads_png_header() -> None:
+    assert image_edit._img_dims(_png(256, 144)) == (256, 144)
+
+
+def test_dims_from_data_url_round_trips_png() -> None:
+    data_url = "data:image/png;base64," + base64.b64encode(_png(320, 180)).decode()
+    assert image_edit._dims_from_data_url(data_url) == (320, 180)
+
+
+def test_dims_from_data_url_returns_none_for_http_or_junk() -> None:
+    assert image_edit._dims_from_data_url("https://cdn/x.png") is None
+    assert image_edit._dims_from_data_url("data:image/png;base64,@@@") is None
+
+
+# --- response normalisation ---------------------------------------------------
+
+
+def test_expand_first_image_accepts_bria_singular() -> None:
+    info = image_edit._expand_first_image({"image": {"url": "u"}, "seed": 1})
+    assert info == {"url": "u"}
+
+
+def test_expand_first_image_falls_back_to_plural() -> None:
+    info = image_edit._expand_first_image({"images": [{"url": "v"}]})
+    assert info == {"url": "v"}
+
+
+# --- end-to-end (mocked fal) --------------------------------------------------
+
+
+async def test_expand_image_parses_bria_and_uses_real_dims(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     captured: dict = {}
 
     async def fake_to_fal(data_url: str) -> str:
@@ -36,19 +96,25 @@ async def test_expand_image_defaults_to_bria(monkeypatch: pytest.MonkeyPatch) ->
     async def fake_sub(model: str, args: dict) -> dict:
         captured["model"] = model
         captured["args"] = args
-        return {"images": [{"url": "http://x"}], "requestId": "r1"}
+        # BRIA Expand's real shape: a singular `image`, not `images: [...]`.
+        return {"image": {"url": "http://x", "content_type": "image/png"}, "seed": 9}
 
     async def fake_fetch(info: dict) -> tuple[bytes, str]:
-        return b"jpeg", "image/jpeg"
+        captured["fetched"] = info
+        return b"jpeg", "image/png"
 
     monkeypatch.setenv("FAL_KEY", "fk")
     monkeypatch.setattr(image_edit, "to_fal_url", fake_to_fal)
     monkeypatch.setattr(image_edit, "_fal_subscribe", fake_sub)
     monkeypatch.setattr(image_edit, "_fetch_image_bytes", fake_fetch)
 
-    out = await image_edit.expand_image("data:image/jpeg;base64,x", "east", 1600, 900)
+    # A real 1024x576 PNG parent — expand_image should measure it, not trust the
+    # 1600x900 default, so the canvas grows from the true width.
+    data_url = "data:image/png;base64," + base64.b64encode(_png(1024, 576)).decode()
+    out = await image_edit.expand_image(data_url, "east")
 
     assert out.jpeg_bytes == b"jpeg"
     assert "bria" in captured["model"]
-    assert captured["args"]["image_url"] == "fal://parent"
-    assert captured["args"]["canvas_size"] == [2400, 900]
+    assert captured["args"]["original_image_size"] == [1024, 576]
+    assert captured["args"]["canvas_size"] == [1536, 576]  # +50% of measured width
+    assert captured["fetched"] == {"url": "http://x", "content_type": "image/png"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,10 @@ services:
       # to A/B against the old text-only generation:
       #   IMAGE_CONDITIONING=false docker compose up -d backend
       IMAGE_CONDITIONING: ${IMAGE_CONDITIONING:-true}
+      # Map-pan: "expand" (Around) outpaints the world outward in 4 directions
+      # instead of blooming neighbour subjects. Default off:
+      #   EXPAND_MAP_PAN=true docker compose up -d backend
+      EXPAND_MAP_PAN: ${EXPAND_MAP_PAN:-false}
     # Force public resolvers — Docker's default 127.0.0.11 link-local resolver
     # has been flaking on the fal.ai / r2.cloudflarestorage.com hosts during
     # E2E runs (sporadic ESERVFAIL / EAI_AGAIN), which manifests as

--- a/scripts/record-demo/record-mappan.ts
+++ b/scripts/record-demo/record-mappan.ts
@@ -1,0 +1,142 @@
+/**
+ * Records a standalone clip of EXPAND = map-pan (the `EXPAND_MAP_PAN` feature).
+ *
+ * Flow: http://localhost:3000/play  →  pick Storybook  →  type a coastal scene
+ *  →  Go  →  wait for the page  →  press "Around"  →  wait for the 4 directional
+ *  pans to bloom into the tray  →  hold a beat  →  tap "Westward"  →  wait for
+ *  the world to pan  →  stop.
+ *
+ * Output (NOT the committed landing video — map-pan is flag-gated off in prod):
+ *   scripts/record-demo/artifacts-mappan/*.webm   (raw capture)
+ *   scripts/record-demo/mappan-demo.mp4           (4x-sped re-encode)
+ *
+ * Needs the stack up on :3000 with EXPAND_MAP_PAN=true (the demo override).
+ * Usage (from repo root):
+ *   scripts/record-demo/node_modules/.bin/tsx scripts/record-demo/record-mappan.ts
+ */
+import { spawn } from "node:child_process";
+import { mkdir, readdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium, type Page } from "playwright";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ARTIFACTS = path.join(HERE, "artifacts-mappan");
+const MP4_OUT = path.join(HERE, "mappan-demo.mp4");
+
+const BASE_URL = process.env.DEMO_BASE_URL ?? "http://localhost:3000";
+const VIEWPORT = { width: 1280, height: 800 };
+const PAGE_TIMEOUT_MS = 120_000;
+const QUERY = "a sprawling coastal fishing village at golden hour, wide aerial map view";
+
+async function run(cmd: string, args: string[]): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: "inherit" });
+    child.on("close", (code: number | null) =>
+      code === 0 ? resolve() : reject(new Error(`${cmd} exited with ${code}`))
+    );
+    child.on("error", reject);
+  });
+}
+
+async function waitForStableImage(page: Page, timeoutMs: number): Promise<string> {
+  const img = page.locator('img[alt^="Generated illustration"]').first();
+  await img.waitFor({ state: "visible", timeout: timeoutMs });
+  let lastSrc = "";
+  let stableSince = 0;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const src = (await img.getAttribute("src")) ?? "";
+    if (src && src === lastSrc) {
+      if (Date.now() - stableSince >= 2500) return src;
+    } else {
+      lastSrc = src;
+      stableSince = Date.now();
+    }
+    await page.waitForTimeout(500);
+  }
+  throw new Error("Timed out waiting for image to stabilize");
+}
+
+async function main(): Promise<void> {
+  await rm(ARTIFACTS, { recursive: true, force: true });
+  await mkdir(ARTIFACTS, { recursive: true });
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    viewport: VIEWPORT,
+    deviceScaleFactor: 2,
+    recordVideo: { dir: ARTIFACTS, size: VIEWPORT },
+  });
+  const page = await context.newPage();
+  page.on("console", (msg) => {
+    if (msg.type() === "error") console.error("[browser]", msg.text());
+  });
+
+  console.log(`[record] opening ${BASE_URL}/play`);
+  await page.goto(`${BASE_URL}/play`, { waitUntil: "networkidle" });
+  await page.waitForTimeout(1200);
+
+  console.log("[record] picking Storybook style");
+  await page.getByRole("button", { name: "Storybook" }).click();
+
+  console.log("[record] typing the scene query");
+  await page.getByRole("textbox").first().fill(QUERY);
+  await page.waitForTimeout(600);
+  await page.getByRole("button", { name: "Go" }).click();
+
+  console.log("[record] waiting for the page to render");
+  const parentSrc = await waitForStableImage(page, PAGE_TIMEOUT_MS);
+  await page.waitForTimeout(1200);
+
+  console.log("[record] pressing Around (fan out 4 map-pans)");
+  await page.getByRole("button", { name: "Around" }).first().click();
+
+  console.log("[record] waiting for the 4 directional pans to bloom");
+  await page
+    .getByRole("button", { name: "Explore Westward" })
+    .waitFor({ state: "visible", timeout: PAGE_TIMEOUT_MS });
+  // Hold a beat so the viewer takes in all four directions.
+  await page.waitForTimeout(2600);
+
+  console.log("[record] tapping Westward — pan the world");
+  await page.getByRole("button", { name: "Explore Westward" }).click();
+  await page.waitForFunction(
+    (prev: string) => {
+      const el = document.querySelector('img[alt^="Generated illustration"]');
+      return !!el && el.getAttribute("src") !== prev;
+    },
+    parentSrc,
+    { timeout: PAGE_TIMEOUT_MS }
+  );
+  await waitForStableImage(page, PAGE_TIMEOUT_MS);
+  await page.waitForTimeout(2200);
+
+  await page.close();
+  await context.close();
+  await browser.close();
+
+  const files = await readdir(ARTIFACTS);
+  const webm = files.find((f) => f.endsWith(".webm"));
+  if (!webm) throw new Error("No .webm produced");
+  const webmPath = path.join(ARTIFACTS, webm);
+
+  // Each gen/outpaint hop takes tens of seconds — speed up 4x like the landing
+  // clip so the result lands around 25-30 s.
+  console.log(`[record] transcoding ${webmPath} → ${MP4_OUT} (4x)`);
+  await run("ffmpeg", [
+    "-y", "-i", webmPath,
+    "-filter:v", "setpts=0.25*PTS",
+    "-c:v", "libx264", "-pix_fmt", "yuv420p",
+    "-crf", "24", "-preset", "slow",
+    "-movflags", "+faststart", "-an",
+    MP4_OUT,
+  ]);
+
+  console.log(`[record] done → ${MP4_OUT}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## what this does

Makes **Around** actually pan the world. Today it blooms 4 *new subjects* around the page — useful, but it doesn't read as "I'm moving through one place." With `EXPAND_MAP_PAN=true`, pressing Around instead **outpaints the parent outward in all 4 directions** (N/S/E/W) so you survey the same continuous scene and pick which way to go — like dragging a map.

It's the right home for visual *continuation*: tap stays informative (go into a topic, learn the details), expand is spatial breadth (more of the same world).

## how

- **`providers/image_edit.py`** — `expand_image(parent, direction, w, h)`. Uses **BRIA Expand** (`fal-ai/bria/expand`), which won a bakeoff for seamless, pixel-preserving outpaint (nano-banana treats refs as loose inspiration; BRIA keeps the parent's pixels and paints only the new margin). `_expand_args_for` builds the canvas + placement per direction.
- **`generate.py`** — flag-gated branch (default **off**). On expand, fan 4 directional outpaints concurrently and stream them through the **same** `neighbor`/`expand_done` SSE events + abort handling the subject-bloom already uses. So the tray, persistence and atlas need **zero** changes — the cards just carry directions (`Eastward`/`Westward`/…) instead of subjects. Flag off → today's behaviour verbatim.
- **`docker-compose.yml`** exposes `EXPAND_MAP_PAN`; conftest scrub + tests added.

## two bugs the live run caught (2nd commit)

The unit mocks were too kind — a real run found:
1. BRIA returns a **singular `image`**, not `images: [...]` → every pan failed with "no images". Added `_expand_first_image` (singular, plural fallback).
2. I grew the canvas from a hardcoded 1600×900, but nano-banana parents aren't that size, so BRIA rescaled/seamed the original. Now I **measure the parent straight from the PNG/JPEG header** (`_img_dims`, no Pillow in the runtime) and grow from the true size.

## verified live

Fresh storybook village page → Around → 4 seamless BRIA outpaints, **0 errors**. Tapping Westward pans the same world out — the original harbor/lighthouse/marshes are pixel-preserved and shifted right, new coastline + hills painted on the left, invisible seam. 243 backend tests green, ruff + mypy clean.

## caveats / follow-ups

- Works on fresh in-session pages (the parent is a data URL we upload to fal). A *reloaded* page hands BRIA a `localhost:9000` Minio URL it can't reach — fine in prod (R2 is public), noted for the local demo.
- Each pan is ~50% bigger than the frame; tapping in re-frames it. A crop-to-frame pass is a possible later polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)