### PR TITLE
feat(world): B2 PR C — logical AROUND

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -178,6 +178,11 @@ class GenerateBody(BaseModel):
     world_mode: bool = False
     autonomy: str = "auto"
     render_mode: str | None = None
+    # B2 logical AROUND (SCALE_AROUND_LOGICAL): the same-scale neighbours the client
+    # already knows from geometry (to exclude) + the focus's rung, so the expand
+    # bloom proposes NEW peers at that scale. Ignored unless the flag is on.
+    known_neighbors: list[str] | None = None
+    around_tier: str | None = None
     # Geometric world (GEOMETRIC_WORLD): the scene's observer pose/level + the
     # geometry engine's expected per-entity layout for this frame.
     scene_view: SceneView | None = None
@@ -659,11 +664,14 @@ async def _event_stream(
             expand_world_context = [e.model_dump() for e in body.world_context]
             yield _sse({"type": "status", "stage": "planning"}, trace_id)
             await _abort_if_disconnected("pre-expand-plan")
+            around_on = env_flag("SCALE_AROUND_LOGICAL")
             neighbors = await llm.propose_neighbors(
                 image_data_url=body.image,
                 parent_title=body.parent_title or body.query,
                 parent_query=body.parent_query or body.query,
                 output_locale=body.output_locale,
+                known_neighbors=body.known_neighbors if around_on else None,
+                scale_tier=body.around_tier if around_on else None,
             )
             total = len(neighbors)
             if total == 0:

--- a/apps/modal-backend/providers/llm.py
+++ b/apps/modal-backend/providers/llm.py
@@ -1633,12 +1633,20 @@ async def propose_neighbors(
     subject_context: str | None = None,
     output_locale: str | None = None,
     max_neighbors: int = 4,
+    known_neighbors: list[str] | None = None,
+    scale_tier: str | None = None,
 ) -> list[Neighbor]:
     """Survey the neighbourhood of a page's focal subject for "expand outward".
 
     Returns up to ``max_neighbors`` notable neighbouring subjects across scales
     (component / peer / container), each a good next page to bloom. Falls back
     to an empty list on parse failure — the caller just blooms nothing.
+
+    B2 logical AROUND (SCALE_AROUND_LOGICAL): when ``scale_tier`` /
+    ``known_neighbors`` are passed (the geometry the session already knows), the
+    survey is CONSTRAINED to NEW peers at the SAME scale, excluding what's mapped —
+    so the bloom is "more places like these", not an arbitrary cross-scale survey.
+    Both empty → today's exact behaviour (back-compat).
     """
     locale_clause = (
         f" Each `subject` MUST be written in language code '{output_locale}'."
@@ -1650,15 +1658,36 @@ async def propose_neighbors(
         if subject_context and subject_context.strip()
         else ""
     )
+    if scale_tier:
+        # Logical AROUND: same-scale peers only, excluding what's already mapped.
+        known = [n.strip() for n in (known_neighbors or []) if n and n.strip()]
+        known_clause = (
+            " These peers are ALREADY known — do NOT repeat them: "
+            + "; ".join(known[:12])
+            + "."
+            if known
+            else ""
+        )
+        survey_clause = (
+            f"Propose up to {max_neighbors} NEW subjects that are PEERS at the SAME "
+            f"scale ('{scale_tier}') — beside the focal subject, not larger or "
+            f"smaller — each a good next page to explore.{known_clause} Set every "
+            "`scale` to \"peer\". Do NOT repeat the focal subject itself."
+        )
+    else:
+        survey_clause = (
+            f"Propose up to {max_neighbors} notable NEIGHBOURING subjects: things "
+            "adjacent to it, larger things that contain it, and notable things it "
+            "is composed of — each of which would make a good next page to explore. "
+            "Favour variety across scales and do NOT repeat the focal subject "
+            "itself."
+        )
     system = (
         f"You examine an illustrated page titled '{parent_title}' (user query: "
         f"'{parent_query}'). The user wants to EXPAND OUTWARD — to see the "
         f"wider world this page's focal subject sits in.{context_clause} "
-        f"Propose up to {max_neighbors} notable NEIGHBOURING subjects: things "
-        "adjacent to it, larger things that contain it, and notable things it "
-        "is composed of — each of which would make a good next page to explore. "
-        "Favour variety across scales and do NOT repeat the focal subject "
-        "itself. Return JSON: {\"neighbors\": [{\"subject\": \"2-8 word noun "
+        + survey_clause
+        + " Return JSON: {\"neighbors\": [{\"subject\": \"2-8 word noun "
         "phrase\", \"scale\": \"component|peer|container\", \"note\": \"<=15 "
         "word reason it neighbours the focal subject\"}]}. `scale` is the "
         "neighbour's size relative to the focal subject: \"component\" (a part "

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -81,6 +81,7 @@ import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useWorldState } from "@/hooks/useWorldState";
 import { useWorldMap } from "@/hooks/useWorldMap";
 import { geoTapRequest, type GeoTapOverride } from "@/lib/geo-tap";
+import { selectNeighbors } from "@/lib/scale-neighbors";
 import { childrenOf } from "@/lib/world-geometry";
 import { viewNeutralAppearance } from "@/lib/appearance";
 import { useImageMorph } from "@/hooks/useImageMorph";
@@ -766,6 +767,15 @@ export default function PlayPage() {
       parent: page.imageDataUrl,
       style: styleRefUrl !== page.imageDataUrl ? styleRefUrl : null,
     });
+    // Logical AROUND (SCALE_AROUND_LOGICAL, server-gated): when you're INSIDE a
+    // place, ground the bloom in the same-scale neighbours the geometry already
+    // knows — pass them as exclusions + the focus's rung so the bloom proposes NEW
+    // peers at that scale. No focus (top-level map) → today's unconstrained bloom.
+    const focusId = page.sceneView?.focus_id ?? null;
+    const around =
+      worldEnabled && focusId
+        ? selectNeighbors(focusId, geoMap.entities, page.sceneView?.scale_tier ?? null)
+        : null;
     startBloom({
       query: page.query,
       aspect_ratio: "16:9",
@@ -785,6 +795,9 @@ export default function PlayPage() {
           }
         : {}),
       ...(styleAnchor ? { session_style_anchor: styleAnchor.style } : {}),
+      ...(around?.tier
+        ? { known_neighbors: around.known, around_tier: around.tier }
+        : {}),
     });
   }, [
     page,

--- a/apps/web/lib/scale-neighbors.test.ts
+++ b/apps/web/lib/scale-neighbors.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import type { WorldEntityGeo } from "@openflipbook/config";
+
+import { selectNeighbors } from "./scale-neighbors";
+
+function geo(over: Partial<WorldEntityGeo> & Pick<WorldEntityGeo, "id">): WorldEntityGeo {
+  return {
+    entity_id: over.id,
+    kind: "place",
+    label: over.id,
+    pos: { x: 0, y: 0 },
+    height: 4,
+    footprint: { w: 6, d: 6 },
+    visual: "",
+    state: {},
+    confidence: 0.9,
+    source: "extracted",
+    updated_at: "2026-06-09T00:00:00Z",
+    parent_id: null,
+    ...over,
+  };
+}
+
+// A University frame ("u") with three room-tier buildings + an object-tier prop,
+// plus a same-tier entity under a DIFFERENT parent.
+const geos: WorldEntityGeo[] = [
+  geo({ id: "u", scale_tier: "place" }),
+  geo({ id: "tower", parent_id: "u", pos: { x: 10, y: 10 }, scale_tier: "room", label: "Tower of Art" }),
+  geo({ id: "library", parent_id: "u", pos: { x: 30, y: 10 }, scale_tier: "room", label: "Library" }),
+  geo({ id: "hall", parent_id: "u", pos: { x: 10, y: 40 }, scale_tier: "room", label: "Great Hall" }),
+  geo({ id: "well", parent_id: "u", pos: { x: 20, y: 20 }, scale_tier: "object", label: "Well" }),
+  geo({ id: "other", parent_id: "city", pos: { x: 0, y: 0 }, scale_tier: "room", label: "Elsewhere" }),
+];
+
+describe("selectNeighbors (B2 AROUND)", () => {
+  it("returns same-parent same-tier siblings with bearings, excluding the rest", () => {
+    const out = selectNeighbors("tower", geos);
+    expect(out.tier).toBe("room");
+    // Well (object tier) + Elsewhere (different parent) excluded; sorted by label.
+    expect(out.known).toEqual(["Great Hall", "Library"]);
+    const lib = out.neighbors.find((n) => n.label === "Library")!;
+    expect(lib.bearing).toBeCloseTo(0, 6); // due east of the tower
+    const hall = out.neighbors.find((n) => n.label === "Great Hall")!;
+    expect(hall.bearing).toBeCloseTo(Math.PI / 2, 6); // due south (y grows down)
+  });
+
+  it("honours an explicit tier hint over the focus's own rung", () => {
+    expect(selectNeighbors("tower", geos, "object").known).toEqual(["Well"]);
+  });
+
+  it("is empty for a focus with no same-scale siblings, or an unknown focus", () => {
+    expect(selectNeighbors("well", geos).known).toEqual([]); // the only object-tier
+    expect(selectNeighbors("missing", geos).known).toEqual([]);
+  });
+});

--- a/apps/web/lib/scale-neighbors.ts
+++ b/apps/web/lib/scale-neighbors.ts
@@ -1,0 +1,50 @@
+import type { ScaleTier, WorldEntityGeo } from "@openflipbook/config";
+
+import { siblingsOf } from "./world-geometry";
+
+export interface LogicalNeighbor {
+  label: string;
+  bearing: number; // radians from the focus, 0 = +x
+}
+
+export interface LogicalNeighbors {
+  tier: ScaleTier | null;
+  // Same-scale sibling labels the session ALREADY knows — passed to the bloom as
+  // exclusions so it proposes NEW peers, not places already on the map.
+  known: string[];
+  // The known neighbours with real bearings (for placement / persistence).
+  neighbors: LogicalNeighbor[];
+}
+
+/**
+ * The logical AROUND cascade (B2, SCALE_AROUND_LOGICAL): the same-scale neighbours
+ * the geometry already knows, so "show me more like these" is grounded in real
+ * bearings + the focus's rung instead of an arbitrary VLM survey.
+ *
+ * Geometry first: `siblingsOf` the focus (same `parent_id`) filtered to the same
+ * `scale_tier`, each with an `atan2` bearing in the shared frame. The geos carry
+ * the codex's labels, so this is geometry + facts in one pass. The `known` labels
+ * become `propose_neighbors`' exclusions + its `scale_tier` constraint, so the
+ * (cold-start-only) VLM adds NEW peers at the SAME scale rather than re-proposing
+ * what's already mapped. Pure; empty for a focus with no seeded siblings → the
+ * caller falls back to today's unconstrained bloom.
+ */
+export function selectNeighbors(
+  focusId: string,
+  geos: WorldEntityGeo[],
+  tierHint?: ScaleTier | null,
+): LogicalNeighbors {
+  const focus = geos.find((g) => g.id === focusId);
+  if (!focus) return { tier: tierHint ?? null, known: [], neighbors: [] };
+  const tier = tierHint ?? focus.scale_tier ?? null;
+  const neighbors = siblingsOf(geos, focusId)
+    .filter((s) => !tier || (s.scale_tier ?? null) === tier)
+    .filter((s) => s.label.trim().length > 0)
+    .map((s) => ({
+      label: s.label.trim(),
+      bearing: Math.atan2(s.pos.y - focus.pos.y, s.pos.x - focus.pos.x),
+    }))
+    .sort((a, b) => (a.label < b.label ? -1 : a.label > b.label ? 1 : 0));
+  const known = [...new Set(neighbors.map((n) => n.label))];
+  return { tier, known, neighbors };
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -132,6 +132,12 @@ export interface GenerateRequestBody {
   world_mode?: boolean;
   autonomy?: Autonomy;
   render_mode?: RenderMode;
+  // B2 logical AROUND (mode:"expand", SCALE_AROUND_LOGICAL). The same-scale
+  // neighbours the client already knows from geometry (excluded) + the focus's
+  // rung, so the bloom proposes NEW peers at that scale. Ignored unless the flag
+  // is on; absent → today's unconstrained bloom.
+  known_neighbors?: string[];
+  around_tier?: ScaleTier;
   // Geometric world (GEOMETRIC_WORLD). The scene's observer pose + level, and the
   // geometry engine's expected per-entity layout for this frame, so the planner
   // can constrain placement and the grounding loop has a target to check against.


### PR DESCRIPTION
## PR C — logical AROUND (B2, phase 5 of 7)

Makes the expand bloom **logical** — same-scale neighbours grounded in the geometry the session
already knows — instead of an arbitrary cross-scale VLM survey. Gated `SCALE_AROUND_LOGICAL`
(off → today's bloom verbatim).

- **`scale-neighbors.ts`** — pure `selectNeighbors(focusId, geos, tier)` cascade: the same-scale
  siblings (same `parent_id` + `scale_tier`) with real `atan2` bearings. The geos carry the codex
  labels, so it's geometry + facts in one pass. Empty for a focus with no seeded siblings (cold
  start). **Golden-tested** (bearings, tier filter, exclusions).
- **`propose_neighbors`** gains optional `known_neighbors` + `scale_tier` → when set, the survey is
  constrained to NEW peers at the SAME scale, excluding what's already mapped. Both empty → today's
  exact prompt (back-compat).
- **`generate.py`** threads `known_neighbors` + `around_tier` to `propose_neighbors`, but only when
  `SCALE_AROUND_LOGICAL` is on (server gate).
- **`page.tsx`** `triggerExpand` computes `selectNeighbors` when you're INSIDE a place (worldEnabled
  + a focus) and passes the known peers + the rung; the top-level map (no focus) stays unconstrained.

Deferred (nice-to-have): persist `scale_tier`/bearing on each bloomed neighbour node.

`make eval` green: web **459**, backend pytest + ruff + mypy + tsc + no circular.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
