### PR TITLE
feat(world): B2 PR B.1 — pure OUTWARD core + INV-1 (audit gate)

### DIFF
--- a/apps/modal-backend/providers/model_router.py
+++ b/apps/modal-backend/providers/model_router.py
@@ -20,9 +20,20 @@ MODEL_SLOTS: dict[str, tuple[str | None, str | None]] = {
     "fresh": (None, None),  # tier-based via image.py (FAL_IMAGE_MODEL_*)
     "zoom_continue": ("fal-ai/flux-pro/kontext", "FAL_CONTINUE_MODEL"),
     "outpaint": ("fal-ai/bria/expand", "FAL_OUTPAINT_MODEL"),
+    # B2 OUTWARD: a centered BRIA outpaint (reuses the bria slot) paints the
+    # container around the source; the medium-flip hop is a tier-based fresh gen.
+    "outpaint_zoomout": ("fal-ai/bria/expand", "FAL_OUTPAINT_MODEL"),
+    "scale_parent_fresh": (None, None),
     "inpaint": ("fal-ai/flux-pro/v1/fill", "FAL_INPAINT_MODEL"),
     "upscale": ("fal-ai/clarity-upscaler", "FAL_UPSCALE_MODEL"),
 }
+
+# Mirrors SCALE_LADDER in packages/config (coarsest→finest); kept in sync by hand
+# (the rungs are stable). Used only to classify an OUTWARD hop's medium.
+_SCALE_LADDER: tuple[str, ...] = (
+    "universe", "galaxy", "star_system", "planet", "world", "region",
+    "city", "district", "place", "room", "object",
+)
 
 
 def resolve_model(op: str) -> str | None:
@@ -52,3 +63,33 @@ def select_operation(render_mode: str | None, has_region: bool) -> str:
     if render_mode == "place_submap" and has_region:
         return "zoom_continue"
     return "fresh"
+
+
+def _tier_index(tier: str) -> int:
+    try:
+        return _SCALE_LADDER.index(tier)
+    except ValueError:
+        return -1
+
+
+def _is_medium_flip(from_tier: str, to_tier: str) -> bool:
+    """A hop crosses the surface↔astronomical boundary when its COARSER endpoint is
+    star_system or coarser — a planet surface becomes an orbital/starfield view,
+    which a seamless outpaint can't paint. Unknown rungs default to same-plane (the
+    safe outpaint path)."""
+    fi, ti = _tier_index(from_tier), _tier_index(to_tier)
+    if fi < 0 or ti < 0:
+        return False
+    return min(fi, ti) <= _tier_index("star_system")
+
+
+def select_outward_op(from_tier: str, to_tier: str) -> str:
+    """Pure: which OUTWARD op synthesizes the container that holds the source.
+
+    A same-plane surface hop (city→region) is a centered BRIA outpaint
+    (`outpaint_zoomout`) — the source's pixels are preserved and become the central
+    sub-region of a wider frame, so style is conserved by construction. A
+    medium-flip hop (planet→star_system) can't be outpainted into a new framing, so
+    it's a reference-conditioned fresh gen (`scale_parent_fresh`, the riskier path,
+    gated SCALE_OUTWARD_RERENDER). `resolve_model()` maps the label to a slug."""
+    return "scale_parent_fresh" if _is_medium_flip(from_tier, to_tier) else "outpaint_zoomout"

--- a/apps/modal-backend/tests/test_model_router.py
+++ b/apps/modal-backend/tests/test_model_router.py
@@ -45,3 +45,41 @@ def test_resolve_model_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
     assert model_router.resolve_model("zoom_continue") == "fal-ai/custom/kontext2"
     monkeypatch.setenv("FAL_OUTPAINT_MODEL", "fal-ai/custom/expand2")
     assert model_router.resolve_model("outpaint") == "fal-ai/custom/expand2"
+
+
+# ── B2 OUTWARD op selection (pure, by tier delta) ────────────────────────────
+@pytest.mark.parametrize(
+    "from_tier,to_tier",
+    [
+        ("city", "region"),  # same-plane surface hop
+        ("place", "district"),
+        ("region", "world"),
+        ("world", "planet"),  # still surface (planet is the surface, not orbital)
+    ],
+)
+def test_select_outward_op_surface_hop_is_outpaint(from_tier, to_tier) -> None:
+    # The source's pixels survive as the central sub-region → centered BRIA outpaint.
+    assert model_router.select_outward_op(from_tier, to_tier) == "outpaint_zoomout"
+
+
+@pytest.mark.parametrize(
+    "from_tier,to_tier",
+    [
+        ("planet", "star_system"),  # surface -> orbital: a new framing
+        ("star_system", "galaxy"),
+        ("galaxy", "universe"),
+    ],
+)
+def test_select_outward_op_medium_flip_is_fresh(from_tier, to_tier) -> None:
+    assert model_router.select_outward_op(from_tier, to_tier) == "scale_parent_fresh"
+
+
+def test_select_outward_op_unknown_tier_defaults_to_outpaint() -> None:
+    # An unknown rung is treated as same-plane — the safe, style-conserving path.
+    assert model_router.select_outward_op("city", "bogus") == "outpaint_zoomout"
+
+
+def test_resolve_model_outward_slots() -> None:
+    # outpaint_zoomout reuses the BRIA slot; the medium-flip fresh op is tier-based.
+    assert "bria" in (model_router.resolve_model("outpaint_zoomout") or "")
+    assert model_router.resolve_model("scale_parent_fresh") is None

--- a/apps/web/lib/scale-tree.test.ts
+++ b/apps/web/lib/scale-tree.test.ts
@@ -106,6 +106,25 @@ describe("scale-tree reparent (B2 OUTWARD)", () => {
     }
   });
 
+  it("never poisons coords when the scale ratio is NaN (malformed footprint, no tier)", () => {
+    const before = [
+      geo({ id: "c", pos: { x: 10, y: 20 }, footprint: { w: NaN, d: NaN } }),
+      geo({ id: "k", parent_id: "c", pos: { x: 1, y: 2 } }),
+    ];
+    const { geos, learnedScale } = reparent(
+      before,
+      "c",
+      geo({ id: "p", footprint: { w: NaN, d: NaN } }),
+      NOW,
+    );
+    expect(Number.isFinite(learnedScale)).toBe(true); // fell back to an identity frame
+    const after = absMap(geos);
+    for (const id of ["c", "k", "p"]) {
+      expect(Number.isFinite(after.get(id)!.x)).toBe(true);
+      expect(Number.isFinite(after.get(id)!.y)).toBe(true);
+    }
+  });
+
   it("rejects a double ascend (C is not a root)", () => {
     expect(() =>
       reparent(cityTree(), "a", geo({ id: "p" }), NOW),

--- a/apps/web/lib/scale-tree.test.ts
+++ b/apps/web/lib/scale-tree.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import type { WorldEntityGeo } from "@openflipbook/config";
+import { tierMetricMultiplier } from "@openflipbook/config";
+
+import { reparent } from "./scale-tree";
+import { type FrameNode, resolveAbsolutePos } from "./world-geometry";
+
+// Build a WorldEntityGeo with sensible defaults; override what a test cares about.
+function geo(over: Partial<WorldEntityGeo> & Pick<WorldEntityGeo, "id">): WorldEntityGeo {
+  return {
+    entity_id: over.id,
+    kind: "place",
+    label: over.id,
+    pos: { x: 0, y: 0 },
+    height: 4,
+    footprint: { w: 6, d: 6 },
+    visual: "",
+    state: {},
+    confidence: 0.9,
+    source: "extracted",
+    updated_at: "2026-06-09T00:00:00Z",
+    parent_id: null,
+    ...over,
+  };
+}
+
+// A small frame tree rooted at the city C, with a learned interior scale and a
+// grandchild — enough to exercise the affine compose at every depth.
+function cityTree(): WorldEntityGeo[] {
+  return [
+    geo({ id: "c", pos: { x: 50, y: 30 }, footprint: { w: 40, d: 30 }, scale: 0.4, scale_tier: "city" }),
+    geo({ id: "a", parent_id: "c", pos: { x: 10, y: 5 }, scale_tier: "place" }),
+    geo({ id: "b", parent_id: "c", pos: { x: 80, y: 50 }, scale_tier: "place" }),
+    geo({ id: "a1", parent_id: "a", pos: { x: 2, y: 3 } }),
+  ];
+}
+
+function absMap(geos: WorldEntityGeo[]): Map<string, { x: number; y: number }> {
+  const byId = new Map<string, FrameNode>(geos.map((g) => [g.id, g]));
+  const out = new Map<string, { x: number; y: number }>();
+  for (const g of geos) {
+    const p = resolveAbsolutePos(g.id, byId);
+    if (p) out.set(g.id, p);
+  }
+  return out;
+}
+
+const NOW = "2026-06-09T12:00:00Z";
+
+describe("scale-tree reparent (B2 OUTWARD)", () => {
+  it("INV-1: every entity's absolute position is conserved across the reparent", () => {
+    const before = cityTree();
+    const beforeAbs = absMap(before);
+
+    // P is a region centred on C (so C lands at P's origin), one rung coarser.
+    const region = geo({
+      id: "p",
+      label: "Region",
+      pos: { x: 50, y: 30 },
+      footprint: { w: 90, d: 60 },
+      scale_tier: "region",
+      source: "user",
+    });
+    const { geos: after, parentGeoId, learnedScale } = reparent(before, "c", region, NOW);
+    const afterAbs = absMap(after);
+
+    expect(parentGeoId).toBe("p");
+    // pScale is the metric ratio meters(city)/meters(region).
+    expect(learnedScale).toBeCloseTo(tierMetricMultiplier("region", "city"), 12);
+
+    // Every original entity resolves to the SAME absolute coordinate it did before.
+    for (const id of ["c", "a", "b", "a1"]) {
+      expect(afterAbs.get(id)!.x).toBeCloseTo(beforeAbs.get(id)!.x, 9);
+      expect(afterAbs.get(id)!.y).toBeCloseTo(beforeAbs.get(id)!.y, 9);
+    }
+  });
+
+  it("re-points C under P and stamps both source:user (protects the edge)", () => {
+    const { geos } = reparent(cityTree(), "c", geo({ id: "p", scale_tier: "region", footprint: { w: 90, d: 60 } }), NOW);
+    const c = geos.find((g) => g.id === "c")!;
+    const p = geos.find((g) => g.id === "p")!;
+    expect(c.parent_id).toBe("p");
+    expect(c.source).toBe("user");
+    expect(p.parent_id).toBeNull();
+    expect(p.source).toBe("user");
+    expect(p.updated_at).toBe(NOW);
+  });
+
+  it("conserves INV-1 even with no scale_tier (footprint÷extent fallback)", () => {
+    const before = [
+      geo({ id: "c", pos: { x: 20, y: 10 }, footprint: { w: 30, d: 20 }, scale: 0.5 }),
+      geo({ id: "k", parent_id: "c", pos: { x: 4, y: 6 } }),
+    ];
+    const beforeAbs = absMap(before);
+    const { geos: after } = reparent(
+      before,
+      "c",
+      geo({ id: "p", pos: { x: 0, y: 0 }, footprint: { w: 80, d: 60 } }),
+      NOW,
+    );
+    const afterAbs = absMap(after);
+    for (const id of ["c", "k"]) {
+      expect(afterAbs.get(id)!.x).toBeCloseTo(beforeAbs.get(id)!.x, 9);
+      expect(afterAbs.get(id)!.y).toBeCloseTo(beforeAbs.get(id)!.y, 9);
+    }
+  });
+
+  it("rejects a double ascend (C is not a root)", () => {
+    expect(() =>
+      reparent(cityTree(), "a", geo({ id: "p" }), NOW),
+    ).toThrow(/not a root/);
+  });
+
+  it("rejects an unknown root and a duplicate parent id", () => {
+    expect(() => reparent(cityTree(), "nope", geo({ id: "p" }), NOW)).toThrow(/not in the entity set/);
+    expect(() => reparent(cityTree(), "c", geo({ id: "a" }), NOW)).toThrow(/already exists/);
+  });
+});

--- a/apps/web/lib/scale-tree.ts
+++ b/apps/web/lib/scale-tree.ts
@@ -1,0 +1,97 @@
+import type { WorldEntityGeo } from "@openflipbook/config";
+import { tierMetricMultiplier } from "@openflipbook/config";
+
+import { localExtent } from "./world-geometry";
+
+// B2 OUTWARD reparent — the one operation that inverts the frame tree: synthesize
+// a coarser parent P and re-root the current root C under it. PURE (no Mongo, no
+// Date.now — the caller passes nowIso, like applyGeoUpsert) so INV-1 is a pure,
+// golden-testable property over resolveAbsolutePos. The impure persistence (the
+// /ascend route) is a thin wrapper around this.
+
+export interface ReparentResult {
+  // The full new entities array: P inserted (parent_id:null) + old root C
+  // re-pointed under P with the conserving local pos + scale.
+  geos: WorldEntityGeo[];
+  // P's geo id (so the caller can anchor the P node's scene_view focus).
+  parentGeoId: string;
+  // P's learned fine frame scale (for logging / the INV-2/INV-4 cross-check).
+  learnedScale: number;
+}
+
+// The same clamp deriveGeoFromExtraction uses (world-map.ts) so a pathological
+// rung ratio or extent can't explode the frame.
+const SCALE_MIN = 1e-3;
+const SCALE_MAX = 10;
+const clampScale = (s: number): number => Math.min(Math.max(s, SCALE_MIN), SCALE_MAX);
+
+/**
+ * Re-root `oldRootId` (the current root C) under the synthesized parent `parentGeo`
+ * (P), conserving every descendant's ABSOLUTE position (INV-1).
+ *
+ * P's fine frame scale is the METRIC ratio meters(child)/meters(parent) =
+ * `tierMetricMultiplier(parentTier, childTier)` (< 1: a city is a small part of a
+ * region), falling back to the footprint÷extent law `deriveGeoFromExtraction`
+ * uses when a rung is missing. Whatever the scale, C is re-expressed in P's frame
+ * as the exact affine INVERSE of inserting the (P.pos, pScale) frame above it:
+ *   C.pos'   = (C.pos − P.pos) / pScale
+ *   C.scale' = (C.scale ?? 1) / pScale
+ * so `resolveAbsolutePos` composes the same `(x, y)` for C and every descendant
+ * as before the reparent — for ANY chosen P.pos / pScale.
+ *
+ * Guards: C must exist and be a root (rejects a double-ascend); P's id must be new.
+ * P and the re-pointed C are stamped `source:"user"` so a later `derived` re-seed
+ * can't clobber the new edge (SOURCE_RANK, world-map.ts).
+ */
+export function reparent(
+  geos: WorldEntityGeo[],
+  oldRootId: string,
+  parentGeo: WorldEntityGeo,
+  nowIso: string,
+): ReparentResult {
+  const child = geos.find((g) => g.id === oldRootId);
+  if (!child) {
+    throw new Error(`reparent: oldRootId "${oldRootId}" is not in the entity set`);
+  }
+  if ((child.parent_id ?? null) !== null) {
+    throw new Error(
+      `reparent: "${oldRootId}" is not a root (parent_id=${child.parent_id}); ` +
+        "refusing a double ascend",
+    );
+  }
+  if (geos.some((g) => g.id === parentGeo.id)) {
+    throw new Error(`reparent: parent id "${parentGeo.id}" already exists`);
+  }
+
+  const parentTier = parentGeo.scale_tier;
+  const childTier = child.scale_tier;
+  const pScale =
+    parentTier && childTier
+      ? clampScale(tierMetricMultiplier(parentTier, childTier))
+      : clampScale(
+          Math.max(parentGeo.footprint.w, parentGeo.footprint.d) / localExtent([child]),
+        );
+
+  const newChild: WorldEntityGeo = {
+    ...child,
+    parent_id: parentGeo.id,
+    pos: {
+      x: (child.pos.x - parentGeo.pos.x) / pScale,
+      y: (child.pos.y - parentGeo.pos.y) / pScale,
+    },
+    scale: (child.scale ?? 1) / pScale,
+    source: "user",
+    updated_at: nowIso,
+  };
+  const newParent: WorldEntityGeo = {
+    ...parentGeo,
+    parent_id: null,
+    scale: pScale,
+    source: "user",
+    updated_at: nowIso,
+  };
+
+  const geosOut = geos.map((g) => (g.id === oldRootId ? newChild : g));
+  geosOut.push(newParent);
+  return { geos: geosOut, parentGeoId: parentGeo.id, learnedScale: pScale };
+}

--- a/apps/web/lib/scale-tree.ts
+++ b/apps/web/lib/scale-tree.ts
@@ -65,12 +65,17 @@ export function reparent(
 
   const parentTier = parentGeo.scale_tier;
   const childTier = child.scale_tier;
-  const pScale =
+  const rawScale =
     parentTier && childTier
-      ? clampScale(tierMetricMultiplier(parentTier, childTier))
-      : clampScale(
-          Math.max(parentGeo.footprint.w, parentGeo.footprint.d) / localExtent([child]),
-        );
+      ? tierMetricMultiplier(parentTier, childTier)
+      : Math.max(parentGeo.footprint.w, parentGeo.footprint.d) / localExtent([child]);
+  // Guard a NaN / 0 / Infinity ratio (a malformed footprint, or a scale_tier that
+  // isn't on the ladder) that would otherwise poison EVERY reparented coordinate;
+  // fall back to an identity frame (which still conserves INV-1 — its inverse is
+  // identity). NOTE: `learnedScale` is the CLAMPED value. For astronomical hops
+  // (<= star_system) the true ratio is far below the 1e-3 floor, so it floors to
+  // 1e-3 — do not compare it literally against `tierMetricMultiplier` once clamped.
+  const pScale = Number.isFinite(rawScale) && rawScale > 0 ? clampScale(rawScale) : 1;
 
   const newChild: WorldEntityGeo = {
     ...child,


### PR DESCRIPTION
## PR B.1 — pure OUTWARD core + INV-1 (B2, phase 2 of 7) · **audit gate**

The structurally-novel part of OUTWARD (re-rooting the frame tree), kept **pure + golden-tested**
before any image gen / persistence / UI. Imported by nothing yet — safe to merge alone.

### `apps/web/lib/scale-tree.ts` — `reparent(geos, oldRootId, parentGeo, nowIso)`
Re-roots the current root **C** under a synthesized coarser parent **P**, conserving **every
descendant's absolute position (INV-1)** by the exact affine inverse of inserting the `(P.pos, pScale)`
frame above C:
```
C.pos'   = (C.pos − P.pos) / pScale
C.scale' = (C.scale ?? 1) / pScale
```
so `resolveAbsolutePos` composes the same `(x, y)` for C and every descendant, for **any** chosen
`P.pos`/`pScale`. P's fine scale is the metric ratio `tierMetricMultiplier(parentTier, childTier)`
(< 1: a city is a small part of a region), with the `footprint ÷ extent` fallback
(`deriveGeoFromExtraction`'s law) when a rung is missing; clamped `[1e-3, 10]` like `world-map.ts`.
Guards double-ascend / unknown-root / duplicate-parent; stamps P + the re-pointed C `source:"user"`
so a later `derived` re-seed can't clobber the new edge (SOURCE_RANK).

### `providers/model_router.py` — `select_outward_op(from, to)`
Pure, beside `select_operation`: a same-plane surface hop → centered BRIA outpaint
(`outpaint_zoomout`); a medium-flip hop (crossing the `star_system` boundary) →
reference-conditioned fresh gen (`scale_parent_fresh`, the riskier path). Two `MODEL_SLOTS` added.

### Verification
- **INV-1**: absolute position byte-close (9 dp) across a 3-level tree, with **and** without tiers
  (fallback path); double-ascend / unknown-root / dup-parent rejection; `source:"user"` stamping.
- `select_outward_op` surface/medium-flip boundary + slot resolution.
- `make eval` green: web **453**, backend pytest + ruff + mypy + tsc + no circular.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
