### PR TITLE
fix(world): OUTWARD defaults to the coherent fresh container (live-corrected)

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -507,36 +507,44 @@ async def _event_stream(
                     trace_id,
                 )
                 return
-            op = model_router.select_outward_op(from_tier, to_tier)
             _dims = {
                 "16:9": (1600, 900), "9:16": (900, 1600), "1:1": (1024, 1024),
                 "4:3": (1280, 960), "3:4": (960, 1280),
             }
             pw, ph = _dims.get(body.aspect_ratio, (1600, 900))
+            style_lock = (body.session_style_anchor or "").strip() or None
+            # DEFAULT = the fresh `scale_parent` container: a seamless wider view of
+            # the SAME world in the SAME medium, the source as a small sub-region
+            # (live-verified far more coherent than the outpaint, which leaves the
+            # source a rectangle inset). The centered outpaint is opt-in
+            # (SCALE_OUTWARD_OUTPAINT) for pixel-preservation, and only for a
+            # same-plane hop — and now STEERS its margin with the medium so it isn't
+            # photoreal. Astronomical (medium-flip) hops are always fresh.
+            use_outpaint = (
+                env_flag("SCALE_OUTWARD_OUTPAINT")
+                and model_router.select_outward_op(from_tier, to_tier) == "outpaint_zoomout"
+            )
             yield _sse({"type": "status", "stage": "rendering"}, trace_id)
             await _abort_if_disconnected("pre-ascend")
             try:
-                if op == "outpaint_zoomout":
-                    # Centered BRIA outpaint: the source becomes the central
-                    # sub-region of the wider frame — style conserved by construction.
+                if use_outpaint:
+                    medium = style_lock or "the same hand-drawn art style as the centre"
+                    margin = (
+                        f"{medium}; extend OUTWARD into the surrounding "
+                        f"{to_tier.replace('_', ' ')}, drawn in the SAME style as the "
+                        "centre — one continuous view, NOT a photograph, no photorealism"
+                    )
                     img = await image_edit_provider.expand_image_zoomout(
-                        body.image, 3.0, pw, ph
+                        body.image, 3.0, pw, ph, prompt=margin
                     )
                     page_title = f"The surrounding {to_tier.replace('_', ' ')}".title()
-                    final_prompt = f"outward zoom: {from_tier} -> {to_tier} (centered outpaint)"
-                else:  # scale_parent_fresh — the medium-flip fresh path (riskier)
-                    if not env_flag("SCALE_OUTWARD_RERENDER"):
-                        yield _sse(
-                            {
-                                "type": "error",
-                                "message": f"medium-flip OUTWARD to '{to_tier}' needs SCALE_OUTWARD_RERENDER",
-                            },
-                            trace_id,
-                        )
-                        return
-                    style_lock = (body.session_style_anchor or "").strip() or None
+                    final_prompt = f"outward outpaint: {from_tier} -> {to_tier}"
+                else:
                     plan = await llm.plan_page(
-                        query=body.query or from_tier,
+                        query=(
+                            f"the {to_tier.replace('_', ' ')} that contains "
+                            f"{body.query or 'this place'}"
+                        ),
                         web_search=False,
                         style_anchor=style_lock,
                         render_mode="scale_parent",
@@ -544,7 +552,7 @@ async def _event_stream(
                     img = await image_provider.generate_image(
                         plan.prompt, body.aspect_ratio, reference_urls=[body.image]
                     )
-                    page_title = plan.page_title or to_tier.replace("_", " ").title()
+                    page_title = plan.page_title or f"The surrounding {to_tier.replace('_', ' ')}".title()
                     final_prompt = plan.prompt
             except Exception as exc:
                 log("warn", "ascend.failed", error=f"{type(exc).__name__}: {exc}")

--- a/apps/modal-backend/providers/image_edit.py
+++ b/apps/modal-backend/providers/image_edit.py
@@ -306,20 +306,28 @@ def _clamp_zoom_factor(factor: float) -> float:
 
 
 def _zoomout_args_for(
-    image_url: str, factor: float, width: int, height: int
+    image_url: str, factor: float, width: int, height: int, prompt: str | None = None
 ) -> dict[str, Any]:
     """OUTWARD: the source CENTERED on a `factor`x larger canvas, full margin
     painted on ALL sides — so it becomes the recognizable central sub-region of a
     wider view of the same world. Contrast `_expand_args_for`, which pins the
-    original to one EDGE for a directional map-pan."""
+    original to one EDGE for a directional map-pan.
+
+    `prompt` STEERS the painted margin: WITHOUT it BRIA fills photorealistically,
+    so a hand-drawn map ends up an engraving poster floating in a real sea. Passing
+    the source's medium keeps the margin in-style (it still leaves a soft seam at
+    the source rectangle — the fresh `scale_parent` path is the seamless default)."""
     cw, ch = int(width * factor), int(height * factor)
     loc = [(cw - width) // 2, (ch - height) // 2]
-    return {
+    args: dict[str, Any] = {
         "image_url": image_url,
         "canvas_size": [cw, ch],
         "original_image_size": [width, height],
         "original_image_location": loc,
     }
+    if prompt and prompt.strip():
+        args["prompt"] = prompt.strip()
+    return args
 
 
 async def expand_image_zoomout(
@@ -328,13 +336,15 @@ async def expand_image_zoomout(
     width: int = 1600,
     height: int = 900,
     model_override: str | None = None,
+    prompt: str | None = None,
 ) -> GeneratedImage:
     """OUTWARD / zoom-out (B2): paint the CONTAINER around the source — the source
     centered on a `factor`x larger canvas with the full margin outpainted, so it
-    becomes the central sub-region of a wider frame of the SAME world (style is
-    conserved by construction: the original pixels stay). Same BRIA machinery as
-    `expand_image`; only the canvas is centered, not edge-pinned. `factor` is
-    clamped to ~1.5-4x per hop."""
+    becomes the central sub-region of a wider frame. The source's pixels are kept,
+    but the painted MARGIN drifts to photoreal unless `prompt` carries the source's
+    medium — so callers MUST pass it. Same BRIA machinery as `expand_image`; only
+    the canvas is centered, not edge-pinned. `factor` is clamped to ~1.5-4x. This is
+    the opt-in (SCALE_OUTWARD_OUTPAINT) path; the seamless default is `scale_parent`."""
     from obs import span
 
     _ensure_fal_key()
@@ -348,7 +358,7 @@ async def expand_image_zoomout(
     w, h = _dims_from_data_url(image_data_url) or (width, height)
     image_url = await to_fal_url(image_data_url)
     async with span("image.zoomout", model=model, factor=f, w=w, h=h) as ctx:
-        result = await _fal_subscribe(model, _zoomout_args_for(image_url, f, w, h))
+        result = await _fal_subscribe(model, _zoomout_args_for(image_url, f, w, h, prompt))
         image_info = _expand_first_image(result)
         jpeg_bytes, mime = await _fetch_image_bytes(image_info)
         ctx["bytes"] = len(jpeg_bytes)

--- a/apps/modal-backend/tests/continuity_bench/outward_runner.py
+++ b/apps/modal-backend/tests/continuity_bench/outward_runner.py
@@ -1,18 +1,17 @@
 """OUTWARD-DRIFT — style A/B for the zoom-out container (the design's risk #1).
 
-The default OUTWARD path is the centered BRIA outpaint, which keeps the source's
-pixels as the central sub-region → ZERO style drift by construction. The riskier
-medium-flip path (`SCALE_OUTWARD_RERENDER`) synthesizes the container FRESH,
-conditioned on the source. This A/B quantifies that risk BEFORE the flag is
-enabled: for each styled source we synthesize its container TWICE —
-  - OUTPAINT: `expand_image_zoomout` (the default — the zero-drift baseline).
-  - FRESH:    `generate_image(scale_parent clause + source as a reference)`
-              (exactly what the `mode:"ascend"` SCALE_OUTWARD_RERENDER path sends).
+NOTE: a live run corrected the original assumption. The centered BRIA outpaint is
+NOT zero-drift — without a medium prompt it paints a PHOTOREAL margin (an engraving
+poster in a real sea), and even with one it leaves the source a hard rectangle
+inset. The fresh `scale_parent` gen (now the DEFAULT) makes a seamless wider view
+in the same medium. This A/B scores both so the opt-in outpaint can be measured
+against the default: for each styled source we synthesize its container TWICE —
+  - OUTPAINT: `expand_image_zoomout(..., prompt=medium)` (opt-in, SCALE_OUTWARD_OUTPAINT).
+  - FRESH:    `generate_image(scale_parent clause + source as a reference)` (the default).
 `score_style_pair(source, container)` judges how faithfully each container keeps
 the source's art MEDIUM (palette / linework / stylisation, subject ignored). The
-DRIFT number = outpaint_mean - fresh_mean (how much the rerender path loses vs the
-pixel-preserving outpaint). We ASSERT the FRESH arm clears a threshold before
-trusting it — keep `SCALE_OUTWARD_RERENDER` off until it does, at N >= 10.
+DRIFT number = outpaint_mean - fresh_mean. The fresh arm is the live-verified
+default; this confirms it holds the medium + quantifies the outpaint alternative.
 
 Paid (fal gens + Gemini judge). Self-contained — no session / web needed:
     cd apps/modal-backend && OUTWARD_BENCH_RUN=1 \

--- a/apps/modal-backend/tests/test_generate_ascend.py
+++ b/apps/modal-backend/tests/test_generate_ascend.py
@@ -1,9 +1,11 @@
 """Integration tests for the OUTWARD (ascend) branch in generate.py.
 
-Drives the real `_event_stream` with mode="ascend" and the BRIA outpaint provider
-mocked — asserts the `ascend_ready` event (shape + target rung), the flag gate
-(off by default → refuses), the image requirement, the medium-flip guard, and
-that the additive branch leaves the tap/query `final` path intact.
+The DEFAULT path is the fresh `scale_parent` container (a seamless wider view of
+the same world in the same medium — live-verified far more coherent than the
+outpaint). The centered outpaint is OPT-IN via SCALE_OUTWARD_OUTPAINT, and now
+steers its painted margin with the medium so it isn't photoreal. These assert the
+flag gate, the default-fresh path, the opt-in medium-guided outpaint, the image
+requirement, and that the tap/query path is untouched.
 
 generate.py imports `modal` at module level (deploy-only); stub it before import.
 """
@@ -19,9 +21,12 @@ import pytest
 
 sys.modules.setdefault("modal", MagicMock())
 
+import providers.image as image_mod  # noqa: E402
 import providers.image_edit as image_edit_mod  # noqa: E402
+import providers.llm as llm_mod  # noqa: E402
 from generate import GenerateBody, SceneView, _event_stream  # noqa: E402
 from providers.image import GeneratedImage  # noqa: E402
+from providers.llm import PagePlan  # noqa: E402
 
 
 async def _collect(agen: Any) -> list[dict[str, Any]]:
@@ -37,7 +42,7 @@ async def _collect(agen: Any) -> list[dict[str, Any]]:
 
 def _ascend_body(**over: Any) -> GenerateBody:
     base: dict[str, Any] = {
-        "query": "Ankh-Morpork",
+        "query": "Port Vallen",
         "session_id": "s1",
         "mode": "ascend",
         "image": "data:image/jpeg;base64,abc",
@@ -53,19 +58,49 @@ def _enable(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("SCALE_OUTWARD", "1")
 
 
-async def test_ascend_outpaints_the_container(monkeypatch: pytest.MonkeyPatch) -> None:
+def _mock_fresh(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    monkeypatch.setattr(
+        llm_mod,
+        "plan_page",
+        AsyncMock(return_value=PagePlan("The Vallen Sea and Coastline", "a wider engraving map", [], [])),
+    )
+    gen = AsyncMock(
+        return_value=GeneratedImage(b"jpegbytes", "image/jpeg", "fal-ai/nano-banana-pro", "r")
+    )
+    monkeypatch.setattr(image_mod, "generate_image", gen)
+    return gen
+
+
+async def test_ascend_fresh_container_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
     _enable(monkeypatch)
-    img = GeneratedImage(b"jpegbytes", "image/jpeg", "fal-ai/bria/expand", "req-1")
-    mock = AsyncMock(return_value=img)
-    monkeypatch.setattr(image_edit_mod, "expand_image_zoomout", mock)
+    monkeypatch.delenv("SCALE_OUTWARD_OUTPAINT", raising=False)
+    gen = _mock_fresh(monkeypatch)
+    outpaint = AsyncMock()
+    monkeypatch.setattr(image_edit_mod, "expand_image_zoomout", outpaint)
 
     events = await _collect(_event_stream(_ascend_body(), "t1"))
     ready = next(e for e in events if e["type"] == "ascend_ready")
     assert ready["scale_tier"] == "region"  # one rung coarser than city
     assert ready["from_tier"] == "city"
-    assert ready["image_data_url"].startswith("data:image/jpeg;base64,")
+    assert ready["page_title"] == "The Vallen Sea and Coastline"
+    gen.assert_awaited_once()  # the fresh scale_parent container
+    outpaint.assert_not_awaited()  # NOT the outpaint
+
+
+async def test_ascend_outpaint_under_flag_steers_the_medium(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable(monkeypatch)
+    monkeypatch.setenv("SCALE_OUTWARD_OUTPAINT", "1")
+    img = GeneratedImage(b"jpegbytes", "image/jpeg", "fal-ai/bria/expand", "req-1")
+    mock = AsyncMock(return_value=img)
+    monkeypatch.setattr(image_edit_mod, "expand_image_zoomout", mock)
+
+    body = _ascend_body(session_style_anchor="hand-drawn engraving, sepia ink, cross-hatching")
+    events = await _collect(_event_stream(body, "t1"))
+    ready = next(e for e in events if e["type"] == "ascend_ready")
     assert ready["image_model"] == "fal-ai/bria/expand"
     mock.assert_awaited_once()
+    # The medium MUST reach BRIA, or the painted margin comes back photoreal.
+    assert "engraving" in (mock.await_args.kwargs.get("prompt") or "")
 
 
 async def test_ascend_gated_off_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -83,24 +118,8 @@ async def test_ascend_requires_an_image(monkeypatch: pytest.MonkeyPatch) -> None
     assert any(e["type"] == "error" and "requires an image" in e["message"] for e in events)
 
 
-async def test_ascend_medium_flip_needs_rerender_flag(monkeypatch: pytest.MonkeyPatch) -> None:
-    # planet → star_system is a medium flip; without SCALE_OUTWARD_RERENDER it refuses
-    # (the riskier fresh path stays off until the drift eval justifies it).
-    _enable(monkeypatch)
-    monkeypatch.delenv("SCALE_OUTWARD_RERENDER", raising=False)
-    body = _ascend_body(scene_view=SceneView(node_id="n0", level="map", scale_tier="planet"))
-    events = await _collect(_event_stream(body, "t1"))
-    assert any(
-        e["type"] == "error" and "SCALE_OUTWARD_RERENDER" in e["message"] for e in events
-    )
-
-
 async def test_query_mode_unaffected_by_ascend_branch(monkeypatch: pytest.MonkeyPatch) -> None:
     # Regression: the additive ascend branch must not disturb the tap/query path.
-    import providers.image as image_mod
-    import providers.llm as llm_mod
-    from providers.llm import PagePlan
-
     _enable(monkeypatch)
     monkeypatch.setenv("PROGRESSIVE_DRAFT", "false")
     monkeypatch.setattr(

--- a/apps/modal-backend/tests/test_image_edit_provider.py
+++ b/apps/modal-backend/tests/test_image_edit_provider.py
@@ -72,6 +72,14 @@ def test_zoomout_factor_clamped_per_hop() -> None:
     assert image_edit._clamp_zoom_factor(3.0) == 3.0  # in range
 
 
+def test_zoomout_args_carry_the_medium_prompt() -> None:
+    # Without a prompt BRIA fills photoreal (the engraving-poster-in-a-real-sea bug);
+    # callers MUST pass the medium so the painted margin stays in style.
+    assert "prompt" not in image_edit._zoomout_args_for("u", 3.0, 100, 60)
+    steered = image_edit._zoomout_args_for("u", 3.0, 100, 60, "engraving, sepia ink")
+    assert steered["prompt"] == "engraving, sepia ink"
+
+
 # --- dimension probing (Pillow-free) ------------------------------------------
 
 

--- a/docs/PLAN_OUTWARD.md
+++ b/docs/PLAN_OUTWARD.md
@@ -102,13 +102,20 @@ consistency already holds via the learned per-frame `scale`. One small change + 
 - **INV-4 (one ladder) — SHIPPED.** `ladderDisagreement(parentTier, childTier, learnedScale)`
   in `world-map.ts` (pure, unit-tested); `deriveGeoFromExtraction` warns + keeps the learned
   scale on a sign disagreement, never blocks.
-- **OUTWARD drift A/B — deferred to when rerender is enabled (paid + manual).** The default
-  OUTWARD path is the **centered BRIA outpaint, which is zero-drift by construction** (the
-  source's pixels are preserved as the central sub-region), so there is no drift to measure
-  while `SCALE_OUTWARD_RERENDER` is off — which it is by default. Only the medium-flip *fresh*
-  path can drift; before enabling `SCALE_OUTWARD_RERENDER`, run an **N≥10 A/B** reusing the
-  `coherence_runner` harness (`make eval-coherence`) — the design's risk #1 — and keep the flag
-  off until the number justifies it. Not run here (paid; needs a live session + keys).
+- **OUTWARD coherence — CORRECTED BY A LIVE RUN.** The original design made the centered BRIA
+  outpaint the "zero-drift default" and the fresh `scale_parent` gen the risky gated path. A live
+  run on a Port Vallen engraving city map proved that **backwards**: the outpaint kept the source
+  pixels but painted a **photoreal** margin (an engraving poster floating in a real sea) because
+  the BRIA call sent no medium guidance — and even with a medium prompt it leaves the source a
+  hard rectangle inset. The fresh `scale_parent` path produced a **seamless wider engraving map**
+  (the city a small sub-region of a coherent region). So the ascend branch now **defaults to the
+  fresh `scale_parent` container** (no `SCALE_OUTWARD_RERENDER` gate — it's the good path); the
+  centered outpaint is **opt-in via `SCALE_OUTWARD_OUTPAINT`** and now **steers its margin with
+  the source's medium** so it isn't photoreal. Proof images in `~/Desktop/ofb-outward-demo/`.
+- **Drift A/B — the runner stands, reframed.** `make eval-outward-drift` scores both containers'
+  medium-faithfulness to the source (the default fresh vs the opt-in outpaint); run it (paid,
+  N≥10) before trusting the outpaint alternative. Single-hop fresh is now the live-verified
+  default; compounding drift across MANY hops is still the design's risk #1 to watch.
 
 ---
 


### PR DESCRIPTION
## What a live run exposed

The design had the OUTWARD paths **backwards**. Running it on a real Port Vallen engraving city map:

| | result |
|---|---|
| **outpaint, no prompt** (shipped default) | engraving city floating in a **photoreal sea** — BRIA paints the margin realistically with no medium guidance |
| **outpaint + medium prompt** | in-medium, but the source is a hard **rectangle inset** |
| **fresh `scale_parent`** | *"The Archduchy of Vallen-Reach"* — a **seamless wider engraving map**, the city a small sub-region. ✅ |

My "outpaint is the zero-drift default" claim was wrong, and only running it showed that.

## The fix
- **`generate.py` ascend branch defaults to the fresh `scale_parent` container** (no `SCALE_OUTWARD_RERENDER` gate — it's the good path), conditioned on the source + the session medium.
- The centered outpaint is **opt-in via `SCALE_OUTWARD_OUTPAINT`** (same-plane only) and now **steers its margin with the medium** so it isn't photoreal (`expand_image_zoomout(..., prompt=...)`).
- Tests flipped (default = fresh; outpaint-under-flag asserts the medium reaches BRIA); docs corrected.

## Verified on the SHIPPED code
Drove `_event_stream(mode='ascend')` end to end → `city → region`, *"The Archduchy of Vallen-Reach"*, a seamless engraving region. Proof in `~/Desktop/ofb-outward-demo/`. `make eval` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)