### PR TITLE
fix(world): B1 solver — 'centre of the room' empty region was a corner

### DIFF
--- a/apps/modal-backend/providers/layout_solver.py
+++ b/apps/modal-backend/providers/layout_solver.py
@@ -124,9 +124,12 @@ def _region_rect(r: EmptyRegion, w: float, h: float) -> tuple[float, float, floa
         rh = float(r.approx.get("h", 0.3)) * h
         return (x, y, x + rw, y + rh)
     note = r.note.lower()
+    # "centre / middle of the room" -> a central reserved box, NOT a corner.
+    if any(s in note for s in ("centre", "center", "middle")):
+        return (w * 0.3, h * 0.3, w * 0.7, h * 0.7)
+    # else a corner/edge quadrant chosen by the side words in the note.
     qx = w / 2 if any(s in note for s in ("right", "east")) else 0.0
     qy = h / 2 if any(s in note for s in ("front", "bottom", "south")) else 0.0
-    # default to a quadrant
     return (qx, qy, qx + w / 2, qy + h / 2)
 
 

--- a/apps/modal-backend/tests/world_bench/test_layout_solver.py
+++ b/apps/modal-backend/tests/world_bench/test_layout_solver.py
@@ -170,3 +170,30 @@ def test_facing_heads_toward_the_object() -> None:
     chair = _by_label(solve_layout(g).geos, "chair")[0]
     # placed to the right of the desk -> faces WEST back at it (heading ~ ±pi).
     assert abs(abs(chair["heading"]) - math.pi) < 0.1
+
+
+def test_centre_empty_region_is_central_not_a_corner() -> None:
+    from providers.layout_solver import _region_rect
+
+    rect = _region_rect(EmptyRegion("c", "the centre of the room kept open"), 100, 60)
+    assert rect[0] > 0 and rect[1] > 0  # not anchored at the origin corner
+    cx, cy = (rect[0] + rect[2]) / 2, (rect[1] + rect[3]) / 2
+    assert abs(cx - 50) < 1 and abs(cy - 30) < 1  # centred in the room
+
+
+def test_wall_object_survives_a_central_clear_region() -> None:
+    # The wizard-study case the demo caught: a desk on the back wall + a globe on
+    # it must NOT collide with a "centre kept clear" region -> solves, not blocked.
+    g = SceneGraph(
+        place_label="study",
+        entities=[
+            PlannedEntity("desk", "item", "desk", "an oak desk", footprint={"w": 6, "d": 3}, height=4),
+            PlannedEntity("globe", "item", "globe", "a brass globe", footprint={"w": 1, "d": 1}, height=1),
+        ],
+        relations=[
+            PlannedRelation("desk", "near", "back_wall"),
+            PlannedRelation("globe", "on_top_of", "desk"),
+        ],
+        empty_regions=[EmptyRegion("circle", "the centre of the room kept open")],
+    )
+    assert solve_layout(g).blocked is False


### PR DESCRIPTION
The live UI demo caught it. A "centre kept open as a casting circle" empty region mapped to the **top-left quadrant** (the no-keyword default in `_region_rect`), so a desk on the back wall + a globe on it spuriously collided with the "empty" area and the solve **blocked** (asked a needless clarifier).

`_region_rect` now maps centre/middle to a central box. +2 golden tests (the central-region geometry + the wizard-study case that had blocked). All 13 solver tests + ruff/mypy green.

Surfaced by the end-to-end UI demo: *"a cozy wizard's study… centre kept open as a casting circle"* now solves cleanly and renders the study with the centre left clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)