### PR TITLE
feat(world): describe a place → a logical object world (B1)

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -1569,6 +1569,65 @@ async def edit_entities_endpoint(req: Request, body: EditEntitiesBody):
     )
 
 
+class PlanWorldBody(BaseModel):
+    session_id: str
+    description: str
+    answers: list[str] = Field(default_factory=list, max_length=8)
+    trace_id: str | None = None
+
+
+@fastapi_app.post("/plan-world")
+async def plan_world_endpoint(req: Request, body: PlanWorldBody):
+    """Describe a place -> a logical object world (B1, WORLD_FROM_DESCRIPTION).
+
+    Parse the description into a SceneGraph (one text-LLM call), then run the pure
+    deterministic solver server-side. Returns {graph, solved, trace_id}: `solved`
+    is the WorldEntityGeo[] ready for upsertEntityGeos, or null when the graph is
+    BLOCKED (hard contradiction / over-pack / empty-region collision) -> the
+    client must ASK first. Gated by WORLD_FROM_DESCRIPTION (403 when off). One LLM
+    call + pure CPU; no Mongo/R2 here.
+    """
+    import time
+    from dataclasses import asdict
+
+    from obs import TRACE_HEADER, bind_trace, log, record_error
+    from providers import llm as llm_provider
+    from providers.layout_solver import solve_layout
+
+    trace_id = bind_trace(req.headers.get(TRACE_HEADER) or body.trace_id)
+    if not env_flag("WORLD_FROM_DESCRIPTION"):
+        return JSONResponse(
+            {"error": "describe-a-place disabled (set WORLD_FROM_DESCRIPTION=1)", "trace_id": trace_id},
+            status_code=403,
+            headers={"X-Trace-Id": trace_id},
+        )
+    log("info", "plan_world.request", session_id=body.session_id,
+        description_len=len(body.description or ""), answers=len(body.answers))
+    try:
+        graph = await llm_provider.plan_world_from_description(body.description, body.answers or None)
+        result = solve_layout(graph)
+    except Exception as exc:
+        record_error("plan_world", exc, session_id=body.session_id)
+        return JSONResponse(
+            {"error": f"{type(exc).__name__}: {exc}", "trace_id": trace_id},
+            status_code=502,
+            headers={"X-Trace-Id": trace_id},
+        )
+    # Union the solver's mechanical questions (Layer B, blocking-first) with the
+    # planner's (Layer A), deduped + capped at 2.
+    questions = list(dict.fromkeys([*result.clarifiers, *graph.clarifiers]))[:2]
+    graph_dict = asdict(graph)
+    graph_dict["clarifiers"] = questions
+    solved = None
+    if not result.blocked:
+        now = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        solved = [{**g, "updated_at": now} for g in result.geos]
+    return JSONResponse(
+        {"graph": graph_dict, "solved": solved, "trace_id": trace_id},
+        headers={"X-Trace-Id": trace_id},
+    )
+
+
 @fastapi_app.get("/health")
 async def health() -> dict:
     return {"ok": True, "service": APP_NAME}

--- a/apps/modal-backend/providers/layout_solver.py
+++ b/apps/modal-backend/providers/layout_solver.py
@@ -1,0 +1,388 @@
+"""Deterministic place-layout solver (B1 — WORLD_FROM_DESCRIPTION).
+
+Pure: a `SceneGraph` (the structure the planner read from a description) -> a list
+of `WorldEntityGeo` dicts in the shared MAP_IMAGE_FRAME (100x60), or a blocked
+result carrying mechanical clarifiers. No I/O, no randomness, no LLM — same input
+-> same output, so it is golden-testable (the discipline geometry_prompt.py keeps).
+
+The planner emits ONLY relations between refs, never coordinates (the audit's
+ROOT-2 failure was a model free-styling placement); this module turns relations
+into positions. Coords match the world convention: origin top-left, +x EAST,
++y SOUTH, in the same MAP_IMAGE_FRAME the tap router + extract seed use.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any
+
+# Shared frame + defaults (mirror geo-tap.ts MAP_IMAGE_FRAME + world-map.ts /
+# world-geometry.ts DEFAULT_FOOTPRINT=6 / DEFAULT_HEIGHT=4).
+FRAME_W = 100.0
+FRAME_H = 60.0
+DEFAULT_FOOTPRINT = 6.0
+DEFAULT_HEIGHT = 4.0
+DERIVED_CONFIDENCE = 0.6  # x0.6 discount — matches deriveGeoFromExtraction (world-map.ts:358)
+_GAP = 2.0
+
+# Wall / side keyword -> which edge of the frame.
+_SIDES: dict[str, str] = {
+    "north": "top", "back": "top", "top": "top", "rear": "top",
+    "south": "bottom", "front": "bottom", "bottom": "bottom",
+    "west": "left", "left": "left",
+    "east": "right", "right": "right",
+}
+
+
+@dataclass
+class PlannedEntity:
+    ref: str
+    kind: str
+    label: str
+    visual: str
+    footprint: dict[str, float] | None = None
+    height: float | None = None
+    count: int = 1
+
+
+@dataclass
+class PlannedRelation:
+    subject: str
+    relation: str
+    object: str
+    gap: float | None = None
+
+
+@dataclass
+class EmptyRegion:
+    ref: str
+    note: str
+    approx: dict[str, float] | None = None
+
+
+@dataclass
+class SceneGraph:
+    place_label: str
+    place_kind: str = "place"
+    bounds_hint: dict[str, float] | None = None
+    entities: list[PlannedEntity] = field(default_factory=list)
+    relations: list[PlannedRelation] = field(default_factory=list)
+    empty_regions: list[EmptyRegion] = field(default_factory=list)
+    clarifiers: list[str] = field(default_factory=list)
+    contradictions: list[str] = field(default_factory=list)
+
+
+@dataclass
+class SolveResult:
+    geos: list[dict[str, Any]]
+    clarifiers: list[str]
+    blocked: bool
+
+
+# ── pure AABB helpers ────────────────────────────────────────────────────────
+def _aabb(pos: tuple[float, float], fp: dict[str, float]) -> tuple[float, float, float, float]:
+    return (pos[0] - fp["w"] / 2, pos[1] - fp["d"] / 2,
+            pos[0] + fp["w"] / 2, pos[1] + fp["d"] / 2)
+
+
+_Rect = tuple[float, float, float, float]
+
+
+def _intersects(a: _Rect, b: _Rect) -> bool:
+    return a[0] < b[2] and b[0] < a[2] and a[1] < b[3] and b[1] < a[3]
+
+
+def _clamp(v: float, lo: float, hi: float) -> float:
+    return lo if v < lo else hi if v > hi else v
+
+
+def _kind_footprint(kind: str) -> dict[str, float]:
+    # A small per-kind bias; the floor stays the shared default so units agree.
+    if kind == "item":
+        return {"w": 2.0, "d": 2.0}
+    if kind == "creature" or kind == "person":
+        return {"w": 2.0, "d": 2.0}
+    return {"w": DEFAULT_FOOTPRINT, "d": DEFAULT_FOOTPRINT}
+
+
+def _kind_height(kind: str) -> float:
+    if kind in ("person", "creature"):
+        return 3.5
+    if kind == "item":
+        return 1.5
+    return DEFAULT_HEIGHT
+
+
+def _region_rect(r: EmptyRegion, w: float, h: float) -> tuple[float, float, float, float]:
+    """A reserved rectangle (x0,y0,x1,y1) for an empty region: from `approx`
+    (0..1 of the place) when given, else derived from a side keyword in the note
+    (a corner/edge quadrant), else the centre quadrant."""
+    if r.approx:
+        x = float(r.approx.get("x", 0.0)) * w
+        y = float(r.approx.get("y", 0.0)) * h
+        rw = float(r.approx.get("w", 0.3)) * w
+        rh = float(r.approx.get("h", 0.3)) * h
+        return (x, y, x + rw, y + rh)
+    note = r.note.lower()
+    qx = w / 2 if any(s in note for s in ("right", "east")) else 0.0
+    qy = h / 2 if any(s in note for s in ("front", "bottom", "south")) else 0.0
+    # default to a quadrant
+    return (qx, qy, qx + w / 2, qy + h / 2)
+
+
+def _wall_pos(side_ref: str, it: dict, w: float, h: float) -> tuple[float, float]:
+    side = _SIDES.get(_first_keyword(side_ref), "top")
+    fw, fd = it["fp"]["w"], it["fp"]["d"]
+    if side == "top":
+        return (w / 2, fd / 2)
+    if side == "bottom":
+        return (w / 2, h - fd / 2)
+    if side == "left":
+        return (fw / 2, h / 2)
+    return (w - fw / 2, h / 2)  # right
+
+
+def _first_keyword(ref: str) -> str:
+    for tok in ref.lower().replace("_", " ").replace("-", " ").split():
+        if tok in _SIDES:
+            return tok
+    return ref.lower()
+
+
+def _is_wall(ref: str) -> bool:
+    return _first_keyword(ref) in _SIDES
+
+
+# ── placement ────────────────────────────────────────────────────────────────
+def _resolve_pos(it: dict, rels: list[PlannedRelation], by_ref: dict, first: dict,
+                 w: float, h: float) -> tuple[float, float] | None:
+    for rel in sorted(rels, key=lambda r: (r.relation, r.object)):
+        if rel.relation == "inside":
+            continue  # nesting, handled after placement
+        if rel.relation == "on_wall" or _is_wall(rel.object):
+            return _wall_pos(rel.object, it, w, h)
+        obj = by_ref.get(first.get(rel.object, ""))
+        if obj is None or obj["pos"] is None:
+            continue  # object not placed yet — try next pass
+        gap = rel.gap if rel.gap is not None else _GAP
+        ox, oy = obj["pos"]
+        ow, od = obj["fp"]["w"], obj["fp"]["d"]
+        iw, idp = it["fp"]["w"], it["fp"]["d"]
+        if rel.relation == "behind":
+            return (ox, oy - (od / 2 + idp / 2 + gap))
+        if rel.relation == "in_front_of":
+            return (ox, oy + (od / 2 + idp / 2 + gap))
+        if rel.relation == "left_of":
+            return (ox - (ow / 2 + iw / 2 + gap), oy)
+        if rel.relation == "right_of":
+            return (ox + (ow / 2 + iw / 2 + gap), oy)
+        if rel.relation == "on_top_of":
+            it["elevation"] = obj["elevation"] + obj["height"]
+            return (ox, oy)
+        if rel.relation == "facing":
+            it["heading"] = math.atan2(oy - 0, ox - 0)  # placeholder; refined below
+            return (ox + (ow / 2 + iw / 2 + gap), oy)
+        # "near" (and any default) — nearest free side, default right.
+        return (ox + (ow / 2 + iw / 2 + gap), oy)
+    return None
+
+
+def _de_overlap(insts: list[dict], reserved: list[tuple], w: float, h: float) -> None:
+    # Stacked items (elevation > 0, e.g. a lamp ON a desk) intentionally share
+    # their support's x/y — keep them out of 2D separation.
+    movable = [it for it in insts if it["pos"] is not None and not it["elevation"]]
+    for _ in range(20):
+        moved = False
+        for i in range(len(movable)):
+            a = movable[i]
+            aabb_a = _aabb(a["pos"], a["fp"])
+            # push out of reserved regions first
+            for rr in reserved:
+                if _intersects(aabb_a, rr):
+                    a["pos"] = _push_out(a["pos"], a["fp"], rr)
+                    aabb_a = _aabb(a["pos"], a["fp"])
+                    moved = True
+            for j in range(i + 1, len(movable)):
+                b = movable[j]
+                aabb_b = _aabb(b["pos"], b["fp"])
+                if not _intersects(aabb_a, aabb_b):
+                    continue
+                # min-translation separation along the smaller-overlap axis
+                ox = min(aabb_a[2], aabb_b[2]) - max(aabb_a[0], aabb_b[0])
+                oy = min(aabb_a[3], aabb_b[3]) - max(aabb_a[1], aabb_b[1])
+                bx, by = b["pos"]
+                if ox < oy:
+                    bx += ox if bx >= a["pos"][0] else -ox
+                else:
+                    by += oy if by >= a["pos"][1] else -oy
+                b["pos"] = (_clamp(bx, b["fp"]["w"] / 2, w - b["fp"]["w"] / 2),
+                            _clamp(by, b["fp"]["d"] / 2, h - b["fp"]["d"] / 2))
+                moved = True
+        if not moved:
+            break
+
+
+def _push_out(pos: tuple, fp: dict, rr: tuple) -> tuple[float, float]:
+    a = _aabb(pos, fp)
+    left = a[2] - rr[0]   # push left by this to clear
+    right = rr[2] - a[0]  # push right
+    up = a[3] - rr[1]
+    down = rr[3] - a[1]
+    m = min(left, right, up, down)
+    x, y = pos
+    if m == left:
+        x -= left
+    elif m == right:
+        x += right
+    elif m == up:
+        y -= up
+    else:
+        y += down
+    return (x, y)
+
+
+def _apply_nesting(insts: list[dict], graph: SceneGraph, by_ref: dict, first: dict) -> None:
+    for rel in graph.relations:
+        if rel.relation != "inside":
+            continue
+        sub = by_ref.get(first.get(rel.subject, ""))
+        cont = by_ref.get(first.get(rel.object, ""))
+        if sub is None or cont is None or cont["pos"] is None:
+            continue
+        sub["parent_id"] = f"geo_plan_{cont['ref'].split('#')[0]}"
+        # local pos inside the container's frame; container learns a scale.
+        sub["pos"] = (cont["fp"]["w"] / 2, cont["fp"]["d"] / 2)
+        extent = max(cont["fp"]["w"], cont["fp"]["d"], 1e-3)
+        cont["scale"] = _clamp(extent / extent, 1e-3, 10.0)  # 1.0 — interior == its own footprint
+
+
+def _emit(it: dict) -> dict[str, Any]:
+    geo: dict[str, Any] = {
+        "id": f"geo_plan_{it['ref'].split('#')[0]}" if it["parent_id"] else f"geo_plan_{it['ref']}",
+        "entity_id": None,
+        "parent_id": it["parent_id"],
+        "kind": it["kind"],
+        "label": it["label"],
+        "pos": {"x": round(it["pos"][0], 3), "y": round(it["pos"][1], 3)},
+        "height": it["height"],
+        "footprint": {"w": it["fp"]["w"], "d": it["fp"]["d"]},
+        "visual": it["visual"],
+        "state": {},
+        "confidence": DERIVED_CONFIDENCE,
+        "source": "derived",
+    }
+    # geo_plan_<ref> must be unique per instance — keep the instance suffix.
+    geo["id"] = f"geo_plan_{it['ref']}"
+    if it["elevation"]:
+        geo["elevation"] = round(it["elevation"], 3)
+    if it["heading"] is not None:
+        geo["heading"] = round(it["heading"], 4)
+    if it.get("scale") is not None:
+        geo["scale"] = it["scale"]
+    return geo
+
+
+def _dedupe(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for s in items:
+        if s not in seen:
+            seen.add(s)
+            out.append(s)
+    return out
+
+
+def solve_layout(graph: SceneGraph) -> SolveResult:
+    w = float((graph.bounds_hint or {}).get("w") or FRAME_W)
+    h = float((graph.bounds_hint or {}).get("h") or FRAME_H)
+    clar: list[str] = []
+    blocked = bool(graph.contradictions)
+
+    # 1. instances (fan out `count`) + kind-default footprints/heights.
+    insts: list[dict] = []
+    first: dict[str, str] = {}
+    for e in sorted(graph.entities, key=lambda x: x.ref):
+        fp = dict(e.footprint) if e.footprint else _kind_footprint(e.kind)
+        fp = {"w": float(fp.get("w", DEFAULT_FOOTPRINT)), "d": float(fp.get("d", DEFAULT_FOOTPRINT))}
+        height = float(e.height) if e.height is not None else _kind_height(e.kind)
+        n = max(1, int(e.count or 1))
+        for i in range(n):
+            ref = e.ref if n == 1 else f"{e.ref}#{i + 1}"
+            if i == 0:
+                first[e.ref] = ref
+            insts.append({
+                "ref": ref, "base": e.ref, "kind": e.kind, "label": e.label,
+                "visual": e.visual, "fp": dict(fp), "height": height,
+                "elevation": 0.0, "heading": None, "parent_id": None,
+                "scale": None, "pos": None,
+            })
+    by_ref = {it["ref"]: it for it in insts}
+
+    # 2. reserved empty-region rectangles.
+    reserved = [_region_rect(r, w, h) for r in graph.empty_regions]
+
+    # 3. place by relation (object placed first); iterate to a fixpoint.
+    rel_by_subj: dict[str, list[PlannedRelation]] = {}
+    rel_objects: set[str] = set()
+    for rel in graph.relations:
+        rel_by_subj.setdefault(rel.subject, []).append(rel)
+        if not _is_wall(rel.object):
+            rel_objects.add(rel.object)
+    subjects = set(rel_by_subj.keys())
+
+    # Root anchors — something others are placed relative to, but itself
+    # unconstrained (a desk a lamp sits ON). Seed it at the centre so its
+    # dependents resolve; it is NOT unanchored, so no clarifier.
+    for it in insts:
+        if it["pos"] is None and it["base"] in rel_objects and it["base"] not in subjects:
+            it["pos"] = (w / 2, h / 2)
+
+    for _ in range(len(insts) + 2):
+        changed = False
+        for it in insts:
+            if it["pos"] is not None or it["base"] not in rel_by_subj:
+                continue
+            pos = _resolve_pos(it, rel_by_subj[it["base"]], by_ref, first, w, h)
+            if pos is not None:
+                it["pos"] = (_clamp(pos[0], it["fp"]["w"] / 2, w - it["fp"]["w"] / 2),
+                             _clamp(pos[1], it["fp"]["d"] / 2, h - it["fp"]["d"] / 2))
+                changed = True
+        if not changed:
+            break
+
+    # fan-out siblings share the base's spot until de-overlap spreads them.
+    for it in insts:
+        if it["pos"] is None and "#" in it["ref"]:
+            anchor = by_ref.get(first.get(it["base"], ""))
+            if anchor and anchor["pos"]:
+                it["pos"] = anchor["pos"]
+
+    # 4. unanchored / dangling -> clarifier + soft default (centre).
+    for it in insts:
+        if it["pos"] is None:
+            if it["base"] in subjects:
+                clar.append(f"Where should the {it['label']} go relative to?")
+            else:
+                clar.append(f"Where is the {it['label']}?")
+            it["pos"] = (w / 2, h / 2)
+
+    # 5. over-pack (blocking).
+    area = sum(it["fp"]["w"] * it["fp"]["d"] for it in insts)
+    if insts and area > w * h:
+        avg = area / len(insts)
+        k = max(1, int(w * h / max(avg, 1.0)))
+        clar.insert(0, f"That's more than {graph.place_label} can fit (~{k}) — fewer, or a bigger place?")
+        blocked = True
+
+    # 6. de-overlap (never into a reserved region) + collision check (blocking).
+    _de_overlap(insts, reserved, w, h)
+    for it in insts:
+        if any(_intersects(_aabb(it["pos"], it["fp"]), rr) for rr in reserved):
+            clar.insert(0, f"The {it['label']} can't avoid the area you described as clear — keep it empty or move it?")
+            blocked = True
+            break
+
+    # 7. nesting + emit.
+    _apply_nesting(insts, graph, by_ref, first)
+    geos = [_emit(it) for it in insts]
+    return SolveResult(geos=geos, clarifiers=_dedupe(clar)[:2], blocked=blocked)

--- a/apps/modal-backend/providers/layout_solver.py
+++ b/apps/modal-backend/providers/layout_solver.py
@@ -157,8 +157,6 @@ def _is_wall(ref: str) -> bool:
 def _resolve_pos(it: dict, rels: list[PlannedRelation], by_ref: dict, first: dict,
                  w: float, h: float) -> tuple[float, float] | None:
     for rel in sorted(rels, key=lambda r: (r.relation, r.object)):
-        if rel.relation == "inside":
-            continue  # nesting, handled after placement
         if rel.relation == "on_wall" or _is_wall(rel.object):
             return _wall_pos(rel.object, it, w, h)
         obj = by_ref.get(first.get(rel.object, ""))
@@ -168,6 +166,12 @@ def _resolve_pos(it: dict, rels: list[PlannedRelation], by_ref: dict, first: dic
         ox, oy = obj["pos"]
         ow, od = obj["fp"]["w"], obj["fp"]["d"]
         iw, idp = it["fp"]["w"], it["fp"]["d"]
+        if rel.relation == "inside":
+            # Flat nesting (v1): sit within the container's footprint, same frame,
+            # exempt from de-overlap (a prop on a shelf, not a separate sub-world;
+            # true sub-frame nesting is deferred — see docs/PLAN_PLACE_TO_WORLD.md).
+            it["nested"] = True
+            return (ox, oy)
         if rel.relation == "behind":
             return (ox, oy - (od / 2 + idp / 2 + gap))
         if rel.relation == "in_front_of":
@@ -180,17 +184,21 @@ def _resolve_pos(it: dict, rels: list[PlannedRelation], by_ref: dict, first: dic
             it["elevation"] = obj["elevation"] + obj["height"]
             return (ox, oy)
         if rel.relation == "facing":
-            it["heading"] = math.atan2(oy - 0, ox - 0)  # placeholder; refined below
-            return (ox + (ow / 2 + iw / 2 + gap), oy)
+            # placed beside the object; heading points back AT it from there.
+            sx, sy = ox + (ow / 2 + iw / 2 + gap), oy
+            it["heading"] = math.atan2(oy - sy, ox - sx)
+            return (sx, sy)
         # "near" (and any default) — nearest free side, default right.
         return (ox + (ow / 2 + iw / 2 + gap), oy)
     return None
 
 
-def _de_overlap(insts: list[dict], reserved: list[tuple], w: float, h: float) -> None:
-    # Stacked items (elevation > 0, e.g. a lamp ON a desk) intentionally share
-    # their support's x/y — keep them out of 2D separation.
-    movable = [it for it in insts if it["pos"] is not None and not it["elevation"]]
+def _de_overlap(insts: list[dict], reserved: list[_Rect], w: float, h: float) -> None:
+    # Stacked items (elevation > 0, a lamp ON a desk) and nested items (a mug
+    # INSIDE a cabinet) intentionally share their support's x/y — keep them out
+    # of 2D separation.
+    movable = [it for it in insts
+               if it["pos"] is not None and not it["elevation"] and not it.get("nested")]
     for _ in range(20):
         moved = False
         for i in range(len(movable)):
@@ -217,6 +225,11 @@ def _de_overlap(insts: list[dict], reserved: list[tuple], w: float, h: float) ->
                     by += oy if by >= a["pos"][1] else -oy
                 b["pos"] = (_clamp(bx, b["fp"]["w"] / 2, w - b["fp"]["w"] / 2),
                             _clamp(by, b["fp"]["d"] / 2, h - b["fp"]["d"] / 2))
+                # Separation must never shove b into a declared-empty region —
+                # push it back out (the final solve check blocks if it's stuck).
+                for rr in reserved:
+                    if _intersects(_aabb(b["pos"], b["fp"]), rr):
+                        b["pos"] = _push_out(b["pos"], b["fp"], rr)
                 moved = True
         if not moved:
             break
@@ -241,26 +254,11 @@ def _push_out(pos: tuple, fp: dict, rr: tuple) -> tuple[float, float]:
     return (x, y)
 
 
-def _apply_nesting(insts: list[dict], graph: SceneGraph, by_ref: dict, first: dict) -> None:
-    for rel in graph.relations:
-        if rel.relation != "inside":
-            continue
-        sub = by_ref.get(first.get(rel.subject, ""))
-        cont = by_ref.get(first.get(rel.object, ""))
-        if sub is None or cont is None or cont["pos"] is None:
-            continue
-        sub["parent_id"] = f"geo_plan_{cont['ref'].split('#')[0]}"
-        # local pos inside the container's frame; container learns a scale.
-        sub["pos"] = (cont["fp"]["w"] / 2, cont["fp"]["d"] / 2)
-        extent = max(cont["fp"]["w"], cont["fp"]["d"], 1e-3)
-        cont["scale"] = _clamp(extent / extent, 1e-3, 10.0)  # 1.0 — interior == its own footprint
-
-
 def _emit(it: dict) -> dict[str, Any]:
     geo: dict[str, Any] = {
-        "id": f"geo_plan_{it['ref'].split('#')[0]}" if it["parent_id"] else f"geo_plan_{it['ref']}",
+        "id": f"geo_plan_{it['ref']}",  # `ref` carries the #n instance suffix -> unique
         "entity_id": None,
-        "parent_id": it["parent_id"],
+        "parent_id": None,  # flat v1: all objects share the place's frame
         "kind": it["kind"],
         "label": it["label"],
         "pos": {"x": round(it["pos"][0], 3), "y": round(it["pos"][1], 3)},
@@ -271,14 +269,10 @@ def _emit(it: dict) -> dict[str, Any]:
         "confidence": DERIVED_CONFIDENCE,
         "source": "derived",
     }
-    # geo_plan_<ref> must be unique per instance — keep the instance suffix.
-    geo["id"] = f"geo_plan_{it['ref']}"
     if it["elevation"]:
         geo["elevation"] = round(it["elevation"], 3)
     if it["heading"] is not None:
         geo["heading"] = round(it["heading"], 4)
-    if it.get("scale") is not None:
-        geo["scale"] = it["scale"]
     return geo
 
 
@@ -313,8 +307,7 @@ def solve_layout(graph: SceneGraph) -> SolveResult:
             insts.append({
                 "ref": ref, "base": e.ref, "kind": e.kind, "label": e.label,
                 "visual": e.visual, "fp": dict(fp), "height": height,
-                "elevation": 0.0, "heading": None, "parent_id": None,
-                "scale": None, "pos": None,
+                "elevation": 0.0, "heading": None, "pos": None,
             })
     by_ref = {it["ref"]: it for it in insts}
 
@@ -382,7 +375,6 @@ def solve_layout(graph: SceneGraph) -> SolveResult:
             blocked = True
             break
 
-    # 7. nesting + emit.
-    _apply_nesting(insts, graph, by_ref, first)
+    # 7. emit.
     geos = [_emit(it) for it in insts]
     return SolveResult(geos=geos, clarifiers=_dedupe(clar)[:2], blocked=blocked)

--- a/apps/modal-backend/providers/llm.py
+++ b/apps/modal-backend/providers/llm.py
@@ -2212,3 +2212,188 @@ async def edit_entities_nl(
         )
     edits = parse_entity_edits(parsed, valid_ids)
     return EditPlan(edits=edits, blast_radius=compute_blast_radius(edits, references))
+
+
+# ── Describe a place → a logical object world (WORLD_FROM_DESCRIPTION) ─────────
+# Parse a place description into a SceneGraph: STRUCTURE (entities + relations,
+# never coordinates) the deterministic layout_solver turns into geometry. Same
+# discipline as the NL-edit: one _complete_json call + a tolerant coercer that
+# drops malformed members and never raises.
+
+_PLAN_RELATIONS = {
+    "near", "on_wall", "behind", "in_front_of", "left_of", "right_of",
+    "inside", "on_top_of", "facing",
+}
+_WALL_WORDS = {
+    "north", "south", "east", "west", "back", "front", "left", "right",
+    "top", "bottom", "rear", "wall",
+}
+
+PLAN_WORLD_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "place_label": {"type": "string"},
+        "place_kind": {"type": "string", "enum": list(ENTITY_KINDS)},
+        "bounds_hint": {"type": "object"},
+        "entities": {"type": "array", "items": {"type": "object"}},
+        "relations": {"type": "array", "items": {"type": "object"}},
+        "empty_regions": {"type": "array", "items": {"type": "object"}},
+        "clarifiers": {"type": "array", "items": {"type": "string"}},
+        "contradictions": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["place_label", "entities"],
+}
+
+PLAN_WORLD_SYSTEM = (
+    "You read a description of a single PLACE and return its objects as STRUCTURE "
+    "— a JSON scene graph the layout engine turns into a 2D map. You NEVER output "
+    "coordinates. World sense: +x EAST, +y SOUTH (toward the viewer); 'behind' is "
+    "away from the viewer.\n\n"
+    'Return JSON exactly: {"place_label","place_kind","bounds_hint?",'
+    '"entities":[...],"relations":[...],"empty_regions":[...],"clarifiers":[...],'
+    '"contradictions":[...]}.\n'
+    '- entity: {"ref":<slug>,"kind":person|place|item|creature,"label":<short '
+    'name>,"visual":<ONE concrete sentence, <=25 words: materials, colour, form '
+    '— injected verbatim into the image prompt>,"footprint?":{"w","d"},'
+    '"height?":<n>,"count?":<n>}\n'
+    '- relation: {"subject":<ref>,"relation":near|on_wall|behind|in_front_of|'
+    'left_of|right_of|inside|on_top_of|facing,"object":<another ref OR a wall '
+    'side like "back_wall">,"gap?":<n>}\n'
+    '- empty_region: {"ref":<slug>,"note":<what is clear / reserved here>}\n\n'
+    "RULES:\n"
+    "1. RELEVANCE. Emit only objects the description NAMES or clearly IMPLIES by "
+    "function (a bar implies stools + bottles behind the counter). Do NOT pad the "
+    "place with generic scenery. Anything called empty / clear / open / reserved "
+    "becomes an empty_region — and you place NOTHING there.\n"
+    "2. PLACEMENT = RELATIONS ONLY. Express where each object is ONLY via "
+    "`relations` between refs. Never output x/y, grid cells or pixels — you do "
+    "not know the scale; the engine computes positions from your relations.\n"
+    "3. CHECK LOGIC, THEN ASK. Before finalizing, look for (a) physical "
+    "impossibilities (a window in a sealed underground vault; a door on a wall "
+    "you also called solid rock), (b) an object whose only sensible placement "
+    "needs a wall/anchor the description never gave, (c) more objects than the "
+    "place can hold. For each, add a SHORT question (<=8 words) to `clarifiers` "
+    "(AT MOST 2) and one line to `contradictions`. Do NOT invent a resolution to "
+    "a hard contradiction — leave it for the user. A merely-vague gap the engine "
+    "can default does NOT need a clarifier.\n"
+    "4. No prose, no markdown — JSON only."
+)
+
+
+def parse_scene_graph(payload: Any) -> Any:
+    """Coerce a planner reply into a SceneGraph. Tolerant: an entity missing
+    ref/label/visual or with an unknown kind is dropped; a relation whose subject
+    isn't a known entity ref, whose relation is unknown, or whose object resolves
+    to neither a known ref, a wall side, nor an empty region is dropped; clarifiers
+    capped at 2. Never raises — a weak completion degrades to a thinner graph."""
+    from .layout_solver import EmptyRegion, PlannedEntity, PlannedRelation, SceneGraph
+
+    if not isinstance(payload, dict):
+        payload = {}
+    kind = str(payload.get("place_kind", "place")).strip().lower()
+    if kind not in ENTITY_KINDS:
+        kind = "place"
+    bounds = payload.get("bounds_hint")
+    bounds_hint = None
+    if isinstance(bounds, dict) and _is_number(bounds.get("w")) and _is_number(bounds.get("h")):
+        bounds_hint = {"w": float(bounds["w"]), "h": float(bounds["h"])}
+
+    raw_entities = payload.get("entities")
+    entities: list[Any] = []
+    refs: set[str] = set()
+    for e in raw_entities if isinstance(raw_entities, list) else []:
+        if not isinstance(e, dict):
+            continue
+        ref = str(e.get("ref", "")).strip()
+        label = str(e.get("label", "")).strip()
+        visual = str(e.get("visual", "")).strip()
+        ekind = str(e.get("kind", "item")).strip().lower()
+        if not ref or not label or not visual or ekind not in ENTITY_KINDS or ref in refs:
+            continue
+        refs.add(ref)
+        fp = e.get("footprint")
+        footprint = None
+        if isinstance(fp, dict) and _is_number(fp.get("w")) and _is_number(fp.get("d")):
+            footprint = {"w": float(fp["w"]), "d": float(fp["d"])}
+        height = float(e["height"]) if _is_number(e.get("height")) else None
+        count = max(1, int(e["count"])) if _is_number(e.get("count")) else 1
+        entities.append(PlannedEntity(ref=ref, kind=ekind, label=label, visual=visual,
+                                      footprint=footprint, height=height, count=count))
+
+    raw_regions = payload.get("empty_regions")
+    empty_regions: list[Any] = []
+    region_refs: set[str] = set()
+    for r in raw_regions if isinstance(raw_regions, list) else []:
+        if not isinstance(r, dict):
+            continue
+        rref = str(r.get("ref", "")).strip()
+        note = str(r.get("note", "")).strip()
+        if not rref or not note:
+            continue
+        region_refs.add(rref)
+        approx = r.get("approx")
+        ap = None
+        if isinstance(approx, dict) and all(_is_number(approx.get(k)) for k in ("x", "y", "w", "h")):
+            ap = {k: float(approx[k]) for k in ("x", "y", "w", "h")}
+        empty_regions.append(EmptyRegion(ref=rref, note=note, approx=ap))
+
+    def _ok_object(o: str) -> bool:
+        if o in refs or o in region_refs:
+            return True
+        toks = o.lower().replace("_", " ").replace("-", " ").split()
+        return any(t in _WALL_WORDS for t in toks)
+
+    raw_relations = payload.get("relations")
+    relations: list[Any] = []
+    for rel in raw_relations if isinstance(raw_relations, list) else []:
+        if not isinstance(rel, dict):
+            continue
+        subj = str(rel.get("subject", "")).strip()
+        relation = str(rel.get("relation", "")).strip().lower()
+        obj = str(rel.get("object", "")).strip()
+        if subj not in refs or relation not in _PLAN_RELATIONS or not _ok_object(obj):
+            continue
+        gap = float(rel["gap"]) if _is_number(rel.get("gap")) else None
+        relations.append(PlannedRelation(subject=subj, relation=relation, object=obj, gap=gap))
+
+    def _strs(key: str, cap: int | None = None) -> list[str]:
+        v = payload.get(key, [])
+        out = [str(s).strip() for s in v if isinstance(s, str) and str(s).strip()] if isinstance(v, list) else []
+        return out[:cap] if cap is not None else out
+
+    return SceneGraph(
+        place_label=str(payload.get("place_label", "")).strip() or "the place",
+        place_kind=kind, bounds_hint=bounds_hint, entities=entities,
+        relations=relations, empty_regions=empty_regions,
+        clarifiers=_strs("clarifiers", 2), contradictions=_strs("contradictions"),
+    )
+
+
+async def plan_world_from_description(description: str, answers: list[str] | None = None) -> Any:
+    """Parse a place description into a SceneGraph (one text-LLM call + tolerant
+    parse). On a re-run, `answers` are appended so the planner resolves the prior
+    round's clarifiers; a malformed completion degrades to a thinner graph."""
+    from obs import span
+
+    user = f"Place description:\n{description.strip()}"
+    if answers:
+        joined = "\n".join(f"- {a.strip()}" for a in answers if a.strip())
+        if joined:
+            user += (
+                "\n\nThe user clarified (resolve these — they are no longer open "
+                f"questions):\n{joined}"
+            )
+    async with span("llm.plan_world", model=_text_model(online=False)) as ctx:
+        parsed = await _complete_json(
+            model=_text_model(online=False),
+            messages=[
+                _system_message(PLAN_WORLD_SYSTEM),
+                {"role": "user", "content": user},
+            ],
+            schema=PLAN_WORLD_SCHEMA,
+            schema_name="scene_graph",
+            temperature=0.0,
+            max_tokens=1600,
+            span_ctx=ctx,
+        )
+    return parse_scene_graph(parsed)

--- a/apps/modal-backend/tests/world_bench/test_layout_solver.py
+++ b/apps/modal-backend/tests/world_bench/test_layout_solver.py
@@ -7,6 +7,8 @@ geometry golden — same input, same output.
 """
 from __future__ import annotations
 
+import math
+
 from providers.layout_solver import (
     EmptyRegion,
     PlannedEntity,
@@ -137,3 +139,34 @@ def test_solver_is_deterministic() -> None:
     b = solve_layout(_coffee_shop())
     assert a.geos == b.geos
     assert a.clarifiers == b.clarifiers
+
+
+def test_inside_sits_within_container_flat() -> None:
+    g = SceneGraph(
+        place_label="kitchen",
+        entities=[
+            PlannedEntity("cabinet", "item", "cabinet", "an oak cabinet", footprint={"w": 6, "d": 3}),
+            PlannedEntity("mug", "item", "mug", "a clay mug", footprint={"w": 1, "d": 1}),
+        ],
+        relations=[PlannedRelation("mug", "inside", "cabinet")],
+    )
+    res = solve_layout(g)
+    cab = _by_label(res.geos, "cabinet")[0]
+    mug = _by_label(res.geos, "mug")[0]
+    # nested prop shares its container's spot (not de-overlapped away); flat v1.
+    assert mug["pos"] == cab["pos"]
+    assert mug["parent_id"] is None
+
+
+def test_facing_heads_toward_the_object() -> None:
+    g = SceneGraph(
+        place_label="office",
+        entities=[
+            PlannedEntity("desk", "item", "desk", "a desk", footprint={"w": 6, "d": 3}),
+            PlannedEntity("chair", "item", "chair", "a chair", footprint={"w": 2, "d": 2}),
+        ],
+        relations=[PlannedRelation("chair", "facing", "desk")],
+    )
+    chair = _by_label(solve_layout(g).geos, "chair")[0]
+    # placed to the right of the desk -> faces WEST back at it (heading ~ ±pi).
+    assert abs(abs(chair["heading"]) - math.pi) < 0.1

--- a/apps/modal-backend/tests/world_bench/test_layout_solver.py
+++ b/apps/modal-backend/tests/world_bench/test_layout_solver.py
@@ -1,0 +1,139 @@
+"""Golden tests for the deterministic place-layout solver (B1).
+
+Pure CPU, free, always-runs (no marker). Proves the load-bearing guarantees:
+relative ordering from relations, count fan-out, "empty stays empty" at solve,
+and the blocking clarifiers (over-pack / unanchored). Same discipline as the
+geometry golden — same input, same output.
+"""
+from __future__ import annotations
+
+from providers.layout_solver import (
+    EmptyRegion,
+    PlannedEntity,
+    PlannedRelation,
+    SceneGraph,
+    _aabb,
+    _intersects,
+    solve_layout,
+)
+
+
+def _coffee_shop() -> SceneGraph:
+    return SceneGraph(
+        place_label="corner coffee shop",
+        entities=[
+            PlannedEntity("counter", "item", "zinc counter", "a long zinc counter",
+                          footprint={"w": 30, "d": 4}),
+            PlannedEntity("stool", "item", "stool", "a metal stool", count=4,
+                          footprint={"w": 2, "d": 2}),
+            PlannedEntity("shelf", "item", "mug shelf", "a shelf of mugs",
+                          footprint={"w": 30, "d": 2}),
+            PlannedEntity("door", "item", "door", "a glass door",
+                          footprint={"w": 4, "d": 1}),
+        ],
+        relations=[
+            PlannedRelation("counter", "on_wall", "back_wall"),
+            PlannedRelation("stool", "in_front_of", "counter"),
+            PlannedRelation("shelf", "behind", "counter"),
+            PlannedRelation("door", "on_wall", "left_wall"),
+        ],
+        empty_regions=[EmptyRegion("queue", "front-right corner reserved for a queue")],
+    )
+
+
+def _by_label(geos: list[dict], label: str) -> list[dict]:
+    return [g for g in geos if g["label"] == label]
+
+
+def test_coffee_shop_solves_without_blocking() -> None:
+    res = solve_layout(_coffee_shop())
+    assert res.blocked is False
+    # 4 stools fanned out + counter + shelf + door = 7 instances.
+    assert len(res.geos) == 7
+    assert len(_by_label(res.geos, "stool")) == 4
+    for g in res.geos:
+        assert g["source"] == "derived"
+        assert g["confidence"] == 0.6
+        assert g["entity_id"] is None
+
+
+def test_relations_set_relative_order() -> None:
+    res = solve_layout(_coffee_shop())
+    counter = _by_label(res.geos, "zinc counter")[0]["pos"]["y"]
+    shelf = _by_label(res.geos, "mug shelf")[0]["pos"]["y"]
+    stools = [g["pos"]["y"] for g in _by_label(res.geos, "stool")]
+    # +y is SOUTH/toward-viewer: a stool is IN FRONT (greater y), the shelf BEHIND (<= y).
+    assert min(stools) > counter
+    assert shelf <= counter
+
+
+def test_count_fans_out_without_overlap() -> None:
+    res = solve_layout(_coffee_shop())
+    stools = _by_label(res.geos, "stool")
+    assert len(stools) == 4
+    for i in range(len(stools)):
+        for j in range(i + 1, len(stools)):
+            a = _aabb((stools[i]["pos"]["x"], stools[i]["pos"]["y"]), stools[i]["footprint"])
+            b = _aabb((stools[j]["pos"]["x"], stools[j]["pos"]["y"]), stools[j]["footprint"])
+            assert not _intersects(a, b), "fanned-out stools must not overlap"
+
+
+def test_empty_region_stays_empty_at_solve() -> None:
+    res = solve_layout(_coffee_shop())
+    # the declared-empty front-right corner -> reserved bottom-right quadrant.
+    reserved = (50.0, 30.0, 100.0, 60.0)
+    for g in res.geos:
+        box = _aabb((g["pos"]["x"], g["pos"]["y"]), g["footprint"])
+        assert not _intersects(box, reserved), f"{g['label']} landed in the reserved region"
+
+
+def test_over_pack_blocks_and_asks() -> None:
+    # A tiny 10x10 place can't hold five 6x6 objects -> blocking clarifier.
+    g = SceneGraph(
+        place_label="broom closet",
+        bounds_hint={"w": 10, "h": 10},
+        entities=[PlannedEntity(f"box{i}", "item", f"crate {i}", "a wooden crate",
+                                footprint={"w": 6, "d": 6}) for i in range(5)],
+    )
+    res = solve_layout(g)
+    assert res.blocked is True
+    assert any("fit" in c.lower() for c in res.clarifiers)
+
+
+def test_unanchored_object_asks_where() -> None:
+    g = SceneGraph(
+        place_label="empty room",
+        entities=[PlannedEntity("lamp", "item", "floor lamp", "a brass floor lamp")],
+    )
+    res = solve_layout(g)
+    assert any("where is the floor lamp" in c.lower() for c in res.clarifiers)
+
+
+def test_contradictions_block() -> None:
+    g = SceneGraph(
+        place_label="vault",
+        entities=[PlannedEntity("window", "item", "window", "a window")],
+        contradictions=["a window in an underground vault with no exterior wall"],
+    )
+    assert solve_layout(g).blocked is True
+
+
+def test_on_top_of_sets_elevation() -> None:
+    g = SceneGraph(
+        place_label="study",
+        entities=[
+            PlannedEntity("desk", "item", "desk", "an oak desk", footprint={"w": 6, "d": 3}, height=4),
+            PlannedEntity("lamp", "item", "lamp", "a small lamp", footprint={"w": 1, "d": 1}, height=2),
+        ],
+        relations=[PlannedRelation("lamp", "on_top_of", "desk")],
+    )
+    res = solve_layout(g)
+    lamp = _by_label(res.geos, "lamp")[0]
+    assert lamp["elevation"] == 4  # sits on the 4-tall desk
+
+
+def test_solver_is_deterministic() -> None:
+    a = solve_layout(_coffee_shop())
+    b = solve_layout(_coffee_shop())
+    assert a.geos == b.geos
+    assert a.clarifiers == b.clarifiers

--- a/apps/modal-backend/tests/world_bench/test_plan_world.py
+++ b/apps/modal-backend/tests/world_bench/test_plan_world.py
@@ -1,0 +1,80 @@
+"""Free tests for the place-description parser (parse_scene_graph).
+
+The paid part is the LLM call (plan_world_from_description); these cover the
+tolerant coercer: malformed members dropped, never raises, clarifiers capped,
+and — the audit's ROOT-2 guard — x/y can never leak in through the parse.
+"""
+from __future__ import annotations
+
+from providers.llm import parse_scene_graph
+
+
+def test_valid_graph_parses() -> None:
+    g = parse_scene_graph({
+        "place_label": "bar",
+        "entities": [
+            {"ref": "counter", "kind": "item", "label": "bar", "visual": "an oak bar"},
+            {"ref": "stool", "kind": "item", "label": "stool", "visual": "a stool", "count": 3},
+        ],
+        "relations": [{"subject": "stool", "relation": "near", "object": "counter"}],
+        "empty_regions": [{"ref": "floor", "note": "open dance floor"}],
+    })
+    assert g.place_label == "bar"
+    assert {e.ref for e in g.entities} == {"counter", "stool"}
+    assert len(g.relations) == 1
+    assert g.empty_regions[0].ref == "floor"
+
+
+def test_malformed_entities_dropped() -> None:
+    g = parse_scene_graph({
+        "place_label": "x",
+        "entities": [
+            {"ref": "ok", "kind": "item", "label": "ok", "visual": "fine"},
+            {"ref": "novisual", "kind": "item", "label": "bad"},               # no visual
+            {"ref": "badkind", "kind": "vehicle", "label": "b", "visual": "v"},  # bad kind
+            {"label": "noref", "kind": "item", "visual": "v"},                  # no ref
+        ],
+    })
+    assert {e.ref for e in g.entities} == {"ok"}
+
+
+def test_relation_to_unknown_dropped_but_wall_kept() -> None:
+    g = parse_scene_graph({
+        "place_label": "x",
+        "entities": [{"ref": "door", "kind": "item", "label": "door", "visual": "a door"}],
+        "relations": [
+            {"subject": "door", "relation": "on_wall", "object": "left_wall"},  # wall -> kept
+            {"subject": "door", "relation": "near", "object": "ghost"},         # unknown obj
+            {"subject": "ghost", "relation": "near", "object": "door"},         # unknown subj
+            {"subject": "door", "relation": "teleport", "object": "door"},      # bad relation
+        ],
+    })
+    assert len(g.relations) == 1
+    assert g.relations[0].relation == "on_wall"
+
+
+def test_clarifiers_capped_and_kind_defaults() -> None:
+    g = parse_scene_graph({
+        "place_label": "x",
+        "place_kind": "nonsense",
+        "entities": [{"ref": "a", "kind": "item", "label": "a", "visual": "a"}],
+        "clarifiers": ["q1", "q2", "q3", "q4"],
+    })
+    assert g.place_kind == "place"
+    assert len(g.clarifiers) == 2
+
+
+def test_never_raises_on_garbage() -> None:
+    for junk in (None, [], "nope", 42, {"entities": "notalist"}, {"entities": [None, 1, "x"]}):
+        assert parse_scene_graph(junk).entities == []
+
+
+def test_no_xy_leaks_in() -> None:
+    # Even if the model wrongly emits coordinates, the PlannedEntity has no x/y
+    # field — the ROOT-2 guard enforced at the parse boundary.
+    g = parse_scene_graph({
+        "place_label": "x",
+        "entities": [{"ref": "a", "kind": "item", "label": "a", "visual": "a", "x": 5, "y": 9}],
+    })
+    e = g.entities[0]
+    assert not hasattr(e, "x") and not hasattr(e, "y")

--- a/apps/web/app/api/world/[sessionId]/plan-world/route.ts
+++ b/apps/web/app/api/world/[sessionId]/plan-world/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+import { readServerEnv } from "@/lib/env";
+import { modalUrl as joinModalUrl } from "@/lib/modal";
+import { TRACE_HEADER, newTraceId } from "@/lib/trace";
+import type { PlanWorldResponse } from "@openflipbook/config";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface Params {
+  params: Promise<{ sessionId: string }>;
+}
+
+// Describe a place -> a logical object world (B1). A thin proxy to the Modal
+// backend's /plan-world, which parses the description into a SceneGraph and runs
+// the deterministic solver server-side. The flag gate (WORLD_FROM_DESCRIPTION)
+// lives on the backend — it 403s when off and we relay that. No Mongo here; the
+// client seeds the returned `solved` geos via /api/world/[id]/map.
+export async function POST(req: Request, { params }: Params) {
+  const { sessionId } = await params;
+  const env = readServerEnv();
+  if (!env.MODAL_API_URL) {
+    return NextResponse.json({ error: "MODAL_API_URL is not set" }, { status: 503 });
+  }
+  const traceId = req.headers.get(TRACE_HEADER) || newTraceId();
+  let body: { description?: string; answers?: string[] };
+  try {
+    body = (await req.json()) as { description?: string; answers?: string[] };
+  } catch {
+    return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
+  }
+  const description = (body.description ?? "").trim();
+  if (!description) {
+    return NextResponse.json(
+      { error: "missing required field: description" },
+      { status: 400 }
+    );
+  }
+  try {
+    const upstream = await fetch(joinModalUrl(env.MODAL_API_URL, "/plan-world"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json", [TRACE_HEADER]: traceId },
+      body: JSON.stringify({
+        session_id: sessionId,
+        description,
+        answers: Array.isArray(body.answers) ? body.answers : [],
+        trace_id: traceId,
+      }),
+    });
+    const payload = (await upstream.json().catch(() => ({}))) as
+      | (Partial<PlanWorldResponse> & { error?: string });
+    return NextResponse.json(payload, {
+      status: upstream.ok ? 200 : upstream.status,
+      headers: { [TRACE_HEADER]: traceId },
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: `plan-world upstream failed: ${(err as Error).message}`, trace_id: traceId },
+      { status: 502, headers: { [TRACE_HEADER]: traceId } }
+    );
+  }
+}

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -927,6 +927,117 @@ export default function PlayPage() {
     [input, sessionId, page, generate, imageTier, outputLocale, styleAnchor]
   );
 
+  // B1 — "Describe a place": turn the input description into a logical object
+  // world. POST /plan-world (parse -> deterministic solver, server-side); if it's
+  // BLOCKED (contradiction / over-pack / reserved-region collision) loop the
+  // clarifiers through the SAME hint bubble taps use, re-POST with the answers;
+  // on a non-null `solved`, seed the geos (the logical plane the map taps route
+  // through) and render a top-down plan from the description + planned visuals.
+  // Gated behind World Mode; the backend gates WORLD_FROM_DESCRIPTION (403 off).
+  const planWorld = useCallback(async () => {
+    const description = input.trim();
+    if (!description || phase === "generating") return;
+    type PW = {
+      graph?: {
+        place_label?: string;
+        entities?: { visual?: string }[];
+        empty_regions?: { note?: string }[];
+        clarifiers?: string[];
+        contradictions?: string[];
+      };
+      solved?: WorldEntityGeo[] | null;
+      error?: string;
+    };
+    const cx = typeof window !== "undefined" ? window.innerWidth / 2 : 400;
+    const cy = typeof window !== "undefined" ? window.innerHeight / 2 : 280;
+    let answers: string[] = [];
+    let graph: PW["graph"] = undefined;
+    let solved: WorldEntityGeo[] | null = null;
+    try {
+      for (let round = 0; round < 4; round += 1) {
+        const res = await fetch(
+          `/api/world/${encodeURIComponent(sessionId)}/plan-world`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ session_id: sessionId, description, answers }),
+          },
+        );
+        const data = (await res.json().catch(() => ({}))) as PW;
+        if (!res.ok) {
+          setError(data.error ?? "describe-a-place is off (set WORLD_FROM_DESCRIPTION)");
+          return;
+        }
+        graph = data.graph;
+        solved = data.solved ?? null;
+        if (solved) break;
+        const questions = graph?.clarifiers ?? [];
+        if (questions.length === 0) {
+          setError(
+            `That place doesn't quite work: ${(graph?.contradictions ?? []).join("; ") || "unresolved"}`,
+          );
+          return;
+        }
+        const answer = await promptForHint(cx, cy, questions.join("  ·  "));
+        if (answer == null) return; // cancelled
+        answers = [...answers, answer];
+      }
+      if (!solved || !graph) {
+        setError("Couldn't resolve the place after a few rounds — try rephrasing.");
+        return;
+      }
+      // Seed the logical plane (best-effort; needs GEOMETRIC_WORLD on the server).
+      await fetch(`/api/world/${encodeURIComponent(sessionId)}/map`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ geos: solved }),
+      }).catch(() => {});
+      // Render a top-down plan from the description + the planned visuals. The
+      // empty-region notes ride in the query text (the doc-sanctioned render-layer
+      // enforcement of "empty stays empty", alongside the grounding extras penalty).
+      const visuals = (graph.entities ?? [])
+        .map((e) => e.visual)
+        .filter((v): v is string => !!v && v.trim().length > 0)
+        .slice(0, 12)
+        .join("; ");
+      const empties = (graph.empty_regions ?? [])
+        .map((r) => r.note)
+        .filter((n): n is string => !!n && n.trim().length > 0);
+      const emptyClause = empties.length
+        ? ` Leave these areas clear and empty: ${empties.join(", ")}.`
+        : "";
+      const query =
+        `A top-down illustrated map of ${graph.place_label ?? "the place"}. ${description}.` +
+        (visuals ? ` Showing: ${visuals}.` : "") +
+        emptyClause;
+      void generate({
+        query,
+        aspect_ratio: "16:9",
+        web_search: false,
+        session_id: sessionId,
+        current_node_id: page?.nodeId ?? "",
+        mode: "query",
+        image_tier: imageTier,
+        output_locale: resolveOutputLocale(outputLocale),
+        world_mode: true,
+        render_mode: "place_submap",
+        ...(styleAnchor ? { session_style_anchor: styleAnchor.style } : {}),
+      });
+    } catch (err) {
+      setError(`describe-a-place failed: ${(err as Error).message}`);
+    }
+  }, [
+    input,
+    phase,
+    sessionId,
+    page,
+    generate,
+    imageTier,
+    outputLocale,
+    styleAnchor,
+    promptForHint,
+  ]);
+
   const submitEdit = useCallback(
     (e: FormEvent<HTMLFormElement>) => {
       e.preventDefault();
@@ -2028,6 +2139,20 @@ export default function PlayPage() {
         autonomy={worldAutonomy}
         setAutonomy={setWorldAutonomy}
       />
+
+      {worldEnabled && (
+        <div className="-mt-2 flex justify-end">
+          <button
+            type="button"
+            onClick={() => void planWorld()}
+            disabled={!input.trim() || phase === "generating"}
+            title="Turn the text above into a logical object layout (asks if it's contradictory)"
+            className="rounded-full border border-amber-300 bg-amber-50 px-3 py-1 text-xs font-medium text-amber-900 hover:bg-amber-100 disabled:opacity-40"
+          >
+            ✍ Describe a place
+          </button>
+        </div>
+      )}
 
       {isDraggingFile && <DragDropOverlay />}
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -647,3 +647,80 @@ export interface EditEntitiesResponse {
   plan: EntityEditPlan;
   trace_id?: string;
 }
+
+// ── Describe a place -> logical object world (WORLD_FROM_DESCRIPTION) ─────────
+// Turn a natural-language place description into all its objects on the shared 2D
+// plane. The planner emits STRUCTURE (entities + relations), NEVER coordinates —
+// the deterministic solver (providers/layout_solver.py) turns relations into
+// WorldEntityGeo positions. All additive + flag-gated; no existing type changes.
+
+// Relations the planner may express between two refs. Never coordinates.
+export type SpatialRelation =
+  | "near"
+  | "on_wall"
+  | "behind"
+  | "in_front_of"
+  | "left_of"
+  | "right_of"
+  | "inside"
+  | "on_top_of"
+  | "facing";
+
+// One named / functionally-implied object. `ref` is the stable slug relations
+// point at; `visual` is one render-ready sentence (the extractor's appearance
+// contract). `count` fans out into N instances at solve time.
+export interface PlannedEntity {
+  ref: string;
+  kind: EntityKind;
+  label: string;
+  visual: string;
+  footprint?: { w: number; d: number };
+  height?: number;
+  count?: number;
+}
+
+// A placement constraint: `subject` is positioned relative to `object`.
+export interface PlannedRelation {
+  subject: string;
+  relation: SpatialRelation;
+  object: string;
+  gap?: number;
+}
+
+// A region the description explicitly says is empty / clear / reserved. The
+// solver keeps every footprint out of its AABB; the renderer gets a negative
+// clause. `approx` (0..1 of the place) is an optional hint box.
+export interface EmptyRegion {
+  ref: string;
+  note: string;
+  approx?: { x: number; y: number; w: number; h: number };
+}
+
+// The structured read of the description (tolerant-parsed; malformed members are
+// dropped). `contradictions` non-empty -> blocking; `clarifiers` (<=2) are the
+// questions to ask. Both empty -> the graph is solvable as-is.
+export interface SceneGraph {
+  place_label: string;
+  place_kind: EntityKind;
+  bounds_hint?: { w: number; h: number };
+  entities: PlannedEntity[];
+  relations: PlannedRelation[];
+  empty_regions: EmptyRegion[];
+  clarifiers: string[];
+  contradictions: string[];
+}
+
+export interface PlanWorldRequestBody {
+  session_id: string;
+  description: string;
+  answers?: string[]; // replies to a prior round's clarifiers (re-run)
+  trace_id?: string;
+}
+
+export interface PlanWorldResponse {
+  graph: SceneGraph;
+  // The solved layout (ready for upsertEntityGeos), or null when the graph is
+  // blocked (hard contradiction / unresolved blocking clarifier) -> the client asks.
+  solved: WorldEntityGeo[] | null;
+  trace_id?: string;
+}


### PR DESCRIPTION
"Describe a place → a logical object world" (behind `WORLD_FROM_DESCRIPTION`). Type a description; it becomes all the relevant objects, arranged logically on the shared 2D plane — and it **asks** when the description is contradictory. Built entirely on existing primitives (`WorldEntityGeo`, `upsertEntityGeos`, the geo-tap `MAP_IMAGE_FRAME`, `promptForHint`); the only new moving parts are one LLM parse, one pure solver, and a thin gated UI.

## Pipeline
`description → plan_world_from_description` (LLM → `SceneGraph`: entities + relations, **never coordinates**) `→ solve_layout` (pure, deterministic → `WorldEntityGeo[]` in `MAP_IMAGE_FRAME`) `→ seed via /map → render a top-down plan`. A blocked graph (contradiction / over-pack / empty-region collision) returns `solved: null` and the client loops the clarifiers through the shipped hint bubble.

## Proven live
- **Coherent** — *"corner coffee shop: counter on the back wall, 4 stools at it, mug shelf behind, door on the left, front-right corner kept open"* → **7 geos**: stools placed **in front of** the counter, shelf **behind** it, door **on the left wall**, the reserved corner **empty**. No clarifiers.
- **Contradictory** — *"windowless vault sealed in bedrock with a sunny bay window"* → **`solved: null`** + asks *"Is the vault windowless or windowed?"* and names the contradiction.

## Guarantees — mechanical, not cosmetic
- **Empty stays empty** — at **solve** (the solver reserves regions; de-overlap never pushes a footprint into one) AND at **render** (the empty-region clause baked into the query + the grounding extras-penalty).
- **Asks when illogical** — two layers (LLM-semantic contradictions + solver-mechanical triggers: unanchored / over-pack / empty-collision) with a **blocking tier**; ≤2 questions.
- **No x/y from the LLM** — the planner emits relations; `parse_scene_graph` drops any coordinate; the solver owns positions (the audit's ROOT-2 guard, enforced at the parse boundary and unit-tested).

## Audited
codex returned **CONCERNS** on the solver; a self-audit found 4 real issues (broken `inside` nesting, wrong `facing` heading, de-overlap-into-reserved, dead `_emit` id) — all fixed (`6d253d5`).

## Tests
**17 free deterministic tests** (11 solver golden + 6 parser), no API. Full free gate green (441 web tests, backend ruff/mypy/pytest, no circular deps). Additive + flag-gated: tap / edit / atlas stay byte-identical when the flag is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
