### PR TITLE
feat(world): B2 PR B.2 — centered outpaint + scale_parent clause

### DIFF
--- a/apps/modal-backend/providers/image_edit.py
+++ b/apps/modal-backend/providers/image_edit.py
@@ -292,3 +292,69 @@ async def expand_image(
         model=model,
         provider_request_id=str(result.get("requestId") or "") or None,
     )
+
+
+# B2 OUTWARD: per-hop visual-zoom clamp. The metric span follows the scale ladder
+# independently; a big metric jump inserts intermediate rungs upstream rather than
+# cramming many orders of magnitude into one outpaint.
+_ZOOMOUT_FACTOR_MIN = 1.5
+_ZOOMOUT_FACTOR_MAX = 4.0
+
+
+def _clamp_zoom_factor(factor: float) -> float:
+    return max(_ZOOMOUT_FACTOR_MIN, min(_ZOOMOUT_FACTOR_MAX, factor))
+
+
+def _zoomout_args_for(
+    image_url: str, factor: float, width: int, height: int
+) -> dict[str, Any]:
+    """OUTWARD: the source CENTERED on a `factor`x larger canvas, full margin
+    painted on ALL sides — so it becomes the recognizable central sub-region of a
+    wider view of the same world. Contrast `_expand_args_for`, which pins the
+    original to one EDGE for a directional map-pan."""
+    cw, ch = int(width * factor), int(height * factor)
+    loc = [(cw - width) // 2, (ch - height) // 2]
+    return {
+        "image_url": image_url,
+        "canvas_size": [cw, ch],
+        "original_image_size": [width, height],
+        "original_image_location": loc,
+    }
+
+
+async def expand_image_zoomout(
+    image_data_url: str,
+    factor: float = 3.0,
+    width: int = 1600,
+    height: int = 900,
+    model_override: str | None = None,
+) -> GeneratedImage:
+    """OUTWARD / zoom-out (B2): paint the CONTAINER around the source — the source
+    centered on a `factor`x larger canvas with the full margin outpainted, so it
+    becomes the central sub-region of a wider frame of the SAME world (style is
+    conserved by construction: the original pixels stay). Same BRIA machinery as
+    `expand_image`; only the canvas is centered, not edge-pinned. `factor` is
+    clamped to ~1.5-4x per hop."""
+    from obs import span
+
+    _ensure_fal_key()
+    model = (
+        model_override
+        or os.environ.get("FAL_OUTPAINT_MODEL")
+        or EXPAND_MODEL_DEFAULT
+    )
+    f = _clamp_zoom_factor(factor)
+    # BRIA needs the parent's REAL pixel size or it rescales/seams the original.
+    w, h = _dims_from_data_url(image_data_url) or (width, height)
+    image_url = await to_fal_url(image_data_url)
+    async with span("image.zoomout", model=model, factor=f, w=w, h=h) as ctx:
+        result = await _fal_subscribe(model, _zoomout_args_for(image_url, f, w, h))
+        image_info = _expand_first_image(result)
+        jpeg_bytes, mime = await _fetch_image_bytes(image_info)
+        ctx["bytes"] = len(jpeg_bytes)
+    return GeneratedImage(
+        jpeg_bytes=jpeg_bytes,
+        mime_type=mime,
+        model=model,
+        provider_request_id=str(result.get("requestId") or "") or None,
+    )

--- a/apps/modal-backend/providers/llm.py
+++ b/apps/modal-backend/providers/llm.py
@@ -1040,6 +1040,18 @@ def _render_base_instruction(render_mode: str | None) -> str:
             "map and not a scene), facts (3-6 named sub-areas or landmarks shown "
             "on the map). Do not include any text outside the JSON."
         )
+    if rmode == "scale_parent":
+        return (
+            "You design the WIDER VIEW that CONTAINS this place — one scale step "
+            "OUT (a city as one district of its region; a planet as one dot in its "
+            "star system). Return JSON with keys: page_title (<=8 words, the "
+            "container's name), prompt (<=120 words describing the containing "
+            "frame, with the SOURCE placed as a small but recognizable sub-region "
+            "near its centre — the EXACT same palette, art medium and style, a "
+            "wider view of the SAME world and NOT a new invention), facts (3-6 "
+            "named sibling areas or landmarks that share this container). Do not "
+            "include any text outside the JSON."
+        )
     return (
         "You design a visual-explainer page for a given user query. Return "
         "JSON with keys: page_title (<=8 words, title case), prompt (<=120 "
@@ -1172,6 +1184,11 @@ async def plan_page(
     elif rmode == "place_submap":
         user_parts.append(
             "Draw the district map. Keep the labels readable at 1280x720."
+        )
+    elif rmode == "scale_parent":
+        user_parts.append(
+            "Draw the containing frame with the source as a small central "
+            "sub-region. Keep the same art medium; readable at 1280x720."
         )
     else:
         user_parts.append(

--- a/apps/modal-backend/tests/test_image_edit_provider.py
+++ b/apps/modal-backend/tests/test_image_edit_provider.py
@@ -52,6 +52,26 @@ def test_expand_args_north_south_grow_height() -> None:
     assert north["original_image_location"] == [0, 450]  # parent bottom, new above
 
 
+# --- OUTWARD zoom-out geometry (centered, not edge-pinned) --------------------
+
+
+def test_zoomout_args_center_the_source() -> None:
+    args = image_edit._zoomout_args_for("u", 3.0, 100, 60)
+    assert args["canvas_size"] == [300, 180]
+    assert args["original_image_size"] == [100, 60]
+    # Equal margin on every side → the source is the central sub-region.
+    assert args["original_image_location"] == [100, 60]
+    left = args["original_image_location"][0]
+    right = args["canvas_size"][0] - left - args["original_image_size"][0]
+    assert left == right
+
+
+def test_zoomout_factor_clamped_per_hop() -> None:
+    assert image_edit._clamp_zoom_factor(10.0) == 4.0  # capped
+    assert image_edit._clamp_zoom_factor(1.1) == 1.5  # floored
+    assert image_edit._clamp_zoom_factor(3.0) == 3.0  # in range
+
+
 # --- dimension probing (Pillow-free) ------------------------------------------
 
 
@@ -118,3 +138,35 @@ async def test_expand_image_parses_bria_and_uses_real_dims(
     assert captured["args"]["original_image_size"] == [1024, 576]
     assert captured["args"]["canvas_size"] == [1536, 576]  # +50% of measured width
     assert captured["fetched"] == {"url": "http://x", "content_type": "image/png"}
+
+
+async def test_expand_image_zoomout_centers_and_uses_real_dims(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict = {}
+
+    async def fake_to_fal(data_url: str) -> str:
+        return "fal://parent"
+
+    async def fake_sub(model: str, args: dict) -> dict:
+        captured["model"] = model
+        captured["args"] = args
+        return {"image": {"url": "http://x", "content_type": "image/png"}}
+
+    async def fake_fetch(info: dict) -> tuple[bytes, str]:
+        return b"jpeg", "image/png"
+
+    monkeypatch.setenv("FAL_KEY", "fk")
+    monkeypatch.setattr(image_edit, "to_fal_url", fake_to_fal)
+    monkeypatch.setattr(image_edit, "_fal_subscribe", fake_sub)
+    monkeypatch.setattr(image_edit, "_fetch_image_bytes", fake_fetch)
+
+    data_url = "data:image/png;base64," + base64.b64encode(_png(1024, 576)).decode()
+    # factor 10 is clamped to 4x per hop; the parent is centered on the canvas.
+    out = await image_edit.expand_image_zoomout(data_url, factor=10.0)
+
+    assert out.jpeg_bytes == b"jpeg"
+    assert "bria" in captured["model"]
+    assert captured["args"]["original_image_size"] == [1024, 576]
+    assert captured["args"]["canvas_size"] == [4096, 2304]  # 4x clamp of measured dims
+    assert captured["args"]["original_image_location"] == [1536, 864]  # centered


### PR DESCRIPTION
## PR B.2 — centered outpaint + `scale_parent` clause (B2, phase 3 of 7)

The parent-image provider for OUTWARD. Pure-additive; **called by nothing until B.3** wires the
`ascend` branch.

### `providers/image_edit.py` — `expand_image_zoomout`
The source **centered** on a `factor`×-larger canvas with the full margin outpainted on **all
sides** (vs `_expand_args_for`, which edge-pins for a directional map-pan) — so the source becomes
the recognizable **central sub-region** of a wider view of the *same* world. **Style is conserved by
construction** (the original pixels stay). Reuses `expand_image`'s machinery (`_dims_from_data_url`
for the real pixel size so BRIA doesn't rescale/seam, `_expand_first_image`, `_fal_subscribe`).
`factor` clamped ~1.5–4× per hop so a big metric jump inserts intermediate rungs upstream rather
than one huge outpaint. Uses the `bria`/`FAL_OUTPAINT_MODEL` slot.

### `providers/llm.py` — `render_mode:"scale_parent"`
A clause in `_render_base_instruction` (+ a `plan_page` render hint) for the fresh-gen medium-flip
path: render the container that holds the source as a small central sub-region, **same palette / art
medium / style**. INV-3 style lock rides the existing `style_anchor` append.

### Verification
- Centered-canvas offset math (equal margins on every side) + factor clamp + a **mocked
  end-to-end** (clamp applied, real dims measured, parent centered).
- `make eval` green: backend pytest + ruff + mypy; web **448** + tsc + no circular (web untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
