### PR TITLE
feat(world): B2 PR E — INV-4 live + drift status (final B2 PR)

### DIFF
--- a/apps/web/lib/world-map.test.ts
+++ b/apps/web/lib/world-map.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { EntityGeoEdit, WorldEntityGeo } from "@openflipbook/config";
 
-import { __test } from "./world-map";
+import { __test, ladderDisagreement } from "./world-map";
 
 const { applyGeoUpsert, recomputeBounds, applyEntityEdit, blastRadius, buildGeoReferences } =
   __test;
@@ -196,5 +196,27 @@ describe("buildGeoReferences (geo id → node refs)", () => {
       { id: "e2", appears_on_node_ids: [] },
     ];
     expect(buildGeoReferences(geos, codex)).toEqual({ geo_a: ["n1", "n2"] });
+  });
+});
+
+describe("ladderDisagreement (INV-4: one ladder)", () => {
+  it("flags a DEEPER seed whose learned scale magnifies instead of shrinking", () => {
+    // child rung finer than parent (DEEPER) but scale > 1 → the interior is bigger
+    // than the parent footprint, contradicting the rung.
+    expect(ladderDisagreement("city", "district", 3)).toMatch(/DEEPER/);
+  });
+
+  it("is silent when the learned scale agrees with the rung step", () => {
+    expect(ladderDisagreement("city", "district", 0.2)).toBeNull(); // DEEPER, shrinks ✓
+    expect(ladderDisagreement("district", "city", 5)).toBeNull(); // OUTWARD, grows ✓
+  });
+
+  it("flags an OUTWARD seed that shrinks instead of growing", () => {
+    expect(ladderDisagreement("district", "city", 0.2)).toMatch(/OUTWARD/);
+  });
+
+  it("never fires when a rung is unknown (back-compat)", () => {
+    expect(ladderDisagreement(null, "city", 99)).toBeNull();
+    expect(ladderDisagreement("city", undefined, 99)).toBeNull();
   });
 });

--- a/apps/web/lib/world-map.ts
+++ b/apps/web/lib/world-map.ts
@@ -12,6 +12,7 @@ import type {
   WorldEntityGeo,
   WorldMapSnapshot,
 } from "@openflipbook/config";
+import { tierStep } from "@openflipbook/config";
 
 import { getDb } from "./db";
 import { optimisticReplace } from "./optimistic-update";
@@ -54,6 +55,31 @@ async function collection(): Promise<Collection<WorldMapDoc>> {
 }
 
 // ── Pure merge core (unit-tested; no Mongo) ──────────────────────────────────
+
+/**
+ * INV-4 (one ladder): the coarse `scale_tier` rung and the fine learned `scale`
+ * must agree in DIRECTION — they're two resolutions of the same axis, never a
+ * parallel system. Seeding a FINER child rung (DEEPER) the child frame should
+ * occupy a fraction of the parent footprint (`scale <= 1`); a learned scale pinned
+ * the other way while the rungs say "much smaller" is a mis-seed. Pure; returns a
+ * warning string or null (agree / unknown rung). The caller WARNS + keeps the
+ * learned scale — never blocks (a wrong rung shouldn't break seeding).
+ */
+export function ladderDisagreement(
+  parentTier: ScaleTier | null | undefined,
+  childTier: ScaleTier | null | undefined,
+  learnedScale: number,
+): string | null {
+  if (!parentTier || !childTier) return null;
+  const step = tierStep(parentTier, childTier); // child finer => +, coarser => -
+  if (step > 0 && learnedScale > 1.0001) {
+    return `DEEPER (${parentTier}→${childTier}) but learned scale ${learnedScale} > 1`;
+  }
+  if (step < 0 && learnedScale < 0.9999) {
+    return `OUTWARD (${parentTier}→${childTier}) but learned scale ${learnedScale} < 1`;
+  }
+  return null;
+}
 
 function geoDiffers(a: WorldEntityGeo, b: WorldEntityGeo): boolean {
   return (
@@ -383,6 +409,9 @@ export async function deriveGeoFromExtraction(
     if (parent) {
       const footprint = Math.max(parent.footprint.w, parent.footprint.d);
       const scale = Math.min(Math.max(footprint / localExtent(geos), 1e-3), 10);
+      // INV-4: warn (never block) if the learned scale contradicts the rung step.
+      const warn = ladderDisagreement(parent.scale_tier, scaleTier, scale);
+      if (warn) console.warn(`[world-map] INV-4: ${warn} — keeping the learned scale`);
       if ((parent.scale ?? 1) !== scale) geos.push({ ...parent, scale });
     }
   }

--- a/docs/PLAN_OUTWARD.md
+++ b/docs/PLAN_OUTWARD.md
@@ -99,12 +99,16 @@ consistency already holds via the learned per-frame `scale`. One small change + 
 
 ## Phase E — invariants live + the drift number
 
-- INV-4 (one ladder): a cheap assertion that `scale_tier` sign agrees with the learned fine
-  `scale` in `deriveGeoFromExtraction` (warn + fall back on disagreement, never block).
-- Reuse the `coherence_runner` harness (`make eval-coherence`) for an **N≥10 A/B of OUTWARD
-  drift** — the design's risk #1 (compounding style/content drift across hops). Prefer
-  outpaint where possible (zero drift); keep `SCALE_OUTWARD_RERENDER` off by default until the
-  number justifies it.
+- **INV-4 (one ladder) — SHIPPED.** `ladderDisagreement(parentTier, childTier, learnedScale)`
+  in `world-map.ts` (pure, unit-tested); `deriveGeoFromExtraction` warns + keeps the learned
+  scale on a sign disagreement, never blocks.
+- **OUTWARD drift A/B — deferred to when rerender is enabled (paid + manual).** The default
+  OUTWARD path is the **centered BRIA outpaint, which is zero-drift by construction** (the
+  source's pixels are preserved as the central sub-region), so there is no drift to measure
+  while `SCALE_OUTWARD_RERENDER` is off — which it is by default. Only the medium-flip *fresh*
+  path can drift; before enabling `SCALE_OUTWARD_RERENDER`, run an **N≥10 A/B** reusing the
+  `coherence_runner` harness (`make eval-coherence`) — the design's risk #1 — and keep the flag
+  off until the number justifies it. Not run here (paid; needs a live session + keys).
 
 ---
 


### PR DESCRIPTION
## PR E — invariants live + drift status (B2, phase 7 of 7 — **completes B2**)

- **INV-4 (one ladder)** — `ladderDisagreement(parentTier, childTier, learnedScale)` in `world-map.ts` (pure, unit-tested). `deriveGeoFromExtraction` **warns (never blocks)** + keeps the learned scale when the coarse rung step and the fine learned scale disagree in direction (a DEEPER seed that magnifies, or an OUTWARD one that shrinks). The coarse `scale_tier` and the fine `scale` stay two resolutions of ONE axis.
- **OUTWARD drift A/B** — documented as deferred (paid + manual) in `PLAN_OUTWARD.md`. The default OUTWARD path is the centered BRIA outpaint, **zero-drift by construction** (source pixels preserved), so there's nothing to measure while `SCALE_OUTWARD_RERENDER` is off (the default). Only the medium-flip fresh path can drift; reuse `coherence_runner` at N≥10 before enabling it.

`make eval` green. **This completes B2 (A–E)** — OUTWARD / AROUND / DEEPER on one metric-conserving ladder, all flag-gated off → prod byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)