### PR TITLE
fix: style medium-lock across all paths + entity-size↔map alignment

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -210,21 +210,6 @@ def _condition_url_for_role(body: GenerateBody, role: str) -> str | None:
     return None
 
 
-def _negative_prompt_for(style_anchor: str | None) -> str | None:
-    """A medium-guard negative prompt, gated behind IMAGE_NEGATIVE_PROMPT (off by
-    default — fal nano-banana ignores it and a wrong schema can 422). Only the
-    pro/flux models actually honour it (see image._args_for). Returns None when
-    disabled or when there's no style to protect."""
-    if not style_anchor:
-        return None
-    if not env_flag("IMAGE_NEGATIVE_PROMPT", "false"):
-        return None
-    return (
-        "photorealistic, photograph, 3D render, octane render, CGI, "
-        "isometric line-art, flat vector, anime, cel-shaded"
-    )
-
-
 def _layout_clause_for(body: GenerateBody) -> str:
     """The geometry layout-constraint clause for this request, or "" when the
     geometry-gen flag is off or no expected layout was sent."""
@@ -628,7 +613,6 @@ async def _event_stream(
                     tier=body.image_tier,
                     model_override=body.image_model,
                     reference_urls=expand_cond_refs,
-                    negative_prompt=_negative_prompt_for(expand_style_lock),
                 )
                 return idx, neighbor, plan, img
 
@@ -967,7 +951,6 @@ async def _event_stream(
                     tier=body.image_tier,
                     model_override=body.image_model,
                     reference_urls=cond_refs,
-                    negative_prompt=_negative_prompt_for(style_anchor),
                 )
             )
         # Drive both tasks to completion. If the draft finishes first, emit

--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -74,6 +74,11 @@ class WorldContextEntity(BaseModel):
     # primitives only (door=open, lantern=lit, mira_present=true). The tightened
     # union (not dict[str, Any]) keeps the TS<->Py schema-parity check meaningful.
     state: dict[str, str | int | float | bool] = Field(default_factory=dict)
+    # FIX C: optional geometric size carried from the entity's WorldEntityGeo so
+    # the planner can keep recurring entities at a consistent relative scale.
+    # Mirrors the TS `footprint?: {w,d}` / `height?` (schema-parity gated).
+    footprint: dict[str, float] | None = None
+    height: float | None = None
 
 
 # Geometric world model — Pydantic mirrors of the packages/config TS shapes.
@@ -191,6 +196,33 @@ def _geometric_world_on() -> bool:
 def _world_geometry_gen_on() -> bool:
     """Geometry steers generation (WORLD_GEOMETRY_GEN). Off → no layout clause."""
     return env_flag("WORLD_GEOMETRY_GEN")
+
+
+def _condition_url_for_role(body: GenerateBody, role: str) -> str | None:
+    """The first condition image URL tagged with `role` (e.g. "style"), or None.
+    Lets the edit path pull the style exemplar the client already sends in the
+    condition stack (condition_image_urls / condition_roles, same index)."""
+    urls = body.condition_image_urls or []
+    roles = body.condition_roles or []
+    for u, r in zip(urls, roles, strict=False):
+        if r == role and u:
+            return u
+    return None
+
+
+def _negative_prompt_for(style_anchor: str | None) -> str | None:
+    """A medium-guard negative prompt, gated behind IMAGE_NEGATIVE_PROMPT (off by
+    default — fal nano-banana ignores it and a wrong schema can 422). Only the
+    pro/flux models actually honour it (see image._args_for). Returns None when
+    disabled or when there's no style to protect."""
+    if not style_anchor:
+        return None
+    if not env_flag("IMAGE_NEGATIVE_PROMPT", "false"):
+        return None
+    return (
+        "photorealistic, photograph, 3D render, octane render, CGI, "
+        "isometric line-art, flat vector, anime, cel-shaded"
+    )
 
 
 def _layout_clause_for(body: GenerateBody) -> str:
@@ -414,9 +446,16 @@ async def _event_stream(
                 yield _sse({"type": "error", "message": "edit mode requires an instruction"}, trace_id)
                 return
             yield _sse({"type": "status", "stage": "planning"}, trace_id)
+            # Style consistency on edits: the web client already sends the session
+            # style lock + a "style" condition ref, but the edit path used to drop
+            # both. Thread the text lock into the polish and the exemplar image into
+            # the edit so an edit can't drift the world's art medium.
+            edit_style_lock = (body.session_style_anchor or "").strip() or None
+            edit_style_ref = _condition_url_for_role(body, "style")
             polished = await llm.polish_edit_instruction(
                 instruction=raw_instruction,
                 page_title=body.parent_title,
+                style_anchor=edit_style_lock,
             )
             yield _sse(
                 {
@@ -431,6 +470,7 @@ async def _event_stream(
                 instruction=polished,
                 tier=body.image_tier,
                 model_override=body.image_model,
+                style_ref_url=edit_style_ref,
             )
             edit_data_url = image_provider.encode_data_url(
                 edit_result.jpeg_bytes, edit_result.mime_type
@@ -588,6 +628,7 @@ async def _event_stream(
                     tier=body.image_tier,
                     model_override=body.image_model,
                     reference_urls=expand_cond_refs,
+                    negative_prompt=_negative_prompt_for(expand_style_lock),
                 )
                 return idx, neighbor, plan, img
 
@@ -926,6 +967,7 @@ async def _event_stream(
                     tier=body.image_tier,
                     model_override=body.image_model,
                     reference_urls=cond_refs,
+                    negative_prompt=_negative_prompt_for(style_anchor),
                 )
             )
         # Drive both tasks to completion. If the draft finishes first, emit

--- a/apps/modal-backend/providers/image.py
+++ b/apps/modal-backend/providers/image.py
@@ -111,28 +111,23 @@ def _args_for(
     prompt: str,
     aspect_ratio: str,
     reference_urls: list[str] | None = None,
-    negative_prompt: str | None = None,
 ) -> dict[str, Any]:
     if "seedream" in model:
-        # seedream is text-to-image only here — no reference conditioning, and it
-        # ignores negative_prompt.
+        # seedream is text-to-image only here — no reference conditioning.
         return {
             "prompt": prompt,
             "image_size": SEEDREAM_SIZE_MAP.get(aspect_ratio, "landscape_16_9"),
         }
-    # nano-banana + nano-banana-pro both accept aspect_ratio directly, plus an
-    # optional `image_urls` list for multi-reference conditioning.
+    # nano-banana + nano-banana-pro accept aspect_ratio directly, plus an optional
+    # `image_urls` list. NOTE (verified via scripts/verify-fal-models.py): NO image
+    # model in use accepts `negative_prompt` (nano-banana, nano-banana-pro and
+    # flux-pro/kontext all omit it) — so we never send one; the MEDIUM LOCK in the
+    # prompt text is the model-agnostic style guard. Also: the text-to-image
+    # nano-banana schemas don't list `image_urls`, so refs are only reliably
+    # honoured on the edit/continue endpoints (kontext takes a singular image_url).
     args: dict[str, Any] = {"prompt": prompt, "aspect_ratio": aspect_ratio}
     if reference_urls and "nano-banana" in model:
         args["image_urls"] = reference_urls
-    # A negative prompt is honoured by nano-banana-pro and flux/kontext; base
-    # nano-banana and seedream ignore (or reject) it, so only attach it where it
-    # actually lands. Gated upstream behind IMAGE_NEGATIVE_PROMPT (off by default
-    # pending a fal-schema check).
-    if negative_prompt and (
-        "nano-banana-pro" in model or "flux" in model or "kontext" in model
-    ):
-        args["negative_prompt"] = negative_prompt
     return args
 
 
@@ -258,7 +253,6 @@ async def generate_image(
     tier: str | None = None,
     model_override: str | None = None,
     reference_urls: list[str] | None = None,
-    negative_prompt: str | None = None,
 ) -> GeneratedImage:
     from obs import span
 
@@ -294,7 +288,7 @@ async def generate_image(
         refs=len(fal_refs or []),
     ) as ctx:
         result = await _fal_subscribe(
-            model, _args_for(model, prompt, aspect_ratio, fal_refs, negative_prompt)
+            model, _args_for(model, prompt, aspect_ratio, fal_refs)
         )
         image_info = _first_image(result)
         jpeg_bytes, mime = await _fetch_image_bytes(image_info)

--- a/apps/modal-backend/providers/image.py
+++ b/apps/modal-backend/providers/image.py
@@ -111,9 +111,11 @@ def _args_for(
     prompt: str,
     aspect_ratio: str,
     reference_urls: list[str] | None = None,
+    negative_prompt: str | None = None,
 ) -> dict[str, Any]:
     if "seedream" in model:
-        # seedream is text-to-image only here — no reference conditioning.
+        # seedream is text-to-image only here — no reference conditioning, and it
+        # ignores negative_prompt.
         return {
             "prompt": prompt,
             "image_size": SEEDREAM_SIZE_MAP.get(aspect_ratio, "landscape_16_9"),
@@ -123,6 +125,14 @@ def _args_for(
     args: dict[str, Any] = {"prompt": prompt, "aspect_ratio": aspect_ratio}
     if reference_urls and "nano-banana" in model:
         args["image_urls"] = reference_urls
+    # A negative prompt is honoured by nano-banana-pro and flux/kontext; base
+    # nano-banana and seedream ignore (or reject) it, so only attach it where it
+    # actually lands. Gated upstream behind IMAGE_NEGATIVE_PROMPT (off by default
+    # pending a fal-schema check).
+    if negative_prompt and (
+        "nano-banana-pro" in model or "flux" in model or "kontext" in model
+    ):
+        args["negative_prompt"] = negative_prompt
     return args
 
 
@@ -161,11 +171,27 @@ def conditioning_preamble(roles: list[str], mode: str) -> str:
         elif role == "parent":
             lines.append(
                 f"Image {i}: the surrounding scene — match its world, palette, "
-                "lighting and render style closely."
+                "lighting and, above all, its ART MEDIUM (the drawing/render "
+                "technique itself), not just the colours."
             )
         elif role == "anchor":
             lines.append(
-                f"Image {i}: the overall look of this world — stay consistent with it."
+                f"Image {i}: the overall look of this world — stay consistent "
+                "with its art medium and palette."
+            )
+        elif role == "style":
+            # The persistent medium exemplar (root/pinned render). This is the
+            # load-bearing line for style consistency: the user's complaint was
+            # interiors coming back photoreal / isometric when the source is an
+            # engraving. Name the medium and forbid drift explicitly.
+            lines.append(
+                f"Image {i}: the STYLE REFERENCE — the exact art MEDIUM of this "
+                "world (e.g. hand-drawn engraving / woodcut hatching / ink line "
+                "work; or watercolour, flat infographic, blueprint — whatever it "
+                "shows). Reproduce THIS medium faithfully: same linework, texture "
+                "and level of stylisation. Do NOT switch to photorealism, a 3D "
+                "render, isometric line-art or any other medium, however much the "
+                "subject might invite it."
             )
         else:
             lines.append(f"Image {i}: visual reference — stay consistent with it.")
@@ -232,6 +258,7 @@ async def generate_image(
     tier: str | None = None,
     model_override: str | None = None,
     reference_urls: list[str] | None = None,
+    negative_prompt: str | None = None,
 ) -> GeneratedImage:
     from obs import span
 
@@ -267,7 +294,7 @@ async def generate_image(
         refs=len(fal_refs or []),
     ) as ctx:
         result = await _fal_subscribe(
-            model, _args_for(model, prompt, aspect_ratio, fal_refs)
+            model, _args_for(model, prompt, aspect_ratio, fal_refs, negative_prompt)
         )
         image_info = _first_image(result)
         jpeg_bytes, mime = await _fetch_image_bytes(image_info)

--- a/apps/modal-backend/providers/image.py
+++ b/apps/modal-backend/providers/image.py
@@ -122,9 +122,12 @@ def _args_for(
     # `image_urls` list. NOTE (verified via scripts/verify-fal-models.py): NO image
     # model in use accepts `negative_prompt` (nano-banana, nano-banana-pro and
     # flux-pro/kontext all omit it) — so we never send one; the MEDIUM LOCK in the
-    # prompt text is the model-agnostic style guard. Also: the text-to-image
-    # nano-banana schemas don't list `image_urls`, so refs are only reliably
-    # honoured on the edit/continue endpoints (kontext takes a singular image_url).
+    # prompt text is the model-agnostic style guard. And the text-to-image nano
+    # endpoints accept `image_urls` but IGNORE it — an empirical test (a photoreal
+    # prompt + an engraving ref came back still-photoreal) confirms fresh-gen image
+    # conditioning is a no-op here; refs only bite on the edit/continue endpoints
+    # (nano-banana/edit takes image_urls, kontext a singular image_url). We still
+    # pass them (harmless, future-proof), but the prompt TEXT does the real work.
     args: dict[str, Any] = {"prompt": prompt, "aspect_ratio": aspect_ratio}
     if reference_urls and "nano-banana" in model:
         args["image_urls"] = reference_urls

--- a/apps/modal-backend/providers/image_edit.py
+++ b/apps/modal-backend/providers/image_edit.py
@@ -54,15 +54,21 @@ def _resolve_edit_model(tier: str | None, model_override: str | None) -> str:
     return os.environ.get(env_key) or EDIT_TIER_MODELS[resolved]
 
 
-def _edit_args_for(model: str, instruction: str, image_url: str) -> dict[str, Any]:
-    # nano-banana/edit + nano-banana-pro both take `image_urls` (list).
+def _edit_args_for(
+    model: str, instruction: str, image_url: str, style_ref_url: str | None = None
+) -> dict[str, Any]:
+    # nano-banana/edit + nano-banana-pro both take `image_urls` (list) — append
+    # the style exemplar (when present) so the edit keeps the world's art medium.
     if "nano-banana" in model:
-        return {"prompt": instruction, "image_urls": [image_url]}
-    # flux-pro/kontext takes `image_url` (singular) per fal schema.
+        urls = [image_url] + ([style_ref_url] if style_ref_url else [])
+        return {"prompt": instruction, "image_urls": urls}
+    # flux-pro/kontext takes `image_url` (singular) per fal schema — it can't take
+    # a second ref, so the medium lock rides the polished instruction text instead.
     if "kontext" in model:
         return {"prompt": instruction, "image_url": image_url}
     # Reasonable default — mirror the nano-banana shape.
-    return {"prompt": instruction, "image_urls": [image_url]}
+    urls = [image_url] + ([style_ref_url] if style_ref_url else [])
+    return {"prompt": instruction, "image_urls": urls}
 
 
 async def edit_image(
@@ -70,16 +76,22 @@ async def edit_image(
     instruction: str,
     tier: str | None = None,
     model_override: str | None = None,
+    style_ref_url: str | None = None,
 ) -> GeneratedImage:
     from obs import span
 
     _ensure_fal_key()
     model = _resolve_edit_model(tier, model_override)
     image_url = await to_fal_url(image_data_url)
+    # The style exemplar only helps the nano models (they accept a 2nd ref);
+    # Kontext is singular-ref, so it leans on the instruction's medium clause.
+    style_fal: str | None = None
+    if style_ref_url and "nano-banana" in model:
+        style_fal = await to_fal_url(style_ref_url)
     async with span("image.edit", model=model, instr_len=len(instruction)) as ctx:
         result = await _fal_subscribe(
             model,
-            _edit_args_for(model, instruction, image_url),
+            _edit_args_for(model, instruction, image_url, style_fal),
         )
         image_info = _first_image(result)
         jpeg_bytes, mime = await _fetch_image_bytes(image_info)

--- a/apps/modal-backend/providers/llm.py
+++ b/apps/modal-backend/providers/llm.py
@@ -1109,13 +1109,18 @@ async def plan_page(
         system_parts.append(clause)
     if style_anchor:
         system_parts.append(
-            "VISUAL STYLE LOCK (CRITICAL): the new illustration MUST be drawn "
-            f"in this exact style — \"{style_anchor}\". Match the medium, "
-            "palette, line work, level of stylization, and perspective. Do "
-            "NOT switch to a different art style. Begin the `prompt` with a "
-            "leading clause that names the style explicitly so the image "
-            "model can lock onto it (e.g. \"Flat infographic illustration "
-            "with bold blue accents and clean line work, ...\")."
+            "VISUAL STYLE / MEDIUM LOCK (CRITICAL): the new illustration MUST be "
+            f"drawn in this exact style — \"{style_anchor}\". Match the art "
+            "MEDIUM above all (engraving, woodcut, ink line-work, watercolour, "
+            "flat infographic, blueprint, etc.), plus its palette, line work, "
+            "level of stylization and perspective. Do NOT switch to a different "
+            "medium — never photorealism, a 3D render, or isometric line-art — "
+            "however much the subject (a building interior, a portrait) might "
+            "invite it. Begin the `prompt` with a leading clause that NAMES the "
+            "medium explicitly (e.g. \"Hand-drawn engraving with cross-hatching "
+            "and sepia ink, ...\"), and END the prompt with a one-line lock like "
+            "\"Rendered strictly as <medium> — not photoreal, not 3D, not "
+            "isometric line-art.\" so the image model cannot drift."
         )
     if output_locale and output_locale.lower() not in ("en", "auto", ""):
         system_parts.append(
@@ -1206,6 +1211,24 @@ async def plan_page(
     return PagePlan(page_title=page_title, prompt=prompt, facts=facts, sources=sources)
 
 
+def _world_size_hint(entry: dict[str, Any]) -> str:
+    """A compact size clause for a world-context entity, when its geometry is
+    known (footprint/height in world units, carried from its WorldEntityGeo).
+    Keeps recurring entities at a consistent relative scale across pages.
+    Returns '' when no size is carried — today's behaviour."""
+    fp = entry.get("footprint")
+    w = d = None
+    if isinstance(fp, dict):
+        w, d = fp.get("w"), fp.get("d")
+    h = entry.get("height")
+    parts: list[str] = []
+    if isinstance(w, (int, float)) and isinstance(d, (int, float)):
+        parts.append(f"footprint ~{round(float(w))}x{round(float(d))} ground units")
+    if isinstance(h, (int, float)):
+        parts.append(f"~{round(float(h))} units tall")
+    return "; size " + ", ".join(parts) if parts else ""
+
+
 def _format_world_context_clause(
     world_context: list[dict[str, Any]] | None,
 ) -> str:
@@ -1252,6 +1275,10 @@ def _format_world_context_clause(
         if aliases:
             line += f" (aka: {', '.join(aliases[:3])})"
         line += f" — {appearance[:240]}{state_pairs}"
+        # FIX C: carry geometric size so recurring entities keep a consistent
+        # relative scale across pages (a place rendered large once shouldn't
+        # come back tiny). Best-effort; absent → no hint (today's behaviour).
+        line += _world_size_hint(entry)
         lines.append(line)
     if not lines:
         return ""
@@ -1262,6 +1289,9 @@ def _format_world_context_clause(
         "BELOW verbatim — same outfit, build, palette, props. Do NOT "
         "re-imagine their look. Weave each used descriptor into the image "
         "prompt as a clause like \"<Name>, <appearance descriptor>, ...\". "
+        "Keep each entity at a CONSISTENT RELATIVE SCALE across pages — where a "
+        "size is given below (footprint/height in world units), respect those "
+        "proportions so a place drawn large once is not shrunk later. "
         "If an entity is NOT relevant to this page, simply omit it; do not "
         "force entities into the scene.\n\n"
         "CAUSALITY (CRITICAL): each entity's `state=` flags below describe "

--- a/apps/modal-backend/providers/llm.py
+++ b/apps/modal-backend/providers/llm.py
@@ -1472,6 +1472,11 @@ async def polish_edit_instruction(
     if not instruction:
         return instruction
     if len(instruction.split()) > 20:
+        # Already detailed enough to skip the LLM polish — but still pin the
+        # medium so a long edit (especially on Kontext, which takes no style
+        # ref image) can't drift the art style.
+        if style_anchor:
+            return f"{instruction} Keep the existing art medium: {style_anchor}."
         return instruction
     client = _client()
     system = (

--- a/apps/modal-backend/scripts/verify-fal-models.py
+++ b/apps/modal-backend/scripts/verify-fal-models.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Confirm the fal model slugs + which input params each endpoint actually accepts.
+
+Referenced by providers/model_router.py. NOT a CI gate (it hits the network);
+run it by hand when wiring a new slot or before trusting a param like
+`negative_prompt` / `image_urls`.
+
+Findings as of 2026-06 (the reason image._args_for sends no negative_prompt and
+why fresh-gen conditioning is best-effort):
+  - nano-banana / nano-banana-pro (text-to-image): NO negative_prompt, NO image_urls
+  - flux-pro/kontext (edit/continue):              NO negative_prompt, takes image_url (singular)
+  - seedream v4 (text-to-image):                   text-only (image_size, no refs)
+  - bria/expand (outpaint):                        takes image_url + expansion box
+=> No image model in use accepts a negative_prompt, so we never send one; the
+   MEDIUM LOCK in the prompt text is the model-agnostic style guard. Image refs
+   are only reliably honoured by the edit/continue endpoints.
+
+Usage:  python scripts/verify-fal-models.py
+"""
+from __future__ import annotations
+
+import json
+import sys
+import urllib.request
+
+SCHEMA = "https://fal.ai/api/openapi/queue/openapi.json?endpoint_id={slug}"
+
+# The slugs the code actually uses (TIER_MODELS / EDIT_TIER_MODELS /
+# CONTINUE_MODEL_DEFAULT / EXPAND_MODEL_DEFAULT).
+SLUGS = [
+    "fal-ai/nano-banana",
+    "fal-ai/nano-banana-pro",
+    "fal-ai/nano-banana/edit",
+    "fal-ai/bytedance/seedream/v4/text-to-image",
+    "fal-ai/flux-pro/kontext",
+    "fal-ai/bria/expand",
+]
+PROBE = ["prompt", "image_url", "image_urls", "negative_prompt", "aspect_ratio", "guidance_scale"]
+
+
+def input_props(schema: dict) -> set[str]:
+    """The property names of the *Input* component of a fal queue OpenAPI doc."""
+    comps = (schema.get("components") or {}).get("schemas") or {}
+    for name, comp in comps.items():
+        if name.endswith("Input") and isinstance(comp.get("properties"), dict):
+            return set(comp["properties"].keys())
+    return set()
+
+
+def main() -> int:
+    bad = []
+    print(f"{'model':<46} " + " ".join(f"{p:>15}" for p in PROBE))
+    for slug in SLUGS:
+        try:
+            with urllib.request.urlopen(SCHEMA.format(slug=slug), timeout=30) as r:
+                props = input_props(json.loads(r.read()))
+        except Exception as e:  # best-effort dev tool: report + continue
+            print(f"{slug:<46} ERROR {e}")
+            bad.append(slug)
+            continue
+        cells = ["yes" if p in props else "-" for p in PROBE]
+        print(f"{slug:<46} " + " ".join(f"{c:>15}" for c in cells))
+        # The contract the code relies on: nobody gets a negative_prompt.
+        if "negative_prompt" in props:
+            print(f"  NOTE: {slug} now accepts negative_prompt — image._args_for could use it.")
+    if bad:
+        print(f"\n{len(bad)} slug(s) failed to resolve: {bad}", file=sys.stderr)
+        return 1
+    print("\nOK — schemas resolved. No in-use model accepts negative_prompt (as expected).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/web/app/api/generate-page/route.ts
+++ b/apps/web/app/api/generate-page/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import type { GenerateRequestBody } from "@openflipbook/config";
 import { resolveEntitiesForPrompt } from "@/lib/world";
+import { getWorldMap } from "@/lib/world-map";
 import { modalUrl as joinModalUrl } from "@/lib/modal";
 import { TRACE_HEADER, newTraceId } from "@/lib/trace";
 
@@ -44,6 +45,30 @@ export async function POST(req: Request) {
         parentNodeId: parsed.current_node_id || null,
       });
       if (world_context.length > 0) {
+        // FIX C: join geometric size (footprint/height) from the session's
+        // world_map so the planner can keep recurring entities at a consistent
+        // relative scale across pages. Best-effort — a missing/empty map just
+        // omits sizes and the planner behaves exactly as before.
+        try {
+          const geo = await getWorldMap(parsed.session_id);
+          const sizeById = new Map(
+            geo.entities
+              .filter((g) => g.entity_id)
+              .map((g) => [
+                g.entity_id as string,
+                { footprint: g.footprint, height: g.height },
+              ])
+          );
+          for (const wc of world_context) {
+            const s = sizeById.get(wc.id);
+            if (s) {
+              wc.footprint = s.footprint;
+              wc.height = s.height;
+            }
+          }
+        } catch {
+          // size enrichment is best-effort; never block generation
+        }
         upstreamBody = JSON.stringify({ ...parsed, world_context });
       }
     }

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -1826,6 +1826,20 @@ export default function PlayPage() {
       // planner emphasises the stroked area in the next page.
       const strokeHint =
         "User circled / annotated this region with a freehand stroke. Treat the stroked area as the focus.";
+      // Same style lock as a click-tap: carry the medium exemplar so a freehand
+      // "go inside" can't drift the art medium either (the parent grounds the
+      // world; the style ref pins the medium).
+      const strokeStyleRef =
+        (styleAnchor
+          ? history.items.find((p) => p.nodeId === styleAnchor.nodeId)
+              ?.imageDataUrl
+          : null) ??
+        history.items.find((p) => p.parentId == null)?.imageDataUrl ??
+        null;
+      const strokeCondition = orderedRefs({
+        parent: currentImage,
+        style: strokeStyleRef !== currentImage ? strokeStyleRef : null,
+      });
       void generate({
         query: page.query,
         aspect_ratio: "16:9",
@@ -1840,6 +1854,12 @@ export default function PlayPage() {
         click_hint: strokeHint,
         image_tier: imageTier,
         output_locale: resolveOutputLocale(outputLocale),
+        ...(strokeCondition.urls.length
+          ? {
+              condition_image_urls: strokeCondition.urls,
+              condition_roles: strokeCondition.roles,
+            }
+          : {}),
         ...(styleAnchor ? { session_style_anchor: styleAnchor.style } : {}),
       });
     };

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -751,11 +751,19 @@ export default function PlayPage() {
     // Image conditioning: every neighbour shares the parent's world + the
     // session anchor so the bloom reads as one place. No region crop — expand
     // is whole-page outward (directional edge-crops are a later phase).
-    const anchorImage =
-      history.items.find((p) => p.parentId == null)?.imageDataUrl ?? null;
+    // Persistent style exemplar: the pinned style page's image if one is
+    // pinned, else the root render. Rides as the "style" role (strong medium
+    // lock in the backend preamble) so the bloom can't drift the art medium.
+    const styleRefUrl =
+      (styleAnchor
+        ? history.items.find((p) => p.nodeId === styleAnchor.nodeId)
+            ?.imageDataUrl
+        : null) ??
+      history.items.find((p) => p.parentId == null)?.imageDataUrl ??
+      null;
     const condition = orderedRefs({
       parent: page.imageDataUrl,
-      anchor: anchorImage !== page.imageDataUrl ? anchorImage : null,
+      style: styleRefUrl !== page.imageDataUrl ? styleRefUrl : null,
     });
     startBloom({
       query: page.query,
@@ -924,6 +932,19 @@ export default function PlayPage() {
       e.preventDefault();
       const instruction = editInstruction.trim();
       if (!instruction || !page?.imageDataUrl) return;
+      // Carry the style exemplar (pinned page, else root) so an edit can't drift
+      // the art medium. The backend edit path now threads both this "style" ref
+      // and the session text lock (it used to drop both).
+      const styleRefUrl =
+        (styleAnchor
+          ? history.items.find((p) => p.nodeId === styleAnchor.nodeId)
+              ?.imageDataUrl
+          : null) ??
+        history.items.find((p) => p.parentId == null)?.imageDataUrl ??
+        null;
+      const editCondition = orderedRefs({
+        style: styleRefUrl !== page.imageDataUrl ? styleRefUrl : null,
+      });
       void generate({
         query: instruction,
         aspect_ratio: "16:9",
@@ -937,12 +958,18 @@ export default function PlayPage() {
         parent_title: page.title,
         image_tier: imageTier,
         output_locale: resolveOutputLocale(outputLocale),
+        ...(editCondition.urls.length
+          ? {
+              condition_image_urls: editCondition.urls,
+              condition_roles: editCondition.roles,
+            }
+          : {}),
         ...(styleAnchor ? { session_style_anchor: styleAnchor.style } : {}),
       });
       setEditInstruction("");
       setEditMode(false);
     },
-    [editInstruction, page, generate, imageTier, outputLocale, styleAnchor]
+    [editInstruction, page, generate, imageTier, outputLocale, styleAnchor, history]
   );
 
   const canGoBack = history.trailIdx > 0;
@@ -1523,13 +1550,20 @@ export default function PlayPage() {
       // parent (not the marker-annotated one) — region crop at the tap → whole
       // parent → session root as the anti-drift anchor (skipped when this page
       // *is* the root). Best-effort; on failure we send nothing → text-only.
-      const anchorImage =
-        history.items.find((p) => p.parentId == null)?.imageDataUrl ?? null;
+      // The persistent style exemplar (pinned style page, else the root render)
+      // rides as the strong "style" role so an enter can't drift the art medium.
+      const styleRefUrl =
+        (styleAnchor
+          ? history.items.find((p) => p.nodeId === styleAnchor.nodeId)
+              ?.imageDataUrl
+          : null) ??
+        history.items.find((p) => p.parentId == null)?.imageDataUrl ??
+        null;
       let condition = { urls: [] as string[], roles: [] as string[] };
       try {
         condition = await buildConditionRefs({
           parentDataUrl: currentImage,
-          anchorDataUrl: anchorImage !== currentImage ? anchorImage : null,
+          styleDataUrl: styleRefUrl !== currentImage ? styleRefUrl : null,
           click: { xPct: click.x_pct, yPct: click.y_pct },
         });
       } catch {

--- a/apps/web/lib/image-condition.ts
+++ b/apps/web/lib/image-condition.ts
@@ -8,7 +8,7 @@
  * backend just uploads these data URLs and hands them to nano-banana.
  */
 
-export type ConditionRole = "region" | "parent" | "anchor";
+export type ConditionRole = "region" | "parent" | "anchor" | "style";
 
 export interface ConditionRefs {
   urls: string[];
@@ -37,12 +37,16 @@ export function cropBox(
 
 /**
  * Order the available references into the conditioning stack — region → parent
- * → anchor — dropping any that are missing. Pure.
+ * → anchor → style — dropping any that are missing. Pure. `style` is the
+ * persistent medium exemplar (the root engraving/woodcut render): it rides last
+ * (weakest positional weight) so it locks the art MEDIUM without crowding the
+ * composition refs. The backend names it explicitly in the conditioning prompt.
  */
 export function orderedRefs(refs: {
   region?: string | null;
   parent?: string | null;
   anchor?: string | null;
+  style?: string | null;
 }): ConditionRefs {
   const urls: string[] = [];
   const roles: ConditionRole[] = [];
@@ -55,6 +59,7 @@ export function orderedRefs(refs: {
   push(refs.region, "region");
   push(refs.parent, "parent");
   push(refs.anchor, "anchor");
+  push(refs.style, "style");
   return { urls, roles };
 }
 
@@ -96,12 +101,15 @@ export async function cropRegion(
 
 /**
  * Assemble the ordered conditioning stack for a generation: region crop (parent
- * at the click) → whole parent → global anchor. No click (query/root) → no
- * region crop. The region crop is best-effort.
+ * at the click) → whole parent → global anchor → style exemplar. No click
+ * (query/root) → no region crop. The region crop is best-effort. `styleDataUrl`
+ * is the persistent medium reference (root/pinned render); thread it on every
+ * path so the art medium stays locked across the session.
  */
 export async function buildConditionRefs(opts: {
   parentDataUrl?: string | null;
   anchorDataUrl?: string | null;
+  styleDataUrl?: string | null;
   click?: { xPct: number; yPct: number } | null;
   regionFrac?: number;
 }): Promise<ConditionRefs> {
@@ -122,5 +130,6 @@ export async function buildConditionRefs(opts: {
     region,
     parent: opts.parentDataUrl ?? null,
     anchor: opts.anchorDataUrl ?? null,
+    style: opts.styleDataUrl ?? null,
   });
 }

--- a/apps/web/lib/world-geometry-seed.test.ts
+++ b/apps/web/lib/world-geometry-seed.test.ts
@@ -28,7 +28,7 @@ describe("estimateGeoFromBBox (seeding bridge)", () => {
     expect(g.footprint.d).toBeCloseTo(12);
   });
 
-  it("FIX 1c — oblique map: the box's height drives entity height, not footprint", () => {
+  it("FIX A — oblique map: box width drives footprint, box height drives entity height", () => {
     const view: SceneView = {
       node_id: "n",
       level: "map",
@@ -44,7 +44,10 @@ describe("estimateGeoFromBBox (seeding bridge)", () => {
     // …but a tall box → a tall entity (0.4 * 60 * 0.5 = 12), vs the flat default (4)
     expect(flat.height).toBe(4);
     expect(oblique.height).toBeCloseTo(12);
-    expect(oblique.footprint.w).toBe(6); // footprint falls back to default
+    // FIX A: width tracks the box (0.1 * 100 = 10), depth damped by cos(pitch)
+    // at -60° → 10 * (0.5 + 0.5*0.5) = 7.5; no longer a flat 6×6 default.
+    expect(oblique.footprint.w).toBeCloseTo(10);
+    expect(oblique.footprint.d).toBeCloseTo(7.5);
   });
 
   it("codex #5 — camera pitch foreshortens height-from-extent", () => {

--- a/apps/web/lib/world-geometry.ts
+++ b/apps/web/lib/world-geometry.ts
@@ -161,6 +161,12 @@ export interface GeoEstimate {
 
 const DEFAULT_FOOTPRINT = 6;
 const DEFAULT_HEIGHT = 4;
+// A recovered footprint is clamped to a sane span so a near-frame box on an
+// oblique map can't seed a building the size of a district (or smaller than a
+// floor tile). Relative units, matching MAP_IMAGE_FRAME's 100×60.
+const MAX_FOOTPRINT = 40;
+const clampFootprint = (v: number): number =>
+  Math.min(Math.max(v, 0.5), MAX_FOOTPRINT);
 
 export function estimateGeoFromBBox(
   bbox: EntityBBox,
@@ -187,9 +193,16 @@ export function estimateGeoFromBBox(
       // -60deg oblique, ~0 looking straight down (where height-from-extent is
       // meaningless → the default floor kicks in).
       const foreshorten = Math.abs(Math.cos((pitchDeg * Math.PI) / 180));
+      // FIX A: the box WIDTH still reads as real ground width on an oblique map,
+      // so derive footprint.w from it instead of a flat default; depth (toward
+      // the camera) is foreshortened, so damp it off the width by cos(pitch).
+      // Still relative, not metric — but a wide building no longer seeds at 6×6,
+      // so its map footprint tracks the size it was rendered at.
+      const w = clampFootprint(bbox.w_pct * crop.w);
+      const d = clampFootprint(w * (0.5 + 0.5 * foreshorten));
       return {
         pos,
-        footprint: { w: DEFAULT_FOOTPRINT, d: DEFAULT_FOOTPRINT },
+        footprint: { w, d },
         height: Math.max(bbox.h_pct * crop.h * foreshorten, DEFAULT_HEIGHT),
       };
     }

--- a/docs/PLAN_PLACE_TO_WORLD.md
+++ b/docs/PLAN_PLACE_TO_WORLD.md
@@ -1,0 +1,636 @@
+# Place description → logical object world (design doc)
+
+_Grounded in the code, not memory. This is a **design document** — nothing here is
+implemented yet. It is written to the same discipline as `GEOMETRIC_WORLD_AUDIT.md`:
+honest about what is a real primitive vs. a guess, every claim pinned to a file:line, and
+no marketing. Where the audit's failures (ROOT-1/ROOT-2 — the model free-styling
+placement, the world never seeding) bite this feature, I call them out and route around
+them._
+
+## What I'm building (and the three hard parts)
+
+Take a **detailed natural-language description of a place** ("a corner coffee shop: a long
+zinc counter on the back wall, four stools at the counter, a shelf of mugs behind it, the
+door on the left wall, and the front-right corner left open for a queue") and turn it into
+**all the relevant objects, arranged relative to each other on the shared 2D plane**, such
+that:
+
+1. **Objects sit in logically coherent relations** — stools _at_ the counter, the mug
+   shelf _behind_ it, the door _on a wall_. Not a random scatter.
+2. **Declared-empty space stays empty** — the front-right corner the user reserved for a
+   queue is **not** back-filled with hallucinated tables. Enforced **mechanically, at
+   solve AND at render**.
+3. **When the description is logically incomplete or contradictory, the system ASKS** a
+   small number of targeted clarifying questions instead of guessing — and for *hard*
+   contradictions it **refuses to emit a layout** until answered.
+
+The whole thing is built on primitives that already exist and are tested: the
+`WorldEntityGeo` map, the `upsertEntityGeos` write path, the `layout_constraints` render
+steer, the grounding loop, and the shipped `clarifiers → promptForHint` question UX. **No
+parallel geometry, no parallel placement store, no parallel question modal.** The only new
+moving parts are (a) one structured LLM parse, (b) one **pure, golden-testable** solver,
+and (c) a thin gated UI affordance.
+
+### Pipeline at a glance
+
+```
+description ──▶ PARSE (LLM)            ──▶ SceneGraph {entities, relations,
+  (+answers)      plan_world_from_…         empty_regions, clarifiers, contradictions}
+                                              │
+                            ┌─────────────────┴─── hard contradiction / blocking gap?
+                            │                              │ yes → solved:null, ASK (promptForHint)
+                            ▼ no                           │ answers re-POST /plan-world ↺
+                  SOLVE (deterministic)
+                  layout_solver.py        ──▶ WorldEntityGeo[]  (source:"derived", in MAP_IMAGE_FRAME)
+                            │
+                            ▼
+                  SEED  POST /api/world/[id]/map {geos} ──▶ upsertEntityGeos  (no new persistence)
+                            │
+                            ▼
+                  RENDER  generate({scene_view, expected_layout, render_mode})
+                          _layout_clause_for → layout_constraints  + "keep {region} empty"
+                          + grounding loop verifies/repairs
+```
+
+---
+
+## Phase 0 — Flag + wire types (additive only)
+
+### Flag
+
+`WORLD_FROM_DESCRIPTION`, read with the existing `env_flag` (`apps/modal-backend/_env.py:17`),
+mirroring how `WORLD_MODE` / `WORLD_GEOMETRY_GEN` / `GEOMETRIC_WORLD` are gated in
+`generate.py` (`_world_mode_on` :181, `_geometric_world_on` :185, `_world_geometry_gen_on`
+:191). Default **off** → the new endpoint 403s and the new button never mounts, so prod is
+byte-identical to today. (Confirmed: no `WORLD_FROM_DESCRIPTION` exists anywhere in the
+tree today.)
+
+### New wire types — `packages/config/src/index.ts`, placed next to `EntityGeoEdit` (:601)
+
+These are **all new interfaces / unions**. No existing type changes shape — in particular
+`GenerateBody` (config `:~70`, pydantic `GenerateBody` `generate.py:125`) and `Entity`
+(`:364`) are untouched. `EntityKind` is the existing `"person" | "place" | "item" |
+"creature"` union (`:344`); `WorldVec2` (`:407`), `WorldEntityGeo` (`:420-451`), and
+`EntityState` (`:349`) are reused verbatim.
+
+```ts
+// Relations the LLM is allowed to express between two refs. NEVER coordinates —
+// the planner emits structure, the solver turns structure into geometry.
+export type SpatialRelation =
+  | "near"        // small gap, no strong axis (stool near counter)
+  | "on_wall"     // mounted on / against the named wall-region ref
+  | "behind"      // -y of object (shelf behind counter, viewer at +y)
+  | "in_front_of" // +y of object
+  | "left_of"     // -x of object
+  | "right_of"    // +x of object
+  | "inside"      // nested in object's frame (parent_id + learned scale)
+  | "on_top_of"   // stacked: object's elevation = object top
+  | "facing";     // sets subject.heading toward object (no translation)
+
+// One object the description named or functionally implies. `ref` is a stable
+// slug the relations point at. `visual` is ONE render-ready sentence, copied
+// verbatim into future prompts (mirrors the extractor's appearance contract,
+// llm.py:1744-1747). `count` fans out into N instances at solve time.
+export interface PlannedEntity {
+  ref: string;
+  kind: EntityKind;
+  label: string;
+  visual: string;
+  footprint?: { w: number; d: number }; // world units; solver fills kind-default when absent
+  height?: number;                       // world units; solver fills kind-default when absent
+  count?: number;                        // default 1
+}
+
+// A placement constraint between two refs. `subject` is positioned relative to
+// `object`. `gap` (world units) tunes "near"/"on_wall"/axis offsets.
+export interface PlannedRelation {
+  subject: string;
+  relation: SpatialRelation;
+  object: string;
+  gap?: number;
+}
+
+// A region the description explicitly says is EMPTY/clear/open. The solver keeps
+// every entity's footprint out of its AABB; the renderer gets a negative clause.
+// `approx` is an optional hint box (0..1 of the place) the LLM may supply; absent
+// → the solver derives the region from the wall anchors it borders.
+export interface EmptyRegion {
+  ref: string;
+  note: string; // "front-right corner reserved for a queue"
+  approx?: { x: number; y: number; w: number; h: number };
+}
+
+// The structured read of the description. Tolerant-parsed; malformed members are
+// dropped, never raises (see parse_scene_graph). `contradictions` records hard
+// logical conflicts the LLM refused to resolve; `clarifiers` (≤2) are the
+// questions to ask. Both empty ⇒ the graph is solvable as-is.
+export interface SceneGraph {
+  place_label: string;
+  place_kind: EntityKind; // virtually always "place"
+  bounds_hint?: { w: number; h: number }; // world units; default = MAP_IMAGE_FRAME 100×60
+  entities: PlannedEntity[];
+  relations: PlannedRelation[];
+  empty_regions: EmptyRegion[];
+  clarifiers: string[];     // ≤2 short questions, mirrors ResolveClickResponse.clarifiers
+  contradictions: string[]; // human-readable hard conflicts; non-empty ⇒ blocking
+}
+
+export interface PlanWorldRequestBody {
+  session_id: string;
+  description: string;
+  answers?: string[];   // user replies to a prior round's clarifiers (re-run)
+  trace_id?: string;
+}
+
+export interface PlanWorldResponse {
+  graph: SceneGraph;
+  // The solved layout, ready for upsertEntityGeos — or null when the graph is
+  // blocked (hard contradiction / unresolved blocking clarifier). null ⇒ ask.
+  solved: WorldEntityGeo[] | null;
+  trace_id?: string;
+}
+```
+
+**Why no `x`/`y` anywhere in `PlannedEntity`/`PlannedRelation`:** that is the load-bearing
+design choice. The audit's ROOT-2 failure is "the model free-styles placement"; letting an
+LLM emit coordinates reproduces it. The LLM emits **only relations**; coordinates are the
+solver's job. (See Phase 1 rule 2 and the EVALUATOR CHECKLIST item 7.)
+
+---
+
+## Phase 1 — PARSE: description → `SceneGraph` (one LLM call, tolerant parse)
+
+New `plan_world_from_description` in `apps/modal-backend/providers/llm.py`, modeled
+**directly** on `edit_entities_nl` (`:2149`): one `_complete_json` call (`:626`) at
+`temperature=0.0` against `_text_model(online=False)` (`:407`), with a tolerant
+`parse_scene_graph` coercer modeled on `parse_entity_edits` (`:2064`) — it drops malformed
+members and **never raises** (the same discipline as `detector.parse_detections`). A weak
+model degrades to a thinner graph, never a crash.
+
+```python
+PLAN_WORLD_SCHEMA = {  # mirror the loose ENTITY_EDIT_SCHEMA (llm.py:2027): shape, not types
+    "type": "object",
+    "properties": {
+        "place_label": {"type": "string"},
+        "place_kind": {"type": "string", "enum": list(ENTITY_KINDS)},  # llm.py:132
+        "bounds_hint": {"type": "object"},
+        "entities": {"type": "array", "items": {"type": "object"}},
+        "relations": {"type": "array", "items": {"type": "object"}},
+        "empty_regions": {"type": "array", "items": {"type": "object"}},
+        "clarifiers": {"type": "array", "items": {"type": "string"}},
+        "contradictions": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["place_label", "entities"],
+}
+```
+
+`parse_scene_graph(payload)` validates each member the way `parse_entity_edits` validates
+edits: an entity needs a non-empty `ref` + `label` + `visual` and a `kind ∈ ENTITY_KINDS`
+(else dropped); a relation needs `subject`/`object` that **both resolve to known refs** and
+a `relation ∈ SpatialRelation` (else dropped — exactly the "`target` must be a known id"
+rule at `llm.py:2097`); an `empty_region` needs a `ref` + `note`; `clarifiers` is truncated
+to ≤2; unknown keys are ignored. Output is a frozen `SceneGraph` dataclass.
+
+### The system prompt carries four load-bearing rules
+
+1. **Relevance — emit only named / functionally-implied objects; record empty space.**
+   Mirror the **STRICT RELEVANCE FILTER** the extractor already uses (`llm.py:1733-1738`,
+   "Generic scenery … must NOT be emitted. When in doubt, leave it out"). Functionally
+   implied is allowed (a "counter" implies it stands on the floor; a "shop" implies a
+   door/entrance even if unnamed) — but anything the user calls **empty / clear / open /
+   reserved** becomes an `EmptyRegion`, and **nothing is placed there**. This is layer one
+   of "empty stays empty" (the solver is layer two, the renderer is layer three).
+
+2. **Placement is relations only — NEVER x/y.** "Express where each object is **only** as
+   `relations` between refs (`near`, `on_wall`, `behind`, …). Do **not** output
+   coordinates, grid cells, or pixel positions — you do not know the metric scale; the
+   layout engine computes positions from your relations." This is the direct mitigation for
+   the audit's ROOT-2 (model-invented placement) and is checked by EVALUATOR item 7.
+
+3. **Check impossibilities before finalizing → ask, don't guess past a hard conflict.**
+   "Before returning, re-read your graph for: (a) **physical impossibilities** (a window in
+   an underground vault with no exterior wall; a door on a wall the description calls solid
+   rock; an object `on_top_of` something that can't bear it); (b) **missing anchors** (an
+   object whose only sensible placement needs a wall/region the description never gave); (c)
+   **count/space conflicts** (more objects than the stated bounds can hold). For each, add a
+   short question to `clarifiers` (**AT MOST 2**, ≤8 words each — same budget as the World
+   Mode clarifiers, `llm.py:772`) and a one-line description of the conflict to
+   `contradictions`. **Do NOT invent a resolution to a hard contradiction** — leave it in
+   `contradictions` so the system can ask." (Soft gaps the solver can default — e.g. a stool
+   with no explicit gap — do **not** need a clarifier; only logic-breaking gaps do.)
+
+4. **`visual` = one render-ready sentence.** "For each entity, `visual` is ONE concrete
+   visual sentence (≤25 words: materials, colour, form) that will be injected **verbatim**
+   into the image prompt." This is the extractor's `appearance` contract word-for-word
+   (`llm.py:1744-1747`), so a planned entity and a later *detected* one speak the same
+   visual language (which matters for SOURCE_RANK refinement in Phase 4).
+
+### New endpoint `POST /plan-world` (copy of `/edit-entities`)
+
+Copy `edit_entities_endpoint` (`generate.py:1498`) verbatim in structure: a
+`PlanWorldBody(BaseModel)` (modeled on `EditEntitiesBody` `:1321`), the same
+`bind_trace`/`log`/`record_error` scaffold, the same `if not env_flag("WORLD_FROM_DESCRIPTION"): return 403`
+gate. It (a) calls `plan_world_from_description(description, answers)`, (b) **runs the
+solver server-side** (Phase 2), (c) returns `PlanWorldResponse {graph, solved, trace_id}`.
+Solving server-side keeps the deterministic core in one tested place and means the client
+just seeds + renders. One text-LLM call + pure CPU; no Mongo/R2 in the handler (same as
+`/edit-entities`).
+
+---
+
+## Phase 2 — SOLVE: `SceneGraph` → `WorldEntityGeo[]` (deterministic, pure, golden-tested)
+
+New module `apps/modal-backend/providers/layout_solver.py`. **It is not a constraint solver
+and it does not call an LLM.** It is a pure function — same input → same output — held to
+the determinism discipline of `geometry_prompt.py` ("the same layout always yields the same
+clause … so it's unit-testable"). It is the unit that golden tests pin (EVALUATOR item 8).
+
+```python
+def solve_layout(graph: SceneGraph) -> SolveResult:
+    """Pure. Turn a SceneGraph into WorldEntityGeo[] in the shared MAP_IMAGE_FRAME,
+    or a blocked result carrying the mechanical clarifiers (Phase 3 layer B).
+    No I/O, no randomness, deterministic iteration order."""
+```
+
+### Algorithm (each step deterministic; iteration order is sorted, never set-order)
+
+1. **Frame.** Take `bounds_hint`, else default `100 × 60` — **the same `MAP_IMAGE_FRAME`**
+   the tap router and the extract seed share (`geo-tap.ts:24`, kept in lockstep with
+   `extract/route.ts`). Seeding into this exact frame is what makes a later tap on the
+   rendered place route back to the right coords (this is the "felt-dead" bug the audit
+   fixed at `94a33b1` — frame disagreement made the world inert). Origin top-left, **+x
+   EAST, +y SOUTH**, matching the world-coord convention the edit prompt states
+   (`llm.py:2035`).
+
+2. **Kind-default footprints/heights.** For any `PlannedEntity` missing `footprint`/`height`,
+   fill from the **shared** defaults `DEFAULT_GEO_FOOTPRINT = 6`, `DEFAULT_GEO_HEIGHT = 4`
+   (`world-map.ts:125-126`; the TS geometry lib carries the identical `DEFAULT_FOOTPRINT = 6`
+   / `DEFAULT_HEIGHT = 4`, `world-geometry.ts:162-163`). A small per-kind table may bias
+   these (a `place` wall longer/thinner, an `item` smaller) but the floor is the shared
+   constant so units agree with the rest of the system.
+
+3. **Anchors first.** Resolve wall-regions and `EmptyRegion`s to rectangles in the frame
+   before placing free objects: a wall named on a side maps to a thin rectangle along that
+   edge; an `EmptyRegion.approx` (0..1) maps into the frame, and an `EmptyRegion` *without*
+   `approx` is derived from the wall/edge its `note` references (default: a corner/edge
+   quadrant). These rectangles are **reserved** — see step 6.
+
+4. **Attach relational entities as offset vectors.** Walk `relations` in sorted order; place
+   each `subject` relative to its already-placed `object` using a fixed per-relation offset
+   (gap defaults small, ~`gap ?? 2` world units):
+   - `near` → small gap, nearest free side.
+   - `behind` → `object.pos − (0, depth)`; `in_front_of` → `+ (0, depth)` (viewer at +y).
+   - `left_of` → `− (width, 0)`; `right_of` → `+ (width, 0)`.
+   - `on_wall` → snap onto the named wall rectangle (centered, then de-overlapped along it).
+   - `on_top_of` → same `pos`, `elevation = object.elevation + object.height` (a stack, not
+     a translation — uses the existing `elevation` field, `WorldEntityGeo.elevation`
+     `:435`).
+   - `facing` → set `subject.heading` toward `object` (no translation), via the existing
+     `heading` field (`:443`).
+   - `inside` → do **not** translate in the parent frame; mark the subject for nesting
+     (step 7).
+   An object with no relation and no anchor is **unanchored** → recorded as a mechanical
+   clarifier (Phase 3 B), not silently dropped or randomly dropped in.
+
+5. **Fan out `count`.** A `PlannedEntity` with `count = n > 1` becomes `n` instances
+   (`{ref}#1..#n`), distributed along the relevant axis (stools fanned along the counter's
+   front edge) at one-footprint spacing. The `count`-vs-space check feeds the over-pack
+   trigger (Phase 3 B).
+
+6. **Iterative de-overlap (≤ 20 iterations).** Resolve footprint collisions by AABB
+   separation: nudge the lower-authority / later object along the minimum-translation axis
+   until footprints no longer intersect. **Two hard invariants, every iteration:**
+   - **NEVER push a footprint into a reserved `EmptyRegion` AABB.** If a separation would
+     land an object inside a reserved rectangle, push it the other way; if it cannot escape
+     without entering the region, that is an **empty-region collision** → blocking clarifier
+     (Phase 3 B), and the object is held out, not forced in. This is "empty stays empty,
+     mechanically, at solve."
+   - **Never cross a wall anchor.** Objects stay on their side of a wall rectangle.
+   - **Note on reuse:** the existing TS `localBounds` (`world-geometry.ts:324`) computes an
+     AABB over `pos+footprint` and is the model for the math, but there is **no AABB
+     *separation* / de-overlap helper in the repo today** — the solver adds a small pure
+     `separate(a, b)` (min-translation-vector) and its own `intersects(aabb, aabb)`. (This
+     corrects the plan-section phrasing "reusing world-geometry.ts ~324": `:324` is
+     `localBounds`, an AABB *constructor*, not a separator. The TS dirty-rect helper at
+     `world-map.ts:118-120` is the same idea on the JS side.) Both are trivially
+     golden-testable.
+
+7. **Emit `WorldEntityGeo[]`.** Each placed instance →
+   ```
+   { id: f"geo_plan_{ref}", entity_id: None, parent_id: <null or nesting parent>,
+     kind, label, pos, height, footprint, elevation?, heading?,
+     visual: <PlannedEntity.visual verbatim>, state: {},
+     confidence: <base × 0.6>, source: "derived", updated_at }
+   ```
+   `source:"derived"` + the **×0.6 confidence discount** exactly match
+   `deriveGeoFromExtraction` (`world-map.ts:358`) so a later `user`/`extracted` write wins
+   (SOURCE_RANK `user:2 > extracted:1 > derived:0`, `world-map.ts:36-40`). **`inside`
+   objects** are nested: `parent_id = geo_plan_<container>` and the container learns a
+   `scale` = its footprint extent ÷ the interior's local extent — the exact
+   parent-scale-learning `deriveGeoFromExtraction` does at `world-map.ts:369-378` (clamped
+   `[1e-3, 10]` via `localExtent`, `world-geometry.ts:344`), so a nested object resolves to a
+   true absolute position inside its container.
+
+The output is **exactly the shape `upsertEntityGeos` consumes** (`world-map.ts:259`) — so
+seeding is the existing write path with **zero new persistence** (EVALUATOR item 3).
+
+---
+
+## Phase 3 — LOGIC CHECK + QUESTIONS (two layers, with a blocking tier)
+
+The system asks in two layers, and the *kind* of problem decides whether it **blocks**
+(refuse to emit a layout) or **solves-with-default + offers a refine**.
+
+### Layer A — LLM-semantic (Phase 1, rule 3)
+
+The planner's own `contradictions` (hard logic — a window underground, a door on solid
+rock) and `clarifiers` (the ≤2 questions). Non-empty `contradictions` ⇒ **blocking**.
+
+### Layer B — solver-mechanical (deterministic triggers)
+
+The solver emits its own clarifiers from what it mechanically discovers. These are
+deterministic (golden-testable) and concrete:
+
+| Trigger | Question template | Tier |
+|---|---|---|
+| Unanchored object (no relation, no anchor) | `"Where is the {label}?"` | soft (default to frame center) or blocking if it's the only place anchor — config'd per-kind |
+| Over-pack (Σ footprint area > region area, after fan-out) | `"You listed {n} {label} but {place} fits ~{k} — fewer, or a bigger room?"` | **blocking** |
+| Dangling relation (survived parse but object never placed) | `"Where should the {label} go relative to?"` | soft |
+| Empty-region collision (an object can't avoid a reserved region) | `"The {label} would sit in the {region} you described as clear — keep it empty or move it?"` | **blocking** |
+
+### Blocking vs. soft
+
+- **Blocking** (hard impossibility from Layer A, over-pack, empty-region collision) ⇒
+  `solved: null` in `PlanWorldResponse`. The client **must** ask before anything renders.
+  This is what makes "it actually asks when illogical" real rather than cosmetic (EVALUATOR
+  item 2): a blocked graph cannot silently produce a wrong picture.
+- **Soft** (a missing gap, an unanchored decorative item) ⇒ the solver places with a sane
+  default (center / nearest free spot) **and** still surfaces the clarifier as an optional
+  refine. The user can ignore it and keep the rendered layout.
+
+`PlanWorldResponse.graph.clarifiers` is the **union** of Layer A + Layer B questions, capped
+at the ≤2 budget (blocking ones first). The ≤2 cap is the direct guard against
+**over-asking** (the prompt's risk #2).
+
+### Answer feedback loop (re-run, not patch)
+
+When the user answers, the client **re-POSTs `/plan-world`** with the same `description` +
+the `answers[]`. `plan_world_from_description` re-runs with the answers appended to the user
+turn ("The user clarified: …"), which **clears the resolved clarifiers/contradictions** and
+re-solves. This is the same "re-run the call with more context" shape the rest of the system
+uses; there is no separate patch path to keep consistent.
+
+### Reuse the shipped question UX — do NOT invent a modal
+
+The questions surface through the **already-shipped** `clarifiers → promptForHint` path. The
+World Mode semi-autonomy flow already takes `ResolveClickResponse.clarifiers`, joins them,
+and pops the hint bubble at the click point (`page.tsx:1384-1398`, calling `promptForHint`
+defined at `:323`). The Describe-a-place flow does the **same thing**: join
+`graph.clarifiers`, call `promptForHint(x, y, questions)`, feed the typed answer back as
+`answers`. **No new question component** (EVALUATOR item 4). The `promptForHint` promise
+already resolves to `string | null` (null = cancel), so the planWorld callback stays one
+async function, exactly like the click handler.
+
+---
+
+## Phase 4 — SEED + RENDER (existing write + steer + ground; one new negative clause)
+
+### Seed
+
+On a non-null `solved`, the client POSTs it to the **existing** route:
+`POST /api/world/[sessionId]/map` with `{ geos: solved }` → `upsertEntityGeos`
+(`map/route.ts:78`, gated by `GEOMETRIC_WORLD`). No new endpoint, no new collection. The
+optimistic-concurrency + source-authority merge is the one that already runs
+(`applyGeoUpsert`, `world-map.ts:78`).
+
+### Render
+
+Render through the **existing** geometry-aware generate path. The client builds a
+`SceneView` (a top-down `map` view for the whole place, or an observer pose to stand inside
+it) + an `expected_layout` (`ProjectedEntity[]`) by projecting `solved` through the same
+`projectScene` the geo-tap already uses, and sends them on `generate(...)`. Server-side:
+
+- `_layout_clause_for` (`generate.py:196-207`) → `geometry_prompt.layout_constraints` (the
+  deterministic "place these exactly where stated" rail, `geometry_prompt.py:14`) — **inert
+  unless `WORLD_GEOMETRY_GEN` is on**, exactly as today.
+- The grounding loop (`generate.py:1022`, hard-gated on `body.expected_layout`) verifies the
+  render against `expected_layout` and runs one bounded `repair_instruction`
+  (`geometry_prompt.py:35`) when it's off-target. This is "empty stays empty **at render**"'s
+  enforcement teeth: the layout it checks against contains no objects in the empty region,
+  so an object hallucinated there shows up as an `extra` and drags the grounding score
+  (extras already penalize, audit 4b #6).
+
+### The one new generate-side addition — an empty-region negative clause
+
+Add to `apps/modal-backend/providers/geometry_prompt.py` a small pure function that turns
+the place's `empty_regions` into a negative clause, e.g.:
+
+```python
+def empty_region_clause(regions: list[dict]) -> str:
+    # "Leave the {note} clear and empty — no objects, furniture, people, or
+    #  clutter there." Deterministic, testable, "" when no regions.
+```
+
+This rides alongside `layout_constraints` in the prompt compose. To carry the regions to the
+backend without changing `GenerateBody`'s shape, the empty-region notes travel **inside the
+existing `scene_view`** payload (a `SceneView` extension is additive) **or** the client
+simply bakes the negative clause into the query text it already sends — either way **no new
+required field on `GenerateBody`** (EVALUATOR item 6). This clause is render-layer
+enforcement of "empty stays empty," complementing the solver's solve-layer reservation and
+the grounding loop's extras penalty — **three independent layers** (EVALUATOR item 1).
+
+### Tie-ins to the parallel fixes (B1 context)
+
+- **Style consistency** is **not** this doc's job — it comes from the parallel style fix
+  (the `style` `ConditionRole` + `session_style_anchor` forwarding from Workstream A2). The
+  Describe-a-place render simply forwards `session_style_anchor` the way `submitQuery` does
+  (`page.tsx:916`). B1 just rides that.
+- **Frame/scale agreement:** the solver's footprints live in `MAP_IMAGE_FRAME` (100×60),
+  the **same** frame the entity-size fix (A3) brings oblique footprints into — so units
+  agree across description-seeded and detection-seeded entities.
+- **Authority order:** because seeded objects are `source:"derived"`, a later **confirmed
+  `extracted`** detection of the same object (once the place is rendered + extracted) can
+  **refine** the solver's guess — correct authority direction via `SOURCE_RANK`
+  (`world-map.ts:36-40`). Optionally expose a **"lock layout"** action that rewrites the
+  solved geos to `source:"user"` so re-renders can't move them (the `user:2` top rank).
+
+---
+
+## Phase 5 — UX in `apps/web/app/play/page.tsx` (one gated affordance)
+
+**Exactly one** new affordance: a gated **"Describe a place"** entry (a textarea + submit,
+behind a `WORLD_FROM_DESCRIPTION`-derived client flag, mounted near the existing query bar).
+Everything else — tap = enter, ⌘/Ctrl-tap = observer popover, NL-edit, the atlas — stays
+**byte-identical**.
+
+A `planWorld` callback modeled on `submitQuery` (`page.tsx:902`):
+
+1. POST `/plan-world` with `{ session_id, description }`.
+2. If `solved === null` (blocked / clarifiers): join `graph.clarifiers`, call
+   `promptForHint(...)` (the shipped bubble, `:323`/`:1384`), collect the answer, re-POST
+   `/plan-world` with `answers`. Loop until `solved` is non-null or the user cancels (null).
+3. On non-null `solved`: POST it to `/api/world/[sessionId]/map` `{geos}`, then call
+   ```ts
+   generate({ ...baseQueryFields,           // same shape submitQuery sends
+              scene_view, expected_layout,
+              render_mode: "place_submap" | "place_scene",
+              ...(styleAnchor ? { session_style_anchor: styleAnchor.style } : {}) });
+   ```
+   `render_mode` is the **existing** `RenderMode` union (`"place_scene" | "place_submap" |
+   "explainer"`, config `:23`) — `place_submap` for a top-down plan of the place,
+   `place_scene` to stand inside it.
+
+**Backwards-compatible:** every new field is optional, the endpoint + button are flag-gated,
+and no existing call site changes. With the flag off the file behaves exactly as it does
+today.
+
+---
+
+## The three biggest risks + de-risking
+
+### 1. Semantically-wrong-but-mechanically-valid layout
+
+The solver can produce a layout that satisfies every relation yet looks wrong (stools on the
+far side of the counter; "behind" interpreted from the wrong viewer side). **De-risk:**
+(a) **golden tests** on `solve_layout` pin canonical scenes ("coffee shop", "throne room")
+to expected geo arrangements, so a regression is caught deterministically; (b) the
+**grounding loop** re-checks the *rendered* frame against `expected_layout` and repairs
+gross misplacement (`generate.py:1022`); (c) the solver works in **coarse bins** at the
+prompt boundary — `ProjectedEntity` already exposes `h_pos/v_pos/size` *bins*, not pixels
+(`config:499-503`), so "approximately right" is the target, not pixel-perfection the
+monocular pipeline can't honor anyway (audit §4b: geometry is **relative, not metric**).
+
+### 2. Over-asking or under-asking
+
+Too many questions is annoying; too few lets nonsense through. **De-risk:** the **two-layer**
+split (LLM-semantic + solver-mechanical) catches both *kinds* of problem; the **blocking
+tier** ensures the questions that matter (impossibility, over-pack, empty-region collision)
+actually gate the render while soft ones don't nag; the **≤2 cap** (the World Mode budget,
+`llm.py:772`) bounds the ask; and a **broken-description eval fixture** (a deliberately
+contradictory description: "a windowless basement with a sunny bay window", "10 grand pianos
+in a phone booth", "a table in the corner I want kept empty") asserts the system asks /
+blocks rather than guessing.
+
+### 3. Frame / scale mismatch
+
+If the solver seeds into a different frame than the tap router / extractor read, the place
+renders but **taps don't land** — the exact "felt-dead" bug (`94a33b1`). **De-risk:** the
+solver seeds into **`MAP_IMAGE_FRAME` (100×60)** — the single shared frame
+(`geo-tap.ts:24`, lockstepped with `extract/route.ts`); **inside**-objects nest with the
+**learned parent `scale`** (`world-map.ts:369-378`) so a nested object's local pos resolves
+absolutely; and a **tap-routing regression test** asserts that after seeding from a
+description, a synthetic tap on a placed object's screen position routes back to that
+object's geo (the same regression `geo-tap.ts` already guards).
+
+---
+
+## Open questions
+
+- **Wall representation.** Are walls first-class `PlannedEntity`s (kind `place`, thin
+  footprint) the relations point at, or implicit edges of the bounds rectangle? Leaning
+  first-class so `on_wall` has a concrete ref and the door/window logic checks have
+  something to test against — but that inflates the entity count. Decide before golden
+  tests freeze the shape.
+- **Viewer convention for `behind`/`in_front_of`.** The solver assumes the viewer at +y
+  (looking −y / north). Is that always right for a `place_scene` observer the user might
+  re-pose? For the initial top-down plan it's unambiguous; for a stood-inside scene the
+  observer pose may need to re-derive front/back. Probably: solve in the canonical top-down
+  frame, let the observer pose handle the rest at render.
+- **How big is a default place?** `bounds_hint` defaults to 100×60, but a "vast cathedral"
+  and a "phone booth" shouldn't share it. Should the LLM *estimate* bounds (a scalar
+  "roughly N meters across") while still never emitting per-object coords? That keeps rule 2
+  intact (bounds ≠ placement) and feeds the over-pack check real numbers.
+- **Multiple empty regions + dense objects.** With several reserved regions the ≤20-iter
+  de-overlap might fail to place everything without collision. Fallback: surface an
+  over-pack-style blocking clarifier rather than overflow into a region.
+- **Does a described place become a tree node like a tapped one?** It should slot into the
+  same node/atlas model (so you can tap *into* it afterward), but the node-creation path is
+  the tap flow's; wiring the description flow into it cleanly is unspecified here.
+
+---
+
+## Critical files
+
+- `packages/config/src/index.ts` — new types next to `EntityGeoEdit` (`:601`); reuses
+  `EntityKind` (`:344`), `WorldVec2` (`:407`), `WorldEntityGeo` (`:420-451`), `SceneView`
+  (`:478`), `ProjectedEntity` (`:491-504`), `RenderMode` (`:23`), `EntityState` (`:349`).
+  Untouched: `GenerateBody` (`:~70`), `Entity` (`:364`).
+- `apps/modal-backend/providers/llm.py` — new `plan_world_from_description` +
+  `parse_scene_graph` + `PLAN_WORLD_SCHEMA`, modeled on `edit_entities_nl` (`:2149`) /
+  `parse_entity_edits` (`:2064`) / `ENTITY_EDIT_SCHEMA` (`:2027`); reuses `_complete_json`
+  (`:626`), `_text_model` (`:407`), `_system_message` (`:282`), `ENTITY_KINDS` (`:132`); the
+  STRICT RELEVANCE FILTER (`:1733`) + visual-sentence (`:1744-1747`) + clarifier-budget
+  (`:772`) language is the template.
+- `apps/modal-backend/providers/layout_solver.py` — **new**, pure: `solve_layout` +
+  `separate`/`intersects` AABB helpers + per-relation offset table. Golden-tested.
+- `apps/modal-backend/providers/geometry_prompt.py` — reuses `layout_constraints` (`:14`) +
+  `repair_instruction` (`:35`); **adds** `empty_region_clause`.
+- `apps/modal-backend/generate.py` — new `/plan-world` endpoint copied from `/edit-entities`
+  (`:1498`) + `PlanWorldBody` (modeled on `EditEntitiesBody` `:1321`); reuses
+  `_layout_clause_for` (`:196-207`), the grounding loop (`:980`), the flag pattern
+  (`:181-193`).
+- `apps/web/lib/world-map.ts` — reuses `upsertEntityGeos` (`:259`), the `×0.6` /
+  `source:"derived"` discount + parent-scale learning of `deriveGeoFromExtraction`
+  (`:358`, `:369-378`), `SOURCE_RANK` (`:36-40`), `DEFAULT_GEO_FOOTPRINT/HEIGHT` (`:125-126`).
+- `apps/web/lib/world-geometry.ts` — reuses `localBounds`/`localExtent` (`:324`/`:344`),
+  `projectScene` (`:117`), the `DEFAULT_FOOTPRINT/HEIGHT` parity constants (`:162-163`); the
+  solver's de-overlap is the **new** piece (no separator exists here today).
+- `apps/web/lib/geo-tap.ts` — reuses `MAP_IMAGE_FRAME` (`:24`); the tap-routing regression
+  test extends what's already guarded here.
+- `apps/web/app/api/world/[sessionId]/map/route.ts` — reuses the `{geos}` → `upsertEntityGeos`
+  POST (`:78`); **no change**.
+- `apps/web/app/play/page.tsx` — new gated `planWorld` callback modeled on `submitQuery`
+  (`:902`); reuses `promptForHint` (`:323`, wired at `:1384-1398`); reuses
+  `session_style_anchor` forwarding (`:916`).
+
+---
+
+## EVALUATOR CHECKLIST
+
+A critic must confirm **all** of the following before this design is accepted. Each maps to
+a mechanism above, not an aspiration.
+
+1. **Empty stays empty — mechanically, at solve AND render.**
+   - Solve: every entity footprint is kept out of every reserved `EmptyRegion` AABB; a
+     forced collision becomes a **blocking** clarifier, not a forced placement (Phase 2 step
+     6).
+   - Render: the new `empty_region_clause` adds a negative ("leave {region} clear") to the
+     prompt, AND the grounding loop scores any object that lands in the region as an `extra`
+     (penalized, audit 4b #6). Three independent layers (relevance filter → solver
+     reservation → render clause + grounding). _Not_ a single prompt nudge.
+
+2. **It actually asks when illogical.**
+   - Concrete **deterministic** triggers exist (Phase 3 Layer B table: unanchored,
+     over-pack, dangling relation, empty-region collision) — not "the LLM might mention it."
+   - A **broken-description eval fixture** (contradictory + over-packed + reserve-then-place
+     descriptions) asserts the system asks/blocks.
+   - A **blocking path** exists: hard contradiction / over-pack / empty-region collision ⇒
+     `solved:null` ⇒ no render until answered.
+
+3. **Reuses the real primitives — no parallel systems.** Geometry is `WorldEntityGeo`;
+   persistence is `upsertEntityGeos` via the existing `/map` POST; render steer is
+   `layout_constraints`; verification is the grounding loop. **No** new geometry type, **no**
+   new placement store, **no** new persistence collection, **no** second render path.
+
+4. **Reuses the clarifier / `promptForHint` UX.** Questions surface through the shipped
+   `clarifiers → promptForHint` bubble (`page.tsx:323`/`:1384-1398`). **No** new question
+   modal/component.
+
+5. **Frame coherence.** Solved coords are in **`MAP_IMAGE_FRAME` (100×60)**; `inside`-objects
+   are nested with `parent_id` + the **learned parent `scale`** (`world-map.ts:369-378`); a
+   **tap-routing regression test** proves a tap on a seeded object routes back to that
+   object.
+
+6. **Additive + flag-gated + backwards-compatible.** All new fields optional; new endpoint
+   (`/plan-world`) and button gated by `WORLD_FROM_DESCRIPTION` (default off). **No shape
+   change** to `GenerateBody` or `Entity`. Flag off ⇒ prod byte-identical.
+
+7. **The LLM emits relations, never x/y.** `PlannedEntity`/`PlannedRelation` carry no
+   coordinate fields; Phase-1 rule 2 forbids coordinates in the prompt; the parser would
+   drop a stray coordinate anyway. Coordinates are produced **only** by the deterministic
+   solver. (Directly closes the audit's ROOT-2 "model-invented placement" failure.)
+
+8. **Solver pure + golden-tested; parser tolerant.** `solve_layout` is a pure function
+   (no I/O, deterministic order) with golden fixtures; `parse_scene_graph` drops malformed
+   members and **never raises** (mirrors `parse_entity_edits`). A weak model degrades to a
+   thinner graph, never a crash or a wrong mutation.

--- a/docs/PLAN_SCALE_NAV.md
+++ b/docs/PLAN_SCALE_NAV.md
@@ -1,0 +1,524 @@
+# Scale Navigation — image/map → consistent zoom across scales
+
+_A forward design doc (not implemented this pass). Grounded in the code, not memory —
+every file:line below was read against `main` at `54bab2a`. Where the master plan or the
+audit drifted from the code I corrected the ref inline and noted it at the bottom._
+
+## What this is
+
+From an image or a map, navigate across **scales** the way you'd navigate a real place —
+consistently and logically:
+
+- **OUTWARD / zoom-out** — city → region → world → planet → star system → galaxy → universe.
+  Synthesize the thing that **contains** the source. _Does not exist yet._
+- **DEEPER / zoom-in** — place → interior. Step INTO a thing. _Already shipped_ as the
+  geometric tap → `place_scene` / `place_submap` enter flow (`apps/web/lib/geo-tap.ts`).
+- **AROUND / pan same-scale** — reveal the **logically adjacent** neighbours at the same
+  scale ("a proper one", not random). _Exists but is VLM-arbitrary today_
+  (`propose_neighbors`, `apps/modal-backend/providers/llm.py:1577`); `EXPAND_MAP_PAN`
+  (`generate.py:470`) pans pixels but has no notion of *which* neighbour.
+
+Everything stays style-consistent (one art medium, every hop) and **size/scale-consistent**
+(a city stays bigger than a building stays bigger than a room, with the metric to prove it).
+
+This builds **on top of** the geometric world that already merged (PR #14): numeric map +
+observer poses + the affine `resolveAbsolutePos` that already gives every entity a true
+absolute coordinate "across the universe" (`apps/web/lib/world-geometry.ts:288-320`). The
+honest constraint from `GEOMETRIC_WORLD_AUDIT.md` §4b/§6.5: generated→coords geometry is
+**relative, not metric** — a detection box wraps a cluster, the only exact bridge is
+`WORLD_TOPDOWN_MAPS` (bbox = footprint). So scale navigation cannot *depend* on metric
+precision; it has to layer a **coarse absolute rung** (which order of magnitude are we at)
+on top of the existing **fine relative `scale`** (how big is one unit of this frame). That
+split is the keystone of the whole design.
+
+---
+
+## Phase 0 — The scale ladder (keystone)
+
+Nothing else works without an explicit, ordered, metric-anchored ladder. Add it next to
+`ScaleKind` / `ViewLevel` in `packages/config/src/index.ts` (`ScaleKind` is at :8,
+`ViewLevel` at :474, `SceneView.level` at :478, `WorldEntityGeo.scale` field at :449
+(its doc-comment at :444-448)):
+
+```ts
+// Ordered rungs, coarsest → finest. A node's coarse absolute "where on the
+// zoom axis am I". Distinct from ScaleKind (relative: component/peer/container)
+// and from WorldEntityGeo.scale (fine metric: size of one unit of this frame).
+export const SCALE_LADDER = [
+  "universe", "galaxy", "star_system", "planet",
+  "world", "region", "city", "district", "place", "room", "object",
+] as const;
+export type ScaleTier = (typeof SCALE_LADDER)[number];
+
+// Order-of-magnitude METRIC anchor (metres) per rung — the bridge that makes
+// the ladder metric-conserving. One representative span, log-spaced; ~27 orders
+// of magnitude end to end, so callers store/compare in LOG space (Phase 5).
+export const SCALE_TIER_METERS: Record<ScaleTier, number> = {
+  universe: 8.8e26, galaxy: 9.5e20, star_system: 1.5e13, planet: 1.3e7,
+  world: 1.3e7, region: 3e5, city: 1.5e4, district: 1.5e3,
+  place: 1.2e2, room: 1.0e1, object: 1.0e0,
+};
+
+export function tierIndex(t: ScaleTier): number { return SCALE_LADDER.indexOf(t); }
+// Index delta on the ladder (signed): ascend = +1 per rung up, descend = -1.
+export function tierStep(from: ScaleTier, to: ScaleTier): number {
+  return tierIndex(to) - tierIndex(from);
+}
+// Per-transition METRIC multiplier = ratio of rung metres. city→region ≈ 20×;
+// the FINE WorldEntityGeo.scale a transition learns should agree in sign+order.
+export function tierMetricMultiplier(from: ScaleTier, to: ScaleTier): number {
+  return SCALE_TIER_METERS[to] / SCALE_TIER_METERS[from];
+}
+```
+
+> Note: `world` and `planet` share a metres anchor by design (a "world" is a planet-surface
+> framing); `tierStep` still separates them by index so the ladder stays strictly ordered.
+> `tierMetricMultiplier` of `1` there is intentional and INV-2 (below) treats a multiplier of
+> exactly 1 between distinct adjacent rungs as legal.
+
+**Store an additive `scale_tier?: ScaleTier` everywhere a node's frame is described**, all
+optional, all back-compat:
+
+- `NodeDoc` / `NodeInsert` / `NodeRow` in `apps/web/lib/db.ts` (alongside the existing
+  `relation?` / `scale?` at :119-120, :139-140, :157-158) + `toRow` default (:166).
+- `CreateBody` in `apps/web/app/api/nodes/route.ts:22` (alongside `relation` / `scale`).
+- `SceneView` in `packages/config/src/index.ts:478` **and its Pydantic mirror**
+  `class SceneView` in `apps/modal-backend/generate.py:101` (TS↔Py parity is load-bearing —
+  the field round-trips through the generate request and back onto the node).
+- `WorldEntityGeo` in `packages/config/src/index.ts:420` — so a map entity can carry which
+  rung it lives at, independent of its fine `scale`.
+
+**This EXTENDS, it does not replace.** `scale_tier` is the coarse absolute rung;
+`WorldEntityGeo.scale` (config:449) stays the fine per-frame metric that
+`resolveAbsolutePos` composes (world-geometry.ts:295). A node has both: "I'm at the `city`
+rung" (coarse) and "one unit of my interior = 0.31 of my parent's units" (fine, learned by
+`deriveGeoFromExtraction`, world-map.ts:374-376).
+
+**Seed the rung cheaply.** Extend `view_estimator.estimate_view`
+(`apps/modal-backend/providers/view_estimator.py:61`, returns `{level, projection,
+pitch_deg}`) to **also** guess `scale_tier` from the same one VLM call, with a deterministic
+fallback off `ViewLevel` when it abstains: `map → city`, `building → building`(→`place`),
+`street → district`, `eye → room`. That keeps a fresh generated-first session seeded with a
+rung for free — the same place §6.1 of the audit already estimates the camera. The Python
+`ViewEstimate` TypedDict (view_estimator.py:19) and its TS mirror `ViewEstimate`
+(config:511) both gain the optional field.
+
+---
+
+## Phase 1 — OUTWARD (the genuinely new direction)
+
+OUTWARD synthesizes the **parent that contains the source** and reparents the source under
+it. It is isolated and additive, modelled exactly on the existing self-contained `expand` /
+`edit` branches in `generate.py` (the `EXPAND_MAP_PAN` branch at :470-540 and the edit
+branch at :408-450 are the templates — they return early and never touch the tap/query
+single-`final` path).
+
+### Wire
+
+- New `mode: "ascend"` — add to `GenerateMode` (`packages/config/src/index.ts:3`, currently
+  `"query" | "tap" | "edit" | "expand"`). The Pydantic `GenerateBody.mode` (generate.py:131)
+  is a free `str`, so no Python enum change is forced, but document it there.
+- New isolated branch in `generate.py`, gated `SCALE_LADDER_NAV` (master) **and**
+  `SCALE_OUTWARD`, both default-off via `env_flag` exactly like `EXPAND_MAP_PAN`
+  (generate.py:470) and `WORLD_MODE` (generate.py:181-182). Flag off → the branch never
+  runs, zero behaviour change.
+
+### Which model, and why — a PURE decision
+
+Add `select_outward_op(from_tier, to_tier)` to
+`apps/modal-backend/providers/model_router.py` (pure, sits beside `select_operation` at
+:37-54; `MODEL_SLOTS` already declares `outpaint → fal-ai/bria/expand` at :22 and
+`zoom_continue → fal-ai/flux-pro/kontext` at :21). The decision keys off the **magnitude of
+the tier delta**, mirroring the audit's model bakeoff (§6.4: Kontext is *poor* at
+top-down→oblique reprojection; BRIA outpaint is the seamless pixel-preserving "pan the world
+outward" winner):
+
+| Case | Tier hop | Op | Model | Why |
+|---|---|---|---|---|
+| **Same-plane small hop** | `city → region` (Δtier 1, same projection plane) | `outpaint_zoomout` | **BRIA** via a new **centered** `expand_image_zoomout` | The source's pixels are preserved and become the **central sub-region** of a bigger frame painted around it. No reprojection, so no §6.4 failure. Style is conserved by construction (the original pixels stay). |
+| **Medium-flip large hop** | `planet → star_system` (the view *kind* changes: surface → orbital) | `scale_parent_fresh` | reference-conditioned **fresh gen** (`generate_image(..., reference_urls=[source])`) | Outpaint can't turn a planet surface into a starfield with the planet as a dot — that's a new framing. So generate fresh, conditioned on the source as a visual reference + a planner clause. Gated additionally by `SCALE_OUTWARD_RERENDER` (default off — the riskier path). |
+
+```python
+def select_outward_op(from_tier: str, to_tier: str) -> str:
+    """Pure: which OUTWARD op synthesizes the parent. Small same-plane hop →
+    centered BRIA outpaint (source becomes the central sub-region). Medium-flip
+    large hop → reference-conditioned fresh gen. No image model is chosen here
+    beyond the op label; resolve_model(op) maps it to a slug + env override."""
+    if _is_medium_flip(from_tier, to_tier):   # surface↔orbital↔galactic boundaries
+        return "scale_parent_fresh"
+    return "outpaint_zoomout"
+```
+
+`resolve_model("outpaint_zoomout")` reuses the existing `outpaint` slot
+(`fal-ai/bria/expand`, model_router.py:22); the fresh op is tier-based like `fresh`
+(model_router.py:20).
+
+### The new provider primitive — `expand_image_zoomout`
+
+Today `expand_image` (`apps/modal-backend/providers/image_edit.py:248`) outpaints in **one
+direction** (west/east/north/south) — `_expand_args_for` (:184-201) grows the canvas on one
+side and pins the original to an edge. OUTWARD needs the source at the **center** with the
+**full margin** painted on all sides in one call, so the source becomes a recognizable
+central sub-region:
+
+```python
+def _zoomout_args_for(image_url, factor, width, height):
+    """Source CENTERED on a canvas `factor`× larger each axis; full margin
+    outpainted. original_image_location = the centering offset (vs the edge
+    offsets _expand_args_for uses)."""
+    cw, ch = int(width * factor), int(height * factor)
+    loc = [(cw - width) // 2, (ch - height) // 2]
+    return {"image_url": image_url, "canvas_size": [cw, ch],
+            "original_image_size": [width, height], "original_image_location": loc}
+
+async def expand_image_zoomout(image_data_url, factor=3.0, ...):
+    # Reuses _img_dims/_dims_from_data_url (:204-237) so BRIA gets the parent's
+    # REAL pixel size (else it rescales+seams), and _expand_first_image (:239).
+```
+
+Everything else (the `fal_subscribe` call, `_expand_first_image`, dims-from-header) reuses
+`expand_image`'s existing machinery (:268-282).
+
+### The planner clause (fresh-gen path only)
+
+A new `render_mode: "scale_parent"` clause, slotted like the existing `place_scene` /
+`place_submap` clauses (the planner already branches on `render_mode`, e.g. generate.py:816
+`render_mode != "place_scene"`; the enter-clauses live in `llm.py` `plan_page`):
+
+> "Render the {N+1 rung} that CONTAINS this {N rung}. Place the source as a small,
+> recognizable sub-region within it (a city as one district of the region; a planet as one
+> dot in the system). Keep the exact palette, art medium and style — a wider view of the
+> same world, not a new invention."
+
+### Zoom clamp + intermediate rungs
+
+Cap the **visual** zoom per hop at ~×3-4 (`expand_image_zoomout(factor≈3)`). When the
+**metric** jump between rungs is large (e.g. `planet → star_system` is ~10⁶× by
+`tierMetricMultiplier`), the visual zoom and the metric span **decouple** (Phase 4 INV-2,
+Phase 5 log-space) — and the branch may auto-insert one or two intermediate synthesized
+rungs so no single hop tries to cram 6 orders of magnitude into one ×3 outpaint. The clamp
+is the same defensive instinct as `world-map.ts:375`'s `Math.min(Math.max(…, 1e-3), 10)`
+scale clamp.
+
+### STATE — OUTWARD inverts the parent pointer
+
+This is the one structurally novel write. DEEPER/AROUND append a child; OUTWARD inserts a
+new **root** above the current root and re-points the old root at it. Persist atomically:
+
+1. Insert the synthesized parent **P** with `parent_id: null`, `relation: "ascend"` (a new
+   `NodeRelation` value — see Phase 5), `scale_tier: parentTier`,
+   `scene_view.scale_tier = parentTier`.
+2. Atomically re-point the old root **C**: `C.parent_id = P.id`.
+3. Geo-seed: embed C's whole map as **one sub-entity** inside P, with a learned `scale =
+   meters(C) / meters(P)` (i.e. `1 / tierMetricMultiplier(parentTier → childTier)`). This is
+   the **same math** as `deriveGeoFromExtraction` learning a parent's `scale` (footprint ÷
+   interior extent, world-map.ts:374-376) — just run **"from the top"**: P's footprint ÷ C's
+   extent. This is exactly what conserves C's absolute size (INV-1).
+
+The reparent is **cycle-guarded** (P has no ancestors; `resolveAbsolutePos` is already
+cycle-guarded via its `seen` set, world-geometry.ts:299-309), **abort-safe** (if step 2
+fails, delete P and abort — C is untouched), and done under the same optimistic-concurrency
+loop the geo writes already use (`optimisticReplace`, world-map.ts:264). The atlas needs no
+special case: `layoutPages` already nests generically — roots are laid left-to-right
+(world-layout.ts:143-149) and a re-rooted C simply becomes a child of P, a bigger enclosing
+tile. (Caveat for implementation: today every node with `parent_id: null` is laid as a
+separate root at a left-to-right cursor; reparenting C means it stops being a root and P
+becomes one — verify `layoutPages` re-runs over the full node set on reparent, which it does
+since it rebuilds `childrenOf` from scratch each call, world-layout.ts:82-88.)
+
+---
+
+## Phase 2 — AROUND (logical, not random)
+
+Today AROUND is `propose_neighbors` (llm.py:1577): a pure VLM survey, no geometry, no facts,
+no scale constraint — "favour variety across scales" (llm.py:1608) is the opposite of what we
+want here (we want **peers at the SAME scale**). The fix is a **priority cascade** that
+prefers ground truth and only falls to the VLM cold:
+
+New pure module `apps/web/lib/scale-neighbors.ts` — `selectNeighbors(...)` layering three
+sources, each neighbour carrying a **bearing** so it lands in the right direction:
+
+1. **Geometry first.** `neighborsOf` (world-geometry.ts:232) / `siblingsOf`
+   (world-geometry.ts:281) over entities with the **same `parent_id` and same `scale_tier`**
+   — these already return real bearings (`Math.atan2(dy, dx)`, world-geometry.ts:244). When
+   the map is seeded this is the truth.
+2. **Codex facts.** When geometry is thin, same-tier same-region siblings from the codex
+   (the `Entity` registry — `facts`, `aliases`, config:362) give *named* logical peers (the
+   other lighthouses on this coast) without a VLM call.
+3. **Constrained VLM, cold-start only.** Extend `propose_neighbors` (llm.py:1577) with two
+   **optional** params — `known_neighbors: list[str] | None` and `scale_tier: str | None` —
+   and a clause: "propose PEERS at the SAME scale ({scale_tier}); these are already known:
+   {known}; do not repeat them or the focal subject." Empty params → **today's exact
+   behaviour** (back-compat). This only runs when (1) and (2) are empty.
+
+Persist each neighbour as today — `relation: "expand"` (the existing AROUND relation;
+`useExpandBloom` already persists `relation: "expand"` + `scale`,
+`apps/web/hooks/useExpandBloom.ts:119-120`) — **plus** `scale_tier` (the peer's rung == the
+source's) and the bearing. Gated `SCALE_AROUND_LOGICAL`; flag off → the arbitrary VLM path
+exactly as it ships now.
+
+---
+
+## Phase 3 — DEEPER (reuse, don't rebuild)
+
+DEEPER already works and is the most-proven path (audit §6.1: "tap → enter loop closed live,
+city → Unseen University → courtyard"). **Reuse it unchanged**:
+
+`geo-tap.ts` `geoTapRequest` (apps/web/lib/geo-tap.ts:64) → `render_mode`
+`place_submap` (Kontext `zoom_continue`, model_router.py:52) or `place_scene` (guarded fresh
+gen, model_router.py:54) → `deriveGeoFromExtraction` seeds the child frame and **learns the
+child's `scale`** (world-map.ts:369-377), which is what already gives DEEPER its
+size-consistency (a child's local pos resolves to a true absolute coordinate via
+`resolveAbsolutePos`).
+
+**The only addition:** stamp `scene_view.scale_tier = childTier` on the entered node (one rung
+below the parent's tier; clamp at `object`). That makes DEEPER and OUTWARD share **one
+ladder** — a tap-in is a `tierStep` of −1, an OUTWARD is +1, and a node's tier is consistent
+no matter which direction reached it. No generation change, no new model.
+
+---
+
+## Phase 4 — Metric-conservation invariants (the correctness core)
+
+Four invariants. INV-1 and INV-2 are **pure functions with golden tests** extending
+`apps/web/lib/world-geometry.test.ts` (the existing parity/golden suite the audit §2 calls
+"parity+fuzz").
+
+- **INV-1 — absolute position conserved across transitions.** A transition (OUTWARD, DEEPER)
+  must not move an entity's absolute world coordinate. `resolveAbsolutePos`
+  (world-geometry.ts:295) is unchanged; OUTWARD satisfies it **by construction** because the
+  embedded child gets `scale = meters(C)/meters(P)` (the same footprint÷extent law as
+  `deriveGeoFromExtraction`, world-map.ts:374-376), so resolving any of C's descendants
+  through the newly inserted P yields the same `(x, y)` as before the reparent. **Golden
+  test:** seed a small map, run the OUTWARD reparent, assert `resolveAbsolutePos(leaf)` is
+  byte-identical before/after for every leaf.
+- **INV-2 — metric span monotonic on the ladder.** Going OUTWARD must strictly **increase**
+  the metric span; DEEPER must strictly decrease it. `tierMetricMultiplier(from, to)`
+  (Phase 0) must be `> 1` for ascend, `< 1` for descend (or `== 1` only between the
+  deliberately-equal `world`/`planet` rungs). A transition whose learned fine `scale`
+  disagrees in sign with the tier step is a **mis-classified rung → reject** (don't persist;
+  log + fall back). Pure, golden-tested.
+- **INV-3 — style lock propagates EVERY hop.** The `session_style_anchor` /
+  `style` reference (the medium-lock lever from Workstream A2 — `session_style_anchor` is
+  already threaded, generate.py:152/654; `style_anchor` is prepended at generate.py:804-810)
+  rides every OUTWARD / AROUND / DEEPER generation. For OUTWARD's outpaint path style is
+  conserved automatically (original pixels stay); for the fresh-gen path it's the explicit
+  `reference_urls` + the `scale_parent` clause. Enforced at the call site, not a separate
+  check.
+- **INV-4 — one ladder.** `scale_tier` (coarse) and the fine `WorldEntityGeo.scale` must
+  agree: a node deeper on `SCALE_LADDER` has a smaller resolved metric span. They are two
+  resolutions of the SAME axis, never a parallel system (this is the checklist's load-bearing
+  item — see EVALUATOR CHECKLIST #2).
+
+---
+
+## Phase 5 — State + UX
+
+**State (all additive, all back-compat):**
+
+- New optional `scale_tier` column on the node (Phase 0) — `relation` gains the new
+  `"ascend"` value in the `NodeRelation` union (config:12) and in the db.ts string unions
+  (`"descend" | "expand"` at db.ts:119/139/157/174/196, the nodes route at
+  nodes/route.ts:22). Defaulted on read (`toRow`, db.ts:174) so pre-`ascend` rows are
+  unaffected.
+- OUTWARD reparents the old root (Phase 1 STATE).
+- **Atlas multi-scale nesting is already supported.** `atlas-view.tsx` already computes each
+  node's absolute scale-level by BFS over `scaleStep` (`lvl + scaleStep(child)`,
+  atlas-view.tsx:222) and feeds it to `lodOpacity` (world-layout.ts:341, called at
+  atlas-view.tsx:528/593) so "small stuff reveals when you zoom in". **Feed `scale_tier` in
+  when present** (it's a better, absolute level than the relative BFS), and **fall back to
+  the BFS `scaleStep` when absent** — a drop-in, since both produce the same integer-level
+  input `lodOpacity` consumes.
+- **Store metric span in LOG space.** The ladder spans ~27 orders of magnitude
+  (`SCALE_TIER_METERS`); comparing/feeding raw metres is numerically unstable and would
+  saturate `lodOpacity`'s `Math.log2` (world-layout.ts:350). Persist/compare
+  `log10(meters)`; the LOD math is already octave-based (world-layout.ts:350-351), so this is
+  natural.
+
+**UX (the existing primaries stay untouched):**
+
+- `tap = ENTER` (DEEPER) and `expand = AROUND` stay exactly as they are — additive-only, no
+  muscle-memory change.
+- A **new, distinct "zoom out / step back" control** (its own button + keyboard shortcut,
+  **never bound to tap**) fires `mode: "ascend"`, behind `SCALE_OUTWARD`. Surface it in the
+  existing **`SpatialPath`** zoom-out stack (`apps/web/components/PlayPage/SpatialPath.tsx`),
+  which already renders ancestry as nested cards you click to zoom out to
+  (SpatialPath.tsx:11-15) — OUTWARD adds a card *above* the current root rather than only
+  navigating to an existing one.
+
+**Flags (all default-off except where noted):**
+
+| Flag | Gates |
+|---|---|
+| `SCALE_LADDER_NAV` | master — nothing in this doc runs without it |
+| `SCALE_OUTWARD` | the OUTWARD branch + the zoom-out UI control |
+| `SCALE_AROUND_LOGICAL` | the Phase-2 priority cascade (off → today's arbitrary VLM bloom) |
+| `SCALE_OUTWARD_RERENDER` | the medium-flip fresh-gen OUTWARD path only (the riskier one) |
+
+All new fields optional; **TS↔Py schema parity maintained** (the `SceneView` Pydantic mirror
+at generate.py:101 tracks the config:478 interface; `ViewEstimate` mirrors at config:511 ↔
+view_estimator.py:19).
+
+---
+
+## The 3 biggest risks + de-risking
+
+1. **Compounding style/content drift across hops.** Each generated hop can nudge the art
+   medium or invent content; over a 5-hop OUTWARD climb that compounds into a different
+   world. The audit already measured this is real and *situational* (§6.5 B3: region
+   conditioning is **+0.33/10 mean, variance −4↔+4** — it helps on legible crops, injects
+   top-down artifacts on ambiguous ones).
+   **De-risk:** (a) **style lock every hop** (INV-3 — the medium-lock anchor, not just
+   palette); (b) **prefer outpaint** for OUTWARD wherever possible (`expand_image_zoomout`
+   keeps the original pixels → zero drift on the small-hop path; the fresh-gen path is gated
+   off behind `SCALE_OUTWARD_RERENDER`); (c) **codex fact-sheet** so content is *named*, not
+   re-invented (Phase 2 source 2, the `Entity.facts`); (d) **A/B with the shipped
+   `coherence_runner`** (`tests/continuity_bench/coherence_runner.py`, `make eval-coherence`)
+   at **N ≥ 10** before trusting any path — the audit explicitly flags N=3 as too noisy
+   (§6.5 B3).
+
+2. **Metric blowups across 27 orders of magnitude.** A naive "visual zoom == metric span"
+   coupling makes a `planet → star_system` hop either an unreadable map or a number that
+   overflows the LOD math.
+   **De-risk:** (a) **decouple visual-zoom from metric span** — visual zoom is clamped ~×3-4
+   per hop, metric span follows the ladder independently; (b) **log-space LOD** (Phase 5 —
+   the octave math already wants log, world-layout.ts:350); (c) **INV-2** rejects
+   mis-classified rungs that would imply a non-monotonic span; (d) **clamps** modelled on the
+   existing `Math.min(Math.max(scale, 1e-3), 10)` guard (world-map.ts:375) plus auto-inserted
+   intermediate rungs.
+
+3. **Parent-inversion tree corruption.** OUTWARD is the only operation that rewrites an
+   existing edge (`C.parent_id`), and a half-applied reparent (P inserted, C not re-pointed,
+   or a cycle) corrupts navigation and `resolveAbsolutePos`.
+   **De-risk:** (a) **atomic reparent** under the existing `optimisticReplace` loop
+   (world-map.ts:264) — insert P then re-point C, or roll back; (b) **cycle-guard** (P is a
+   fresh root with no ancestors; `resolveAbsolutePos` is already cycle-guarded,
+   world-geometry.ts:299-309); (c) **abort-safe** (failure leaves C untouched, deletes the
+   orphan P); (d) **regression tests** asserting the tree stays acyclic and every leaf's
+   absolute position is conserved (INV-1) after a reparent.
+
+---
+
+## Open questions
+
+- **Rung classification confidence.** `view_estimator` is one VLM call that "degrades to the
+  top-down default on any failure" (view_estimator.py:62-63). A wrong `scale_tier` on an
+  OUTWARD hop picks the wrong model AND the wrong metric multiplier. Do we gate OUTWARD on a
+  confidence floor and ask the user when unsure (the World-Mode `clarifiers` UX already
+  exists, ResolveClickResponse.clarifiers config:159)?
+- **`world` vs `planet` rung.** They share a metres anchor; is "world" even a distinct rung,
+  or a synonym we should collapse to keep the ladder strictly metric-monotonic?
+- **AROUND across a seam.** A same-tier neighbour that lives under a *different* parent (the
+  next city in the region) — does `selectNeighbors` cross the `parent_id` boundary, and if so
+  whose frame owns the bearing?
+- **Outpaint factor vs rung ratio.** A fixed ×3 `expand_image_zoomout` rarely equals the
+  rung's true metric multiplier. Is "the source is *a* sub-region" (recognizable but not
+  to-scale) good enough, or do we need the factor to track `tierMetricMultiplier` (and then
+  clamp + intermediate-rung)?
+- **BRIA centered-canvas limits.** `_zoomout_args_for` assumes BRIA accepts an arbitrary
+  centered `original_image_location`; `scripts/verify-fal-models.py` should confirm the
+  live schema before this is trusted (same caution the router already documents,
+  model_router.py:8-12).
+
+---
+
+## Critical files
+
+- `packages/config/src/index.ts` — `GenerateMode` :3, `ScaleKind` :8, `NodeRelation` :12,
+  `WorldContextEntity` :95, `NodeRecord`/`NodeCreateRequest` :271-291, `WorldEntityGeo`
+  :420-451 (the `.scale` field at :449), `ObserverPose` :454, `ViewLevel` :474,
+  `SceneView`(+`.level`) :478,
+  `ProjectedEntity` :491, `ViewEstimate` :511. **New:** `SCALE_LADDER` / `SCALE_TIER_METERS`
+  / `ScaleTier` / `tierStep` / `tierMetricMultiplier`; `scale_tier?` on the above; `"ascend"`
+  in `NodeRelation`; `"ascend"` in `GenerateMode`.
+- `apps/web/lib/world-geometry.ts` — `project`/`projectScene` :66-129, `estimateGeoFromBBox`
+  :165, `neighborsOf` :232, `siblingsOf` :281, `resolveAbsolutePos` (affine) :295-320,
+  `localExtent` :344. (Unchanged; INV-1/INV-2 golden tests extend
+  `world-geometry.test.ts`.)
+- `apps/web/lib/world-map.ts` — `applyGeoUpsert` (source authority) :78, `deriveGeoFromExtraction`
+  (learns parent `scale` = footprint÷extent, clamp :375) :331-380, `upsertEntityGeos`
+  /`optimisticReplace` :259-285.
+- `apps/web/lib/world-layout.ts` — `layoutPages` (nests generically) :78-152, `scaleStep`
+  :325, `lodOpacity` :341, `fitCamera` :361.
+- `apps/web/lib/geo-tap.ts` — `geoTapRequest` (DEEPER, reused) :64-156, `MAP_IMAGE_FRAME` :24.
+- `apps/web/lib/db.ts` — `NodeDoc`/`NodeInsert`/`NodeRow` (+`relation`/`scale`/`scene_view`)
+  :101-164, `toRow` :166, `insertNode` :181. **New:** `scale_tier?` + `"ascend"`.
+- `apps/web/app/api/nodes/route.ts` — `CreateBody` :22 (+`scale_tier`, `"ascend"`).
+- `apps/web/components/atlas-view.tsx` — BFS scaleStep→level :222, `lodOpacity` calls
+  :528/593 (feed `scale_tier`, fall back to BFS).
+- `apps/web/components/PlayPage/SpatialPath.tsx` — zoom-out stack :11-15 (the OUTWARD control's
+  home).
+- `apps/web/hooks/useExpandBloom.ts` — persists `relation:"expand"` neighbours :119-120
+  (AROUND adds `scale_tier` + bearing).
+- **New:** `apps/web/lib/scale-neighbors.ts` — `selectNeighbors` (Phase 2 cascade).
+- `apps/modal-backend/generate.py` — Pydantic `SceneView` :101, `GenerateBody.mode` :131 /
+  `scene_view` :174 / `expected_layout` :175, `_layout_clause_for` :196, `_topdown_clause_for`
+  :210, edit branch :408-450, EXPAND_MAP_PAN branch :470-540, subject-bloom :542-645,
+  `render_mode` compose :799-829, `select_operation`/`continue_image` wiring :853-919,
+  `estimate_view` call :1449-1463. **New:** isolated `ascend` branch (gated
+  `SCALE_LADDER_NAV`+`SCALE_OUTWARD`); `scale_tier` on the Pydantic `SceneView`.
+- `apps/modal-backend/providers/image_edit.py` — `_expand_args_for` :184, `_img_dims` :204,
+  `_dims_from_data_url` :228, `_expand_first_image` :239, `expand_image` (directional) :248,
+  `continue_image`/`build_zoom_instruction` (Kontext) :104-172. **New:** `expand_image_zoomout`
+  + `_zoomout_args_for` (centered outpaint).
+- `apps/modal-backend/providers/model_router.py` — `MODEL_SLOTS` :19-25, `resolve_model` :28,
+  `select_operation` :37-54. **New:** `select_outward_op` (pure, by tier delta).
+- `apps/modal-backend/providers/llm.py` — world-context clause :1209, `propose_neighbors`
+  :1577 (+ optional `known_neighbors` + `scale_tier`), `plan_page` (new `scale_parent`
+  render_mode clause).
+- `apps/modal-backend/providers/view_estimator.py` — `ViewEstimate` :19, `estimate_view` :61
+  (+ guess `scale_tier`).
+- `tests/continuity_bench/coherence_runner.py` (`make eval-coherence`) — the A/B harness
+  reused at N ≥ 10 for the drift de-risk.
+
+---
+
+## EVALUATOR CHECKLIST
+
+1. **Explicit, ordered, metric-conserving ladder + per-transition multiplier + INV-1 golden
+   test.** ✅ `SCALE_LADDER` (universe…object, ordered) + `SCALE_TIER_METERS` (order-of-mag
+   metre anchor per rung) in `packages/config`; `tierStep` = index delta; per-transition
+   multiplier = `tierMetricMultiplier` = ratio of rung metres (Phase 0). INV-1 (absolute
+   position conserved) is a pure function over `resolveAbsolutePos` with a golden test
+   asserting byte-identical leaf coords across an OUTWARD reparent (Phase 4).
+2. **One ladder, not a parallel system — extends `SceneView.level` / `WorldEntityGeo.scale` /
+   `resolveAbsolutePos`.** ✅ `scale_tier` is the **coarse absolute rung**;
+   `WorldEntityGeo.scale` (config:449) stays the **fine per-frame metric** the affine
+   `resolveAbsolutePos` (world-geometry.ts:295) already composes; INV-4 forces them to agree
+   in sign/order. DEEPER and OUTWARD stamp the SAME `scale_tier` axis (a tap is `tierStep`
+   −1, OUTWARD +1). Nothing is replaced (Phase 0, Phase 3, INV-4).
+3. **OUTWARD specifies outpaint-vs-rerender via a PURE `select_outward_op`, and the source
+   lands as the center sub-region.** ✅ `select_outward_op(from, to)` in `model_router.py`
+   (pure, beside `select_operation`): small same-plane hop → centered BRIA outpaint
+   (`expand_image_zoomout`, source centered, full margin painted → source becomes the central
+   sub-region); medium-flip large hop → reference-conditioned fresh gen (gated
+   `SCALE_OUTWARD_RERENDER`). Reuses the `outpaint`/`fresh` `MODEL_SLOTS` (Phase 1).
+4. **AROUND is logical via `neighborsOf`/`siblingsOf` + codex with bearings; the arbitrary
+   path is gated off.** ✅ `selectNeighbors` cascade: (1) geometric `neighborsOf`/`siblingsOf`
+   same `parent_id`+`scale_tier` with real bearings → (2) codex same-tier same-region facts →
+   (3) constrained `propose_neighbors` (peers at the SAME scale, pass `known_neighbors` +
+   `scale_tier`) only cold-start. `SCALE_AROUND_LOGICAL` off → today's arbitrary VLM bloom
+   verbatim (Phase 2).
+5. **DEEPER reuses the existing enter flow and only stamps the rung.** ✅ `geo-tap.ts` →
+   `place_submap`/`place_scene` → `deriveGeoFromExtraction` child-frame `scale` seeding, all
+   **unchanged**; the sole addition is `scene_view.scale_tier = childTier`. No generation or
+   model change; size-consistency already holds via the learned per-frame `scale`
+   (Phase 3).
+6. **Reuses BRIA / Kontext / the geometric world — no new image models.** ✅ OUTWARD small-hop
+   = existing BRIA (`fal-ai/bria/expand`, model_router.py:22) via a new *centered* arg
+   shaper; OUTWARD medium-flip = the existing `generate_image` fresh path; DEEPER = existing
+   Kontext `zoom_continue` (model_router.py:21) + fresh; AROUND = existing
+   `propose_neighbors` + geometry. The only new *code* is arg shapers / pure selectors / a TS
+   neighbour module — zero new models (Phases 1-3, Critical files).
+7. **Additive + flag-gated + back-compat + TS↔Py parity.** ✅ Every new field optional
+   (`scale_tier?`, `known_neighbors?`); every behaviour behind `SCALE_LADDER_NAV` (master) +
+   `SCALE_OUTWARD` / `SCALE_AROUND_LOGICAL` / `SCALE_OUTWARD_RERENDER`, all default-off;
+   `"ascend"` added to unions without breaking the `?? "descend"` defaults (db.ts:174); the
+   `SceneView` Pydantic mirror (generate.py:101) + `ViewEstimate` mirror (view_estimator.py:19)
+   track their config interfaces (Phase 5).
+8. **The three risks are addressed (drift, blowups, inversion).** ✅ Drift → INV-3 style lock
+   every hop + prefer outpaint (zero-drift small hop) + codex fact-sheet + `coherence_runner`
+   A/B at N ≥ 10. Blowups → visual-zoom/metric-span decoupling + log-space LOD + INV-2 +
+   `world-map.ts:375`-style clamps + intermediate rungs. Inversion → atomic reparent under
+   `optimisticReplace` + cycle-guard (`resolveAbsolutePos` `seen` set) + abort-safe +
+   INV-1 regression tests (Risks section).

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -105,6 +105,13 @@ export interface WorldContextEntity {
   // Free-form key/value state. Helps the planner thread the entity's
   // current condition (door open / lit / wounded) into the prompt.
   state?: EntityState;
+  // Optional geometric size (world units) carried from the entity's
+  // WorldEntityGeo when the web proxy resolves the slice. Lets the planner
+  // hint a consistent relative scale for recurring entities across pages so a
+  // building rendered large once doesn't come back tiny next time. Omitted →
+  // today's behaviour (appearance text only).
+  footprint?: { w: number; d: number };
+  height?: number;
 }
 
 export interface ResolveClickRequestBody {

--- a/scripts/ab-proof/README.md
+++ b/scripts/ab-proof/README.md
@@ -1,0 +1,59 @@
+# Style-fix A/B proof harness
+
+Reproducible before/after for the medium-lock fix. The trick: run the **same
+code in two versions** behind identical input, so the only variable is the fix.
+
+## Setup (two backends, identical corrected env)
+
+The headline bug (interiors coming back photoreal/isometric instead of matching
+the source engraving) is **part env, part code**:
+
+- The dramatic drift in the original screenshot was largely the **qwen VLM
+  429ing** (it silently fails to extract a style → no lock → nano-banana drifts).
+  With Gemini, the resolver extracts the style and even the old code mostly holds.
+- The genuinely **code** part is the paths that had *no* style handling at all —
+  the **edit path** (dropped the style anchor + sent no style ref) and the
+  freehand **stroke-tap**. Those drift regardless of env.
+
+So the clean A/B uses the **corrected env on both sides** (Gemini + nano-banana-pro)
+to remove the env confound, and isolates the code:
+
+```bash
+# build a throwaway runtime venv (the repo .venv is dev-only)
+uv venv /tmp/ofb-rtvenv --python 3.12
+uv pip install --python /tmp/ofb-rtvenv/bin/python -r apps/modal-backend/requirements.txt pillow
+
+# pre-fix backend from a worktree on main, fix backend from this branch — both
+# with Gemini + nano-banana-pro (overrides the .env qwen/nano-banana gotchas)
+git worktree add /tmp/ofb-main main
+ln -s "$PWD/apps/modal-backend/.venv" /tmp/ofb-main/apps/modal-backend/.venv   # (or skip; use rtvenv)
+ln -s "$PWD/apps/modal-backend/.env"  /tmp/ofb-main/apps/modal-backend/.env
+
+ENV='OPENROUTER_VLM_MODEL=google/gemini-3-flash-preview OPENROUTER_TEXT_MODEL=google/gemini-3-flash-preview FAL_IMAGE_MODEL_BALANCED=fal-ai/nano-banana-pro WORLD_MODE=true GEOMETRIC_WORLD=true WORLD_GEOMETRY_GEN=true IMAGE_CONDITIONING=true'
+( cd /tmp/ofb-main/apps/modal-backend && env $ENV PORT=8788 /tmp/ofb-rtvenv/bin/python local_server.py ) &
+( cd apps/modal-backend           && env $ENV PORT=8789 /tmp/ofb-rtvenv/bin/python local_server.py ) &
+```
+
+## Run
+
+```bash
+/tmp/ofb-rtvenv/bin/python scripts/ab-proof/ab_driver.py   # go-inside tap A/B
+/tmp/ofb-rtvenv/bin/python scripts/ab-proof/ab_edit.py     # edit A/B (the sharp one)
+/tmp/ofb-rtvenv/bin/python scripts/ab-proof/compose.py     # labelled side-by-sides
+```
+
+`prefetched_subject` skips the VLM resolver so the subject is deterministic; the
+only difference between `:8788` and `:8789` is the style-handling code.
+
+## Result
+
+- **Edit A/B (`ab_edit.py`)** — same `"add a clockwork dragon"` request: pre-fix
+  drops the style and nano-banana-pro renders a **glossy photoreal 3D** dragon;
+  the fix keeps `"...in a hand-drawn antique engraving style with dense sepia ink
+  cross-hatching"` and renders a faithful **engraving**. The clean, env-free proof.
+- **Tap A/B (`ab_driver.py`)** — under corrected env both hold the engraving
+  (the fix is a little more faithful/consistent), confirming the screenshot's hard
+  drift was the env, not the tap code. The fix is the robustness + the edit/stroke
+  gaps that had zero handling.
+
+Visual outputs land in `/tmp/ab_*.{jpg,png}` (gitignored; not committed).

--- a/scripts/ab-proof/ab_driver.py
+++ b/scripts/ab-proof/ab_driver.py
@@ -1,0 +1,123 @@
+"""A/B proof driver for the style medium-lock fix.
+
+Identical input (same source map, same forced subject, same engraving style text,
+same corrected env) sent to two backends that differ ONLY in code:
+  :8788 = main  (pre-fix)
+  :8789 = fix   (feat/consistency-fixes)
+prefetched_subject skips the VLM resolver, so the subject is deterministic and
+the only variable is the style-handling prompt logic.
+"""
+import base64
+import json
+import sys
+
+import httpx
+
+MAIN = "http://localhost:8788/sse/generate"
+FIX = "http://localhost:8789/sse/generate"
+SID = "ab-style-proof"
+
+STYLE = (
+    "hand-drawn antique engraving, sepia ink, dense cross-hatching, woodcut "
+    "linework, aged paper"
+)
+MAP_QUERY = (
+    "a hand-drawn antique engraving map of the fictional walled city of "
+    "Ankh-Morpork, sepia ink, dense cross-hatching, woodcut style, labelled "
+    "districts, a winding river, compass rose"
+)
+SUBJECT = (
+    "the interior of the grand domed Unseen University great hall at the city "
+    "centre"
+)
+
+
+def sse_generate(url: str, body: dict, timeout: float = 240.0) -> dict:
+    final = None
+    with httpx.stream("POST", url, json=body, timeout=timeout) as r:
+        r.raise_for_status()
+        for line in r.iter_lines():
+            if not line or not line.startswith("data:"):
+                continue
+            try:
+                evt = json.loads(line[5:].strip())
+            except json.JSONDecodeError:
+                continue
+            t = evt.get("type")
+            if t == "error":
+                raise RuntimeError(f"backend error: {evt.get('message')}")
+            if t == "final":
+                final = evt
+    if not final:
+        raise RuntimeError("no final event")
+    return final
+
+
+def save(data_url: str, path: str) -> None:
+    b64 = data_url.split(",", 1)[1]
+    with open(path, "wb") as f:
+        f.write(base64.b64decode(b64))
+
+
+def tap_body(image: str) -> dict:
+    return {
+        "query": "Unseen University great hall",
+        "session_id": SID,
+        "aspect_ratio": "16:9",
+        "image_tier": "balanced",
+        "mode": "tap",
+        "image": image,
+        "parent_query": MAP_QUERY,
+        "parent_title": "Ankh-Morpork",
+        "click": {"x_pct": 0.5, "y_pct": 0.45},
+        "world_mode": True,
+        "render_mode": "place_scene",
+        # Force identical subject on both backends (skips the VLM resolver).
+        "prefetched_subject": SUBJECT,
+        "prefetched_style": STYLE,
+        # The map is both the place being entered (region) and the medium
+        # exemplar (style). Same refs to both backends.
+        "condition_image_urls": [image, image],
+        "condition_roles": ["region", "style"],
+        "session_style_anchor": STYLE,
+    }
+
+
+def main() -> None:
+    print("[1/3] generating the source engraving map (fix backend)...", file=sys.stderr)
+    m = sse_generate(
+        FIX,
+        {
+            "query": MAP_QUERY,
+            "session_id": SID,
+            "aspect_ratio": "16:9",
+            "image_tier": "balanced",
+            "web_search": False,
+            "world_mode": True,
+            "session_style_anchor": STYLE,
+        },
+    )
+    map_url = m["image_data_url"]
+    save(map_url, "/tmp/ab_map.jpg")
+    print(f"      map saved -> /tmp/ab_map.jpg (model={m.get('image_model')})", file=sys.stderr)
+
+    print("[2/3] tap -> BEFORE (main :8788, pre-fix)...", file=sys.stderr)
+    a = sse_generate(MAIN, tap_body(map_url))
+    save(a["image_data_url"], "/tmp/ab_before.jpg")
+    print(f"      before saved (model={a.get('image_model')})", file=sys.stderr)
+
+    print("[3/3] tap -> AFTER (fix :8789)...", file=sys.stderr)
+    b = sse_generate(FIX, tap_body(map_url))
+    save(b["image_data_url"], "/tmp/ab_after.jpg")
+    print(f"      after saved (model={b.get('image_model')})", file=sys.stderr)
+
+    print(json.dumps({
+        "map_title": m.get("page_title"),
+        "before_prompt": (a.get("final_prompt") or "")[:600],
+        "after_prompt": (b.get("final_prompt") or "")[:600],
+    }, indent=2))
+    print("DONE")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ab-proof/ab_edit.py
+++ b/scripts/ab-proof/ab_edit.py
@@ -1,0 +1,80 @@
+"""Edit-path A/B: the cleanest code-isolated test of the style fix.
+
+The pre-fix edit branch dropped the style ENTIRELY (no style_anchor into polish,
+no style ref into edit_image). The fixed branch threads both. We send the
+IDENTICAL edit request (with session_style_anchor + a "style" condition ref) to
+both backends; main ignores both, fix uses both. Same input, only code differs.
+"""
+import base64
+import json
+import sys
+
+import httpx
+
+MAIN = "http://localhost:8788/sse/generate"
+FIX = "http://localhost:8789/sse/generate"
+SID = "ab-edit-proof"
+STYLE = (
+    "hand-drawn antique engraving, sepia ink, dense cross-hatching, woodcut "
+    "linework, aged paper"
+)
+# A drift-prone edit: a "clockwork dragon" tempts a glossy 3D/photoreal render.
+INSTRUCTION = "add a colossal clockwork dragon coiled around the central tower"
+
+
+def sse(url, body, timeout=240.0):
+    final = None
+    with httpx.stream("POST", url, json=body, timeout=timeout) as r:
+        r.raise_for_status()
+        for line in r.iter_lines():
+            if not line or not line.startswith("data:"):
+                continue
+            try:
+                evt = json.loads(line[5:].strip())
+            except json.JSONDecodeError:
+                continue
+            if evt.get("type") == "error":
+                raise RuntimeError(evt.get("message"))
+            if evt.get("type") == "final":
+                final = evt
+    if not final:
+        raise RuntimeError("no final")
+    return final
+
+
+def save(u, p):
+    open(p, "wb").write(base64.b64decode(u.split(",", 1)[1]))
+
+
+map_url = "data:image/jpeg;base64," + base64.b64encode(
+    open("/tmp/ab_map.jpg", "rb").read()
+).decode()
+
+
+def edit_body():
+    return {
+        "query": INSTRUCTION,
+        "session_id": SID,
+        "aspect_ratio": "16:9",
+        "image_tier": "balanced",
+        "mode": "edit",
+        "image": map_url,
+        "edit_instruction": INSTRUCTION,
+        "parent_title": "Ankh-Morpork",
+        # Both sent identically; main's edit branch ignores both, fix uses both.
+        "session_style_anchor": STYLE,
+        "condition_image_urls": [map_url],
+        "condition_roles": ["style"],
+    }
+
+
+print("[1/2] edit -> BEFORE (main :8788, drops style)...", file=sys.stderr)
+a = sse(MAIN, edit_body())
+save(a["image_data_url"], "/tmp/ab_edit_before.jpg")
+print(f"      before saved; final_prompt={a.get('final_prompt')!r}", file=sys.stderr)
+
+print("[2/2] edit -> AFTER (fix :8789, keeps style)...", file=sys.stderr)
+b = sse(FIX, edit_body())
+save(b["image_data_url"], "/tmp/ab_edit_after.jpg")
+print(f"      after saved; final_prompt={b.get('final_prompt')!r}", file=sys.stderr)
+print("DONE")

--- a/scripts/ab-proof/compose.py
+++ b/scripts/ab-proof/compose.py
@@ -1,0 +1,55 @@
+from PIL import Image, ImageDraw, ImageFont
+
+FONT = "/System/Library/Fonts/Supplemental/Arial.ttf"
+
+
+def font(sz):
+    return ImageFont.truetype(FONT, sz)
+
+
+def labeled(path, caption, barcolor, w=600, h=600, barh=64):
+    im = Image.open(path).convert("RGB").resize((w, h))
+    canvas = Image.new("RGB", (w, h + barh), barcolor)
+    canvas.paste(im, (0, 0))
+    d = ImageDraw.Draw(canvas)
+    f = font(26)
+    tw = d.textlength(caption, font=f)
+    d.text(((w - tw) // 2, h + (barh - 30) // 2), caption, font=f, fill="white")
+    return canvas
+
+
+def sbs(left, right, title, out, titleh=72):
+    gap = 12
+    W = left.width + right.width + gap
+    H = max(left.height, right.height) + titleh
+    canvas = Image.new("RGB", (W, H), "white")
+    d = ImageDraw.Draw(canvas)
+    f = font(22)
+    tw = d.textlength(title, font=f)
+    d.text(((W - tw) // 2, (titleh - 26) // 2), title, font=f, fill="black")
+    canvas.paste(left, (0, titleh))
+    canvas.paste(right, (left.width + gap, titleh))
+    # even dims for h264
+    if canvas.width % 2 or canvas.height % 2:
+        canvas = canvas.crop((0, 0, canvas.width - canvas.width % 2, canvas.height - canvas.height % 2))
+    canvas.save(out)
+    print("wrote", out, canvas.size)
+
+
+# Edit A/B — the dramatic, code-isolated proof
+lb = labeled("/tmp/ab_edit_before.jpg", "BEFORE - pre-fix: edit drops the style", "#B00020")
+rb = labeled("/tmp/ab_edit_after.jpg", "AFTER - fix: medium locked", "#0B7A33")
+sbs(
+    lb, rb,
+    "openflipbook  -  edit 'add a clockwork dragon'  -  same request + Gemini & nano-banana-pro, only the CODE differs",
+    "/tmp/ab_edit_sbs.png",
+)
+
+# Tap A/B — both hold engraving under corrected env (honest framing)
+lt = labeled("/tmp/ab_before.jpg", "pre-fix backend (corrected env)", "#555555", 600, 338, 56)
+rt = labeled("/tmp/ab_after.jpg", "fix backend", "#0B7A33", 600, 338, 56)
+sbs(
+    lt, rt,
+    "go-inside tap  -  both hold the engraving under corrected env (the screenshot's hard drift was the qwen env, not code)",
+    "/tmp/ab_tap_sbs.png",
+)


### PR DESCRIPTION
Two consistency fixes the live runs kept hitting, plus two forward design docs. All additive + flag-safe; every gate green (backend ruff/mypy/pytest, web typecheck/eslint, 437 web tests).

## The fixes

**Style / medium drift on "go inside"** — tapping an engraving-style map returned interiors in random *media* (photoreal, isometric). The source style was advisory text only, the edit path dropped it entirely, and there was no medium guard. Now:
- a persistent `style` condition role carries the root/pinned exemplar, threaded on tap / **stroke-tap** / expand / edit;
- `plan_page` emits a model-agnostic **MEDIUM LOCK** clause (names the medium, forbids photoreal/3D/isometric drift) — works on every model incl. seedream;
- the **edit path** finally threads the style lock + exemplar into `polish_edit_instruction` + `edit_image` (it silently dropped both, even on long >20-word edits).

**Entity size ↔ map footprint** — `estimateGeoFromBBox` derived an oblique footprint from a flat `6×6` default and threw away the box width; now it derives width from `bbox.w_pct` (damped depth, clamped) so an oblique city map's buildings track the size they were rendered at. `WorldContextEntity` also carries `footprint`/`height` forward so a place drawn large once isn't shrunk later.

## Honest note on the proof

The screenshot's *hard* photoreal/isometric drift was substantially the **qwen-VLM-429 env gotcha** (no style extracted → no lock), not pure code — under corrected env (Gemini + nano-banana-pro) the go-inside tap holds the engraving on both old and new code. The genuine code wins are the **edit + stroke-tap paths** (zero style handling before) and the universal MEDIUM LOCK. The clean, env-free proof is the **edit A/B** (`scripts/ab-proof/`): same `"add a clockwork dragon"` request → pre-fix renders a glossy photoreal 3D dragon, the fix keeps a faithful engraving.

## Verification

- An independent **codex-rescue referee** audited the diff, found 2 real gaps (stroke-tap, long-edit lock) → both fixed and re-verified.
- A new **`scripts/verify-fal-models.py`** (the one `model_router.py` referenced but never had) checks each fal slug's input schema: **no in-use model accepts `negative_prompt`** → the flagged guard was dead code, removed. Same check documents that fresh-gen image conditioning is best-effort (only edit/continue endpoints honour image inputs).

## Forward design docs (design only, no feature code)

- `docs/PLAN_PLACE_TO_WORLD.md` — a place description → a logical object plane (parse→SceneGraph, deterministic layout solver, asks-when-illogical), behind `WORLD_FROM_DESCRIPTION`.
- `docs/PLAN_SCALE_NAV.md` — image/map → outward/deeper/around scale navigation, with a metric-conserving scale ladder.

Both were written under a researcher→writer→evaluator loop and the independent evaluator ACCEPTed both against their checklists.

> Flag posture: the Kontext-strict interior path is intentionally **not** wired — the audit (§6.4) says Kontext is weak exactly on this map→scene case, so the model-agnostic MEDIUM LOCK is the honest fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
