### PR TITLE
fix(world): faithful interiors — feed the map's landmarks into the enter

### DIFF
--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -1865,6 +1865,13 @@ export default function PlayPage() {
                     ),
                   }
                 : {}),
+              // FAITHFUL backdrop: the focus's frame-mates straight from the geo
+              // (real bearings + appearances), so a stepped-into scene draws the
+              // SAME landmarks the map shows in the right directions — overriding
+              // the VLM-invented surroundings above (geoTap is spread last → wins).
+              ...(geoTap.surroundings
+                ? { prefetched_surroundings: geoTap.surroundings }
+                : {}),
             }
           : {}),
         ...(styleAnchor ? { session_style_anchor: styleAnchor.style } : {}),

--- a/apps/web/lib/geo-tap.test.ts
+++ b/apps/web/lib/geo-tap.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { MapCrop, SceneView, WorldEntityGeo } from "@openflipbook/config";
 
-import { geoTapRequest } from "./geo-tap";
+import { describeSurroundings, geoTapRequest } from "./geo-tap";
 
 function geo(
   id: string,
@@ -62,6 +62,34 @@ describe("geoTapRequest (close the geometric tap loop)", () => {
     };
     const t = geoTapRequest(map, "n1", { x_pct: 60 / 100, y_pct: 30 / 60 }, 16 / 9);
     expect(t!.scene_view.focus_id).toBe("clock");
+  });
+
+  it("describeSurroundings names frame-mates with map directions + appearances", () => {
+    const entities = [
+      geo("sq", "Market Square", 50, 30, { visual: "a cobbled plaza" }),
+      geo("cit", "The Citadel", 80, 15, { visual: "square-towered keep" }), // NE
+      geo("dock", "The Docks", 50, 55, { visual: "masted ships" }), // due south
+    ];
+    const s = describeSurroundings("sq", entities);
+    expect(s).toMatch(/north-east, The Citadel \(square-towered keep\)/);
+    expect(s).toMatch(/south, The Docks \(masted ships\)/);
+  });
+
+  it("describeSurroundings is empty for a lone focus (cold start)", () => {
+    expect(describeSurroundings("only", [geo("only", "Alone", 0, 0)])).toBe("");
+    expect(describeSurroundings("missing", [geo("a", "A", 0, 0)])).toBe("");
+  });
+
+  it("a scene tap carries the geo-derived surroundings", () => {
+    const map = {
+      entities: [
+        geo("clock", "clock tower", 60, 30, { height: 18 }),
+        geo("lh", "lighthouse", 30, 30, { visual: "white-and-red tower" }),
+      ],
+      bounds: CROP,
+    };
+    const t = geoTapRequest(map, "n1", { x_pct: 60 / 100, y_pct: 30 / 60 }, 16 / 9);
+    expect(t!.surroundings).toContain("lighthouse");
   });
 
   it("D — DEEPER stamps the child rung (one finer than the frame you tapped from)", () => {

--- a/apps/web/lib/geo-tap.ts
+++ b/apps/web/lib/geo-tap.ts
@@ -43,6 +43,57 @@ export interface GeoTap {
   // stone, concentric rings, moss-covered) across zoom levels, even as the angle
   // changes between map and scene.
   focus_visual: string | null;
+  // The focus's FRAME-MATES drawn straight from the geo (their real bearings +
+  // appearance descriptors), e.g. "to the north-east, The Citadel (square-towered
+  // stone bastion on a rise); to the south, The Docks (masted ships)". Fed as the
+  // enter's `surroundings` so a stepped-into scene renders the SAME landmarks the
+  // map shows, in the right directions — instead of the model reinventing them
+  // (nano-banana ignores the image ref on a fresh gen; only text carries this).
+  surroundings: string;
+}
+
+// Image-frame bearing → a cartographer's cardinal. +x = east, +y = SOUTH (the
+// world frame's y grows downward, like the map image).
+function cardinal(dx: number, dy: number): string {
+  const deg = ((Math.atan2(dy, dx) * 180) / Math.PI + 360) % 360;
+  const dirs = [
+    "east", "south-east", "south", "south-west",
+    "west", "north-west", "north", "north-east",
+  ];
+  return dirs[Math.round(deg / 45) % 8] ?? "nearby";
+}
+
+/** Describe the focus's frame-mates (same parent frame) as visible backdrop —
+ *  each with its real bearing from the focus + its appearance — so an entered
+ *  scene stays faithful to the map's geography. Pure; empty when the focus has no
+ *  mapped neighbours (cold start → the planner's own surroundings stand). */
+export function describeSurroundings(
+  focusId: string,
+  entities: WorldEntityGeo[],
+  max = 5,
+): string {
+  const focus = entities.find((e) => e.id === focusId);
+  if (!focus) return "";
+  const parent = focus.parent_id ?? null;
+  const mates = entities
+    .filter(
+      (e) => e.id !== focusId && (e.parent_id ?? null) === parent && e.label.trim(),
+    )
+    .map((m) => ({
+      label: m.label.trim(),
+      visual: (m.visual ?? "").trim(),
+      dir: cardinal(m.pos.x - focus.pos.x, m.pos.y - focus.pos.y),
+      // nearest first, so the most relevant backdrop survives the cap
+      dist: Math.hypot(m.pos.x - focus.pos.x, m.pos.y - focus.pos.y),
+    }))
+    .sort((a, b) => a.dist - b.dist)
+    .slice(0, max);
+  if (mates.length === 0) return "";
+  return (
+    mates
+      .map((m) => `to the ${m.dir}, ${m.label}${m.visual ? ` (${m.visual})` : ""}`)
+      .join("; ") + "."
+  );
 }
 
 /**
@@ -123,6 +174,7 @@ export function geoTapRequest(
       focus_id: route.focus_id,
       focus_label: route.focus_id ? byId.get(route.focus_id)?.label ?? null : null,
       focus_visual: route.focus_id ? byId.get(route.focus_id)?.visual ?? null : null,
+      surroundings: route.focus_id ? describeSurroundings(route.focus_id, map.entities) : "",
     };
   }
 
@@ -162,5 +214,6 @@ export function geoTapRequest(
     focus_id: route.focus_id,
     focus_label: byId.get(route.focus_id)?.label ?? null,
     focus_visual: byId.get(route.focus_id)?.visual ?? null,
+    surroundings: describeSurroundings(route.focus_id, map.entities),
   };
 }


### PR DESCRIPTION
## The "totally ass" fix

Stepping into a place rendered a plausible-but-**wrong** scene — the Citadel came back round-towered and bordering the market when the map shows a **square-towered keep to the NE**. Root cause: the enter is a fresh nano-banana gen, which **ignores the image ref**, so it had only the focus text ("Market Square, a plaza") and reinvented everything around it.

**Validated by a live A/B** (`~/Desktop/ofb-outward-demo/6_scene_focus_only.jpg` vs `7_scene_with_surroundings.jpg`): injecting the map's surrounding landmarks as text makes the scene faithful — the square-towered Citadel on its rise to the NE, the encircling sea wall, ships at the docks to the south.

### The fix
- **`geo-tap.ts` `describeSurroundings(focusId, entities)`** — the focus's frame-mates straight from the geo, nearest-first, each with its real bearing (atan2 → cardinal) + appearance: *"to the north-east, The Citadel (square-towered keep on a rise); to the south, The Docks (masted ships)"*. Surfaced on `GeoTap` (scene + submap).
- **`page.tsx`** — thread `geoTap.surroundings` → `prefetched_surroundings` (spread last, so the faithful geo backdrop wins over the click-resolver's invented one).
- The backend already turns `surroundings` into the `place_scene` spatial-anchor clause — the gap was the **source**.

Result: *"a different city"* → *"recognizably this city,"* same medium, right geography. Still text-driven (not pixel-identical — that needs a reference-honoring view-change model), but the landmarks + directions now match. + geo-tap tests; `make eval` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)