### PR TITLE
feat(world): B2 keystone (scale ladder) + OUTWARD roadmap + session audit

### DIFF
--- a/apps/web/lib/scale-ladder.test.ts
+++ b/apps/web/lib/scale-ladder.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SCALE_LADDER,
+  SCALE_TIER_METERS,
+  tierMetricMultiplier,
+  tierStep,
+  tierTransitionValid,
+} from "@openflipbook/config";
+
+// B2 keystone: the scale ladder must be ordered + metric-conserving (INV-2), so
+// OUTWARD always grows the span and DEEPER always shrinks it. Pure + golden.
+describe("scale ladder (B2 keystone)", () => {
+  it("is ordered coarsest -> finest, 11 rungs", () => {
+    expect(SCALE_LADDER.length).toBe(11);
+    expect(SCALE_LADDER[0]).toBe("universe");
+    expect(SCALE_LADDER[SCALE_LADDER.length - 1]).toBe("object");
+  });
+
+  it("metric anchors never grow going finer (world == planet by design)", () => {
+    for (let i = 0; i < SCALE_LADDER.length - 1; i += 1) {
+      const a = SCALE_LADDER[i];
+      const b = SCALE_LADDER[i + 1];
+      if (!a || !b) continue;
+      expect(SCALE_TIER_METERS[a]).toBeGreaterThanOrEqual(SCALE_TIER_METERS[b]);
+    }
+    expect(SCALE_TIER_METERS.planet).toBe(SCALE_TIER_METERS.world); // the one equal pair
+  });
+
+  it("tierStep: DEEPER is +, OUTWARD is -", () => {
+    expect(tierStep("city", "district")).toBe(1); // deeper (finer)
+    expect(tierStep("city", "region")).toBe(-1); // outward (coarser)
+  });
+
+  it("tierMetricMultiplier: city->region grows ~20x; region->city shrinks", () => {
+    expect(tierMetricMultiplier("city", "region")).toBeCloseTo(20, 0);
+    expect(tierMetricMultiplier("region", "city")).toBeCloseTo(0.05, 2);
+  });
+
+  it("INV-2: every adjacent transition is metric-monotonic, both directions", () => {
+    for (let i = 0; i < SCALE_LADDER.length - 1; i += 1) {
+      const a = SCALE_LADDER[i];
+      const b = SCALE_LADDER[i + 1];
+      if (!a || !b) continue;
+      expect(tierTransitionValid(a, b)).toBe(true);
+      expect(tierTransitionValid(b, a)).toBe(true);
+    }
+    // world<->planet (the deliberately-equal pair) is legal both ways.
+    expect(tierTransitionValid("world", "planet")).toBe(true);
+    expect(tierTransitionValid("planet", "world")).toBe(true);
+  });
+});

--- a/docs/PLAN_OUTWARD.md
+++ b/docs/PLAN_OUTWARD.md
@@ -1,0 +1,137 @@
+# B2 execution plan — OUTWARD and on
+
+_The design lives in `PLAN_SCALE_NAV.md` (evaluator-accepted). This is the **execution
+roadmap** for the rest of B2, in build order, using the rhythm that worked for B1: a pure,
+golden-tested core first → an independent audit → integration → a live UI proof. The
+**keystone is already merged** — `SCALE_LADDER` / `SCALE_TIER_METERS` / `tierStep` /
+`tierMetricMultiplier` / `tierTransitionValid` (INV-2) in `packages/config`, 5 golden tests._
+
+## Where we are
+
+- ✅ **Keystone** — the metric-conserving scale ladder + INV-2, tested. The foundation
+  every direction stands on.
+- ⏳ Everything below is unbuilt. Each phase is independently shippable behind its flag.
+
+Master flag: `SCALE_LADDER_NAV` (off → the whole feature inert, prod byte-identical).
+Sub-flags: `SCALE_OUTWARD`, `SCALE_AROUND_LOGICAL`, `SCALE_OUTWARD_RERENDER`.
+
+---
+
+## Phase A — `scale_tier` plumbing (additive, low-risk, do first)
+
+Thread the optional `scale_tier?: ScaleTier` everywhere a frame is described, so OUTWARD/
+DEEPER have a rung to read/stamp. All optional, all back-compat.
+
+- `SceneView` (`packages/config/src/index.ts`) **and its Pydantic mirror** (`generate.py`
+  `class SceneView`) — **update the parity fixture** `packages/config/src/world-geo-fixture.json`
+  (the `test_geo_schema` SceneView keys + sample) in the SAME change, or the parity gate fails.
+- `WorldEntityGeo` (config) — a map entity can carry its rung.
+- `NodeDoc`/`NodeInsert`/`NodeRow` + `toRow` (`apps/web/lib/db.ts`), `CreateBody`
+  (`apps/web/app/api/nodes/route.ts`) — persist + restore alongside the existing `relation`/`scale`.
+- Seed it cheaply: extend `view_estimator.estimate_view` (`providers/view_estimator.py`) to
+  also guess `scale_tier`, with a deterministic `ViewLevel→tier` fallback (`map→city`,
+  `building→place`, `street→district`, `eye→room`). Mirror the `ViewEstimate` TypedDict ↔ TS.
+
+**Verify:** `test_geo_schema` parity stays green; a node round-trips its `scale_tier`. No new
+required field anywhere.
+
+---
+
+## Phase B — OUTWARD (`mode:"ascend"`) — the genuinely new direction
+
+The structurally-novel part (the design's risk #3: inverting the tree). Build the pure core +
+tests first, **then audit**, then integrate.
+
+### B.1 — pure core (test first)
+- `select_outward_op(from: ScaleTier, to: ScaleTier) -> "outpaint" | "rerender"` in
+  `providers/model_router.py` (a pure decision beside `select_operation`): **outpaint** for a
+  same-medium hop (city→region — BRIA paints more of the same plane); **rerender** when the
+  medium flips (planet→star_system — a map becomes an orbit diagram). Golden-test the boundary.
+- **INV-1 golden test** extending `apps/web/lib/world-geometry.test.ts`: seed a small map, run
+  the reparent (below) in a pure helper, assert `resolveAbsolutePos(leaf)` is byte-identical
+  before/after for every leaf (the embedded child gets `scale = meters(C)/meters(P)`, the same
+  footprint÷extent law as `deriveGeoFromExtraction`).
+- A pure `reparent(nodes, childId, parent)` in `apps/web/lib/world-map.ts` (or a new
+  `scale-tree.ts`): insert P with `parent_id:null` + `relation:"ascend"`, re-point the old
+  root's `parent_id → P`, cycle-guard (reuse `resolveAbsolutePos`'s `seen` set), abort-safe
+  (only mutate after P fully persists). Golden-test reparent + the abort/double-ascend cases.
+
+### B.2 — provider + planner
+- `expand_image_zoomout(image, factor)` in `providers/image_edit.py` — BRIA outpaint with the
+  source **centred** in a larger canvas (so the source becomes the central sub-region of the
+  parent). Reuse the existing `expand_image` plumbing; clamp the visual zoom to ~×3–4/hop and
+  auto-insert an intermediate rung when the metric jump is large (Risk 2).
+- A `render_mode:"scale_parent"` planner clause for the fresh-gen path ("render the {N+1}
+  that contains this {N}; place it as a recognisable sub-region; keep palette + medium").
+- INV-3: `session_style_anchor` / the `style` ref rides every hop (outpaint conserves pixels;
+  fresh-gen passes `reference_urls` + the clause).
+
+### B.3 — integration
+- `mode:"ascend"` branch in `generate.py`, modelled on the isolated `EXPAND_MAP_PAN` / edit
+  branches (return early; never touch the tap/query path). Gated `SCALE_LADDER_NAV` + `SCALE_OUTWARD`
+  (+ `SCALE_OUTWARD_RERENDER` for the medium-flip path, default off).
+- Web: a thin proxy route; a **distinct** "zoom out / step back" control in `page.tsx`
+  (never bound to tap — tap stays ENTER), firing `mode:"ascend"`; surface in the existing
+  `SpatialPath` zoom-out stack. Reparent via a new/extended nodes route, atomic.
+
+**Audit checkpoint** after B.1 (independent review of the reparent + INV-1) before integrating.
+
+---
+
+## Phase C — AROUND (logical, not random)
+
+Make the existing `expand` bloom logical: a new pure `apps/web/lib/scale-neighbors.ts`
+`selectNeighbors(focusId, geoMap, codex, tier)` layering (1) geometry `neighborsOf`/
+`siblingsOf` (real bearings, same `parent_id` + `scale_tier`) → (2) codex facts → (3) a
+constrained `propose_neighbors` (pass `scale_tier` + known facts, "peers at the SAME scale")
+only as cold-start. Persist as today (`relation:"expand"`) + the rung + a bearing. Gated
+`SCALE_AROUND_LOGICAL` (off → today's arbitrary bloom). Golden-test the cascade + bearings.
+
+---
+
+## Phase D — DEEPER (reuse, don't rebuild)
+
+The shipped geo-tap enter flow is unchanged; the **only** addition is stamping
+`scene_view.scale_tier = childTier` on enter so DEEPER and OUTWARD share one ladder. Size
+consistency already holds via the learned per-frame `scale`. One small change + a test.
+
+---
+
+## Phase E — invariants live + the drift number
+
+- INV-4 (one ladder): a cheap assertion that `scale_tier` sign agrees with the learned fine
+  `scale` in `deriveGeoFromExtraction` (warn + fall back on disagreement, never block).
+- Reuse the `coherence_runner` harness (`make eval-coherence`) for an **N≥10 A/B of OUTWARD
+  drift** — the design's risk #1 (compounding style/content drift across hops). Prefer
+  outpaint where possible (zero drift); keep `SCALE_OUTWARD_RERENDER` off by default until the
+  number justifies it.
+
+---
+
+## Risks (from the design) + how this order de-risks them
+
+1. **Compounding drift across hops** → INV-3 style lock every hop + prefer outpaint + the
+   coherence A/B before trusting rerender.
+2. **Metric blowups** (27 orders of magnitude) → store/compare span in **log space**; cap
+   visual zoom per hop + auto-insert rungs; clamp the learned `scale` (as `deriveGeoFromExtraction`
+   already does).
+3. **Tree-inversion corruption** → reparent is pure + golden-tested first (B.1), atomic +
+   cycle-guarded + abort-safe; INV-1 proves no leaf moves.
+
+---
+
+## Build order (one focused pass each, like B1)
+
+`A (plumbing) → B.1 (pure reparent + select_outward_op + INV-1, AUDIT) → B.2/B.3 (OUTWARD
+integration + UI, live proof) → C (AROUND) → D (DEEPER) → E (invariants + drift number)`.
+
+Each phase: pure core + golden tests → independent audit on the risky ones → integration →
+live UI proof → PR.
+
+---
+
+## Beyond B2 — the roadmap's last milestone
+
+After B2, the remaining roadmap item is the **on-ramp** (provider-freedom → eval → worlds →
+**on-ramp**): make the whole thing approachable for a first-time user — sensible default
+flags, a guided first session, and the BYO-keys path documented. Scope it once B2 lands.

--- a/docs/SESSION_AUDIT.md
+++ b/docs/SESSION_AUDIT.md
@@ -1,0 +1,149 @@
+# Session audit — the consistency + worlds work
+
+_Honest, code-grounded review of everything shipped in this run, same discipline as
+`GEOMETRIC_WORLD_AUDIT.md`: what's solid, what's a deliberate simplification, what's deferred.
+Written so the next session can pick up without re-discovering the gaps._
+
+## What shipped (merged to `main`)
+
+| # | Area | PR | State |
+|---|---|---|---|
+| 1 | **Cleanup** — purge demo artifacts from history | — | merged; `.git` 68 MB → 9.3 MB |
+| 2 | **A2 style medium-lock** + **A3 size↔map** | #15 | merged |
+| 3 | **Eval** — style A/B + size regression | #16 | merged |
+| 4 | **B1 — describe → logical object world** | #17 | merged |
+| 5 | **B1 centre-region fix** (caught by the live demo) | #18 | merged |
+| 6 | **B2 keystone** — the scale ladder | feat/scale-nav | banked (this PR) |
+
+Verification: `make eval` green on `main` (backend pytest/ruff/mypy + web vitest/tsc + no
+circular deps). Proof artifacts (style A/B, size overlay, image_urls null result, B1 demo) in
+`~/Desktop/ofb-consistency-proof/`.
+
+## Per-area assessment
+
+### 1. Cleanup — solid
+History rewritten (`git-filter-repo`) + force-pushed; 3 merged origin branches deleted; a CI
+guard + broadened `.gitignore` prevent regression. **Open:** `origin/backup/pre-purge` still
+holds the old blobs (kept as a recovery net — delete once a fresh clone is confirmed lean).
+
+### 2. A2 style medium-lock — solid, with one honest nuance
+- The **MEDIUM LOCK** text clause (`llm.py` plan_page) is the universal workhorse — it works
+  on every model incl. seedream, and the edit-path fix was dramatic in the A/B (photoreal 3D
+  dragon → engraving). The edit path used to drop the style **entirely**; it now threads the
+  text anchor + the style ref.
+- **Honest nuance:** the *fresh-gen* style REF image is a **no-op** — verified that fal's
+  text-to-image nano-banana(-pro) accept-but-ignore `image_urls` (a photoreal prompt + an
+  engraving ref came back photoreal). So on the tap "fresh" + expand paths the **text** does
+  the work; the ref image only bites on the **edit/continue** endpoints. Documented in
+  `providers/image.py`. The screenshot's *hard* drift was largely the **qwen-429 env**, not
+  pure code; the real code wins are the edit + stroke-tap paths.
+- **Cleanup candidate (deferred):** stop uploading the inert fresh-gen ref to save the fal
+  upload cost (it's currently harmless but wasted).
+
+### 3. Harden — solid
+`negative_prompt` verified-dead for every in-use model (`scripts/verify-fal-models.py`, the one
+`model_router.py` referenced but never had) → removed. The `image_urls` no-op is now documented.
+
+### 4. A3 size↔map — solid, honestly scoped
+- **FIX A** (oblique footprint from box width, clamped) is wired for the top-level oblique map
+  and **proven live** (the overlay showed footprints `8.0 → 35.4` wide vs the old flat `6×6`).
+- **FIX C** (carry footprint/height in `world_context` + a prompt size hint) done.
+- **FIX B intentionally NOT done:** the seeding gate is correct as-is; force-seeding focus-less
+  oblique scenes would inject unframed noise. Generated→coords geometry stays **relative, not
+  metric** — the exact path remains the `WORLD_TOPDOWN_MAPS` lever (honest, per the audit).
+
+### 5. Eval — solid
+`style_runner.py` (paid A/B, reuses `score_style_pair`) measured the medium lock at
+**0.5 → 9.0 (+8.5), pass**; `world-geometry-size.test.ts` guards FIX A free in CI. The pass/fail
+brain (`summarize`) + the parser are unit-tested free; the paid run is `make eval-style`
+(matches the other paid evals — manual targets, free gates in CI).
+
+### 6. B1 describe → world — works end-to-end, with two known simplifications
+- Proven live: *"a cozy wizard's study…"* → a logical top-down woodcut map (desk on the back
+  wall, hearth left, centre kept open) + the seeded geo plane; a contradictory description →
+  `solved:null` + a clarifier. Logical placement ✓, empty-stays-empty ✓ (solve + render + the
+  grounding extras-penalty), asks-when-illogical ✓, no x/y from the LLM ✓ (parse-boundary guard).
+- **Simplification 1 — `expected_layout` is NOT wired into the render.** The first render is a
+  description gen styled as a top-down plan (`render_mode:"place_submap"`); the **logical layout
+  lives in the seeded `world_map` geos** (tap-routable, overlay-visible), not necessarily in the
+  rendered pixels. Wiring `projectScene → expected_layout` to *steer* the render is a clean
+  follow-up.
+- **Simplification 2 — `inside` is flat v1.** A prop "inside" a container sits within its
+  footprint, same frame (exempt from de-overlap); true sub-frame nesting (`parent_id` + learned
+  `scale`) is deferred (the broken placeholder was removed in the solver audit).
+- `updated_at` is stamped by the endpoint (the solver stays deterministic). The centre-region
+  bug (a "centre" empty region mapping to a corner) was caught by the live demo and fixed (#18).
+
+### 7. B2 keystone — solid, foundation only
+The scale ladder + `tierStep`/`tierMetricMultiplier`/`tierTransitionValid` (INV-2), 5 golden
+tests. **Everything else in B2 is unbuilt** — see `PLAN_OUTWARD.md`.
+
+## Deferred / tech-debt (carry forward)
+
+1. **`origin/backup/pre-purge`** — delete once a fresh clone is confirmed lean.
+2. **B1 `expected_layout` steering** — wire `projectScene` so the render reflects the solved
+   positions (today it's description-driven; the geos hold the layout).
+3. **B1 `inside` flat-nesting** — sub-frame nesting deferred.
+4. **A2 fresh-gen ref upload** — inert (fal ignores it); stop uploading to save cost.
+5. **Flagged Kontext-scene path** — not built (intentional; the audit cautions it for map→scene).
+6. **B2 integration** — OUTWARD / AROUND / DEEPER / UI + the `scale_tier` plumbing through
+   `db`/`SceneView`/Pydantic + the parity fixture (the whole of `PLAN_OUTWARD.md`).
+7. **Merged local branches** — `feat/consistency-fixes`, `feat/eval`, `feat/world-from-description`,
+   `fix/centre-empty-region` are merged; tidy locally.
+8. **mypy coverage split (CI hygiene)** — `make eval` type-checks `generate.py` + 5 provider
+   files; CI type-checks `providers` but **not** `generate.py`. The union is covered, but neither
+   gate alone is complete (a `generate.py` type error passes CI; a `layout_solver.py` one passes
+   `make eval`). Cheap follow-up: align the two file lists.
+9. **Style ref on non-default edit paths** — the `pro`/`flux-pro/kontext` edit tier drops the
+   style exemplar (singular `image_url`), and `continue_image` (World-Mode submap zoom) takes no
+   style ref at all. Default edit tier is `balanced`=nano-banana-pro (which *does* use the ref),
+   so default behaviour is fine; these two paths lean on text-only medium lock.
+10. **B1 realism nits** — a `facing` subject's heading isn't recomputed if de-overlap later
+    relocates it; residual *item-item* overlap after the 20-iter cap isn't asserted away (only
+    reserved-region collisions block). Cosmetic, non-blocking.
+
+**Resolved by the audit (no change needed):** the top-down `estimateGeoFromBBox` footprint is
+left **un-clamped on purpose** — it's the exact metric bridge (bbox = footprint under
+`WORLD_TOPDOWN_MAPS`); clamping would cap legitimately-large entities. The oblique clamp guards
+monocular-depth blowups, which top-down doesn't have.
+
+## Flag posture (prod safety)
+
+Everything new is **off by default** in prod: `WORLD_FROM_DESCRIPTION` (B1 backend),
+`SCALE_LADDER_NAV` (B2), `IMAGE_NEGATIVE_PROMPT` (removed entirely). The style + size fixes are
+always-on but additive (no behaviour change when no style/geo is present). Tap/edit/atlas stay
+byte-identical with the flags off.
+
+## Independent audit
+
+_An independent agent re-derived every file:line claim, ran `make eval` on `main`, and reviewed
+all merged diffs. Verdict: **CONCERNS — ship-able**, off-by-default and honestly documented. The
+"concerns" (not "pass") are about scope-labelling and a few openly-deferred no-ops, **not**
+correctness regressions. `make eval` is **green**: backend `392 passed, 2 skipped` (the 2 are the
+paid bench markers) + ruff/mypy clean; web `446 passed` + `tsc` clean + no circular deps._
+
+What it **confirmed** (matches this doc): the style image-REF is a no-op on every fresh-gen path
+(query / tap-new / **and the expand bloom** — `generate.py` calls the text-to-image
+`generate_image` there too, so the parent/style refs are sent-but-ignored; only the MEDIUM-LOCK
+text holds style); `expected_layout` is not wired into the B1 render (the seeded geos carry the
+logical layout, the pixels are description-driven); `inside` is flat-nesting v1; schema parity
+(`test_geo_schema`) holds field-for-field; everything new is correctly off-by-default (B1 is
+**double-gated** — backend `WORLD_FROM_DESCRIPTION` 403 + client `worldEnabled`).
+
+New items it surfaced (folded into the deferred list below): the **mypy coverage split** (#8), the
+**`pro`/Kontext edit tier dropping the style exemplar** and **`continue_image` taking no style
+ref** (#9), and two minor B1 realism nits (#10).
+
+**One finding I adjudicated rather than applied** — the auditor flagged that the **top-down**
+branch of `estimateGeoFromBBox` floors footprint at 0.5 but (unlike oblique) applies no
+`MAX_FOOTPRINT` cap, and offered "clamp it too **or** document the intentional exemption." The
+exemption is **intentional and the clamp would be wrong**: top-down is the *exact metric bridge*
+(`WORLD_TOPDOWN_MAPS`, bbox **is** the footprint) — a building that genuinely spans 80% of the
+frame must seed an ~80 footprint; capping it at 40 would corrupt the one honest metric path. The
+oblique clamp exists only to tame unreliable *monocular-depth* blowups, which don't occur on a
+top-down map. So: no code change; documented here as a deliberate design decision.
+
+**Scope note:** the auditor was checked out on `feat/scale-nav`, so it read the B2 keystone in
+`git log` and (correctly) observed it is **not on `main`**. That's not a doc error — this audit
+lists the keystone as "banked (this PR)," and both this doc and `PLAN_OUTWARD.md` state the rest
+of B2 is unbuilt. This PR is exactly that bank.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -7,6 +7,53 @@ export type GenerateMode = "query" | "tap" | "edit" | "expand";
 // scale-level: component = -1, peer = 0, container = +1.
 export type ScaleKind = "component" | "peer" | "container";
 
+// ── Scale ladder (B2, SCALE_LADDER_NAV) ──────────────────────────────────────
+// An explicit, ordered, metric-anchored zoom axis: a node's COARSE absolute
+// "where on the zoom axis am I". Distinct from ScaleKind (relative:
+// component/peer/container) and from WorldEntityGeo.scale (fine metric: the size
+// of one unit of this frame). B2 navigation (OUTWARD/AROUND/DEEPER) moves along
+// this ladder; it EXTENDS the existing relative scale, never replaces it.
+export const SCALE_LADDER = [
+  "universe", "galaxy", "star_system", "planet",
+  "world", "region", "city", "district", "place", "room", "object",
+] as const;
+export type ScaleTier = (typeof SCALE_LADDER)[number];
+
+// Order-of-magnitude metric anchor (metres) per rung — the bridge that makes the
+// ladder metric-conserving. ~27 orders of magnitude end to end, so callers
+// store/compare in LOG space. `world` and `planet` share an anchor by design (a
+// "world" is a planet-surface framing); tierStep still separates them by index.
+export const SCALE_TIER_METERS: Record<ScaleTier, number> = {
+  universe: 8.8e26, galaxy: 9.5e20, star_system: 1.5e13, planet: 1.3e7,
+  world: 1.3e7, region: 3e5, city: 1.5e4, district: 1.5e3,
+  place: 1.2e2, room: 1.0e1, object: 1.0e0,
+};
+
+export function tierIndex(t: ScaleTier): number {
+  return SCALE_LADDER.indexOf(t);
+}
+// Signed index delta (universe=0 .. object=last). A finer target (toward
+// `object`, DEEPER) is +; a coarser target (toward `universe`, OUTWARD) is -.
+export function tierStep(from: ScaleTier, to: ScaleTier): number {
+  return tierIndex(to) - tierIndex(from);
+}
+// Per-transition metric multiplier = ratio of rung metres. OUTWARD (coarser)
+// is > 1 (region/city ~= 20x); DEEPER (finer) is < 1.
+export function tierMetricMultiplier(from: ScaleTier, to: ScaleTier): number {
+  return SCALE_TIER_METERS[to] / SCALE_TIER_METERS[from];
+}
+// INV-2: the metric span must move monotonically with the rung step — going
+// DEEPER (step > 0) shrinks it (multiplier <= 1), OUTWARD (step < 0) grows it
+// (multiplier >= 1); ==1 is allowed only between the deliberately-equal
+// world/planet rungs. A transition that violates this is a mis-classified rung
+// and must be rejected (don't persist; fall back).
+export function tierTransitionValid(from: ScaleTier, to: ScaleTier): boolean {
+  const step = tierStep(from, to);
+  if (step === 0) return true;
+  const m = tierMetricMultiplier(from, to);
+  return step > 0 ? m <= 1 : m >= 1;
+}
+
 // How a node relates to its parent: "descend" = went IN (a tap child, the
 // default), "expand" = bloomed OUT (a neighbour from mode:"expand").
 export type NodeRelation = "descend" | "expand";


### PR DESCRIPTION
## What this banks

The **B2 keystone** — the metric-conserving **scale ladder** — plus the two forward docs that
close out this session's consistency + worlds run.

### Code (the keystone, off-by-default)
- `packages/config/src/index.ts` — `SCALE_LADDER` (universe…object, 11 rungs), `SCALE_TIER_METERS`,
  and the pure transition helpers `tierStep` / `tierMetricMultiplier` / `tierTransitionValid`
  (**INV-2**: DEEPER always shrinks the span, OUTWARD always grows it; `world == planet` is the one
  deliberately-equal pair, legal both ways). No consumers yet — a foundation, not a behaviour change.
- `apps/web/lib/scale-ladder.test.ts` — 5 golden tests (ordering, metric monotonicity, step
  direction, multiplier, INV-2 both directions).

### Docs
- **`docs/PLAN_OUTWARD.md`** — the OUTWARD-and-on execution roadmap for the rest of B2:
  `A` scale_tier plumbing → `B` OUTWARD (`mode:"ascend"`, the genuinely-new direction; pure
  reparent + INV-1, audit, then integrate) → `C` AROUND (logical) → `D` DEEPER (reuse) →
  `E` invariants + the drift number. Build order + risk de-risking, one focused pass each (the
  rhythm that worked for B1).
- **`docs/SESSION_AUDIT.md`** — honest, code-grounded audit of the whole run (cleanup, A2 style
  medium-lock, A3 size, B1 describe-a-place, B2 keystone). Folds in an **independent agent's**
  review — verdict **CONCERNS, ship-able**; `make eval` green. Documents the deliberate
  simplifications (fresh-gen style **ref** is a verified no-op — only the MEDIUM-LOCK *text* holds
  style on fresh gen; `expected_layout` not yet steering the B1 render; `inside` flat-nested) and a
  full deferred/tech-debt list. Adjudicates the auditor's top-down-clamp finding as an **intentional
  metric-bridge exemption** (clamping would corrupt the exact bbox=footprint path).

## Verification
- Keystone verified green at commit time: 5 ladder tests + `tsc --noEmit` + eslint.
- Independent audit ran `make eval` on `main`: backend `392 passed, 2 skipped` (paid markers) +
  ruff/mypy clean; web `446 passed` + `tsc` clean + no circular deps.
- Purely additive (**+385 / −0**); nothing wired to a consumer; master flag `SCALE_LADDER_NAV`
  keeps the whole feature inert. Prod byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
