### PR TITLE
feat(world): B2 PR D — DEEPER rung stamp (one ladder)

### DIFF
--- a/apps/web/lib/geo-tap.test.ts
+++ b/apps/web/lib/geo-tap.test.ts
@@ -64,6 +64,38 @@ describe("geoTapRequest (close the geometric tap loop)", () => {
     expect(t!.scene_view.focus_id).toBe("clock");
   });
 
+  it("D — DEEPER stamps the child rung (one finer than the frame you tapped from)", () => {
+    const map = {
+      entities: [geo("clock", "clock tower", 60, 30, { height: 18 })],
+      bounds: CROP,
+    };
+    const cityView: SceneView = {
+      node_id: "n0",
+      level: "map",
+      observer: null,
+      map_crop: { x: 0, y: 0, w: 100, h: 60 },
+      scale_tier: "city",
+    };
+    const t = geoTapRequest(
+      map,
+      "n1",
+      { x_pct: 60 / 100, y_pct: 30 / 60 },
+      16 / 9,
+      undefined,
+      cityView,
+    );
+    expect(t!.scene_view.scale_tier).toBe("district"); // finerTier("city")
+  });
+
+  it("D — no rung stamped when the source frame has none (back-compat)", () => {
+    const map = {
+      entities: [geo("clock", "clock tower", 60, 30, { height: 18 })],
+      bounds: CROP,
+    };
+    const t = geoTapRequest(map, "n1", { x_pct: 60 / 100, y_pct: 30 / 60 }, 16 / 9);
+    expect(t!.scene_view.scale_tier).toBeUndefined();
+  });
+
   it("P7c — a place with a saved interior steers by its sub-entities, not the city", () => {
     const map = {
       entities: [

--- a/apps/web/lib/geo-tap.ts
+++ b/apps/web/lib/geo-tap.ts
@@ -6,6 +6,7 @@ import type {
   ViewLevel,
   WorldEntityGeo,
 } from "@openflipbook/config";
+import { finerTier } from "@openflipbook/config";
 
 import { routeClick, type ClickPoint } from "./click-route";
 import {
@@ -97,6 +98,13 @@ export function geoTapRequest(
   if (route.kind === "explainer") return null;
   const byId = new Map(map.entities.map((e) => [e.id, e]));
 
+  // DEEPER shares ONE ladder with OUTWARD: the entered view sits one rung FINER
+  // than the frame you tapped from (a tap = tierStep +1). Stamp it on the entered
+  // scene_view so a node's rung is consistent however it was reached. Optional —
+  // only when the source frame carries a rung (PR A seeds it).
+  const parentTier = currentView?.scale_tier ?? byId.get(route.focus_id ?? "")?.scale_tier ?? null;
+  const childTier = parentTier ? finerTier(parentTier) : undefined;
+
   // Tap on empty map area that still holds a cluster → stay in MAP mode + crop
   // the region (a sub-map), instead of entering a single place.
   if (route.kind === "submap") {
@@ -108,6 +116,7 @@ export function geoTapRequest(
         observer: null,
         map_crop: route.crop,
         focus_id: route.focus_id,
+        ...(childTier ? { scale_tier: childTier } : {}),
       },
       expected_layout: [],
       layout_entities: cropEntities(candidates.entities, route.crop),
@@ -146,6 +155,7 @@ export function geoTapRequest(
       // The place you entered: its geo id anchors the child frame the entered
       // scene's sub-entities seed into.
       focus_id: route.focus_id,
+      ...(childTier ? { scale_tier: childTier } : {}),
     },
     expected_layout: projectScene(layoutEntities, observer, aspect),
     layout_entities: layoutEntities,

--- a/apps/web/lib/scale-ladder.test.ts
+++ b/apps/web/lib/scale-ladder.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  finerTier,
   SCALE_LADDER,
   SCALE_TIER_METERS,
   tierMetricMultiplier,
@@ -30,6 +31,13 @@ describe("scale ladder (B2 keystone)", () => {
   it("tierStep: DEEPER is +, OUTWARD is -", () => {
     expect(tierStep("city", "district")).toBe(1); // deeper (finer)
     expect(tierStep("city", "region")).toBe(-1); // outward (coarser)
+  });
+
+  it("finerTier steps one rung toward object and clamps there", () => {
+    expect(finerTier("city")).toBe("district");
+    expect(finerTier("place")).toBe("room");
+    expect(finerTier("room")).toBe("object");
+    expect(finerTier("object")).toBe("object"); // clamped at the finest
   });
 
   it("tierMetricMultiplier: city->region grows ~20x; region->city shrinks", () => {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -53,6 +53,13 @@ export function tierTransitionValid(from: ScaleTier, to: ScaleTier): boolean {
   const m = tierMetricMultiplier(from, to);
   return step > 0 ? m <= 1 : m >= 1;
 }
+// One rung FINER (toward `object`, DEEPER); clamps at `object`. The inverse of the
+// Python `model_router.coarser_tier` used by OUTWARD — together they make a tap a
+// `tierStep` of +1 and an OUTWARD −1 on the SAME ladder.
+export function finerTier(t: ScaleTier): ScaleTier {
+  const i = tierIndex(t);
+  return SCALE_LADDER[Math.min(i + 1, SCALE_LADDER.length - 1)] ?? t;
+}
 
 // How a node relates to its parent: "descend" = went IN (a tap child, the
 // default), "expand" = bloomed OUT (a neighbour from mode:"expand"), "ascend" =


### PR DESCRIPTION
## PR D — DEEPER rung stamp (B2, phase 6 of 7)

The shipped geo tap-enter flow is unchanged; the only addition is stamping `scene_view.scale_tier = finerTier(parentTier)` on the entered scene/submap, so **DEEPER and OUTWARD share ONE ladder** — a tap is a `tierStep` of +1, an OUTWARD −1, and a node's rung is consistent however it was reached.

- **config** `finerTier(t)` — one rung toward `object`, clamped (the TS inverse of the Python `coarser_tier` OUTWARD uses).
- **geo-tap.ts** — `geoTapRequest` derives the parent rung from the frame you tapped from (`currentView.scale_tier`, else the focus geo's) and stamps the finer child rung on both entered `scene_view`s. Optional — only when the source frame carries a rung (PR A seeds it), so pre-B2 / classic taps are byte-identical.

Tests: `finerTier` steps + clamp; `geoTapRequest` stamps `district` from a `city` view, and stamps nothing when the source has no rung. `make eval` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)