### PR TITLE
feat(world): B2 PR B.3 — OUTWARD integration + zoom-out UI

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -478,6 +478,93 @@ async def _event_stream(
             )
             return
 
+        # OUTWARD / zoom-out (SCALE_LADDER_NAV + SCALE_OUTWARD): synthesize the
+        # CONTAINER that holds the current root and stream it back as `ascend_ready`
+        # — the web /ascend route persists the reparent. Isolated like edit/expand:
+        # returns early, never touches the tap/query single-`final` path below.
+        if body.mode == "ascend":
+            if not (env_flag("SCALE_LADDER_NAV") and env_flag("SCALE_OUTWARD")):
+                yield _sse(
+                    {"type": "error", "message": "OUTWARD disabled (SCALE_LADDER_NAV+SCALE_OUTWARD)"},
+                    trace_id,
+                )
+                return
+            if not body.image:
+                yield _sse(
+                    {"type": "error", "message": "ascend mode requires an image"}, trace_id
+                )
+                return
+            from_tier = (body.scene_view.scale_tier if body.scene_view else None) or "city"
+            to_tier = model_router.coarser_tier(from_tier)
+            if to_tier is None:
+                yield _sse(
+                    {"type": "error", "message": f"no coarser rung above '{from_tier}'"},
+                    trace_id,
+                )
+                return
+            op = model_router.select_outward_op(from_tier, to_tier)
+            _dims = {
+                "16:9": (1600, 900), "9:16": (900, 1600), "1:1": (1024, 1024),
+                "4:3": (1280, 960), "3:4": (960, 1280),
+            }
+            pw, ph = _dims.get(body.aspect_ratio, (1600, 900))
+            yield _sse({"type": "status", "stage": "rendering"}, trace_id)
+            await _abort_if_disconnected("pre-ascend")
+            try:
+                if op == "outpaint_zoomout":
+                    # Centered BRIA outpaint: the source becomes the central
+                    # sub-region of the wider frame — style conserved by construction.
+                    img = await image_edit_provider.expand_image_zoomout(
+                        body.image, 3.0, pw, ph
+                    )
+                    page_title = f"The surrounding {to_tier.replace('_', ' ')}".title()
+                    final_prompt = f"outward zoom: {from_tier} -> {to_tier} (centered outpaint)"
+                else:  # scale_parent_fresh — the medium-flip fresh path (riskier)
+                    if not env_flag("SCALE_OUTWARD_RERENDER"):
+                        yield _sse(
+                            {
+                                "type": "error",
+                                "message": f"medium-flip OUTWARD to '{to_tier}' needs SCALE_OUTWARD_RERENDER",
+                            },
+                            trace_id,
+                        )
+                        return
+                    style_lock = (body.session_style_anchor or "").strip() or None
+                    plan = await llm.plan_page(
+                        query=body.query or from_tier,
+                        web_search=False,
+                        style_anchor=style_lock,
+                        render_mode="scale_parent",
+                    )
+                    img = await image_provider.generate_image(
+                        plan.prompt, body.aspect_ratio, reference_urls=[body.image]
+                    )
+                    page_title = plan.page_title or to_tier.replace("_", " ").title()
+                    final_prompt = plan.prompt
+            except Exception as exc:
+                log("warn", "ascend.failed", error=f"{type(exc).__name__}: {exc}")
+                record_error("ascend", exc)
+                yield _sse({"type": "error", "message": f"ascend failed: {exc}"}, trace_id)
+                return
+            data_url = await _asyncio.to_thread(
+                image_provider.encode_data_url, img.jpeg_bytes, img.mime_type
+            )
+            yield _sse(
+                {
+                    "type": "ascend_ready",
+                    "page_title": page_title,
+                    "image_data_url": data_url,
+                    "image_model": img.model,
+                    "prompt_author_model": "",
+                    "final_prompt": final_prompt,
+                    "scale_tier": to_tier,
+                    "from_tier": from_tier,
+                    "session_id": body.session_id,
+                },
+                trace_id,
+            )
+            return
+
         # Expand mode blooms the world AROUND the focal subject: propose a few
         # neighbouring subjects across scales (component/peer/container), then
         # generate their pages concurrently and stream one `neighbor` event per

--- a/apps/modal-backend/providers/model_router.py
+++ b/apps/modal-backend/providers/model_router.py
@@ -72,6 +72,14 @@ def _tier_index(tier: str) -> int:
         return -1
 
 
+def coarser_tier(tier: str) -> str | None:
+    """The rung one step OUTWARD (coarser) on the ladder, or None if already at the
+    coarsest (universe) or the tier is unknown. The OUTWARD branch picks the target
+    rung with this."""
+    i = _tier_index(tier)
+    return _SCALE_LADDER[i - 1] if i > 0 else None
+
+
 def _is_medium_flip(from_tier: str, to_tier: str) -> bool:
     """A hop crosses the surface↔astronomical boundary when its COARSER endpoint is
     star_system or coarser — a planet surface becomes an orbital/starfield view,

--- a/apps/modal-backend/tests/test_generate_ascend.py
+++ b/apps/modal-backend/tests/test_generate_ascend.py
@@ -1,0 +1,118 @@
+"""Integration tests for the OUTWARD (ascend) branch in generate.py.
+
+Drives the real `_event_stream` with mode="ascend" and the BRIA outpaint provider
+mocked — asserts the `ascend_ready` event (shape + target rung), the flag gate
+(off by default → refuses), the image requirement, the medium-flip guard, and
+that the additive branch leaves the tap/query `final` path intact.
+
+generate.py imports `modal` at module level (deploy-only); stub it before import.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.modules.setdefault("modal", MagicMock())
+
+import providers.image_edit as image_edit_mod  # noqa: E402
+from generate import GenerateBody, SceneView, _event_stream  # noqa: E402
+from providers.image import GeneratedImage  # noqa: E402
+
+
+async def _collect(agen: Any) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    async for chunk in agen:
+        text = chunk.decode() if isinstance(chunk, bytes) else chunk
+        for block in text.strip().split("\n\n"):
+            block = block.strip()
+            if block.startswith("data:"):
+                events.append(json.loads(block[len("data:") :].strip()))
+    return events
+
+
+def _ascend_body(**over: Any) -> GenerateBody:
+    base: dict[str, Any] = {
+        "query": "Ankh-Morpork",
+        "session_id": "s1",
+        "mode": "ascend",
+        "image": "data:image/jpeg;base64,abc",
+        "scene_view": SceneView(node_id="n0", level="map", scale_tier="city"),
+        "web_search": False,
+    }
+    base.update(over)
+    return GenerateBody(**base)
+
+
+def _enable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SCALE_LADDER_NAV", "1")
+    monkeypatch.setenv("SCALE_OUTWARD", "1")
+
+
+async def test_ascend_outpaints_the_container(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable(monkeypatch)
+    img = GeneratedImage(b"jpegbytes", "image/jpeg", "fal-ai/bria/expand", "req-1")
+    mock = AsyncMock(return_value=img)
+    monkeypatch.setattr(image_edit_mod, "expand_image_zoomout", mock)
+
+    events = await _collect(_event_stream(_ascend_body(), "t1"))
+    ready = next(e for e in events if e["type"] == "ascend_ready")
+    assert ready["scale_tier"] == "region"  # one rung coarser than city
+    assert ready["from_tier"] == "city"
+    assert ready["image_data_url"].startswith("data:image/jpeg;base64,")
+    assert ready["image_model"] == "fal-ai/bria/expand"
+    mock.assert_awaited_once()
+
+
+async def test_ascend_gated_off_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Flags unset → the branch refuses; prod byte-identical.
+    monkeypatch.delenv("SCALE_LADDER_NAV", raising=False)
+    monkeypatch.delenv("SCALE_OUTWARD", raising=False)
+    events = await _collect(_event_stream(_ascend_body(), "t1"))
+    assert events[0]["type"] == "error"
+    assert "disabled" in events[0]["message"]
+
+
+async def test_ascend_requires_an_image(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable(monkeypatch)
+    events = await _collect(_event_stream(_ascend_body(image=None), "t1"))
+    assert any(e["type"] == "error" and "requires an image" in e["message"] for e in events)
+
+
+async def test_ascend_medium_flip_needs_rerender_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    # planet → star_system is a medium flip; without SCALE_OUTWARD_RERENDER it refuses
+    # (the riskier fresh path stays off until the drift eval justifies it).
+    _enable(monkeypatch)
+    monkeypatch.delenv("SCALE_OUTWARD_RERENDER", raising=False)
+    body = _ascend_body(scene_view=SceneView(node_id="n0", level="map", scale_tier="planet"))
+    events = await _collect(_event_stream(body, "t1"))
+    assert any(
+        e["type"] == "error" and "SCALE_OUTWARD_RERENDER" in e["message"] for e in events
+    )
+
+
+async def test_query_mode_unaffected_by_ascend_branch(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression: the additive ascend branch must not disturb the tap/query path.
+    import providers.image as image_mod
+    import providers.llm as llm_mod
+    from providers.llm import PagePlan
+
+    _enable(monkeypatch)
+    monkeypatch.setenv("PROGRESSIVE_DRAFT", "false")
+    monkeypatch.setattr(
+        llm_mod, "plan_page", AsyncMock(return_value=PagePlan("Boilers", "a diagram", ["x"], []))
+    )
+    monkeypatch.setattr(
+        image_mod,
+        "generate_image",
+        AsyncMock(return_value=GeneratedImage(b"jpeg", "image/jpeg", "fal-model", "r")),
+    )
+    body = GenerateBody(query="how do boilers work", session_id="s1")
+    events = await _collect(_event_stream(body, "t1"))
+    finals = [e for e in events if e["type"] == "final"]
+    assert len(finals) == 1
+    assert not [e for e in events if e["type"] == "ascend_ready"]

--- a/apps/modal-backend/tests/test_model_router.py
+++ b/apps/modal-backend/tests/test_model_router.py
@@ -83,3 +83,11 @@ def test_resolve_model_outward_slots() -> None:
     # outpaint_zoomout reuses the BRIA slot; the medium-flip fresh op is tier-based.
     assert "bria" in (model_router.resolve_model("outpaint_zoomout") or "")
     assert model_router.resolve_model("scale_parent_fresh") is None
+
+
+def test_coarser_tier_steps_outward() -> None:
+    assert model_router.coarser_tier("city") == "region"
+    assert model_router.coarser_tier("region") == "world"
+    assert model_router.coarser_tier("place") == "district"
+    assert model_router.coarser_tier("universe") is None  # already the coarsest
+    assert model_router.coarser_tier("bogus") is None  # unknown rung

--- a/apps/web/app/api/world/[sessionId]/ascend/route.ts
+++ b/apps/web/app/api/world/[sessionId]/ascend/route.ts
@@ -149,12 +149,15 @@ export async function POST(req: Request, { params }: Params) {
     );
   }
 
-  // 3. Commit: re-point C's node under P (atomic single-field $set).
+  // 3. Commit: re-point C's node under P (atomic single-field $set, guarded on C
+  //    still being a root). A concurrent ascend that already re-rooted C loses here
+  //    (matchedCount 0) → tidy this loser's orphan P node so it can't strand.
   const repointed = await updateNodeParent(body.child_node_id, pId);
   if (!repointed) {
+    await deleteNode(pId).catch(() => {});
     return NextResponse.json(
-      { error: "failed to re-point child (it may have been removed)", parent_node_id: pId },
-      { status: 500 },
+      { error: "child was concurrently reparented or removed", parent_node_id: pId },
+      { status: 409 },
     );
   }
 

--- a/apps/web/app/api/world/[sessionId]/ascend/route.ts
+++ b/apps/web/app/api/world/[sessionId]/ascend/route.ts
@@ -1,0 +1,166 @@
+import { NextResponse } from "next/server";
+import type { ScaleTier, SceneView, WorldEntityGeo } from "@openflipbook/config";
+
+import { deleteNode, getNode, insertNode, updateNodeParent } from "@/lib/db";
+import { decodeDataUrl, uploadJpeg } from "@/lib/r2";
+import { getWorldMap, upsertEntityGeos } from "@/lib/world-map";
+import { reparentRoots } from "@/lib/scale-tree";
+import { MAP_IMAGE_FRAME } from "@/lib/geo-tap";
+import { readServerEnv } from "@/lib/env";
+import { envFlag } from "@/lib/env-flag";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface Params {
+  params: Promise<{ sessionId: string }>;
+}
+
+// OUTWARD reparent: the synthesized container image P (from the backend ascend
+// branch) + which root to re-root under it + its rung.
+interface AscendBody {
+  child_node_id: string;
+  image_data_url: string;
+  parent_tier: ScaleTier;
+  page_title: string;
+  query?: string;
+  image_model?: string;
+  prompt_author_model?: string;
+  aspect_ratio?: string;
+  final_prompt?: string | null;
+}
+
+// Atomically re-root the current root C under a synthesized coarser parent P.
+// Commit order is chosen so any single failure leaves C + the existing tree fully
+// intact and INV-1-safe (the structural node edge is flipped LAST):
+//   1. insert P node (a harmless 2nd root until step 3)
+//   2. seed geo — reparentRoots re-points every root geo under P (atomic in one
+//      optimisticReplace) with the conserving scale; abort + delete P on failure
+//   3. re-point C's node parent_id = P (the commit point; single-field $set)
+// Geo BEFORE the node re-point: repointing the node first would briefly compose C
+// through a P with no geo frame → INV-1 violation.
+export async function POST(req: Request, { params }: Params) {
+  const { sessionId } = await params;
+
+  if (!(envFlag("SCALE_LADDER_NAV") && envFlag("SCALE_OUTWARD"))) {
+    return NextResponse.json(
+      { error: "OUTWARD disabled (set SCALE_LADDER_NAV=1 and SCALE_OUTWARD=1)" },
+      { status: 403 },
+    );
+  }
+  const env = readServerEnv();
+  if (!env.MONGODB_URI || !env.MONGODB_DB || !env.R2_BUCKET) {
+    return NextResponse.json(
+      { error: "MONGODB_URI/MONGODB_DB or R2_* not set — persistence disabled." },
+      { status: 503 },
+    );
+  }
+
+  const body = (await req.json()) as AscendBody;
+  if (!body.child_node_id || !body.image_data_url || !body.parent_tier) {
+    return NextResponse.json(
+      { error: "missing required fields: child_node_id, image_data_url, parent_tier" },
+      { status: 400 },
+    );
+  }
+
+  // Double-ascend guard: C must exist and still be a root.
+  const child = await getNode(body.child_node_id);
+  if (!child) {
+    return NextResponse.json({ error: "child_node_id not found" }, { status: 404 });
+  }
+  if (child.parent_id !== null) {
+    return NextResponse.json(
+      { error: "child is not a root (already ascended)", parent_id: child.parent_id },
+      { status: 409 },
+    );
+  }
+
+  // Upload P's image, then mint P's id so its scene_view can self-reference.
+  const decoded = decodeDataUrl(body.image_data_url);
+  const ext = decoded.contentType === "image/png" ? "png" : "jpg";
+  const keyPrefix = sessionId.replace(/[^a-zA-Z0-9._-]/g, "_");
+  const uploaded = await uploadJpeg(
+    `${keyPrefix}/${crypto.randomUUID()}.${ext}`,
+    decoded.bytes,
+    decoded.contentType,
+  );
+  const pId = crypto.randomUUID();
+  const nowIso = new Date().toISOString();
+  const sceneView: SceneView = {
+    node_id: pId,
+    level: "map",
+    observer: null,
+    map_crop: MAP_IMAGE_FRAME,
+    focus_id: null,
+    scale_tier: body.parent_tier,
+  };
+
+  // 1. Insert P node (parent_id:null, relation:"ascend").
+  await insertNode({
+    id: pId,
+    parent_id: null,
+    session_id: sessionId,
+    query: body.query ?? body.page_title,
+    page_title: body.page_title,
+    image_key: uploaded.key,
+    image_model: body.image_model ?? "",
+    prompt_author_model: body.prompt_author_model ?? "",
+    aspect_ratio: body.aspect_ratio ?? child.aspect_ratio,
+    final_prompt: body.final_prompt ?? null,
+    relation: "ascend",
+    scale_tier: body.parent_tier,
+    scene_view: sceneView,
+  });
+
+  // 2. Seed geo — re-point every root geo under P (load-bearing for ascend, NOT
+  //    best-effort). Skip cleanly when the world map has no roots yet.
+  let learnedScale: number | null = null;
+  try {
+    const snapshot = await getWorldMap(sessionId);
+    const hasRoots = snapshot.entities.some((e) => (e.parent_id ?? null) === null);
+    if (hasRoots) {
+      const pGeo: WorldEntityGeo = {
+        id: `geo_${pId}`,
+        entity_id: null,
+        parent_id: null,
+        kind: "place",
+        label: body.page_title,
+        pos: { x: MAP_IMAGE_FRAME.w / 2, y: MAP_IMAGE_FRAME.h / 2 },
+        height: 4,
+        footprint: { w: MAP_IMAGE_FRAME.w, d: MAP_IMAGE_FRAME.h },
+        scale_tier: body.parent_tier,
+        visual: "",
+        state: {},
+        confidence: 0.9,
+        source: "user",
+        updated_at: nowIso,
+      };
+      const result = reparentRoots(snapshot.entities, pGeo, nowIso);
+      learnedScale = result.learnedScale;
+      await upsertEntityGeos(sessionId, result.geos);
+    }
+  } catch (err) {
+    // Abort: delete the orphan P node so C + the existing tree are untouched.
+    await deleteNode(pId).catch(() => {});
+    return NextResponse.json(
+      { error: `geo reparent failed: ${err instanceof Error ? err.message : String(err)}` },
+      { status: 500 },
+    );
+  }
+
+  // 3. Commit: re-point C's node under P (atomic single-field $set).
+  const repointed = await updateNodeParent(body.child_node_id, pId);
+  if (!repointed) {
+    return NextResponse.json(
+      { error: "failed to re-point child (it may have been removed)", parent_node_id: pId },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({
+    parent_node_id: pId,
+    child_node_id: body.child_node_id,
+    learned_scale: learnedScale,
+  });
+}

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -41,6 +41,7 @@ import {
 import { getStrings, resolveOutputLocale } from "@/lib/i18n";
 import { useImageTier, useVideoTier } from "@/hooks/usePersistedTier";
 import { useExpandBloom } from "@/hooks/useExpandBloom";
+import { type Ascended, useAscend } from "@/hooks/useAscend";
 import { buildConditionRefs, orderedRefs } from "@/lib/image-condition";
 import { enterAsToRenderMode, findRevisitTarget } from "@/lib/world-mode";
 import { usePersistedLocale } from "@/hooks/usePersistedLocale";
@@ -1154,6 +1155,55 @@ export default function PlayPage() {
     setViewMode("page");
   }, []);
 
+  // OUTWARD / zoom-out landed: mirror the persisted reparent into the live
+  // session — insert the container P, re-point the old root C under it (so the
+  // breadcrumb shows P above C), navigate to P, and refetch the geo store.
+  const onAscended = useCallback(
+    (a: Ascended) => {
+      const parentPage: Page = {
+        nodeId: a.parentNodeId,
+        sessionId,
+        query: a.pageTitle,
+        title: a.pageTitle,
+        imageDataUrl: a.imageDataUrl,
+        parentId: null,
+        sceneView: a.sceneView,
+      };
+      setHistory((prev) => {
+        const items = prev.items.map((p) =>
+          p.nodeId === a.childNodeId ? { ...p, parentId: a.parentNodeId } : p,
+        );
+        const trail = [...prev.trail.slice(0, prev.trailIdx + 1), a.parentNodeId];
+        return { items: [...items, parentPage], trail, trailIdx: trail.length - 1 };
+      });
+      setPage(parentPage);
+      setPhase("ready");
+      setViewMode("page");
+      const url = new URL(window.location.href);
+      url.pathname = `/n/${a.parentNodeId}`;
+      window.history.replaceState({}, "", url.toString());
+      void geoRefetch();
+    },
+    [sessionId, geoRefetch],
+  );
+  const { start: startAscend, pending: ascendPending, error: ascendError } =
+    useAscend(onAscended);
+  // OUTWARD is offered only from a ROOT page (a top-level map): it synthesizes the
+  // container ABOVE it. Gated by worldEnabled (client) + SCALE_OUTWARD (server).
+  const canAscend = Boolean(
+    worldEnabled && page?.nodeId && page.imageDataUrl && !page.parentId && !ascendPending,
+  );
+  const handleAscend = useCallback(() => {
+    if (!page?.nodeId || !page.imageDataUrl) return;
+    startAscend(sessionId, {
+      nodeId: page.nodeId,
+      query: page.query,
+      imageDataUrl: page.imageDataUrl,
+      aspectRatio: "16:9",
+      sceneView: page.sceneView ?? null,
+    });
+  }, [page, sessionId, startAscend]);
+
   useKeyboardShortcuts({
     onBack: goBack,
     onForward: goForward,
@@ -2167,6 +2217,24 @@ export default function PlayPage() {
           <Breadcrumb crumbs={breadcrumb} onJump={selectFromMap} />
           {worldEnabled && (
             <SpatialPath crumbs={breadcrumb} onNavigate={selectFromMap} />
+          )}
+          {worldEnabled && (page?.parentId == null || ascendPending) && (
+            <div className="flex items-center gap-2 text-xs">
+              <button
+                type="button"
+                onClick={handleAscend}
+                disabled={!canAscend}
+                className="rounded-full border border-[var(--color-ink)]/40 px-3 py-1 hover:bg-[var(--color-ink)]/5 disabled:opacity-40"
+                title="Zoom out to the place that contains this one (OUTWARD)"
+              >
+                {ascendPending ? "⤡ zooming out…" : "⤡ zoom out / step back"}
+              </button>
+              {ascendError && (
+                <span className="text-red-700/80" title={ascendError}>
+                  couldn’t zoom out
+                </span>
+              )}
+            </div>
           )}
           <div className="flex items-center justify-between gap-3 text-xs opacity-80">
           <div className="flex items-center gap-2">

--- a/apps/web/hooks/useAscend.ts
+++ b/apps/web/hooks/useAscend.ts
@@ -1,0 +1,160 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+import type {
+  GenerateAscendReadyEvent,
+  GenerateEvent,
+  ScaleTier,
+  SceneView,
+} from "@openflipbook/config";
+
+import { MAP_IMAGE_FRAME } from "@/lib/geo-tap";
+import { TRACE_HEADER, newTraceId } from "@/lib/trace";
+
+export interface AscendRoot {
+  nodeId: string;
+  query: string;
+  imageDataUrl: string;
+  aspectRatio: string;
+  sceneView?: SceneView | null;
+}
+
+export interface Ascended {
+  parentNodeId: string;
+  childNodeId: string;
+  pageTitle: string;
+  imageDataUrl: string;
+  sceneView: SceneView;
+  scaleTier: ScaleTier;
+}
+
+// Drain the SSE stream until the single `ascend_ready` lands (or an error).
+async function readAscendReady(
+  body: ReadableStream<Uint8Array>,
+  signal: AbortSignal,
+): Promise<GenerateAscendReadyEvent | null> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const chunks = buffer.split("\n\n");
+    buffer = chunks.pop() ?? "";
+    for (const chunk of chunks) {
+      const trimmed = chunk.trim();
+      if (!trimmed.startsWith("data:")) continue;
+      const payload = trimmed.slice(5).trim();
+      if (!payload) continue;
+      if (signal.aborted) return null;
+      const evt = JSON.parse(payload) as GenerateEvent;
+      if (evt.type === "ascend_ready") return evt;
+      if (evt.type === "error") throw new Error(evt.message);
+    }
+  }
+  return null;
+}
+
+/**
+ * OUTWARD / zoom-out: synthesize the CONTAINER above the current root and persist
+ * the reparent. Own fetch + SSE loop (independent of the page's `generate()`), so
+ * tap/expand/edit are untouched. The backend `mode:"ascend"` branch streams a
+ * single `ascend_ready` with the container image; we hand it to the web `/ascend`
+ * route (which atomically inserts the parent node, re-roots the geo store, and
+ * re-points the old root), then `onAscended` updates the live session.
+ */
+export function useAscend(onAscended: (a: Ascended) => void): {
+  start: (sessionId: string, root: AscendRoot) => void;
+  pending: boolean;
+  error: string | null;
+} {
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const start = useCallback(
+    (sessionId: string, root: AscendRoot) => {
+      abortRef.current?.abort();
+      const ac = new AbortController();
+      abortRef.current = ac;
+      setPending(true);
+      setError(null);
+
+      void (async () => {
+        const traceId = newTraceId();
+        try {
+          // 1. Backend: synthesize the container image (outpaint / fresh).
+          const res = await fetch("/api/generate-page", {
+            method: "POST",
+            headers: { "Content-Type": "application/json", [TRACE_HEADER]: traceId },
+            body: JSON.stringify({
+              query: root.query,
+              session_id: sessionId,
+              current_node_id: root.nodeId,
+              mode: "ascend",
+              image: root.imageDataUrl,
+              scene_view: root.sceneView ?? null,
+              aspect_ratio: root.aspectRatio,
+              web_search: false,
+              trace_id: traceId,
+            }),
+            signal: ac.signal,
+          });
+          if (!res.ok || !res.body) throw new Error(`ascend failed: HTTP ${res.status}`);
+          const ready = await readAscendReady(res.body, ac.signal);
+          if (ac.signal.aborted) return;
+          if (!ready) throw new Error("no container was produced");
+
+          // 2. Web route: persist the reparent atomically (both stores).
+          const saveRes = await fetch(`/api/world/${sessionId}/ascend`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json", [TRACE_HEADER]: traceId },
+            body: JSON.stringify({
+              child_node_id: root.nodeId,
+              image_data_url: ready.image_data_url,
+              parent_tier: ready.scale_tier,
+              page_title: ready.page_title,
+              query: ready.page_title,
+              image_model: ready.image_model,
+              final_prompt: ready.final_prompt,
+              aspect_ratio: root.aspectRatio,
+            }),
+            signal: ac.signal,
+          });
+          if (!saveRes.ok) {
+            const errBody = (await saveRes.json().catch(() => ({}))) as { error?: string };
+            throw new Error(errBody.error || `persist failed: HTTP ${saveRes.status}`);
+          }
+          const saved = (await saveRes.json()) as { parent_node_id: string };
+          if (ac.signal.aborted) return;
+
+          onAscended({
+            parentNodeId: saved.parent_node_id,
+            childNodeId: root.nodeId,
+            pageTitle: ready.page_title,
+            imageDataUrl: ready.image_data_url,
+            scaleTier: ready.scale_tier,
+            sceneView: {
+              node_id: saved.parent_node_id,
+              level: "map",
+              observer: null,
+              map_crop: MAP_IMAGE_FRAME,
+              focus_id: null,
+              scale_tier: ready.scale_tier,
+            },
+          });
+          setPending(false);
+        } catch (err) {
+          if ((err as Error).name === "AbortError") return;
+          setError((err as Error).message);
+          setPending(false);
+        }
+      })();
+    },
+    [onAscended],
+  );
+
+  return { start, pending, error };
+}

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -227,14 +227,19 @@ export async function getNode(id: string): Promise<NodeRow | null> {
   return doc ? toRow(doc) : null;
 }
 
-/** Re-point an existing node's parent — the ONLY mutate path on the nodes
- *  collection, for the OUTWARD reparent (re-root the old root under a synthesized
- *  parent). A single-field `$set` on one doc, atomic in Mongo. Returns whether the
- *  node existed. Deliberately narrow (parent_id only) so it can't be misused to
- *  rewrite arbitrary topology. */
+/** Re-root a CURRENT ROOT under a synthesized parent — the ONLY mutate path on the
+ *  nodes collection, for the OUTWARD reparent. A single-field `$set` on one doc,
+ *  atomic in Mongo, **guarded on `parent_id: null`** so it only ever re-points a
+ *  root: a concurrent double-ascend that already re-rooted this node loses the race
+ *  (`matchedCount === 0`) instead of stacking a second parent. Returns whether it
+ *  matched. Deliberately narrow (parent_id only) so it can't rewrite arbitrary
+ *  topology or invert an interior edge. */
 export async function updateNodeParent(id: string, parentId: string | null): Promise<boolean> {
   const collection = await nodes();
-  const res = await collection.updateOne({ _id: id }, { $set: { parent_id: parentId } });
+  const res = await collection.updateOne(
+    { _id: id, parent_id: null },
+    { $set: { parent_id: parentId } },
+  );
   return res.matchedCount === 1;
 }
 

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -128,6 +128,9 @@ export interface NodeDoc extends Document {
 }
 
 export interface NodeInsert {
+  // Optional caller-supplied id (default: a fresh UUID). Lets the OUTWARD reparent
+  // build the new parent's self-referential scene_view.node_id before inserting.
+  id?: string;
   parent_id: string | null;
   session_id: string;
   query: string;
@@ -196,7 +199,7 @@ export function toRow(doc: NodeDoc): NodeRow {
 export async function insertNode(n: NodeInsert): Promise<NodeRow> {
   const collection = await nodes();
   const doc: NodeDoc = {
-    _id: crypto.randomUUID(),
+    _id: n.id ?? crypto.randomUUID(),
     parent_id: n.parent_id,
     session_id: n.session_id,
     query: n.query,
@@ -222,6 +225,25 @@ export async function getNode(id: string): Promise<NodeRow | null> {
   const collection = await nodes();
   const doc = await collection.findOne({ _id: id });
   return doc ? toRow(doc) : null;
+}
+
+/** Re-point an existing node's parent — the ONLY mutate path on the nodes
+ *  collection, for the OUTWARD reparent (re-root the old root under a synthesized
+ *  parent). A single-field `$set` on one doc, atomic in Mongo. Returns whether the
+ *  node existed. Deliberately narrow (parent_id only) so it can't be misused to
+ *  rewrite arbitrary topology. */
+export async function updateNodeParent(id: string, parentId: string | null): Promise<boolean> {
+  const collection = await nodes();
+  const res = await collection.updateOne({ _id: id }, { $set: { parent_id: parentId } });
+  return res.matchedCount === 1;
+}
+
+/** Delete a node by id — used only to roll back an orphaned parent P when an
+ *  OUTWARD reparent aborts after inserting P but before re-pointing the child. */
+export async function deleteNode(id: string): Promise<boolean> {
+  const collection = await nodes();
+  const res = await collection.deleteOne({ _id: id });
+  return res.deletedCount === 1;
 }
 
 export interface ListNodesResult {

--- a/apps/web/lib/scale-tree.test.ts
+++ b/apps/web/lib/scale-tree.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { WorldEntityGeo } from "@openflipbook/config";
 import { tierMetricMultiplier } from "@openflipbook/config";
 
-import { reparent } from "./scale-tree";
+import { reparent, reparentRoots } from "./scale-tree";
 import { type FrameNode, resolveAbsolutePos } from "./world-geometry";
 
 // Build a WorldEntityGeo with sensible defaults; override what a test cares about.
@@ -134,5 +134,43 @@ describe("scale-tree reparent (B2 OUTWARD)", () => {
   it("rejects an unknown root and a duplicate parent id", () => {
     expect(() => reparent(cityTree(), "nope", geo({ id: "p" }), NOW)).toThrow(/not in the entity set/);
     expect(() => reparent(cityTree(), "c", geo({ id: "a" }), NOW)).toThrow(/already exists/);
+  });
+});
+
+describe("scale-tree reparentRoots (the multi-root geo store)", () => {
+  it("re-points EVERY root under P, conserving all absolute positions", () => {
+    // A map seeded as several top-level roots (its buildings), one with an interior.
+    const before = [
+      geo({ id: "b1", pos: { x: 10, y: 10 }, scale_tier: "city" }),
+      geo({ id: "b2", pos: { x: 70, y: 40 }, scale: 0.3, scale_tier: "city" }),
+      geo({ id: "b2i", parent_id: "b2", pos: { x: 5, y: 5 } }), // interior of b2
+      geo({ id: "b3", pos: { x: 40, y: 55 }, scale_tier: "city" }),
+    ];
+    const beforeAbs = absMap(before);
+    const region = geo({
+      id: "p",
+      pos: { x: 30, y: 25 },
+      footprint: { w: 90, d: 60 },
+      scale_tier: "region",
+    });
+    const { geos: after, learnedScale } = reparentRoots(before, region, NOW);
+
+    expect(learnedScale).toBeCloseTo(tierMetricMultiplier("region", "city"), 12);
+    for (const id of ["b1", "b2", "b3"]) {
+      expect(after.find((g) => g.id === id)!.parent_id).toBe("p"); // every root -> P
+    }
+    expect(after.find((g) => g.id === "b2i")!.parent_id).toBe("b2"); // interior untouched
+    const afterAbs = absMap(after);
+    for (const id of ["b1", "b2", "b2i", "b3"]) {
+      expect(afterAbs.get(id)!.x).toBeCloseTo(beforeAbs.get(id)!.x, 9);
+      expect(afterAbs.get(id)!.y).toBeCloseTo(beforeAbs.get(id)!.y, 9);
+    }
+  });
+
+  it("rejects when there are no roots or the parent id already exists", () => {
+    expect(() =>
+      reparentRoots([geo({ id: "x", parent_id: "missing" })], geo({ id: "p" }), NOW),
+    ).toThrow(/no root/);
+    expect(() => reparentRoots(cityTree(), geo({ id: "c" }), NOW)).toThrow(/already exists/);
   });
 });

--- a/apps/web/lib/scale-tree.ts
+++ b/apps/web/lib/scale-tree.ts
@@ -1,4 +1,4 @@
-import type { WorldEntityGeo } from "@openflipbook/config";
+import type { WorldEntityGeo, WorldVec2 } from "@openflipbook/config";
 import { tierMetricMultiplier } from "@openflipbook/config";
 
 import { localExtent } from "./world-geometry";
@@ -24,6 +24,47 @@ export interface ReparentResult {
 const SCALE_MIN = 1e-3;
 const SCALE_MAX = 10;
 const clampScale = (s: number): number => Math.min(Math.max(s, SCALE_MIN), SCALE_MAX);
+
+// P's fine frame scale: the METRIC ratio meters(child)/meters(parent) =
+// `tierMetricMultiplier(parentTier, childTier)` (< 1: a city is a small part of a
+// region), falling back to the footprint÷extent law `deriveGeoFromExtraction`
+// uses when a rung is missing. Guards a NaN / 0 / ∞ ratio (a malformed footprint
+// or an off-ladder tier) that would poison every coordinate → identity frame (1).
+// NOTE: the result is CLAMPED — astronomical hops (≤ star_system) floor to 1e-3.
+function learnPScale(
+  parentGeo: WorldEntityGeo,
+  childTier: WorldEntityGeo["scale_tier"],
+  childExtent: number,
+): number {
+  const parentTier = parentGeo.scale_tier;
+  const raw =
+    parentTier && childTier
+      ? tierMetricMultiplier(parentTier, childTier)
+      : Math.max(parentGeo.footprint.w, parentGeo.footprint.d) / childExtent;
+  return Number.isFinite(raw) && raw > 0 ? clampScale(raw) : 1;
+}
+
+// Re-express a former root R inside P's frame so abs(R) and ALL its descendants
+// are conserved (INV-1): the exact affine inverse of inserting the (P.pos, pScale)
+// frame above R. resolveAbsolutePos composes the same (x, y) as before for any
+// chosen P.pos / pScale, because the inserted pScale frame and the /pScale here
+// cancel identically.
+function reExpressUnder(
+  node: WorldEntityGeo,
+  parentId: string,
+  parentPos: WorldVec2,
+  pScale: number,
+  nowIso: string,
+): WorldEntityGeo {
+  return {
+    ...node,
+    parent_id: parentId,
+    pos: { x: (node.pos.x - parentPos.x) / pScale, y: (node.pos.y - parentPos.y) / pScale },
+    scale: (node.scale ?? 1) / pScale,
+    source: "user", // protect the new edge from a later derived re-seed (SOURCE_RANK)
+    updated_at: nowIso,
+  };
+}
 
 /**
  * Re-root `oldRootId` (the current root C) under the synthesized parent `parentGeo`
@@ -63,40 +104,51 @@ export function reparent(
     throw new Error(`reparent: parent id "${parentGeo.id}" already exists`);
   }
 
-  const parentTier = parentGeo.scale_tier;
-  const childTier = child.scale_tier;
-  const rawScale =
-    parentTier && childTier
-      ? tierMetricMultiplier(parentTier, childTier)
-      : Math.max(parentGeo.footprint.w, parentGeo.footprint.d) / localExtent([child]);
-  // Guard a NaN / 0 / Infinity ratio (a malformed footprint, or a scale_tier that
-  // isn't on the ladder) that would otherwise poison EVERY reparented coordinate;
-  // fall back to an identity frame (which still conserves INV-1 — its inverse is
-  // identity). NOTE: `learnedScale` is the CLAMPED value. For astronomical hops
-  // (<= star_system) the true ratio is far below the 1e-3 floor, so it floors to
-  // 1e-3 — do not compare it literally against `tierMetricMultiplier` once clamped.
-  const pScale = Number.isFinite(rawScale) && rawScale > 0 ? clampScale(rawScale) : 1;
-
-  const newChild: WorldEntityGeo = {
-    ...child,
-    parent_id: parentGeo.id,
-    pos: {
-      x: (child.pos.x - parentGeo.pos.x) / pScale,
-      y: (child.pos.y - parentGeo.pos.y) / pScale,
-    },
-    scale: (child.scale ?? 1) / pScale,
-    source: "user",
-    updated_at: nowIso,
-  };
-  const newParent: WorldEntityGeo = {
-    ...parentGeo,
-    parent_id: null,
-    scale: pScale,
-    source: "user",
-    updated_at: nowIso,
-  };
+  const pScale = learnPScale(parentGeo, child.scale_tier, localExtent([child]));
+  const newChild = reExpressUnder(child, parentGeo.id, parentGeo.pos, pScale, nowIso);
+  const newParent = makeRootParent(parentGeo, pScale, nowIso);
 
   const geosOut = geos.map((g) => (g.id === oldRootId ? newChild : g));
+  geosOut.push(newParent);
+  return { geos: geosOut, parentGeoId: parentGeo.id, learnedScale: pScale };
+}
+
+// P always lands as a fresh root with the learned fine scale.
+function makeRootParent(
+  parentGeo: WorldEntityGeo,
+  pScale: number,
+  nowIso: string,
+): WorldEntityGeo {
+  return { ...parentGeo, parent_id: null, scale: pScale, source: "user", updated_at: nowIso };
+}
+
+/**
+ * The OUTWARD reparent the session geo store actually needs: a map is seeded as
+ * MANY top-level roots (its buildings), not one — so re-point EVERY current root
+ * under the synthesized parent P, conserving each one's absolute position (INV-1).
+ * One shared `pScale` (from the roots' common rung, or their joint extent) re-
+ * expresses every root via the same affine inverse. Non-root entities (sub-place
+ * interiors) are untouched — they ride along as P's grandchildren, still conserved.
+ */
+export function reparentRoots(
+  geos: WorldEntityGeo[],
+  parentGeo: WorldEntityGeo,
+  nowIso: string,
+): ReparentResult {
+  const roots = geos.filter((g) => (g.parent_id ?? null) === null);
+  if (roots.length === 0) {
+    throw new Error("reparentRoots: no root entities to reparent");
+  }
+  if (geos.some((g) => g.id === parentGeo.id)) {
+    throw new Error(`reparentRoots: parent id "${parentGeo.id}" already exists`);
+  }
+  const childTier = roots.find((r) => r.scale_tier)?.scale_tier;
+  const pScale = learnPScale(parentGeo, childTier, localExtent(roots));
+  const rootIds = new Set(roots.map((r) => r.id));
+  const newParent = makeRootParent(parentGeo, pScale, nowIso);
+  const geosOut = geos.map((g) =>
+    rootIds.has(g.id) ? reExpressUnder(g, parentGeo.id, parentGeo.pos, pScale, nowIso) : g,
+  );
   geosOut.push(newParent);
   return { geos: geosOut, parentGeoId: parentGeo.id, learnedScale: pScale };
 }

--- a/apps/web/lib/world-map.ts
+++ b/apps/web/lib/world-map.ts
@@ -63,6 +63,11 @@ function geoDiffers(a: WorldEntityGeo, b: WorldEntityGeo): boolean {
     a.footprint.w !== b.footprint.w ||
     a.footprint.d !== b.footprint.d ||
     (a.scale ?? 1) !== (b.scale ?? 1) ||
+    // Topology + rung: an equal-rank write that re-points (or re-tiers) an entity
+    // must register as a change, or an OUTWARD reparent could be silently undone
+    // by a later same-source edit that carries the stale parent_id (audit follow-up).
+    (a.parent_id ?? null) !== (b.parent_id ?? null) ||
+    a.scale_tier !== b.scale_tier ||
     a.label !== b.label ||
     a.visual !== b.visual ||
     a.kind !== b.kind ||

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -315,13 +315,30 @@ export interface GenerateExpandDoneEvent {
   trace_id?: string;
 }
 
+// OUTWARD (mode:"ascend"): the synthesized container image is ready; the client
+// hands it to the /ascend route to persist the reparent. `scale_tier` is the
+// container's rung, `from_tier` the source's.
+export interface GenerateAscendReadyEvent {
+  type: "ascend_ready";
+  page_title: string;
+  image_data_url: string;
+  image_model: string;
+  prompt_author_model: string;
+  final_prompt: string;
+  scale_tier: ScaleTier;
+  from_tier: ScaleTier;
+  session_id: string;
+  trace_id?: string;
+}
+
 export type GenerateEvent =
   | GenerateStatusEvent
   | GenerateProgressEvent
   | GenerateFinalEvent
   | GenerateErrorEvent
   | GenerateNeighborEvent
-  | GenerateExpandDoneEvent;
+  | GenerateExpandDoneEvent
+  | GenerateAscendReadyEvent;
 
 export interface NodeRecord {
   id: string;


### PR DESCRIPTION
## PR B.3 — OUTWARD integration + zoom-out UI (B2, phase 4 of 7)

The first **user-visible OUTWARD**: synthesize the container above the current root and atomically
reparent. Gated `SCALE_LADDER_NAV` + `SCALE_OUTWARD` (off by default → prod byte-identical).

### Backend (`generate.py`)
Isolated `mode:"ascend"` branch (modelled on `expand`): `select_outward_op` picks the op
(`coarser_tier` steps the rung out), runs the centered BRIA `expand_image_zoomout` (or the
`SCALE_OUTWARD_RERENDER`-gated fresh `scale_parent` path), streams one `ascend_ready`, returns
early. `model_router` gains `coarser_tier`. **5 mocked integration tests.**

### Persistence (the genuinely-new write path)
- **`scale-tree.ts` `reparentRoots`** — the geo store is seeded as MANY top-level roots (a map's
  buildings), so re-point EVERY root under P, conserving each one's absolute position (INV-1) via
  the shared affine inverse. + tests.
- **`db.ts`** — `updateNodeParent` (`$set parent_id`, the only node mutate path) + `deleteNode`
  (abort rollback) + an optional `insertNode` id (so P's `scene_view` self-references).
- **`/api/world/[sessionId]/ascend`** — the atomic reparent in the audited order: **insert P node →
  seed geo (`reparentRoots` + `upsertEntityGeos`) → re-point C node LAST**. Geo-before-node so C
  never composes through a frame-less P; abort deletes the orphan P; double-ascend → 409.
- **`world-map.ts`** — `geoDiffers` now compares `parent_id` + `scale_tier` (B.1 audit follow-up) so
  an equal-rank user edit can't silently re-detach a reparented C.

### UI
`useAscend` hook (SSE → `/ascend` → `onAscended`) + a distinct **"zoom out / step back"** button
(worldEnabled, root pages only; never bound to tap) that mirrors the persisted reparent into the
live session and refetches the geo store. New `ascend_ready` event in config.

### Verification
`make eval` green: web **456**, backend pytest + ruff + mypy + tsc + no circular. Live OUTWARD is the
manual proof (flags on → zoom out → P renders → breadcrumb shows P above the old root).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
