### PR TITLE
feat(world): B2 PR A — scale_tier plumbing

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -112,6 +112,10 @@ class SceneView(BaseModel):
     # sets it and the extract route reads it to anchor the child frame; without
     # it the field was silently dropped on validation, breaking the round-trip.
     focus_id: str | None = None
+    # Coarse SCALE_LADDER rung for this view (B2 scale navigation). Mirrors the
+    # optional `scale_tier?` on the TS SceneView; a free str so the ladder lives
+    # in one place (packages/config).
+    scale_tier: str | None = None
 
 
 class ProjectedEntity(BaseModel):

--- a/apps/modal-backend/providers/view_estimator.py
+++ b/apps/modal-backend/providers/view_estimator.py
@@ -20,13 +20,35 @@ class ViewEstimate(TypedDict):
     level: ViewLevel
     projection: ViewProjection
     pitch_deg: float
+    # Coarse SCALE_LADDER rung (B2). Mirrors the optional `scale_tier?` on the TS
+    # ViewEstimate; a free str so the ladder is defined once (packages/config).
+    scale_tier: str
 
 
 LEVELS: tuple[ViewLevel, ...] = ("map", "building", "street", "eye")
 PROJECTIONS: tuple[ViewProjection, ...] = ("top_down", "oblique", "perspective")
 
-# Safe default when estimation fails: a flat top-down map.
-DEFAULT_VIEW: ViewEstimate = {"level": "map", "projection": "top_down", "pitch_deg": -90.0}
+# The SCALE_LADDER rungs (coarsest→finest), mirrored from packages/config. A valid
+# scale_tier reply is one of these; anything else falls back off the camera level.
+SCALE_TIERS: tuple[str, ...] = (
+    "universe", "galaxy", "star_system", "planet", "world", "region",
+    "city", "district", "place", "room", "object",
+)
+# Deterministic rung when the model abstains, keyed off the camera level.
+LEVEL_TO_TIER: dict[ViewLevel, str] = {
+    "map": "city",
+    "building": "place",
+    "street": "district",
+    "eye": "room",
+}
+
+# Safe default when estimation fails: a flat top-down map at the city rung.
+DEFAULT_VIEW: ViewEstimate = {
+    "level": "map",
+    "projection": "top_down",
+    "pitch_deg": -90.0,
+    "scale_tier": "city",
+}
 
 
 def _model() -> str:
@@ -47,14 +69,19 @@ def parse_view(payload: Any) -> ViewEstimate:
         return cast(ViewEstimate, dict(DEFAULT_VIEW))
     level = str(payload.get("level", "")).strip().lower()
     proj = str(payload.get("projection", "")).strip().lower()
+    tier = str(payload.get("scale_tier", "")).strip().lower()
     try:
         pitch = float(payload.get("pitch_deg"))  # type: ignore[arg-type]
     except (TypeError, ValueError):
         pitch = -90.0
+    valid_level: ViewLevel = level if level in LEVELS else "map"
     return {
-        "level": level if level in LEVELS else "map",
+        "level": valid_level,
         "projection": proj if proj in PROJECTIONS else "top_down",
         "pitch_deg": max(-90.0, min(90.0, pitch)),
+        # An unknown/absent rung falls back deterministically off the level, so a
+        # fresh session is always seeded with *a* tier (the design's cheap seed).
+        "scale_tier": tier if tier in SCALE_TIERS else LEVEL_TO_TIER[valid_level],
     }
 
 
@@ -65,16 +92,19 @@ async def estimate_view(image_bytes: bytes, caption: str = "") -> ViewEstimate:
 
     b64 = base64.b64encode(image_bytes).decode("ascii")
     system = (
-        "You classify the CAMERA of an illustration so a geometry engine knows how "
-        "to read positions out of it. Return JSON exactly: "
-        '{"level":..,"projection":..,"pitch_deg":..}.\n'
+        "You classify the CAMERA + SCALE of an illustration so a geometry engine "
+        "knows how to read positions out of it. Return JSON exactly: "
+        '{"level":..,"projection":..,"pitch_deg":..,"scale_tier":..}.\n'
         "level: map (a top-down or bird's-eye map of an area), building (looking at "
         "a single structure), street (standing within a street/scene), eye "
         "(eye-level on one subject).\n"
         "projection: top_down (straight down, flat), oblique (tilted bird's-eye / "
         "isometric / 2.5D), perspective (ground-level with a vanishing point).\n"
         "pitch_deg: camera tilt from horizontal — -90 straight down, -45 tilted "
-        "bird's-eye, 0 level/horizon."
+        "bird's-eye, 0 level/horizon.\n"
+        "scale_tier: the real-world SCALE the frame spans, one of universe, galaxy, "
+        "star_system, planet, world, region, city, district, place, room, object "
+        "(coarsest→finest)."
     )
     user = "Classify this image's camera." + (
         f' Caption: "{caption[:200]}"' if caption else ""

--- a/apps/modal-backend/tests/test_view_estimator.py
+++ b/apps/modal-backend/tests/test_view_estimator.py
@@ -5,14 +5,35 @@ from providers.view_estimator import DEFAULT_VIEW, parse_view
 
 
 def test_parse_valid_oblique() -> None:
+    # scale_tier absent in the reply → falls back off the level (map → city).
     assert parse_view(
         {"level": "map", "projection": "oblique", "pitch_deg": -45}
-    ) == {"level": "map", "projection": "oblique", "pitch_deg": -45.0}
+    ) == {"level": "map", "projection": "oblique", "pitch_deg": -45.0, "scale_tier": "city"}
 
 
 def test_parse_unknown_values_fall_back() -> None:
     out = parse_view({"level": "satellite", "projection": "weird", "pitch_deg": "x"})
-    assert out == {"level": "map", "projection": "top_down", "pitch_deg": -90.0}
+    assert out == {
+        "level": "map",
+        "projection": "top_down",
+        "pitch_deg": -90.0,
+        "scale_tier": "city",
+    }
+
+
+def test_parse_scale_tier_explicit_and_fallback() -> None:
+    # An explicit valid rung passes through unchanged.
+    assert parse_view(
+        {"level": "map", "projection": "top_down", "pitch_deg": -90, "scale_tier": "region"}
+    )["scale_tier"] == "region"
+    # An unknown rung falls back deterministically off the level (eye → room).
+    assert parse_view(
+        {"level": "eye", "projection": "perspective", "pitch_deg": 0, "scale_tier": "bogus"}
+    )["scale_tier"] == "room"
+    # An absent rung also falls back off the level (building → place).
+    assert parse_view(
+        {"level": "building", "projection": "oblique", "pitch_deg": -30}
+    )["scale_tier"] == "place"
 
 
 def test_parse_clamps_pitch() -> None:

--- a/apps/web/app/api/nodes/route.ts
+++ b/apps/web/app/api/nodes/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import type { SceneView } from "@openflipbook/config";
+import type { ScaleTier, SceneView } from "@openflipbook/config";
 import { insertNode } from "@/lib/db";
 import { decodeDataUrl, uploadJpeg } from "@/lib/r2";
 import { readServerEnv } from "@/lib/env";
@@ -19,8 +19,9 @@ interface CreateBody {
   final_prompt?: string | null;
   click_in_parent?: { x_pct: number; y_pct: number } | null;
   sources?: { url: string; title: string | null }[] | null;
-  relation?: "descend" | "expand";
+  relation?: "descend" | "expand" | "ascend";
   scale?: "component" | "peer" | "container";
+  scale_tier?: ScaleTier | null;
   scene_view?: SceneView | null;
 }
 
@@ -65,6 +66,7 @@ export async function POST(req: Request) {
     sources: Array.isArray(body.sources) ? body.sources.slice(0, 3) : null,
     relation: body.relation ?? "descend",
     scale: body.scale ?? "peer",
+    scale_tier: body.scale_tier ?? null,
     scene_view: body.scene_view ?? null,
   });
 

--- a/apps/web/app/api/world/[sessionId]/extract/route.ts
+++ b/apps/web/app/api/world/[sessionId]/extract/route.ts
@@ -211,6 +211,7 @@ export async function POST(req: Request, { params }: Params) {
               "top_down",
               -60,
               parentFrameId,
+              upstreamView?.scale_tier,
             );
           }
         } else {
@@ -231,6 +232,8 @@ export async function POST(req: Request, { params }: Params) {
               items,
               upstreamView?.projection ?? "top_down",
               upstreamView?.pitch_deg ?? -60,
+              null,
+              upstreamView?.scale_tier,
             );
           }
         }

--- a/apps/web/lib/db.test.ts
+++ b/apps/web/lib/db.test.ts
@@ -49,3 +49,16 @@ describe("toRow scene_view round-trip", () => {
     expect(row.scene_view).toBeNull();
   });
 });
+
+describe("toRow scale_tier round-trip (B2)", () => {
+  it("preserves a persisted scale_tier and an ascend relation", () => {
+    const row = toRow(doc({ scale_tier: "city", relation: "ascend" }));
+    expect(row.scale_tier).toBe("city");
+    expect(row.relation).toBe("ascend");
+  });
+
+  it("defaults a missing scale_tier to null (back-compat with pre-B2 rows)", () => {
+    const row = toRow(doc());
+    expect(row.scale_tier).toBeNull();
+  });
+});

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -1,5 +1,5 @@
 import { MongoClient, type Collection, type Db, type Document } from "mongodb";
-import type { SceneView } from "@openflipbook/config";
+import type { ScaleTier, SceneView } from "@openflipbook/config";
 import { readServerEnv, requireMongo } from "./env";
 
 declare global {
@@ -114,10 +114,13 @@ export interface NodeDoc extends Document {
   // pre-citations nodes and treated as []. Domain-deduped, max ~3.
   sources?: NodeSource[] | null;
   // M3 scale-space: how this node relates to its parent ("descend" = tap-in /
-  // default, "expand" = bloomed neighbour) + its size vs the parent's focal
-  // subject. Optional + defaulted for back-compat with pre-M3 rows.
-  relation?: "descend" | "expand" | null;
+  // default, "expand" = bloomed neighbour, "ascend" = OUTWARD container) + its
+  // size vs the parent's focal subject. Optional + defaulted for back-compat.
+  relation?: "descend" | "expand" | "ascend" | null;
   scale?: "component" | "peer" | "container" | null;
+  // B2 scale ladder: the coarse absolute rung this node's frame sits at.
+  // Optional + null for pre-B2 rows.
+  scale_tier?: ScaleTier | null;
   // Geometric world (GEOMETRIC_WORLD): the observer pose + view level this
   // scene was rendered from. Optional + null for pre-geometry / classic nodes.
   scene_view?: SceneView | null;
@@ -136,8 +139,9 @@ export interface NodeInsert {
   final_prompt: string | null;
   click_in_parent?: ClickInParent | null;
   sources?: NodeSource[] | null;
-  relation?: "descend" | "expand" | null;
+  relation?: "descend" | "expand" | "ascend" | null;
   scale?: "component" | "peer" | "container" | null;
+  scale_tier?: ScaleTier | null;
   scene_view?: SceneView | null;
 }
 
@@ -154,8 +158,9 @@ export interface NodeRow {
   final_prompt: string | null;
   click_in_parent: ClickInParent | null;
   sources: NodeSource[];
-  relation: "descend" | "expand";
+  relation: "descend" | "expand" | "ascend";
   scale: "component" | "peer" | "container";
+  scale_tier: ScaleTier | null;
   // The observer pose + view level this node was rendered from. Null on
   // pre-geometry / classic nodes. Read back on revisit so the minimap scopes to
   // the right frame and the entered angle is reproducible.
@@ -164,8 +169,17 @@ export interface NodeRow {
 }
 
 export function toRow(doc: NodeDoc): NodeRow {
-  const { _id, created_at, click_in_parent, sources, relation, scale, scene_view, ...rest } =
-    doc;
+  const {
+    _id,
+    created_at,
+    click_in_parent,
+    sources,
+    relation,
+    scale,
+    scale_tier,
+    scene_view,
+    ...rest
+  } = doc;
   return {
     id: _id,
     ...rest,
@@ -173,6 +187,7 @@ export function toRow(doc: NodeDoc): NodeRow {
     sources: Array.isArray(sources) ? sources : [],
     relation: relation ?? "descend",
     scale: scale ?? "peer",
+    scale_tier: scale_tier ?? null,
     scene_view: scene_view ?? null,
     created_at: created_at.toISOString(),
   };
@@ -195,6 +210,7 @@ export async function insertNode(n: NodeInsert): Promise<NodeRow> {
     sources: n.sources ?? null,
     relation: n.relation ?? "descend",
     scale: n.scale ?? "peer",
+    scale_tier: n.scale_tier ?? null,
     scene_view: n.scene_view ?? null,
     created_at: new Date(),
   };

--- a/apps/web/lib/node-kind.ts
+++ b/apps/web/lib/node-kind.ts
@@ -29,7 +29,7 @@ export const NODE_KIND_LEGEND = [LEVELS.map, LEVELS.building, LEVELS.eye];
 // root map don't all read the same. Pure; the data already lives on every node.
 export function nodeKind(opts: {
   level?: ViewLevel | null;
-  relation?: "descend" | "expand" | null;
+  relation?: "descend" | "expand" | "ascend" | null;
   isRoot: boolean;
 }): NodeKind {
   const lv = (opts.level && LEVELS[opts.level]) || PAGE_FALLBACK;
@@ -37,7 +37,9 @@ export function nodeKind(opts: {
     ? { glyph: "◆", label: "root" }
     : opts.relation === "expand"
       ? { glyph: "⤢", label: "expanded" }
-      : { glyph: "↓", label: "inside" };
+      : opts.relation === "ascend"
+        ? { glyph: "⤡", label: "container" } // OUTWARD — the synthesized parent
+        : { glyph: "↓", label: "inside" };
   return {
     levelGlyph: lv.glyph,
     levelLabel: lv.label,

--- a/apps/web/lib/world-geo-schema.test.ts
+++ b/apps/web/lib/world-geo-schema.test.ts
@@ -42,6 +42,7 @@ const sceneView: SceneView = {
   observer: observerPose,
   map_crop: null,
   focus_id: "g1",
+  scale_tier: "city",
 };
 const projectedEntity: ProjectedEntity = {
   id: "g1",
@@ -65,6 +66,7 @@ const worldEntityGeo: WorldEntityGeo = {
   elevation: 0,
   footprint: { w: 4, d: 4 },
   scale: 1,
+  scale_tier: "place",
   heading: 0,
   visual: "red-and-white striped tower",
   state: { lit: true },

--- a/apps/web/lib/world-map.ts
+++ b/apps/web/lib/world-map.ts
@@ -6,6 +6,7 @@ import type {
   EntityKind,
   EntityState,
   MapCrop,
+  ScaleTier,
   SceneView,
   ViewProjection,
   WorldEntityGeo,
@@ -339,6 +340,9 @@ export async function deriveGeoFromExtraction(
   // id) — i.e. these are sub-entities INSIDE a place, positioned in its local
   // frame, not top-level city entities.
   parentId: string | null = null,
+  // The coarse SCALE_LADDER rung the view estimator read for this frame (B2).
+  // Stamped on each seeded geo so a fresh session carries a rung for free.
+  scaleTier?: ScaleTier,
 ): Promise<WorldMapSnapshot> {
   const nowIso = new Date().toISOString();
   const geos: WorldEntityGeo[] = items.map((item) => {
@@ -352,6 +356,7 @@ export async function deriveGeoFromExtraction(
       pos: est.pos,
       height: est.height,
       footprint: est.footprint,
+      ...(scaleTier ? { scale_tier: scaleTier } : {}),
       visual: item.visual ?? "",
       state: item.state ?? {},
       // Derived placements are discounted so a later user/extracted write wins.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,6 +1,6 @@
 export type AspectRatio = "16:9" | "9:16" | "1:1" | "4:3" | "3:4";
 
-export type GenerateMode = "query" | "tap" | "edit" | "expand";
+export type GenerateMode = "query" | "tap" | "edit" | "expand" | "ascend";
 
 // Scale of a node's subject relative to its parent's focal subject, for the
 // scale-space world map + zoom level-of-detail. Composes into an integer
@@ -55,8 +55,9 @@ export function tierTransitionValid(from: ScaleTier, to: ScaleTier): boolean {
 }
 
 // How a node relates to its parent: "descend" = went IN (a tap child, the
-// default), "expand" = bloomed OUT (a neighbour from mode:"expand").
-export type NodeRelation = "descend" | "expand";
+// default), "expand" = bloomed OUT (a neighbour from mode:"expand"), "ascend" =
+// zoomed OUT to a synthesized container (the OUTWARD reparent, SCALE_OUTWARD).
+export type NodeRelation = "descend" | "expand" | "ascend";
 
 export type ImageTier = "fast" | "balanced" | "pro";
 
@@ -494,6 +495,10 @@ export interface WorldEntityGeo {
   // resolves to a true absolute position INSIDE this place. Metric — distinct
   // from the categorical Entity.scale LOD bucket.
   scale?: number;
+  // Coarse absolute rung on SCALE_LADDER (city / place / room …) — which order of
+  // magnitude this entity's frame sits at, independent of the fine metric `scale`.
+  // Optional; seeded by the view estimator, used by B2 scale navigation.
+  scale_tier?: ScaleTier;
   heading?: number; // facing, radians, 0 = +x; optional
   visual: string; // short appearance descriptor (mirrors Entity.appearance)
   state: EntityState;
@@ -538,6 +543,9 @@ export interface SceneView {
   // into this place's child frame (parent_id = its geo) so the interior layout
   // stays consistent across re-entries. Null for a top-level map view.
   focus_id?: string | null;
+  // Coarse absolute rung on SCALE_LADDER for this view (DEEPER stamps childTier,
+  // OUTWARD stamps parentTier) — so both directions share one ladder. Optional.
+  scale_tier?: ScaleTier;
 }
 
 // One entity's projected place in a rendered frame (geometry-engine output),
@@ -566,6 +574,9 @@ export interface ViewEstimate {
   level: ViewLevel;
   projection: ViewProjection;
   pitch_deg: number;
+  // Coarse SCALE_LADDER rung the estimator read (or the ViewLevel→tier fallback).
+  // Optional; mirrored in the Python ViewEstimate TypedDict (view_estimator.py).
+  scale_tier?: ScaleTier;
 }
 
 // A per-session snapshot of the geometric world (the `world_map` collection).

--- a/packages/config/src/world-geo-fixture.json
+++ b/packages/config/src/world-geo-fixture.json
@@ -2,10 +2,10 @@
   "_comment": "Single source of truth for the geometric-world wire shapes. The P0 schema-parity gate (apps/web/lib/world-geo-schema.test.ts + apps/modal-backend/tests/test_geo_schema.py) asserts both the TS interfaces and the Pydantic mirrors match these key sets. Edit here when a shape changes; both gates will fail until both sides follow.",
   "keys": {
     "WorldVec2": ["x", "y"],
-    "WorldEntityGeo": ["id", "entity_id", "kind", "label", "pos", "height", "elevation", "footprint", "scale", "heading", "visual", "state", "confidence", "source", "updated_at"],
+    "WorldEntityGeo": ["id", "entity_id", "kind", "label", "pos", "height", "elevation", "footprint", "scale", "scale_tier", "heading", "visual", "state", "confidence", "source", "updated_at"],
     "ObserverPose": ["pos", "eye_height", "gaze", "pitch", "fov"],
     "MapCrop": ["x", "y", "w", "h"],
-    "SceneView": ["node_id", "level", "observer", "map_crop", "focus_id"],
+    "SceneView": ["node_id", "level", "observer", "map_crop", "focus_id", "scale_tier"],
     "ProjectedEntity": ["id", "label", "x_pct", "y_pct", "w_pct", "h_pct", "depth", "h_pos", "v_pos", "size"],
     "WorldMapSnapshot": ["session_id", "entities", "bounds", "schema_version", "updated_at"]
   },
@@ -22,6 +22,7 @@
       "elevation": 0,
       "footprint": { "w": 4, "d": 4 },
       "scale": 1,
+      "scale_tier": "place",
       "heading": 0,
       "visual": "red-and-white striped tower",
       "state": { "lit": true },
@@ -36,7 +37,8 @@
       "level": "eye",
       "observer": { "pos": { "x": 0, "y": 0 }, "eye_height": 1.7, "gaze": 0, "pitch": 0, "fov": 1.2 },
       "map_crop": null,
-      "focus_id": "g1"
+      "focus_id": "g1",
+      "scale_tier": "city"
     },
     "ProjectedEntity": {
       "id": "g1",


### PR DESCRIPTION
## PR A — `scale_tier` plumbing (B2 OUTWARD/AROUND/DEEPER, phase 1 of 7)

First PR of the B2 build (design: `docs/PLAN_SCALE_NAV.md`, roadmap: `docs/PLAN_OUTWARD.md`).
Pure **additive plumbing** — threads an optional `scale_tier?: ScaleTier` (the coarse
`SCALE_LADDER` rung) through every surface where a node's frame is described, mirroring the
existing `relation?`/`scale?` pattern exactly. No behaviour change; nothing reads the field for
navigation yet.

### What's threaded
- **`packages/config`** — `scale_tier?` on `SceneView` / `WorldEntityGeo` / `ViewEstimate`;
  `"ascend"` added to `GenerateMode` + `NodeRelation` (harmless until the OUTWARD branch lands).
- **Parity fixture** (`world-geo-fixture.json`) — `scale_tier` in the `SceneView` + `WorldEntityGeo`
  `keys` **and** `samples`, updated in lockstep with the TS interfaces **and** the Pydantic mirror
  so the `test_geo_schema` gate (TS + Py) stays green.
- **`generate.py`** — `scale_tier` on the Pydantic `SceneView`.
- **`db.ts` + nodes route** — `scale_tier` on `NodeDoc`/`NodeInsert`/`NodeRow` + `toRow`/`insertNode`
  defaults (`?? null`) + `CreateBody`; `"ascend"` in the relation unions; `nodeKind` learns the
  `"ascend"` container glyph.
- **Cheap seeding** — `view_estimator.estimate_view` now also reads `scale_tier` (validated against
  the ladder, else a deterministic `ViewLevel→tier` fallback: map→city, building→place,
  street→district, eye→room); the extract route stamps it onto the seeded geos via
  `deriveGeoFromExtraction` — so a fresh session carries a rung for free.

### Verification
- `make eval` green: backend pytest (not-paid) + ruff + mypy; web **448 tests** + tsc + no circular.
- The **TS↔Py parity gate is the teeth** here. New: a node `scale_tier`/`ascend` round-trip test +
  view-estimator validate/fallback tests.
- Every field optional, no new required field → prod byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
