### PR TITLE
World Mode: tap to ENTER places — scenes, aligned sub-maps, revisit (flag-gated)

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -80,6 +80,10 @@ class GenerateBody(BaseModel):
     prefetched_subject: str | None = None
     prefetched_style: str | None = None
     prefetched_subject_context: str | None = None
+    # World Mode semi-autonomy already resolved the tap client-side; this carries
+    # the resolver's spatial-anchor note back so the planner can keep the
+    # entered place's neighbours where the parent map had them.
+    prefetched_surroundings: str | None = None
     # Multi-turn refer (SAMA / MM-Conv pattern): when the user rejects a
     # resolved subject and taps again nearby, the client forwards the
     # rejected phrase so the VLM picks something different.
@@ -383,6 +387,9 @@ async def _event_stream(
         render_mode = (body.render_mode or "").strip().lower()
         if render_mode not in ("place_scene", "place_submap", "explainer"):
             render_mode = ""
+        # World Mode spatial anchor — what's around the tapped spot + directions,
+        # threaded into the planner so the entered place keeps its neighbours.
+        surroundings_for_plan: str | None = None
         if body.mode == "tap" and body.click and body.image:
             # Trust-but-verify on client-supplied prefetch hints. The web
             # client computes these via the same VLM the backend would call,
@@ -404,11 +411,13 @@ async def _event_stream(
                 body.prefetched_subject_context, 400
             )
             cleaned_user_hint = _sanitize_hint(body.click_hint, 240)
+            cleaned_surroundings = _sanitize_hint(body.prefetched_surroundings, 240)
             prefetched_ok = bool(cleaned_subject)
             if prefetched_ok:
                 effective_query = cleaned_subject
                 style_anchor = cleaned_style or None
                 subject_context = cleaned_subject_context or None
+                surroundings_for_plan = cleaned_surroundings or None
                 yield _sse(
                     {
                         "type": "status",
@@ -470,6 +479,8 @@ async def _event_stream(
                     style_anchor = resolution.style
                 if resolution.subject_context:
                     subject_context = resolution.subject_context
+                if resolution.surroundings:
+                    surroundings_for_plan = resolution.surroundings
 
             # Fold the user's free-form note into the planner query so the next
             # page reflects their angle even when the prefetched-subject path
@@ -509,6 +520,7 @@ async def _event_stream(
             subject_context=subject_context,
             world_context=world_context_payload,
             render_mode=render_mode or "explainer",
+            surroundings=surroundings_for_plan,
         )
 
         composed_prompt = plan.prompt
@@ -853,6 +865,7 @@ async def resolve_click(req: Request, body: ResolveClickBody):
             ),
             "enter_as": resolution.enter_as,
             "clarifiers": resolution.clarifiers,
+            "surroundings": resolution.surroundings,
             "trace_id": trace_id,
         },
         headers={"X-Trace-Id": trace_id},

--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -97,7 +97,30 @@ class GenerateBody(BaseModel):
     # `condition_roles` labels each url in order. Built client-side. Capped.
     condition_image_urls: list[str] | None = Field(default=None, max_length=4)
     condition_roles: list[str] | None = None
+    # World Mode (gated server-side by the WORLD_MODE env). When on, a tap
+    # ENTERS the tapped place (scene / closer sub-map) instead of explaining a
+    # topic. `render_mode` is an explicit framing override; otherwise the click
+    # classifier's `enter_as` decides. `autonomy` is carried for symmetry.
+    world_mode: bool = False
+    autonomy: str = "auto"
+    render_mode: str | None = None
     trace_id: str | None = None
+
+
+# World Mode is gated behind an env flag (default off) so it's a no-op in prod
+# until a deployer turns it on — like EXPAND_MAP_PAN / IMAGE_CONDITIONING.
+def _world_mode_on(requested: bool) -> bool:
+    return bool(requested) and os.environ.get("WORLD_MODE", "false").lower() in (
+        "1", "true", "yes",
+    )
+
+
+# The click classifier's `enter_as` → the planner's render mode.
+_ENTER_AS_TO_RENDER: dict[str, str] = {
+    "scene": "place_scene",
+    "submap": "place_submap",
+    "explainer": "explainer",
+}
 
 
 def _sse(data: dict, trace_id: str | None = None) -> bytes:
@@ -353,6 +376,13 @@ async def _event_stream(
         # the click subject IS in the parent's domain — fed to the planner
         # to prevent semantic drift on ambiguous phrases like "Memory Bank".
         subject_context: str | None = None
+        # World Mode render framing: an explicit request override wins; else the
+        # click classifier's `enter_as` (set below) decides; else today's
+        # explainer. Empty string = "not yet decided / fall back to explainer".
+        effective_world_mode = _world_mode_on(body.world_mode)
+        render_mode = (body.render_mode or "").strip().lower()
+        if render_mode not in ("place_scene", "place_submap", "explainer"):
+            render_mode = ""
         if body.mode == "tap" and body.click and body.image:
             # Trust-but-verify on client-supplied prefetch hints. The web
             # client computes these via the same VLM the backend would call,
@@ -398,7 +428,17 @@ async def _event_stream(
                     output_locale=body.output_locale,
                     user_hint=cleaned_user_hint or None,
                     prior_rejected_subject=body.prior_rejected_subject,
+                    world_mode=effective_world_mode,
+                    # Clarifiers are surfaced client-side before this generate
+                    # call, so the in-band resolve only needs the classification.
+                    autonomy="auto",
                 )
+                # In world mode, let the classifier's read pick the framing
+                # unless the request already pinned one.
+                if effective_world_mode and not render_mode:
+                    render_mode = _ENTER_AS_TO_RENDER.get(
+                        resolution.enter_as, "explainer"
+                    )
                 if resolution.subject:
                     effective_query = resolution.subject
                     yield _sse(
@@ -468,6 +508,7 @@ async def _event_stream(
             parent_query=body.parent_query,
             subject_context=subject_context,
             world_context=world_context_payload,
+            render_mode=render_mode or "explainer",
         )
 
         composed_prompt = plan.prompt
@@ -532,9 +573,12 @@ async def _event_stream(
             and body.condition_image_urls
         ):
             cond_refs = body.condition_image_urls
+            # Entering a place reframes the region ref ("reveal the fuller place
+            # within") vs. an explainer tap ("reveal what is inside").
+            cond_mode = "place_scene" if render_mode == "place_scene" else body.mode
             main_prompt = (
                 image_provider.conditioning_preamble(
-                    body.condition_roles or [], body.mode
+                    body.condition_roles or [], cond_mode
                 )
                 + composed_prompt
             )
@@ -746,6 +790,10 @@ class ResolveClickBody(BaseModel):
     parent_query: str | None = None
     output_locale: str | None = None
     prior_rejected_subject: str | None = None
+    # World Mode: ask the resolver to also classify what was tapped and (in
+    # "semi") propose clarifying questions to surface before entering.
+    world_mode: bool = False
+    autonomy: str = "auto"
     trace_id: str | None = None
 
 
@@ -771,6 +819,8 @@ async def resolve_click(req: Request, body: ResolveClickBody):
             parent_query=body.parent_query or "",
             output_locale=body.output_locale,
             prior_rejected_subject=body.prior_rejected_subject,
+            world_mode=_world_mode_on(body.world_mode),
+            autonomy=(body.autonomy or "auto"),
         )
     except Exception as exc:
         record_error("resolve_click", exc)
@@ -801,6 +851,8 @@ async def resolve_click(req: Request, body: ResolveClickBody):
                 if resolution.bbox is not None
                 else None
             ),
+            "enter_as": resolution.enter_as,
+            "clarifiers": resolution.clarifiers,
             "trace_id": trace_id,
         },
         headers={"X-Trace-Id": trace_id},

--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -544,6 +544,27 @@ async def _event_stream(
             trace_id,
         )
 
+        # World Mode sub-map: pixel-continue the click region with a continuation
+        # model (Kontext) so the closer map keeps the parent's streets/buildings
+        # in place instead of re-planning a fresh image. Needs the region crop.
+        region_ref: str | None = None
+        if body.condition_image_urls:
+            roles = body.condition_roles or []
+            for i, url in enumerate(body.condition_image_urls):
+                if i < len(roles) and roles[i] == "region":
+                    region_ref = url
+                    break
+            if region_ref is None:
+                region_ref = body.condition_image_urls[0]
+        use_continuation = render_mode == "place_submap" and region_ref is not None
+        zoom_instruction = (
+            f"Zoom in and draw a closer map of {plan.page_title} — the area at the "
+            "centre of this image. Keep the same hand-drawn cartographic style, "
+            "palette and line work; keep the existing streets, buildings and "
+            "landmarks where they are and continue them outward; label its "
+            "sub-areas. A closer continuation of this map, not a new scene."
+        )
+
         # 3. Image gen — with progressive fast-tier draft.
         #
         # When the user picked balanced/pro the cheap nano-banana model is
@@ -564,6 +585,9 @@ async def _event_stream(
             # tiers to one model, so a draft would just regenerate the same
             # image — skip it.
             and image_provider.active_provider() == "fal"
+            # Sub-map continuation is a single Kontext call on the region crop;
+            # a nano-banana text draft would just be an unrelated preview.
+            and not use_continuation
         )
         draft_task: _asyncio.Task | None = None
         if wants_draft:
@@ -594,15 +618,22 @@ async def _event_stream(
                 )
                 + composed_prompt
             )
-        main_task = _asyncio.create_task(
-            image_provider.generate_image(
-                prompt=main_prompt,
-                aspect_ratio=body.aspect_ratio,
-                tier=body.image_tier,
-                model_override=body.image_model,
-                reference_urls=cond_refs,
+        if use_continuation and region_ref is not None:
+            main_task = _asyncio.create_task(
+                image_edit_provider.continue_image(
+                    region_ref, zoom_instruction, model_override=body.image_model
+                )
             )
-        )
+        else:
+            main_task = _asyncio.create_task(
+                image_provider.generate_image(
+                    prompt=main_prompt,
+                    aspect_ratio=body.aspect_ratio,
+                    tier=body.image_tier,
+                    model_override=body.image_model,
+                    reference_urls=cond_refs,
+                )
+            )
         # Drive both tasks to completion. If the draft finishes first, emit
         # `progress`; if the main finishes first, drop the draft.
         if draft_task is not None:
@@ -667,7 +698,7 @@ async def _event_stream(
                 "image_model": result.model,
                 "prompt_author_model": text_model,
                 "session_id": body.session_id,
-                "final_prompt": composed_prompt,
+                "final_prompt": zoom_instruction if use_continuation else composed_prompt,
                 "sources": sources_payload,
             },
             trace_id,

--- a/apps/modal-backend/providers/image.py
+++ b/apps/modal-backend/providers/image.py
@@ -133,11 +133,14 @@ def conditioning_preamble(roles: list[str], mode: str) -> str:
     anchor. Empty roles → no preamble (plain text-to-image)."""
     if not roles:
         return ""
-    enter = (
-        "Continue the scene outward from"
-        if mode == "expand"
-        else "Reveal what is inside"
-    )
+    if mode == "expand":
+        enter = "Continue the scene outward from"
+    elif mode == "place_scene":
+        # World Mode: the user is stepping INTO the tapped spot — reveal the
+        # fuller place that lies within it (a scene to stand in, not a diagram).
+        enter = "Reveal the fuller place within"
+    else:
+        enter = "Reveal what is inside"
     lines: list[str] = []
     for i, role in enumerate(roles, start=1):
         if role == "region":

--- a/apps/modal-backend/providers/image_edit.py
+++ b/apps/modal-backend/providers/image_edit.py
@@ -88,3 +88,44 @@ async def edit_image(
         model=model,
         provider_request_id=str(result.get("requestId") or "") or None,
     )
+
+
+# --- Continuation (zoom-in that keeps the surroundings) ----------------------
+
+# FLUX Kontext: strict in-context reference editing — a bakeoff picked it for a
+# ZOOM continuation that keeps the parent's content/style/layout (vs nano-banana
+# which treats refs as loose inspiration). Used for World Mode sub-map entries so
+# a closer map literally continues the click region. Override FAL_CONTINUE_MODEL.
+CONTINUE_MODEL_DEFAULT = "fal-ai/flux-pro/kontext"
+
+
+async def continue_image(
+    image_data_url: str,
+    instruction: str,
+    model_override: str | None = None,
+) -> GeneratedImage:
+    """Zoom-continue `image_data_url` per `instruction`, keeping its content,
+    style and layout — a closer continuation rather than a fresh generation.
+    Default FLUX Kontext (bakeoff winner); FAL_CONTINUE_MODEL override."""
+    from obs import span
+
+    _ensure_fal_key()
+    model = (
+        model_override
+        or os.environ.get("FAL_CONTINUE_MODEL")
+        or CONTINUE_MODEL_DEFAULT
+    )
+    image_url = await to_fal_url(image_data_url)
+    async with span("image.continue", model=model, instr_len=len(instruction)) as ctx:
+        result = await _fal_subscribe(
+            model, _edit_args_for(model, instruction, image_url)
+        )
+        image_info = _first_image(result)
+        jpeg_bytes, mime = await _fetch_image_bytes(image_info)
+        ctx["bytes"] = len(jpeg_bytes)
+    return GeneratedImage(
+        jpeg_bytes=jpeg_bytes,
+        mime_type=mime,
+        model=model,
+        provider_request_id=str(result.get("requestId") or "") or None,
+    )

--- a/apps/modal-backend/providers/llm.py
+++ b/apps/modal-backend/providers/llm.py
@@ -90,6 +90,10 @@ class ClickResolution:
     # Semi-autonomy: up to two short clarifying questions to ask before entering
     # (e.g. "Day or night?"). Empty in auto mode and in classic (non-world) mode.
     clarifiers: list[str] = field(default_factory=list)
+    # World Mode spatial anchor: what is adjacent to the tapped spot and in which
+    # direction, so the entered place keeps its neighbours where the parent map
+    # had them. Empty in classic mode.
+    surroundings: str = ""
 
 
 @dataclass
@@ -445,6 +449,7 @@ CLICK_SCHEMA: dict[str, Any] = {
         "scale": {"type": "string", "enum": ["component", "peer", "container"]},
         "enter_as": {"type": "string", "enum": ["scene", "submap", "explainer"]},
         "clarifiers": {"type": "array", "items": {"type": "string"}},
+        "surroundings": {"type": "string"},
     },
     "required": ["subject"],
 }
@@ -755,10 +760,16 @@ async def click_to_subject(
             "interior); \"submap\" when it is a sub-region of a map or area best "
             "shown as a CLOSER MAP; \"explainer\" when it is an object, "
             "mechanism, or concept best shown as a labelled diagram."
+            " (10) `surroundings` — a short phrase (<=30 words) naming what sits "
+            "immediately AROUND the crosshair and in which direction, read from "
+            "the parent image's own layout (e.g. \"the river runs along the "
+            "south, a row of timbered houses to the west, a market square to the "
+            "north-east\"). This anchors the entered place so its neighbours "
+            "stay where they are. Empty string if nothing is discernible."
         )
         if autonomy == "semi":
             world_clause += (
-                " (10) `clarifiers` — an array of AT MOST 2 very short questions "
+                " (11) `clarifiers` — an array of AT MOST 2 very short questions "
                 "(<=8 words each) whose answers would change how this place is "
                 "drawn (e.g. \"Day or night?\", \"Bustling or abandoned?\"). "
                 "Return an empty array when you are confident or when `enter_as` "
@@ -963,6 +974,7 @@ def _build_click_resolution(
         if isinstance(clarifiers_raw, list)
         else []
     )
+    surroundings = str(parsed.get("surroundings", "")).strip()
 
     return ClickResolution(
         subject=subject or fallback_subject,
@@ -975,6 +987,25 @@ def _build_click_resolution(
         scale=scale,
         enter_as=enter_as,
         clarifiers=clarifiers,
+        surroundings=surroundings,
+    )
+
+
+def _spatial_anchor_clause(render_mode: str | None, surroundings: str | None) -> str:
+    """World Mode spatial anchor: keep the entered place's neighbours where the
+    parent map had them. Empty unless we're entering a place AND the resolver
+    reported surroundings — so classic + explainer pages are unaffected."""
+    rmode = (render_mode or "explainer").lower()
+    if rmode not in ("place_scene", "place_submap"):
+        return ""
+    if not surroundings or not surroundings.strip():
+        return ""
+    return (
+        "SPATIAL ANCHOR (CRITICAL): you are entering this exact spot on the "
+        "parent map — keep its neighbours where they are: "
+        f"{surroundings.strip()}. Place these surrounding features in the same "
+        "relative directions so the view continues the established map rather "
+        "than inventing a new layout."
     )
 
 
@@ -1030,6 +1061,7 @@ async def plan_page(
     subject_context: str | None = None,
     world_context: list[dict[str, Any]] | None = None,
     render_mode: str | None = None,
+    surroundings: str | None = None,
 ) -> PagePlan:
     """Produce a page title, image-gen prompt, and factual snippets for the query.
 
@@ -1096,6 +1128,9 @@ async def plan_page(
             "callouts, and text inside the illustration are written in "
             f"{output_locale}.\" near the start of the prompt."
         )
+    anchor_clause = _spatial_anchor_clause(rmode, surroundings)
+    if anchor_clause:
+        system_parts.append(anchor_clause)
     world_clause = _format_world_context_clause(world_context)
     if world_clause:
         system_parts.append(world_clause)

--- a/apps/modal-backend/providers/llm.py
+++ b/apps/modal-backend/providers/llm.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import json
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, cast
 
 from openai import AsyncOpenAI, BadRequestError
@@ -82,6 +82,14 @@ class ClickResolution:
     # (it is part of this / bigger). Powers the scale-space map + zoom
     # level-of-detail. Default "peer" keeps older payloads valid.
     scale: str = "peer"
+    # World Mode: the VLM's read of what the tapped thing is — "scene" (a place
+    # to step INTO), "submap" (a sub-area to map closer), or "explainer" (an
+    # object/concept to diagram). Drives the planner's render framing. Default
+    # "explainer" keeps classic tap=learn behaviour for non-world callers.
+    enter_as: str = "explainer"
+    # Semi-autonomy: up to two short clarifying questions to ask before entering
+    # (e.g. "Day or night?"). Empty in auto mode and in classic (non-world) mode.
+    clarifiers: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -435,6 +443,8 @@ CLICK_SCHEMA: dict[str, Any] = {
             },
         },
         "scale": {"type": "string", "enum": ["component", "peer", "container"]},
+        "enter_as": {"type": "string", "enum": ["scene", "submap", "explainer"]},
+        "clarifiers": {"type": "array", "items": {"type": "string"}},
     },
     "required": ["subject"],
 }
@@ -705,6 +715,8 @@ async def click_to_subject(
     output_locale: str | None = None,
     user_hint: str | None = None,
     prior_rejected_subject: str | None = None,
+    world_mode: bool = False,
+    autonomy: str = "auto",
 ) -> ClickResolution:
     """Resolve the click region to a subject phrase AND a style descriptor.
 
@@ -731,6 +743,27 @@ async def click_to_subject(
         if output_locale and output_locale.lower() not in ("en", "auto", "")
         else ""
     )
+    # World Mode adds a classification field so the caller can decide whether a
+    # tap ENTERS a place (scene / closer sub-map) or explains a concept, and —
+    # in semi autonomy — proposes a couple of short questions to ask first.
+    world_clause = ""
+    if world_mode:
+        world_clause = (
+            " (9) `enter_as` — one of \"scene\", \"submap\", or \"explainer\": "
+            "\"scene\" when the crosshair is on a PLACE the user would step INTO "
+            "(a building, street, district, room, landscape, ship/vehicle "
+            "interior); \"submap\" when it is a sub-region of a map or area best "
+            "shown as a CLOSER MAP; \"explainer\" when it is an object, "
+            "mechanism, or concept best shown as a labelled diagram."
+        )
+        if autonomy == "semi":
+            world_clause += (
+                " (10) `clarifiers` — an array of AT MOST 2 very short questions "
+                "(<=8 words each) whose answers would change how this place is "
+                "drawn (e.g. \"Day or night?\", \"Bustling or abandoned?\"). "
+                "Return an empty array when you are confident or when `enter_as` "
+                "is \"explainer\"."
+            )
     system = (
         "You examine a generated illustration of the page titled "
         f"'{parent_title}' (user query: '{parent_query}'). A red crosshair with "
@@ -768,6 +801,7 @@ async def click_to_subject(
         "subject: \"component\" (a part of it / smaller), \"peer\" (a separate "
         "thing of similar size), or \"container\" (a larger thing the focal "
         "subject is part of). Default to \"peer\" when unsure."
+        + world_clause
         + locale_clause
     )
     hint_clause = ""
@@ -918,6 +952,18 @@ def _build_click_resolution(
     bbox = _parse_bbox(parsed.get("bbox"))
     scale = _coerce_scale(parsed.get("scale"))
 
+    # World Mode fields — absent on classic payloads, so default to the
+    # explainer framing with no questions (keeps tap=learn behaviour intact).
+    enter_as = str(parsed.get("enter_as", "")).strip().lower()
+    if enter_as not in ("scene", "submap", "explainer"):
+        enter_as = "explainer"
+    clarifiers_raw = parsed.get("clarifiers")
+    clarifiers = (
+        [c.strip() for c in clarifiers_raw if isinstance(c, str) and c.strip()][:2]
+        if isinstance(clarifiers_raw, list)
+        else []
+    )
+
     return ClickResolution(
         subject=subject or fallback_subject,
         style=style,
@@ -927,6 +973,50 @@ def _build_click_resolution(
         point=point,
         bbox=bbox,
         scale=scale,
+        enter_as=enter_as,
+        clarifiers=clarifiers,
+    )
+
+
+def _render_base_instruction(render_mode: str | None) -> str:
+    """The opening planner instruction, keyed by World Mode render mode.
+
+    `place_scene` → an immersive scene the reader steps into (no diagram
+    labels); `place_submap` → a closer cartographic map of a sub-area;
+    `explainer` (default, and every classic non-world call) → today's
+    labelled visual-explainer page, verbatim.
+    """
+    rmode = (render_mode or "explainer").lower()
+    if rmode == "place_scene":
+        return (
+            "You design an illustrated SCENE the reader has just stepped into — "
+            "a place to BE, not a diagram. Return JSON with keys: page_title "
+            "(<=8 words, the place's name), prompt (<=120 words describing the "
+            "view as if you just walked in — architecture, materials, light, "
+            "weather, depth, and the people/creatures and goings-on, as one "
+            "coherent illustrated scene with NO callout labels, annotation "
+            "lines, or diagram arrows), facts (3-6 short sensory or landmark "
+            "details a visitor would notice). Do not include any text outside "
+            "the JSON."
+        )
+    if rmode == "place_submap":
+        return (
+            "You design a closer MAP of just this district/area — a zoom of the "
+            "parent map into this region, in the same cartographic style. Return "
+            "JSON with keys: page_title (<=8 words, the area's name), prompt "
+            "(<=120 words describing an illustrated map of this sub-area — its "
+            "streets, sub-districts and landmarks laid out and named, drawn as a "
+            "map and not a scene), facts (3-6 named sub-areas or landmarks shown "
+            "on the map). Do not include any text outside the JSON."
+        )
+    return (
+        "You design a visual-explainer page for a given user query. Return "
+        "JSON with keys: page_title (<=8 words, title case), prompt (<=120 "
+        "words, a rich description of a single illustrated diagram suitable "
+        "for a text-capable image model — include labels, annotations, "
+        "callouts, and layout hints), facts (list of 3-6 short factual "
+        "bullets that should be visible as labels in the illustration). Do "
+        "not include any text outside the JSON."
     )
 
 
@@ -939,6 +1029,7 @@ async def plan_page(
     parent_query: str | None = None,
     subject_context: str | None = None,
     world_context: list[dict[str, Any]] | None = None,
+    render_mode: str | None = None,
 ) -> PagePlan:
     """Produce a page title, image-gen prompt, and factual snippets for the query.
 
@@ -955,15 +1046,11 @@ async def plan_page(
     per-object tracker memory). `subject_context` comes from the click VLM
     and is treated as authoritative — the planner must not contradict it.
     """
-    system_parts = [
-        "You design a visual-explainer page for a given user query. Return JSON "
-        "with keys: page_title (<=8 words, title case), prompt (<=120 words, a "
-        "rich description of a single illustrated diagram suitable for a "
-        "text-capable image model — include labels, annotations, callouts, and "
-        "layout hints), facts (list of 3-6 short factual bullets that should be "
-        "visible as labels in the illustration). Do not include any text "
-        "outside the JSON."
-    ]
+    # World Mode reframes the page from a labelled explainer into a PLACE: a
+    # scene the reader has stepped into, or a closer cartographic sub-map.
+    # `explainer` (the default) is today's behaviour, untouched.
+    rmode = (render_mode or "explainer").lower()
+    system_parts = [_render_base_instruction(rmode)]
     has_parent_frame = bool(
         (parent_title and parent_title.strip())
         or (parent_query and parent_query.strip())
@@ -1037,9 +1124,19 @@ async def plan_page(
                 f"PERTAINS TO \"{parent_label}\" — not the popular meaning "
                 "of the phrase in unrelated fields."
             )
-    user_parts.append(
-        "Design the illustrated page. Keep the layout readable at 1280x720."
-    )
+    if rmode == "place_scene":
+        user_parts.append(
+            "Paint the scene as if the reader just stepped into it. Keep it "
+            "readable at 1280x720."
+        )
+    elif rmode == "place_submap":
+        user_parts.append(
+            "Draw the district map. Keep the labels readable at 1280x720."
+        )
+    else:
+        user_parts.append(
+            "Design the illustrated page. Keep the layout readable at 1280x720."
+        )
     user = "\n\n".join(user_parts)
     if style_anchor:
         user += f"\n\nVisual style to preserve verbatim: {style_anchor}"

--- a/apps/modal-backend/tests/conftest.py
+++ b/apps/modal-backend/tests/conftest.py
@@ -44,6 +44,8 @@ _SCRUB = (
     "IMAGE_API_KEY",
     "IMAGE_MODEL",
     "IMAGE_SIZE",
+    # World Mode (tap enters a place; gated off by default).
+    "WORLD_MODE",
     "SENTRY_DSN",
 )
 

--- a/apps/modal-backend/tests/conftest.py
+++ b/apps/modal-backend/tests/conftest.py
@@ -46,6 +46,7 @@ _SCRUB = (
     "IMAGE_SIZE",
     # World Mode (tap enters a place; gated off by default).
     "WORLD_MODE",
+    "FAL_CONTINUE_MODEL",
     "SENTRY_DSN",
 )
 

--- a/apps/modal-backend/tests/test_click_resolution.py
+++ b/apps/modal-backend/tests/test_click_resolution.py
@@ -199,3 +199,45 @@ def test_build_garbage_confidence_falls_back_to_one() -> None:
         payload, x_pct=0.0, y_pct=0.0, fallback_subject="X"
     )
     assert res.confidence == 1.0
+
+
+# ---------- World Mode: enter_as + clarifiers -----------------------------
+
+
+def test_build_defaults_enter_as_explainer_and_no_clarifiers() -> None:
+    # Classic (non-world) payloads omit these → explainer, no questions.
+    res = llm._build_click_resolution(
+        {"subject": "x"}, x_pct=0.5, y_pct=0.5, fallback_subject="X"
+    )
+    assert res.enter_as == "explainer"
+    assert res.clarifiers == []
+
+
+def test_build_parses_enter_as_scene() -> None:
+    res = llm._build_click_resolution(
+        {"subject": "The Shades", "enter_as": "scene"},
+        x_pct=0.5,
+        y_pct=0.5,
+        fallback_subject="X",
+    )
+    assert res.enter_as == "scene"
+
+
+def test_build_invalid_enter_as_falls_back_to_explainer() -> None:
+    res = llm._build_click_resolution(
+        {"subject": "x", "enter_as": "teleport"},
+        x_pct=0.5,
+        y_pct=0.5,
+        fallback_subject="X",
+    )
+    assert res.enter_as == "explainer"
+
+
+def test_build_clarifiers_caps_at_two_and_filters_non_strings() -> None:
+    res = llm._build_click_resolution(
+        {"subject": "x", "clarifiers": ["Day or night?", "  ", "Busy?", "Third?", 5]},
+        x_pct=0.5,
+        y_pct=0.5,
+        fallback_subject="X",
+    )
+    assert res.clarifiers == ["Day or night?", "Busy?"]

--- a/apps/modal-backend/tests/test_click_resolution.py
+++ b/apps/modal-backend/tests/test_click_resolution.py
@@ -241,3 +241,17 @@ def test_build_clarifiers_caps_at_two_and_filters_non_strings() -> None:
         fallback_subject="X",
     )
     assert res.clarifiers == ["Day or night?", "Busy?"]
+
+
+def test_build_parses_surroundings_and_defaults_empty() -> None:
+    res = llm._build_click_resolution(
+        {"subject": "x", "surroundings": "  river to the south, market NE "},
+        x_pct=0.5,
+        y_pct=0.5,
+        fallback_subject="X",
+    )
+    assert res.surroundings == "river to the south, market NE"
+    bare = llm._build_click_resolution(
+        {"subject": "x"}, x_pct=0.5, y_pct=0.5, fallback_subject="X"
+    )
+    assert bare.surroundings == ""

--- a/apps/modal-backend/tests/test_image_continue.py
+++ b/apps/modal-backend/tests/test_image_continue.py
@@ -1,0 +1,66 @@
+"""Tests for the continuation provider (image_edit.continue_image).
+
+Kept in its own file so it doesn't collide with the expand-provider tests on
+another branch. No network: fal is mocked at the module level.
+"""
+from __future__ import annotations
+
+import pytest
+
+from providers import image_edit
+
+
+async def test_continue_image_defaults_to_kontext(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict = {}
+
+    async def fake_to_fal(data_url: str) -> str:
+        return "fal://region"
+
+    async def fake_sub(model: str, args: dict) -> dict:
+        captured["model"] = model
+        captured["args"] = args
+        return {"images": [{"url": "http://x"}], "requestId": "r1"}
+
+    async def fake_fetch(info: dict) -> tuple[bytes, str]:
+        return b"jpeg", "image/jpeg"
+
+    monkeypatch.setenv("FAL_KEY", "fk")
+    monkeypatch.setattr(image_edit, "to_fal_url", fake_to_fal)
+    monkeypatch.setattr(image_edit, "_fal_subscribe", fake_sub)
+    monkeypatch.setattr(image_edit, "_fetch_image_bytes", fake_fetch)
+
+    out = await image_edit.continue_image("data:image/png;base64,x", "zoom in")
+
+    assert out.jpeg_bytes == b"jpeg"
+    assert "kontext" in captured["model"]
+    # Kontext takes a singular image_url + prompt (per _edit_args_for).
+    assert captured["args"]["image_url"] == "fal://region"
+    assert captured["args"]["prompt"] == "zoom in"
+
+
+async def test_continue_image_respects_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict = {}
+
+    async def fake_to_fal(data_url: str) -> str:
+        return "fal://region"
+
+    async def fake_sub(model: str, args: dict) -> dict:
+        captured["model"] = model
+        return {"images": [{"url": "http://x"}]}
+
+    async def fake_fetch(info: dict) -> tuple[bytes, str]:
+        return b"j", "image/jpeg"
+
+    monkeypatch.setenv("FAL_KEY", "fk")
+    monkeypatch.setenv("FAL_CONTINUE_MODEL", "fal-ai/custom/continue")
+    monkeypatch.setattr(image_edit, "to_fal_url", fake_to_fal)
+    monkeypatch.setattr(image_edit, "_fal_subscribe", fake_sub)
+    monkeypatch.setattr(image_edit, "_fetch_image_bytes", fake_fetch)
+
+    await image_edit.continue_image("data:image/png;base64,x", "z")
+
+    assert captured["model"] == "fal-ai/custom/continue"

--- a/apps/modal-backend/tests/test_image_provider.py
+++ b/apps/modal-backend/tests/test_image_provider.py
@@ -148,6 +148,14 @@ def test_conditioning_preamble_empty_is_blank() -> None:
     assert image.conditioning_preamble([], "tap") == ""
 
 
+def test_conditioning_preamble_place_scene_reveals_within() -> None:
+    # World Mode entering a place: the region ref should say to reveal the
+    # fuller place within (a scene), distinct from the explainer "inside".
+    out = image.conditioning_preamble(["region", "parent"], "place_scene")
+    assert "reveal the fuller place within" in out.lower()
+    assert "outward" not in out.lower()
+
+
 def test_first_image_extracts_first_dict() -> None:
     assert image._first_image({"images": [{"url": "x"}, {"url": "y"}]}) == {"url": "x"}
 

--- a/apps/modal-backend/tests/test_llm_provider.py
+++ b/apps/modal-backend/tests/test_llm_provider.py
@@ -36,6 +36,17 @@ def test_render_base_place_submap_is_cartographic() -> None:
     assert "visual-explainer page" not in text
 
 
+def test_spatial_anchor_clause_only_for_places_with_surroundings() -> None:
+    s = "river to the south, market square NE"
+    assert "SPATIAL ANCHOR" in llm._spatial_anchor_clause("place_scene", s)
+    assert s in llm._spatial_anchor_clause("place_submap", s)
+    # No surroundings, or an explainer/classic page → no anchor clause.
+    assert llm._spatial_anchor_clause("place_scene", "") == ""
+    assert llm._spatial_anchor_clause("place_scene", None) == ""
+    assert llm._spatial_anchor_clause("explainer", s) == ""
+    assert llm._spatial_anchor_clause(None, s) == ""
+
+
 # ---------- _system_message + caching ------------------------------------
 
 

--- a/apps/modal-backend/tests/test_llm_provider.py
+++ b/apps/modal-backend/tests/test_llm_provider.py
@@ -14,6 +14,28 @@ import pytest
 
 from providers import llm
 
+# ---------- World Mode: render-mode base instruction ----------------------
+
+
+def test_render_base_explainer_is_default() -> None:
+    assert "visual-explainer page" in llm._render_base_instruction(None)
+    assert "visual-explainer page" in llm._render_base_instruction("explainer")
+    assert "visual-explainer page" in llm._render_base_instruction("bogus")
+
+
+def test_render_base_place_scene_is_immersive_without_labels() -> None:
+    text = llm._render_base_instruction("place_scene")
+    assert "stepped into" in text
+    assert "NO callout labels" in text
+    assert "visual-explainer page" not in text
+
+
+def test_render_base_place_submap_is_cartographic() -> None:
+    text = llm._render_base_instruction("place_submap")
+    assert "closer MAP" in text
+    assert "visual-explainer page" not in text
+
+
 # ---------- _system_message + caching ------------------------------------
 
 

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -37,9 +37,11 @@ import { getStrings, resolveOutputLocale } from "@/lib/i18n";
 import { useImageTier, useVideoTier } from "@/hooks/usePersistedTier";
 import { useExpandBloom } from "@/hooks/useExpandBloom";
 import { buildConditionRefs, orderedRefs } from "@/lib/image-condition";
+import { enterAsToRenderMode, findRevisitTarget } from "@/lib/world-mode";
 import { usePersistedLocale } from "@/hooks/usePersistedLocale";
 import { usePersistedTheme } from "@/hooks/usePersistedTheme";
 import { useStyleAnchor } from "@/hooks/useStyleAnchor";
+import { useWorldMode } from "@/hooks/useWorldMode";
 import { useStyleGalleryDismissed } from "@/hooks/useStyleGalleryDismissed";
 import { useTraceEmitter } from "@/hooks/useTraceEmitter";
 import { QueryToolbar } from "@/components/PlayPage/QueryToolbar";
@@ -290,11 +292,13 @@ export default function PlayPage() {
     xPx: number;
     yPx: number;
     resolve: (text: string | null) => void;
+    // World Mode semi-autonomy seeds this with the resolver's question(s).
+    question?: string;
   } | null>(null);
   const promptForHint = useCallback(
-    (xPx: number, yPx: number): Promise<string | null> => {
+    (xPx: number, yPx: number, question?: string): Promise<string | null> => {
       return new Promise((resolve) => {
-        setHintPrompt({ xPx, yPx, resolve });
+        setHintPrompt({ xPx, yPx, resolve, ...(question ? { question } : {}) });
       });
     },
     []
@@ -403,6 +407,15 @@ export default function PlayPage() {
     togglePin,
     setFromPreset,
   } = useStyleAnchor(sessionId);
+  // World Mode (per-session, off by default): a tap ENTERS the tapped place
+  // instead of explaining it, and entered places persist + reopen. `autonomy`
+  // chooses auto (just go) vs semi (ask a quick question first).
+  const {
+    enabled: worldEnabled,
+    autonomy: worldAutonomy,
+    setEnabled: setWorldEnabled,
+    setAutonomy: setWorldAutonomy,
+  } = useWorldMode(sessionId);
   const [styleGalleryDismissed, dismissStyleGallery] =
     useStyleGalleryDismissed(sessionId);
   const togglePinStyle = useCallback(
@@ -1192,6 +1205,40 @@ export default function PlayPage() {
       })();
     };
 
+    // World Mode "semi": a blocking click resolve so we can ask the model's
+    // clarifying questions before entering. Returns the parsed payload or null.
+    const resolveClickRemote = async (
+      xPct: number,
+      yPct: number
+    ): Promise<{
+      subject?: string;
+      style?: string;
+      subject_context?: string;
+      enter_as?: string;
+      clarifiers?: string[];
+    } | null> => {
+      try {
+        const res = await fetch("/api/resolve-click", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            image_data_url: currentImage,
+            x_pct: xPct,
+            y_pct: yPct,
+            parent_title: page.title,
+            parent_query: page.query,
+            output_locale: resolveOutputLocale(outputLocale),
+            world_mode: true,
+            autonomy: "semi",
+          }),
+        });
+        if (!res.ok) return null;
+        return await res.json();
+      } catch {
+        return null;
+      }
+    };
+
     const handler = async (evt: MouseEvent) => {
       if (phase === "generating") return;
       if (editMode) return;
@@ -1208,12 +1255,59 @@ export default function PlayPage() {
       // between setMorphFx and React installing a new effect with
       // phase==="generating".
       clickInFlightRef.current = true;
+      // World Mode: a plain re-tap near an already-entered spot REOPENS that
+      // saved place instead of generating a new one — the persistence that
+      // makes the atlas read as one continuous world.
+      if (worldEnabled && !evt.metaKey && !evt.ctrlKey) {
+        const revisitId = findRevisitTarget(
+          history.items,
+          currentNodeId,
+          click
+        );
+        if (revisitId) {
+          clickInFlightRef.current = false;
+          selectFromMap(revisitId);
+          return;
+        }
+      }
       // ⌘/Ctrl + click → float an inline hint input at the click point
       // and await the user's note (or null on cancel). Captured before any
       // ripple/morph state so the bubble is the first thing they see; on
       // cancel we release the in-flight slot so the next click is honored.
       let hint = "";
-      if (evt.metaKey || evt.ctrlKey) {
+      // World Mode "semi": resolve the tap up front and, when the model has
+      // clarifying questions, ask them in the hint bubble before entering.
+      let worldResolved:
+        | {
+            subject?: string;
+            style?: string;
+            subject_context?: string;
+            enter_as?: string;
+            clarifiers?: string[];
+          }
+        | null = null;
+      if (
+        worldEnabled &&
+        worldAutonomy === "semi" &&
+        !evt.metaKey &&
+        !evt.ctrlKey
+      ) {
+        worldResolved = await resolveClickRemote(click.x_pct, click.y_pct);
+        const questions = (worldResolved?.clarifiers ?? []).join("  ·  ");
+        if (questions) {
+          const rect = img.getBoundingClientRect();
+          const raw = await promptForHint(
+            evt.clientX - rect.left,
+            evt.clientY - rect.top,
+            questions
+          );
+          if (raw === null) {
+            clickInFlightRef.current = false;
+            return;
+          }
+          hint = raw;
+        }
+      } else if (evt.metaKey || evt.ctrlKey) {
         const rect = img.getBoundingClientRect();
         const raw = await promptForHint(
           evt.clientX - rect.left,
@@ -1257,9 +1351,12 @@ export default function PlayPage() {
       // Skip the prefetched-subject shortcut when a hint is present — the
       // hover prefetch was resolved without the user's note, so it would
       // ignore the angle they just typed.
-      const cached = hint
-        ? undefined
-        : cache.get(bucketKey(currentNodeId, click.x_pct, click.y_pct));
+      // In World Mode we skip the hover-prefetch shortcut so the backend always
+      // classifies the tap (scene / sub-map / explainer) and frames the page.
+      const cached =
+        hint || worldEnabled
+          ? undefined
+          : cache.get(bucketKey(currentNodeId, click.x_pct, click.y_pct));
       // Image conditioning: build the weighted reference stack from the CLEAN
       // parent (not the marker-annotated one) — region crop at the tap → whole
       // parent → session root as the anti-drift anchor (skipped when this page
@@ -1302,6 +1399,26 @@ export default function PlayPage() {
               prefetched_style: cached.style,
               ...(cached.subject_context
                 ? { prefetched_subject_context: cached.subject_context }
+                : {}),
+            }
+          : {}),
+        // World Mode "semi" already resolved the tap → reuse it (skips the
+        // backend's own VLM round-trip) and carry the place framing.
+        ...(worldResolved?.subject
+          ? {
+              prefetched_subject: worldResolved.subject,
+              prefetched_style: worldResolved.style ?? "",
+              ...(worldResolved.subject_context
+                ? { prefetched_subject_context: worldResolved.subject_context }
+                : {}),
+            }
+          : {}),
+        ...(worldEnabled
+          ? {
+              world_mode: true,
+              autonomy: worldAutonomy,
+              ...(enterAsToRenderMode(worldResolved?.enter_as) !== "explainer"
+                ? { render_mode: enterAsToRenderMode(worldResolved?.enter_as) }
                 : {}),
             }
           : {}),
@@ -1488,7 +1605,7 @@ export default function PlayPage() {
       inflight.clear();
       prefetchCurrentKeyRef.current = null;
     };
-  }, [page, phase, generate, imageTier, editMode, outputLocale, bucketKey, streamStatus, styleAnchor, promptForHint]);
+  }, [page, phase, generate, imageTier, editMode, outputLocale, bucketKey, streamStatus, styleAnchor, promptForHint, worldEnabled, worldAutonomy, history, selectFromMap]);
 
   // When the page changes, tear down any running stream.
   useEffect(() => {
@@ -1617,6 +1734,10 @@ export default function PlayPage() {
         setTheme={setTheme}
         imageTier={imageTier}
         setImageTier={setImageTier}
+        worldMode={worldEnabled}
+        setWorldMode={setWorldEnabled}
+        autonomy={worldAutonomy}
+        setAutonomy={setWorldAutonomy}
       />
 
       {isDraggingFile && <DragDropOverlay />}
@@ -1822,6 +1943,7 @@ export default function PlayPage() {
                 <HintPrompt
                   xPx={hintPrompt.xPx}
                   yPx={hintPrompt.yPx}
+                  placeholder={hintPrompt.question ?? ""}
                   onSubmit={(text) => {
                     hintPrompt.resolve(text);
                     setHintPrompt(null);

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -1216,6 +1216,7 @@ export default function PlayPage() {
       subject_context?: string;
       enter_as?: string;
       clarifiers?: string[];
+      surroundings?: string;
     } | null> => {
       try {
         const res = await fetch("/api/resolve-click", {
@@ -1284,6 +1285,7 @@ export default function PlayPage() {
             subject_context?: string;
             enter_as?: string;
             clarifiers?: string[];
+            surroundings?: string;
           }
         | null = null;
       if (
@@ -1412,6 +1414,9 @@ export default function PlayPage() {
                 ? { prefetched_subject_context: worldResolved.subject_context }
                 : {}),
             }
+          : {}),
+        ...(worldResolved?.surroundings
+          ? { prefetched_surroundings: worldResolved.surroundings }
           : {}),
         ...(worldEnabled
           ? {

--- a/apps/web/components/PlayPage/HintPrompt.tsx
+++ b/apps/web/components/PlayPage/HintPrompt.tsx
@@ -8,6 +8,9 @@ interface Props {
   yPx: number;
   onSubmit: (text: string) => void;
   onCancel: () => void;
+  /** Override the placeholder — World Mode semi-autonomy seeds it with the
+   * resolver's clarifying question(s) so the bubble asks before entering. */
+  placeholder?: string;
 }
 
 const MAX_LEN = 240;
@@ -17,7 +20,13 @@ const MAX_LEN = 240;
  * a small text bubble anchored above the click point inside the image
  * figure. Enter submits, Esc cancels, click-outside cancels.
  */
-export function HintPrompt({ xPx, yPx, onSubmit, onCancel }: Props) {
+export function HintPrompt({
+  xPx,
+  yPx,
+  onSubmit,
+  onCancel,
+  placeholder,
+}: Props) {
   const [value, setValue] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -54,7 +63,9 @@ export function HintPrompt({ xPx, yPx, onSubmit, onCancel }: Props) {
               onCancel();
             }
           }}
-          placeholder="add a note — e.g. cross-section, for a 5-year-old"
+          placeholder={
+            placeholder || "add a note — e.g. cross-section, for a 5-year-old"
+          }
           maxLength={MAX_LEN}
           aria-label="Click hint"
           className="w-80 bg-transparent text-sm leading-tight outline-none placeholder:text-[var(--color-ink)]/40"

--- a/apps/web/components/PlayPage/QueryToolbar.tsx
+++ b/apps/web/components/PlayPage/QueryToolbar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ChangeEvent, FormEvent, RefObject } from "react";
-import type { ImageTier } from "@openflipbook/config";
+import type { Autonomy, ImageTier } from "@openflipbook/config";
 
 import { SUPPORTED_LOCALES, type SupportedLocale, type LocaleStrings } from "@/lib/i18n";
 import { THEMES, type Theme } from "@/hooks/usePersistedTheme";
@@ -22,6 +22,10 @@ interface Props {
   setTheme: (t: Theme) => void;
   imageTier: ImageTier;
   setImageTier: (t: ImageTier) => void;
+  worldMode: boolean;
+  setWorldMode: (on: boolean) => void;
+  autonomy: Autonomy;
+  setAutonomy: (a: Autonomy) => void;
 }
 
 export function QueryToolbar({
@@ -38,6 +42,10 @@ export function QueryToolbar({
   setTheme,
   imageTier,
   setImageTier,
+  worldMode,
+  setWorldMode,
+  autonomy,
+  setAutonomy,
 }: Props) {
   return (
     <>
@@ -126,6 +134,48 @@ export function QueryToolbar({
               {tier}
             </button>
           ))}
+        </div>
+        <div
+          role="group"
+          aria-label="World Mode"
+          className="flex items-center overflow-hidden rounded-full border border-[var(--color-edge)] text-xs"
+          title="World Mode — tap to ENTER places (immersive scenes / closer sub-maps) instead of explaining a topic; entered places persist and reopen."
+        >
+          <button
+            type="button"
+            onClick={() => setWorldMode(!worldMode)}
+            aria-pressed={worldMode}
+            className={
+              "px-2.5 py-1 transition-colors " +
+              (worldMode
+                ? "bg-[var(--color-ink)] text-[var(--color-canvas)]"
+                : "hover:bg-[var(--color-ink)]/5")
+            }
+          >
+            world
+          </button>
+          {worldMode &&
+            (["auto", "semi"] as const).map((a) => (
+              <button
+                key={a}
+                type="button"
+                onClick={() => setAutonomy(a)}
+                aria-pressed={autonomy === a}
+                title={
+                  a === "auto"
+                    ? "Auto — enter straight away"
+                    : "Semi — ask a quick question first"
+                }
+                className={
+                  "px-2.5 py-1 transition-colors " +
+                  (autonomy === a
+                    ? "bg-[var(--color-ink)] text-[var(--color-canvas)]"
+                    : "hover:bg-[var(--color-ink)]/5")
+                }
+              >
+                {a}
+              </button>
+            ))}
         </div>
         <button
           type="submit"

--- a/apps/web/hooks/useWorldMode.ts
+++ b/apps/web/hooks/useWorldMode.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import type { Autonomy } from "@openflipbook/config";
+
+export interface WorldModeState {
+  enabled: boolean;
+  autonomy: Autonomy;
+}
+
+const DEFAULT: WorldModeState = { enabled: false, autonomy: "auto" };
+
+function storageKey(sessionId: string): string {
+  return `openflipbook.worldMode.${sessionId}`;
+}
+
+/**
+ * Per-session World Mode preference (off by default), persisted to localStorage
+ * and hydrated on mount / sessionId change — mirrors {@link useStyleAnchor}.
+ * When off the classic tap=learn experience is unchanged; when on, a tap enters
+ * the tapped place and `autonomy` chooses auto (just go) vs semi (ask first).
+ */
+export function useWorldMode(sessionId: string) {
+  const [state, setState] = useState<WorldModeState>(DEFAULT);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const raw = window.localStorage.getItem(storageKey(sessionId));
+      if (!raw) {
+        setState(DEFAULT);
+        return;
+      }
+      const parsed = JSON.parse(raw) as Partial<WorldModeState>;
+      setState({
+        enabled: Boolean(parsed.enabled),
+        autonomy: parsed.autonomy === "semi" ? "semi" : "auto",
+      });
+    } catch {
+      setState(DEFAULT);
+    }
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(storageKey(sessionId), JSON.stringify(state));
+    } catch {
+      /* private mode / full disk — accept the loss */
+    }
+  }, [state, sessionId]);
+
+  const setEnabled = useCallback(
+    (enabled: boolean) => setState((s) => ({ ...s, enabled })),
+    [],
+  );
+  const setAutonomy = useCallback(
+    (autonomy: Autonomy) => setState((s) => ({ ...s, autonomy })),
+    [],
+  );
+
+  return {
+    enabled: state.enabled,
+    autonomy: state.autonomy,
+    setEnabled,
+    setAutonomy,
+  } as const;
+}

--- a/apps/web/lib/world-mode.test.ts
+++ b/apps/web/lib/world-mode.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  REVISIT_RADIUS,
+  enterAsToRenderMode,
+  findRevisitTarget,
+} from "./world-mode";
+
+describe("enterAsToRenderMode", () => {
+  it("maps scene/submap and defaults to explainer", () => {
+    expect(enterAsToRenderMode("scene")).toBe("place_scene");
+    expect(enterAsToRenderMode("submap")).toBe("place_submap");
+    expect(enterAsToRenderMode("explainer")).toBe("explainer");
+    expect(enterAsToRenderMode(undefined)).toBe("explainer");
+    expect(enterAsToRenderMode("bogus")).toBe("explainer");
+  });
+});
+
+describe("findRevisitTarget", () => {
+  const items = [
+    { nodeId: "a", parentId: "P", clickInParent: { xPct: 0.2, yPct: 0.2 } },
+    { nodeId: "b", parentId: "P", clickInParent: { xPct: 0.8, yPct: 0.8 } },
+    { nodeId: "c", parentId: "Q", clickInParent: { xPct: 0.21, yPct: 0.21 } },
+    { nodeId: "d", parentId: "P" }, // a tap child with no recorded origin
+  ];
+
+  it("reopens the nearest child of the current node within radius", () => {
+    expect(findRevisitTarget(items, "P", { x_pct: 0.22, y_pct: 0.22 })).toBe("a");
+  });
+
+  it("returns null when the tap is outside every child's radius", () => {
+    expect(findRevisitTarget(items, "P", { x_pct: 0.5, y_pct: 0.5 })).toBeNull();
+  });
+
+  it("ignores children of other parents", () => {
+    // (0.21,0.21) is right on c — but c belongs to Q, so under P we get a.
+    expect(findRevisitTarget(items, "P", { x_pct: 0.21, y_pct: 0.21 })).toBe("a");
+  });
+
+  it("returns null without a current node", () => {
+    expect(findRevisitTarget(items, null, { x_pct: 0.2, y_pct: 0.2 })).toBeNull();
+  });
+
+  it("respects a custom radius", () => {
+    expect(
+      findRevisitTarget(items, "P", { x_pct: 0.3, y_pct: 0.2 }, REVISIT_RADIUS),
+    ).toBeNull();
+    expect(findRevisitTarget(items, "P", { x_pct: 0.3, y_pct: 0.2 }, 0.2)).toBe("a");
+  });
+});

--- a/apps/web/lib/world-mode.ts
+++ b/apps/web/lib/world-mode.ts
@@ -1,0 +1,46 @@
+import type { EnterAs, RenderMode } from "@openflipbook/config";
+
+/**
+ * World Mode client helpers (pure).
+ *
+ * `enterAsToRenderMode` maps the resolver's read of what was tapped onto the
+ * planner's render mode. `findRevisitTarget` is the "reopen the same district"
+ * check: a re-tap that lands near an existing child's origin reopens that saved
+ * node instead of generating a fresh place — the persistence the world needs.
+ */
+
+export function enterAsToRenderMode(
+  enterAs: EnterAs | string | undefined | null,
+): RenderMode {
+  if (enterAs === "scene") return "place_scene";
+  if (enterAs === "submap") return "place_submap";
+  return "explainer";
+}
+
+export interface RevisitCandidate {
+  nodeId: string | null;
+  parentId?: string | null;
+  clickInParent?: { xPct: number; yPct: number };
+}
+
+// How close (normalised image units, euclidean) a re-tap must land to an
+// existing child's origin to REOPEN it rather than generate a new place.
+export const REVISIT_RADIUS = 0.07;
+
+export function findRevisitTarget(
+  items: readonly RevisitCandidate[],
+  parentNodeId: string | null,
+  click: { x_pct: number; y_pct: number },
+  radius: number = REVISIT_RADIUS,
+): string | null {
+  if (!parentNodeId) return null;
+  let best: { id: string; d: number } | null = null;
+  for (const it of items) {
+    if (!it.nodeId || it.parentId !== parentNodeId || !it.clickInParent) continue;
+    const dx = it.clickInParent.xPct - click.x_pct;
+    const dy = it.clickInParent.yPct - click.y_pct;
+    const d = Math.hypot(dx, dy);
+    if (d <= radius && (best === null || d < best.d)) best = { id: it.nodeId, d };
+  }
+  return best ? best.id : null;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,11 @@ services:
       # to A/B against the old text-only generation:
       #   IMAGE_CONDITIONING=false docker compose up -d backend
       IMAGE_CONDITIONING: ${IMAGE_CONDITIONING:-true}
+      # World Mode: a tap ENTERS the tapped place (an immersive scene / a closer
+      # sub-map) instead of explaining a topic, and places persist + reopen.
+      # Default off — turn on per-session from the UI once enabled here:
+      #   WORLD_MODE=true docker compose up -d backend
+      WORLD_MODE: ${WORLD_MODE:-false}
     # Force public resolvers — Docker's default 127.0.0.11 link-local resolver
     # has been flaking on the fal.ai / r2.cloudflarestorage.com hosts during
     # E2E runs (sporadic ESERVFAIL / EAI_AGAIN), which manifests as

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -152,6 +152,10 @@ export interface ResolveClickResponse {
   // clarifying questions (semi autonomy only). Absent in classic mode.
   enter_as?: EnterAs;
   clarifiers?: string[];
+  // World Mode spatial anchor: what sits AROUND the tapped spot and in which
+  // direction ("river to the south, timbered houses west, market square NE"),
+  // so the entered place keeps its neighbours where the parent map had them.
+  surroundings?: string;
 }
 
 export interface GenerateProgressEvent {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -15,6 +15,15 @@ export type ImageTier = "fast" | "balanced" | "pro";
 
 export type VideoTier = "fast" | "balanced" | "pro";
 
+// World Mode (opt-in). `autonomy` "auto" generates straight away; "semi" first
+// surfaces the resolver's clarifying questions. `RenderMode` is how a tapped
+// subject is drawn — an immersive place you've stepped into, a closer
+// cartographic map of a sub-area, or today's labelled explainer diagram.
+export type Autonomy = "auto" | "semi";
+export type RenderMode = "place_scene" | "place_submap" | "explainer";
+// The click-resolver's read of what was tapped (drives RenderMode in world mode).
+export type EnterAs = "scene" | "submap" | "explainer";
+
 export interface GenerateRequestBody {
   query: string;
   aspect_ratio: AspectRatio;
@@ -67,6 +76,14 @@ export interface GenerateRequestBody {
   // Built client-side (lib/image-condition.ts). Omit → today's text-only gen.
   condition_image_urls?: string[];
   condition_roles?: string[];
+  // World Mode (opt-in; the backend also gates it behind the WORLD_MODE env so
+  // it's a no-op in prod until enabled). When on, a tap ENTERS the tapped place
+  // — a scene you stand in or a closer sub-map — instead of explaining a topic,
+  // and the place persists + reopens. `render_mode` explicitly overrides the
+  // per-place framing the resolver would otherwise pick from `enter_as`.
+  world_mode?: boolean;
+  autonomy?: Autonomy;
+  render_mode?: RenderMode;
   trace_id?: string;
 }
 
@@ -93,6 +110,10 @@ export interface ResolveClickRequestBody {
   parent_query?: string;
   output_locale?: string;
   prior_rejected_subject?: string;
+  // World Mode: ask the resolver to also classify what was tapped (`enter_as`)
+  // and, in "semi" autonomy, propose short clarifying questions before entering.
+  world_mode?: boolean;
+  autonomy?: Autonomy;
   trace_id?: string;
 }
 
@@ -126,6 +147,11 @@ export interface ResolveClickResponse {
   confidence?: number;
   point?: ResolveClickPoint | null;
   bbox?: ResolveClickBBox | null;
+  // World Mode: the resolver's read of what was tapped (a place to step into, a
+  // sub-area to map closer, or a concept to explain) + up to two short
+  // clarifying questions (semi autonomy only). Absent in classic mode.
+  enter_as?: EnterAs;
+  clarifiers?: string[];
 }
 
 export interface GenerateProgressEvent {


### PR DESCRIPTION
## what this is

**World Mode** — opt-in, off in prod behind the `WORLD_MODE` env. When on, a tap stops *explaining a topic* and **enters the tapped place**, the world stays put (places persist + reopen), and a sub-map literally *continues* the map you came from. This is the foundation of the "living atlas": seed a world (a query map or an uploaded map) → enter its parts on demand → they're saved and coherent. Off → today's tap=learn is byte-for-byte unchanged.

## the loop

- **Enter a place.** The click classifier reads what you tapped (`enter_as`): a **scene** you step into (the planner paints an immersive view — no diagram callouts), a **sub-map** (a closer cartographic zoom), or an **explainer** (today's labelled diagram, so tapping an actual *concept* still teaches).
- **Keep the neighbours where they were.** The same classifier also reports `surroundings` ("river to the south, market NE", read from the parent's own layout); the planner pins the entered place to that exact spot and keeps those neighbours in their directions — it *continues* the map instead of re-imagining it.
- **Sub-maps continue the pixels.** A `place_submap` entry doesn't re-plan — it zoom-continues the click region with **FLUX Kontext**, so the closer map keeps the same streets / buildings / labels. (Same move map-pan makes with BRIA outpaint; Kontext is the zoom-in counterpart, and it was the bakeoff winner for strict in-context continuation.)
- **Revisit.** Re-tapping within ~7% of a spot you already entered reopens that *saved* node instead of generating a new one.
- **Auto / Semi.** Auto just goes; semi first asks ≤2 short clarifying questions (surfaced in the existing hint bubble) before entering, folding your answer into the planner.

## how it's wired (additive, flag-gated)

- **packages/config** — `world_mode` / `autonomy` / `render_mode` on the generate body; `enter_as` / `clarifiers` / `surroundings` on the resolve-click response.
- **backend** — `click_to_subject` classifies (`enter_as` + `surroundings` + semi `clarifiers`) in the same VLM call; `plan_page` swaps its opening brief per `render_mode` (`_render_base_instruction`) and pins neighbours (`_spatial_anchor_clause`); `generate.py` derives the framing, threads it through, and routes `place_submap` to `image_edit.continue_image` (Kontext); `_world_mode_on` gates everything behind the env flag.
- **frontend** — `useWorldMode` (per-session localStorage, off by default), a `world ◦ auto|semi` toolbar group, and a tap handler that reopens within ~7% (`findRevisitTarget`), skips the prefetch shortcut so the backend always frames the place, and runs the semi ask via the hint bubble.

## verified live (`WORLD_MODE=true`, Gemini planner)

Ankh-Morpork map → **tapped the Patrician's Palace** → dropped *inside* a columned throne-hall (a scene, titled "Inside the Stately Patrician's Palace"), river out the windows. **Tapped The Shades** → classified sub-map → `image.continue model=fal-ai/flux-pro/kontext` → a closer map keeping the same buildings + the "maze of ancient back-alleys" banner, zoomed and aligned ("The Labyrinthine Alleys of The Shades"). **Re-tapped the same spot** → reopened the saved node in ~400ms, no regeneration. World **off** → tap = explainer diagram, unchanged.

## caveats / follow-ups

- Works on fresh in-session pages (the parent is a data URL we upload to fal); a *reloaded* page hands fal a `localhost:9000` Minio URL it can't reach — fine in prod (R2 is public), noted for local.
- Scene entries can't pixel-continue an aerial map into a street view (the camera moves), so there alignment is semantic (the `surroundings` anchor) rather than pixel-true — pixel-true is the sub-map/Kontext path.
- Next: persist an explicit entity→node link for revisit that survives re-layout; a "describe a world" seed + a tappable district overlay; upload-a-map.

256 backend tests + 294 web tests green; ruff + mypy + tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)