### PR TITLE
fix(world): close the three documented B2 gaps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,13 @@ eval-coherence:
 # self-contained, no session needed:  make eval-style
 eval-style:
 	cd apps/modal-backend && STYLE_BENCH_RUN=1 .venv/bin/python -m tests.continuity_bench.style_runner
+# B2 OUTWARD-drift A/B: synthesize each container TWICE — the default zero-drift
+# BRIA outpaint vs the SCALE_OUTWARD_RERENDER fresh path — and judge how faithfully
+# each keeps the source's medium → the drift number + a trust threshold. Run before
+# enabling SCALE_OUTWARD_RERENDER. PAID (fal gens + Gemini judge); no session:
+#   make eval-outward-drift
+eval-outward-drift:
+	cd apps/modal-backend && OUTWARD_BENCH_RUN=1 .venv/bin/python -m tests.continuity_bench.outward_runner
 # The full paid sweep (spends fal/openrouter on the tiny golden set).
 eval-paid:
 	cd apps/modal-backend && LAYOUT_BENCH_RUN=1 GROUNDING_BENCH_RUN=1 REPAIR_BENCH_RUN=1 EDIT_BENCH_RUN=1 .venv/bin/python -m pytest -m paid -q

--- a/apps/modal-backend/tests/continuity_bench/outward_runner.py
+++ b/apps/modal-backend/tests/continuity_bench/outward_runner.py
@@ -1,0 +1,204 @@
+"""OUTWARD-DRIFT — style A/B for the zoom-out container (the design's risk #1).
+
+The default OUTWARD path is the centered BRIA outpaint, which keeps the source's
+pixels as the central sub-region → ZERO style drift by construction. The riskier
+medium-flip path (`SCALE_OUTWARD_RERENDER`) synthesizes the container FRESH,
+conditioned on the source. This A/B quantifies that risk BEFORE the flag is
+enabled: for each styled source we synthesize its container TWICE —
+  - OUTPAINT: `expand_image_zoomout` (the default — the zero-drift baseline).
+  - FRESH:    `generate_image(scale_parent clause + source as a reference)`
+              (exactly what the `mode:"ascend"` SCALE_OUTWARD_RERENDER path sends).
+`score_style_pair(source, container)` judges how faithfully each container keeps
+the source's art MEDIUM (palette / linework / stylisation, subject ignored). The
+DRIFT number = outpaint_mean - fresh_mean (how much the rerender path loses vs the
+pixel-preserving outpaint). We ASSERT the FRESH arm clears a threshold before
+trusting it — keep `SCALE_OUTWARD_RERENDER` off until it does, at N >= 10.
+
+Paid (fal gens + Gemini judge). Self-contained — no session / web needed:
+    cd apps/modal-backend && OUTWARD_BENCH_RUN=1 \
+      .venv/bin/python -m tests.continuity_bench.outward_runner
+or:  make eval-outward-drift
+The judge + text model default to Gemini (qwen 429s — memory
+project_qwen_ratelimit); the balanced image model is forced to nano-banana-pro.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import statistics
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from ._score import score_style_pair
+
+_REPORTS = Path(__file__).resolve().parent / "reports"
+# Below this mean the FRESH (rerender) container drifts too far off the source's
+# medium to trust — keep SCALE_OUTWARD_RERENDER off until it clears this.
+_PASS_THRESHOLD = float(os.environ.get("OUTWARD_BENCH_THRESHOLD", "6.5"))
+
+
+@dataclass(frozen=True)
+class Case:
+    name: str
+    # The source map/scene is generated in this exact medium; the container must
+    # keep it across the OUTWARD hop.
+    source_prompt: str
+    style: str
+    # The source's rung; the container is one step coarser (coarser_tier).
+    from_tier: str
+    # The subject phrase the fresh planner expands into the wider view.
+    subject: str
+
+
+_CASES: list[Case] = [
+    Case(
+        name="engraving_city",
+        source_prompt=(
+            "a hand-drawn antique engraving map of a small fantasy port city, "
+            "sepia ink, dense cross-hatching, woodcut linework, aged paper"
+        ),
+        style="hand-drawn antique engraving, sepia ink, dense cross-hatching, woodcut linework",
+        from_tier="city",
+        subject="a small fantasy port city",
+    ),
+    Case(
+        name="watercolor_town",
+        source_prompt=(
+            "a soft watercolour map of a walled hill town, loose washes, pale "
+            "pastel palette, visible paper texture"
+        ),
+        style="soft watercolour, loose washes, pale pastel palette, visible paper texture",
+        from_tier="city",
+        subject="a walled hill town",
+    ),
+]
+
+
+@dataclass(frozen=True)
+class CaseResult:
+    name: str
+    outpaint_score: float
+    fresh_score: float
+    outpaint_rationale: str
+    fresh_rationale: str
+
+    @property
+    def drift(self) -> float:
+        # How much the fresh rerender loses vs the zero-drift outpaint (>0 = drift).
+        return round(self.outpaint_score - self.fresh_score, 4)
+
+
+async def _run_case(case: Case, aspect: str, model: str) -> CaseResult:
+    from providers import image as image_provider
+    from providers import image_edit as image_edit_provider
+    from providers import llm, model_router
+
+    # 1. Generate the styled source (the thing we zoom OUT from).
+    src = await image_provider.generate_image(
+        prompt=case.source_prompt, aspect_ratio=aspect, tier="balanced", model_override=model
+    )
+    src_url = image_provider.encode_data_url(src.jpeg_bytes)
+    w, h = (900, 1600) if aspect == "9:16" else (1600, 900)
+
+    # 2a. OUTPAINT — the default OUTWARD path: source centred in a larger frame.
+    outp = await image_edit_provider.expand_image_zoomout(src_url, 3.0, w, h)
+
+    # 2b. FRESH — the SCALE_OUTWARD_RERENDER path: plan the container + condition on
+    #     the source (exactly what generate.py's ascend branch sends).
+    to_tier = model_router.coarser_tier(case.from_tier) or "region"
+    plan = await llm.plan_page(
+        query=f"{case.subject} (the {to_tier} that contains it)",
+        web_search=False,
+        style_anchor=case.style,
+        render_mode="scale_parent",
+    )
+    fresh = await image_provider.generate_image(
+        plan.prompt, aspect, tier="balanced", reference_urls=[src_url]
+    )
+
+    # 3. Judge how faithfully each container kept the SOURCE's medium.
+    outp_j = await score_style_pair(src.jpeg_bytes, outp.jpeg_bytes)
+    fresh_j = await score_style_pair(src.jpeg_bytes, fresh.jpeg_bytes)
+
+    _REPORTS.mkdir(parents=True, exist_ok=True)
+    (_REPORTS / f"outward_{case.name}_source.jpg").write_bytes(src.jpeg_bytes)
+    (_REPORTS / f"outward_{case.name}_outpaint.jpg").write_bytes(outp.jpeg_bytes)
+    (_REPORTS / f"outward_{case.name}_fresh.jpg").write_bytes(fresh.jpeg_bytes)
+
+    return CaseResult(
+        name=case.name,
+        outpaint_score=outp_j.score,
+        fresh_score=fresh_j.score,
+        outpaint_rationale=outp_j.rationale,
+        fresh_rationale=fresh_j.rationale,
+    )
+
+
+def summarize(results: list[CaseResult]) -> dict[str, Any]:
+    """Aggregate the per-case scores, the drift number + the trust pass/fail. Pure,
+    so the decision (the gate's brain) is unit-tested without spending."""
+    outpaint_mean = round(statistics.mean(r.outpaint_score for r in results), 4)
+    fresh_mean = round(statistics.mean(r.fresh_score for r in results), 4)
+    return {
+        "n_cases": len(results),
+        "outpaint_medium_mean": outpaint_mean,
+        "fresh_medium_mean": fresh_mean,
+        # >0 → the fresh rerender drifts off-medium vs the zero-drift outpaint.
+        "drift": round(outpaint_mean - fresh_mean, 4),
+        # Whether the fresh path is faithful enough to enable SCALE_OUTWARD_RERENDER.
+        "fresh_trustworthy": fresh_mean >= _PASS_THRESHOLD,
+    }
+
+
+async def run_bench(model: str) -> dict[str, Any]:
+    results = [await _run_case(c, "16:9", model) for c in _CASES]
+    return {
+        "judge_model": os.environ.get("CONTINUITY_BENCH_JUDGE_MODEL"),
+        "image_model": model,
+        "started_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "threshold": _PASS_THRESHOLD,
+        "cases": [asdict(r) | {"drift": r.drift} for r in results],
+        "summary": summarize(results),
+    }
+
+
+def _load_env() -> None:
+    """Load apps/modal-backend/.env, force nano-banana-pro for the balanced tier
+    (the .env pins plain nano-banana — memory project_fal_model_pin) and pin the
+    judge + text model to Gemini (the .env's qwen rate-limits)."""
+    env_path = Path(__file__).resolve().parents[2] / ".env"
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+    os.environ.setdefault("CONTINUITY_BENCH_JUDGE_MODEL", "google/gemini-3-flash-preview")
+    os.environ.setdefault("FAL_IMAGE_MODEL_BALANCED", "fal-ai/nano-banana-pro")
+
+
+def _cli() -> None:
+    if not os.environ.get("OUTWARD_BENCH_RUN"):
+        raise SystemExit("set OUTWARD_BENCH_RUN=1 to spend on the paid OUTWARD-drift A/B")
+    _load_env()
+    if not os.environ.get("FAL_KEY") or not os.environ.get("OPENROUTER_API_KEY"):
+        raise SystemExit("FAL_KEY + OPENROUTER_API_KEY required (apps/modal-backend/.env)")
+    model = os.environ.get("OUTWARD_BENCH_MODEL", "fal-ai/nano-banana-pro")
+    report = asyncio.run(run_bench(model))
+    _REPORTS.mkdir(parents=True, exist_ok=True)
+    (_REPORTS / "outward_latest.json").write_text(json.dumps(report, indent=2))
+    print(json.dumps(report, indent=2))
+    print(
+        f"\nDRIFT (outpaint - fresh) = {report['summary']['drift']}; "
+        f"fresh trustworthy = {report['summary']['fresh_trustworthy']} "
+        f"(threshold {_PASS_THRESHOLD}). Outpaint is the zero-drift default; only "
+        f"enable SCALE_OUTWARD_RERENDER once 'fresh_trustworthy' holds at N >= 10."
+    )
+
+
+if __name__ == "__main__":
+    _cli()

--- a/apps/modal-backend/tests/continuity_bench/test_outward.py
+++ b/apps/modal-backend/tests/continuity_bench/test_outward.py
@@ -1,0 +1,50 @@
+"""Free (unpaid) tests for the OUTWARD-drift A/B — the cases + the gate's brain.
+
+The paid run (`outward_runner._cli`, gated on OUTWARD_BENCH_RUN) spends on fal gens
++ the Gemini judge. These cover the parts that don't: the cases are well-formed and
+`summarize` computes the drift + flips `fresh_trustworthy` at the threshold, so the
+"is the rerender path safe to enable" decision is itself unit-tested.
+"""
+from __future__ import annotations
+
+from tests.continuity_bench.outward_runner import (
+    _CASES,
+    CaseResult,
+    summarize,
+)
+
+
+def _result(name: str, outpaint: float, fresh: float) -> CaseResult:
+    return CaseResult(
+        name=name,
+        outpaint_score=outpaint,
+        fresh_score=fresh,
+        outpaint_rationale="",
+        fresh_rationale="",
+    )
+
+
+def test_cases_are_well_formed() -> None:
+    assert _CASES, "need at least one styled source to measure OUTWARD drift"
+    for c in _CASES:
+        assert c.source_prompt.strip() and c.style.strip() and c.subject.strip()
+        assert c.from_tier in ("city", "district", "place", "region", "world", "room")
+
+
+def test_drift_is_outpaint_minus_fresh() -> None:
+    # The fresh container lost 4 points of medium-faithfulness vs the zero-drift outpaint.
+    assert _result("x", 9.0, 5.0).drift == 4.0
+
+
+def test_summarize_drift_and_distrust() -> None:
+    s = summarize([_result("a", 9.0, 5.0), _result("b", 8.0, 6.0)])
+    assert s["outpaint_medium_mean"] == 8.5
+    assert s["fresh_medium_mean"] == 5.5
+    assert s["drift"] == 3.0
+    assert s["fresh_trustworthy"] is False  # 5.5 < 6.5 → keep SCALE_OUTWARD_RERENDER off
+
+
+def test_summarize_trusts_fresh_when_it_holds() -> None:
+    s = summarize([_result("a", 9.0, 8.0), _result("b", 9.0, 7.0)])
+    assert s["fresh_trustworthy"] is True  # 7.5 >= 6.5
+    assert s["drift"] == 1.5

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -8,6 +8,7 @@ import type {
   GenerateEvent,
   MapCrop,
   ObserverPose,
+  ScaleTier,
   SceneView,
   ViewLevel,
   WorldEntityGeo,
@@ -141,6 +142,7 @@ interface PersistBody {
   sources?: { url: string; title: string | null }[] | null;
   relation?: "descend" | "expand";
   scale?: "component" | "peer" | "container";
+  scale_tier?: ScaleTier;
   scene_view?: SceneView | null;
 }
 

--- a/apps/web/hooks/useExpandBloom.test.tsx
+++ b/apps/web/hooks/useExpandBloom.test.tsx
@@ -104,6 +104,44 @@ describe("useExpandBloom", () => {
     );
   });
 
+  it("persists scale_tier on each neighbour when the bloom is logical (around_tier)", async () => {
+    const persist = vi.fn().mockResolvedValue({ id: "node-x" });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        cannedResponse([
+          neighbor({ subject: "The Library", scale: "peer", index: 0, total: 1 }),
+          { type: "expand_done", count: 1 },
+        ]),
+      ),
+    );
+    const { result } = renderHook(() =>
+      useExpandBloom(persist as unknown as PersistNeighbour),
+    );
+    act(() => result.current.start({ ...BODY, around_tier: "room" }));
+    await waitFor(() => expect(result.current.bloom?.done).toBe(true));
+    expect(persist).toHaveBeenCalledWith(
+      expect.objectContaining({ relation: "expand", scale_tier: "room" }),
+      expect.anything(),
+    );
+  });
+
+  it("omits scale_tier for an unconstrained bloom (no around_tier)", async () => {
+    const persist = vi.fn().mockResolvedValue({ id: "n" });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        cannedResponse([neighbor({ index: 0, total: 1 }), { type: "expand_done", count: 1 }]),
+      ),
+    );
+    const { result } = renderHook(() =>
+      useExpandBloom(persist as unknown as PersistNeighbour),
+    );
+    act(() => result.current.start(BODY));
+    await waitFor(() => expect(result.current.bloom?.done).toBe(true));
+    expect("scale_tier" in (persist.mock.calls[0]![0] as object)).toBe(false);
+  });
+
   it("resolves the bloom (done) when the stream closes without an expand_done", async () => {
     // Defensive: if the backend ever closes the stream without a terminal
     // expand_done (e.g. an early bail), the bloom must still flip to done so

--- a/apps/web/hooks/useExpandBloom.ts
+++ b/apps/web/hooks/useExpandBloom.ts
@@ -2,7 +2,12 @@
 
 import { useCallback, useRef, useState } from "react";
 
-import type { GenerateEvent, GenerateRequestBody, ScaleKind } from "@openflipbook/config";
+import type {
+  GenerateEvent,
+  GenerateRequestBody,
+  ScaleKind,
+  ScaleTier,
+} from "@openflipbook/config";
 
 import type { NeighbourItem } from "@/components/PlayPage/NeighbourTray";
 import { TRACE_HEADER, newTraceId } from "@/lib/trace";
@@ -30,6 +35,9 @@ export type PersistNeighbour = (
     final_prompt: string;
     relation: "expand";
     scale: ScaleKind;
+    // B2 logical AROUND: the rung these same-scale peers sit at (the focus's tier),
+    // when the bloom was constrained by SCALE_AROUND_LOGICAL. Omitted otherwise.
+    scale_tier?: ScaleTier;
   },
   traceId: string | null,
 ) => Promise<{ id: string } | null>;
@@ -118,6 +126,7 @@ export function useExpandBloom(persist: PersistNeighbour): {
                     final_prompt: evt.final_prompt,
                     relation: "expand",
                     scale: evt.scale,
+                    ...(body.around_tier ? { scale_tier: body.around_tier } : {}),
                   },
                   traceId,
                 ).then((saved) => {

--- a/apps/web/lib/scale-tree.test.ts
+++ b/apps/web/lib/scale-tree.test.ts
@@ -173,4 +173,31 @@ describe("scale-tree reparentRoots (the multi-root geo store)", () => {
     ).toThrow(/no root/);
     expect(() => reparentRoots(cityTree(), geo({ id: "c" }), NOW)).toThrow(/already exists/);
   });
+
+  it("derives the shared pScale from the MODAL rung, not an arbitrary first root", () => {
+    // A district root listed FIRST, but the city rung is the majority (3 of 4).
+    const before = [
+      geo({ id: "d", pos: { x: 5, y: 5 }, scale_tier: "district" }),
+      geo({ id: "c1", pos: { x: 10, y: 10 }, scale_tier: "city" }),
+      geo({ id: "c2", pos: { x: 70, y: 40 }, scale_tier: "city" }),
+      geo({ id: "c3", pos: { x: 40, y: 55 }, scale_tier: "city" }),
+    ];
+    const beforeAbs = absMap(before);
+    const region = geo({
+      id: "p",
+      pos: { x: 30, y: 25 },
+      footprint: { w: 90, d: 60 },
+      scale_tier: "region",
+    });
+    const { learnedScale, geos: after } = reparentRoots(before, region, NOW);
+    // The majority (city) sets the ratio — not the first root (district).
+    expect(learnedScale).toBeCloseTo(tierMetricMultiplier("region", "city"), 12);
+    expect(learnedScale).not.toBeCloseTo(tierMetricMultiplier("region", "district"), 6);
+    // INV-1 still holds for EVERY root (incl. the minority district one).
+    const afterAbs = absMap(after);
+    for (const id of ["d", "c1", "c2", "c3"]) {
+      expect(afterAbs.get(id)!.x).toBeCloseTo(beforeAbs.get(id)!.x, 9);
+      expect(afterAbs.get(id)!.y).toBeCloseTo(beforeAbs.get(id)!.y, 9);
+    }
+  });
 });

--- a/apps/web/lib/scale-tree.ts
+++ b/apps/web/lib/scale-tree.ts
@@ -122,13 +122,36 @@ function makeRootParent(
   return { ...parentGeo, parent_id: null, scale: pScale, source: "user", updated_at: nowIso };
 }
 
+// The most-common rung among a set of geos (insertion order breaks ties), or
+// undefined if none carry one. P has ONE `scale` field that `resolveAbsolutePos`
+// applies uniformly to all its children, so a single shared pScale is unavoidable;
+// the MODAL rung makes it representative of the majority (a uniform-tier map — the
+// normal case — is exact) instead of an arbitrary first root. A genuinely mixed
+// set is a relative-scale approximation; INV-1 is conserved either way.
+function modalTier(geos: WorldEntityGeo[]): WorldEntityGeo["scale_tier"] {
+  const counts = new Map<NonNullable<WorldEntityGeo["scale_tier"]>, number>();
+  for (const g of geos) {
+    if (g.scale_tier) counts.set(g.scale_tier, (counts.get(g.scale_tier) ?? 0) + 1);
+  }
+  let best: WorldEntityGeo["scale_tier"];
+  let bestN = 0;
+  for (const [t, n] of counts) {
+    if (n > bestN) {
+      best = t;
+      bestN = n;
+    }
+  }
+  return best;
+}
+
 /**
  * The OUTWARD reparent the session geo store actually needs: a map is seeded as
  * MANY top-level roots (its buildings), not one — so re-point EVERY current root
  * under the synthesized parent P, conserving each one's absolute position (INV-1).
- * One shared `pScale` (from the roots' common rung, or their joint extent) re-
- * expresses every root via the same affine inverse. Non-root entities (sub-place
- * interiors) are untouched — they ride along as P's grandchildren, still conserved.
+ * One shared `pScale` (P has a single `scale` field) from the roots' MODAL rung
+ * (or their joint extent) re-expresses every root via the same affine inverse.
+ * Non-root entities (sub-place interiors) are untouched — they ride along as P's
+ * grandchildren, still conserved.
  */
 export function reparentRoots(
   geos: WorldEntityGeo[],
@@ -142,7 +165,7 @@ export function reparentRoots(
   if (geos.some((g) => g.id === parentGeo.id)) {
     throw new Error(`reparentRoots: parent id "${parentGeo.id}" already exists`);
   }
-  const childTier = roots.find((r) => r.scale_tier)?.scale_tier;
+  const childTier = modalTier(roots);
   const pScale = learnPScale(parentGeo, childTier, localExtent(roots));
   const rootIds = new Set(roots.map((r) => r.id));
   const newParent = makeRootParent(parentGeo, pScale, nowIso);


### PR DESCRIPTION
## Close the three honest B2 gaps

Addresses the gaps flagged after the B2 build — two real code fixes + making the deferred drift A/B **runnable** (not just documented).

1. **OUTWARD drift A/B — now runnable.** New `tests/continuity_bench/outward_runner.py` + `make eval-outward-drift`: synthesize each container TWICE (the default **zero-drift** BRIA outpaint vs the `SCALE_OUTWARD_RERENDER` fresh path) and judge medium-faithfulness to the source → the **drift number** + a `fresh_trustworthy` gate. Paid (fal + Gemini judge), self-contained, **not run here**. The pure `summarize`/`drift` brain is free-unit-tested (`test_outward.py`), mirroring `style_runner`; reuses `score_style_pair`.

2. **Mixed-tier `reparentRoots`.** Derive the shared `pScale` from the **modal rung** among the roots, not the arbitrary first (a uniform-tier map is exact; outliers no longer flip the representative rung). Documented that P's single `scale` field makes a truly mixed set a relative approximation — **INV-1 stays exact for every root either way**. + test (district-first, city-majority).

3. **AROUND neighbour rung.** `around_tier` now threads `useExpandBloom` → `persistNode` → `/api/nodes`, so logical-bloom peers persist `scale_tier` = the focus's rung. + 2 hook tests.

`make eval` green: web **469**, backend pytest + ruff + mypy + tsc + no circular.

🤖 Generated with [Claude Code](https://claude.com/claude-code)