### PR TITLE
Consistency research + budgeted bakeoff (layout bins steer: +0.33)

### DIFF
--- a/docs/research/00-overview.md
+++ b/docs/research/00-overview.md
@@ -15,6 +15,14 @@ to 14 refs + identity). So the one model call to **change** is OUTWARD `scale_pa
 today it passes a ref through the text-to-image endpoint (a no-op) → route it through the edit
 endpoint (or drop the inert ref). [confirmed by code + fal docs]
 
+**Update (`07`, paid broad bakeoff):** tried the whole field — gpt-image-2, Recraft v4.1,
+Riverflow v2.5 vs the incumbents. The layout clause saturates fidelity for ALL of them (tight
+0.94–0.99), so effect is model-independent and the ratio is dominated by price. The current
+default `nano-banana-pro` is ~7× worse price/effect than the cheap-compliant models
+(riverflow-fast / seedream / gpt-image-2-low) at equal layout fidelity; `riverflow-v2.5-pro` leads
+on quality + medium (pilot it for the final render). Re-price the tiers; pay premium only on the
+final artifact; the label-legibility axis is the untested follow-up. Price-to-effect table in `07`.
+
 **Prompting** (`02`). The MEDIUM-LOCK *text* clause is the universal style workhorse (refs only
 bite on edit paths). Coordinate constraints should stay **coarse relative bins** (`h_pos`/`v_pos`/
 `size`), never raw `x_pct` — Gemini-class structured prompting reports >90% spatial compliance on

--- a/docs/research/00-overview.md
+++ b/docs/research/00-overview.md
@@ -1,0 +1,67 @@
+# 00 — Consistency research: the decisions that parameterize Branch 2
+
+Purpose: turn the consistency/geometry questions into concrete, code-grounded decisions
+so Branch 2 (`feat/systematic-consistency`) builds the right thing. Each call below is
+either CONFIRMED (code + literature agree) or PENDING the paid bakeoff (`01`'s design).
+Detail + sources in `01`–`05`.
+
+## The verdicts
+
+**Models per task** (`01`). Keep `nano-banana-pro` (fresh map + entity-edit — the one path
+where the style ref + identity actually work), `flux-pro/kontext` (zoom-continue/DEEPER),
+`bria/expand` (directional map-pan). The reference-image "no-op" is **endpoint-specific**, not
+model-wide: fal *text-to-image* slugs ignore `image_urls`; the *`/edit`* slugs honour them (up
+to 14 refs + identity). So the one model call to **change** is OUTWARD `scale_parent_fresh` —
+today it passes a ref through the text-to-image endpoint (a no-op) → route it through the edit
+endpoint (or drop the inert ref). [confirmed by code + fal docs]
+
+**Prompting** (`02`). The MEDIUM-LOCK *text* clause is the universal style workhorse (refs only
+bite on edit paths). Coordinate constraints should stay **coarse relative bins** (`h_pos`/`v_pos`/
+`size`), never raw `x_pct` — Gemini-class structured prompting reports >90% spatial compliance on
+relative/grid language; numeric coords are untested. Whether our `layout_constraints` bins
+*actually* steer the fresh render is the **single most decision-relevant unknown** → the S5 A/B
+(feed the bins into the fresh nano-banana-pro render, score with the existing `grounding.diff`).
+[PENDING bakeoff]
+
+**Coordinate injection + entity edits** (`03`). Keep the coordinate-free LLM boundary — the
+LLM emits relations, the deterministic solver computes coordinates (Open-Universe confirms
+LLM-emitted metric coords perform poorly; this is the right architecture). Hosted-API gen can't
+use ControlNet/GLIGEN spatial control, so bins + the grounding loop are the available levers.
+Make entity add/move/update/delete **verifiably faithful** with a project→apply→re-project→
+detect-diff loop (assert the edited entity moved and the others didn't). [confirmed]
+
+**Recursion** (`04`). The pipeline is linear at the top with recursion contained in two places:
+the solver's relation fixpoint, and a one-level persisted frame tree (DEEPER learns
+`parent.footprint/localExtent`; OUTWARD reparents up `SCALE_LADDER`). The honest gap: B1's
+`inside` is flat-v1 (the `parent_id` + learned-`scale` model exists but the solver emits
+`parent_id:null`). Recommendation: promote `inside` to the DEEPER nesting model (small solver
+change, already guarded by `geometry_checks` cycle/parent/scale invariants); cap **~2 frame
+levels per render**, unbounded in the persisted tree (log-space, cycle-guarded). [confirmed by
+hierarchical-scene literature: 3–4 semantic levels, constraints enforced per level]
+
+**Baseline methodology** (`05`). Layer the checks: deterministic anchors (`geometry_checks` +
+INV-1/INV-2 chains) run **free every commit**; VLM-judged evals spend only on the perceptual
+residue, **on a label**. Two missing pieces designed: (a) a baseline-drift guard (committed
+`tests/eval_baselines.json` thresholds + a free schema/threshold check + a paid compare), and
+(b) a multi-hop `chain_runner.py` that walks k real OUTWARD/DEEPER hops and reports a
+**`half_life`** (hops until drift crosses a floor — Risk #1, currently unmeasured). Gate on
+**relative lifts + drop-vs-baseline bands**, not absolute scores — VLM judges are rankers
+(Spearman ~0.6), not calibrated meters, and they under-penalize misalignment.
+
+## What Branch 2 builds (each line traces to a finding)
+
+| Branch 2 target | Parameterized by | Status |
+|---|---|---|
+| Wire `expected_layout` → fresh render | `02` S5 A/B decides if bins steer | gated on bakeoff |
+| Fix OUTWARD `scale_parent_fresh` ref no-op (→ edit endpoint) | `01` R4 (S4) | gated on bakeoff |
+| Verifiable entity edit/delete loop | `03` | confirmed — buildable now |
+| Promote `inside` to real sub-frame nesting | `04` | confirmed — buildable now |
+| Multi-hop drift `chain_runner` + `half_life` | `05` | confirmed — buildable now |
+| Baseline-drift guard | `05` | confirmed — buildable now |
+| Live grounding signal + runtime INV-2 | `05` + existing geometry_checks | confirmed — buildable now |
+
+## Next: the paid bakeoff
+
+`01`'s design (~90 generations, <$25, Gemini judge, `FAL_IMAGE_MODEL_BALANCED=nano-banana-pro`
+override) answers the two gated questions (do layout bins steer? does the edit endpoint fix the
+OUTWARD ref no-op?) plus confirms the per-task model calls. Its results append here as `06`.

--- a/docs/research/01-model-bakeoff.md
+++ b/docs/research/01-model-bakeoff.md
@@ -1,0 +1,174 @@
+# 01 — Model bakeoff: the right model per task
+
+_Code-grounded, honest. Builds on the prior verdict in `docs/SESSION_AUDIT.md:34-39` and the
+per-op router in `providers/model_router.py`. Each task = the model the code uses today, whether
+its reference-image support is real or a no-op, and a keep/change recommendation. Ends with a
+~$25 paid run designed to confirm or refute each call._
+
+## How the code wires models (today)
+
+Two registries, both tier-keyed (`fast`/`balanced`/`pro`), both overridable per-env and
+per-request:
+
+- **Generate** (`providers/image.py:29-33`): fast=`nano-banana`, balanced=`nano-banana-pro`,
+  pro=`seedream/v4/text-to-image`. Default tier `balanced` (`image.py:39`).
+- **Edit** (`providers/image_edit.py:29-33`): fast=`nano-banana/edit`, balanced=`nano-banana-pro`,
+  pro=`flux-pro/kontext`. Default `balanced` (`image_edit.py:39`).
+- **Per-op overrides** (`model_router.py:19-29`): `zoom_continue`→`flux-pro/kontext`,
+  `outpaint`/`outpaint_zoomout`→`bria/expand`, `inpaint`→`flux-pro/v1/fill`,
+  `upscale`→`clarity-upscaler`. `fresh`/`scale_parent_fresh` are tier-based (no slug).
+
+The op is chosen purely in `select_operation` (`model_router.py:48-65`): `place_submap` + a region
+crop → `zoom_continue`; everything else → `fresh`.
+
+## The reference-image reality (the load-bearing distinction)
+
+The prior finding holds and the current fal docs **sharpen** it: it is the **text-to-image
+endpoint** that ignores `image_urls`, not the model family.
+
+- `_args_for` (`image.py:109-134`) only attaches `image_urls` for `nano-banana` slugs, and the
+  inline comment records the empirical no-op (a photoreal prompt + an engraving ref came back
+  photoreal). fal's own nano-banana-pro **text-to-image** page lists no `image_urls` input;
+  the **`/edit`** page lists `image_urls` (up to 14 refs, identity for up to 5 people) plus
+  `num_images`/`resolution`. [fal nano-banana-pro/edit]
+- So the no-op is structural: fresh-gen + the expand bloom (`generate.py:578-579`, `:736-741`)
+  call `generate_image` (text-to-image) → refs are accept-but-ignored; only the **MEDIUM-LOCK
+  text** (`llm.py:1131-1143`) holds style there. This matches `SESSION_AUDIT.md:34-39,125-127`.
+- Refs **do** bite on the edit/continue endpoints: `nano-banana(-pro)` edit takes `image_urls`
+  (`image_edit.py:62-64`), Kontext takes a singular `image_url` (`image_edit.py:67-68`).
+- **Literature why:** loose cross-attention reference conditioning (IP-Adapter style) gives only
+  weak identity/style adherence vs. fine-tuning; spatial/structure control needs a separate
+  signal. [IP-Adapter docs; Mercity] The text-to-image nano refs behave like weak IP-Adapter
+  conditioning at best; the edit endpoints concatenate the image into context (Kontext's
+  "sequence concatenation" [Kontext arXiv 2506.15742]) which is why they actually preserve it.
+
+## Per-task recommendations
+
+### 1. Fresh map render (`fresh`, tier-based)
+- **Today:** `nano-banana-pro` (balanced). Strong text-following, good label legibility at
+  2K/4K, no spatial-control inputs (natural language only). [fal nano-banana-pro/edit;
+  DeepMind prompt guide]
+- **Ref support:** **no-op** (text-to-image). Style rides MEDIUM-LOCK text.
+- **Limit:** the `FAL_IMAGE_MODEL=nano-banana` (non-pro) env pin garbles map labels
+  (memory `project_fal_model_pin`); keep balanced=`nano-banana-pro` for clean text.
+- **Recommendation:** **keep nano-banana-pro.** Stop uploading the inert fresh-gen ref
+  (`SESSION_AUDIT.md:87`) — pure wasted fal upload. seedream (pro tier) is a viable text-to-image
+  alternative but buys nothing for the map case and has weaker label text.
+
+### 2. Zoom-continue / DEEPER (`zoom_continue` → `flux-pro/kontext`)
+- **Today:** Kontext, singular-ref in-context edit, "closer faithful continuation of this exact
+  map" (`image_edit.py:113-152`). The bakeoff picked it for strict zoom that keeps content +
+  style + layout vs. nano-banana's loose refs.
+- **Ref support:** **real** but singular (`image_url`) — so it carries **no separate style
+  exemplar** (`SESSION_AUDIT.md:99`); the medium clause rides the instruction text. Kontext is
+  purpose-built for identity/composition preservation across iterative edits.
+  [Kontext arXiv 2506.15742; together.ai]
+- **Limit:** renders label text as garble — the code deliberately works named features in as
+  *things to draw*, not captions (`image_edit.py:141-149`), and asks for sparse legible lettering.
+- **Recommendation:** **keep Kontext.** Open question to settle in the paid run: does
+  nano-banana-pro **/edit** (which *can* take a 2nd style ref + does multi-image) now match
+  Kontext on faithful zoom? If yes, the default-tier edit model and zoom could unify on one slug
+  and regain the style exemplar.
+
+### 3. Outpaint / AROUND map-pan (`outpaint`/`outpaint_zoomout` → `bria/expand`)
+- **Today:** BRIA Expand — pixel-preserving outpaint; the parent keeps its pixels, the margin is
+  painted to match (`image_edit.py:188-294`). Directional pin for map-pan (`_expand_args_for`),
+  centered canvas for OUTWARD zoom-out (`_zoomout_args_for`).
+- **Ref support:** N/A (it's an outpaint, not a ref-conditioned gen). Critical gotcha the code
+  already handles: BRIA's `prompt` is **optional and auto-generated from the image when empty**,
+  which fills photorealistically — so a hand-drawn map drifts to a photo in the margin.
+  [fal bria/expand; Bria docs] The code **must** pass the medium in `prompt`
+  (`image_edit.py:308-330`, `generate.py:557-565`).
+- **Limit:** the centered zoom-out leaves a soft seam at the source rectangle
+  (`image_edit.py:316-319`); the seamless OUTWARD default is instead the fresh `scale_parent`
+  gen (`generate.py:542-548`).
+- **Recommendation:** **keep BRIA** for directional map-pan (its core strength). For OUTWARD,
+  the code already prefers fresh `scale_parent` over the seamed outpaint — correct.
+
+### 4. OUTWARD container synth (`scale_parent_fresh`, tier-based + ref)
+- **Today:** text-to-image fresh gen with the source passed as `reference_urls=[body.image]`
+  (`generate.py:578-579`) — but per §"ref reality" that ref is a **no-op**; only the
+  `scale_parent` style-anchored prompt (`llm.plan_page(..., render_mode="scale_parent")`,
+  `generate.py:569-577`) holds the look. Used for medium-flip hops (planet→star_system) where an
+  outpaint can't reframe (`model_router.py:83-103`).
+- **Ref support:** **no-op** (text-to-image path) — this is the riskiest path for style drift.
+- **Recommendation:** **change.** Either (a) route `scale_parent_fresh` through the **edit**
+  endpoint (nano-banana-pro/edit, which honors refs + identity), or (b) accept text-only and
+  drop the inert ref. The paid run should measure style-drift on this hop specifically.
+
+### 5. Entity-edit / grounding repair (`edit` default = `nano-banana-pro`)
+- **Today:** `edit_image` default balanced=`nano-banana-pro`, which takes `image_urls`
+  (image + optional style exemplar, `image_edit.py:62-64`) — refs are **real** here. The
+  grounding repair loop also calls `edit_image` with a minimal "fix just these" instruction
+  (`generate.py:315-324`, `geometry_prompt.py:35-66`).
+- **Ref support:** **real** on the default tier (2 refs). The `pro`/Kontext edit tier drops the
+  2nd (style) ref (singular `image_url`) — `SESSION_AUDIT.md:99`.
+- **Recommendation:** **keep nano-banana-pro** as the default edit model — it is the one path
+  where the style exemplar + identity actually work. Don't route entity-edits through Kontext
+  (loses the style ref).
+
+## PAID BAKEOFF DESIGN (~$25 budget)
+
+**Goal:** confirm/refute the five calls above with numbers, on the project's real failure modes
+(style drift on fresh/scale_parent, faithful zoom, in-style outpaint, layout compliance).
+
+### Candidates × scenarios × conditions
+
+| Scenario | Candidates | Conditions |
+|---|---|---|
+| **S1 Fresh map** | nano-banana-pro, seedream-v4-t2i | MEDIUM-LOCK text on/off; ref attached on/off (prove the no-op) |
+| **S2 Zoom-continue** | flux-pro/kontext, nano-banana-pro/edit | with/without named-features clause |
+| **S3 Map-pan outpaint** | bria/expand | margin-prompt present vs empty (prove the photoreal drift) |
+| **S4 OUTWARD container** | nano-banana-pro/edit (ref-real) vs nano-banana-pro t2i (ref no-op) | both with style-anchor text |
+| **S5 Layout compliance** | nano-banana-pro | bins clause on/off (the 02-doc A/B; shared with §02) |
+
+Fixed seed-prompt set: 5 worlds (engraving city, watercolour forest, blueprint station, flat
+infographic, ink dungeon) so style + label legibility are judged across mediums.
+
+### Generation count + cost
+
+- S1: 2 models × 5 worlds × 4 conditions = 40
+- S2: 2 × 5 × 2 = 20
+- S3: 1 × 5 × 2 = 10
+- S4: 2 × 5 × 1 = 10
+- S5: 1 × 5 × 2 = 10
+- **Total ≈ 90 generations.** At fal's ~$0.04–0.15/image (nano-banana-pro/seedream-edit class;
+  Kontext/BRIA similar) → **~$4–14**. Budget 2 reruns + the VLM-judge calls (Gemini, cheap) →
+  comfortably **< $25**.
+
+### VLM-judge rubric (judge = **Gemini**, never qwen — it 429s and silently breaks judging;
+memory `project_qwen_ratelimit`)
+
+Score each output 0–10 on four axes, reusing the project's existing `score_style_pair` shape
+where possible:
+1. **Medium fidelity** — is it the same art medium as the reference world? (the core drift metric)
+2. **Faithfulness** (S2/S3/S4 only) — does it continue the SAME place (walls/landmarks kept), not
+   a reinvention?
+3. **Layout compliance** (S5) — fraction of listed entities at their stated h_pos/v_pos bin
+   (mirror T2I-CompBench: detector centroids vs. expected bins [T2I-CompBench NeurIPS'23]).
+4. **Label legibility** — are in-image labels readable, not garbled? (separates nano-banana-pro
+   from the non-pro pin and from Kontext).
+
+### What the run must measure (per recommendation)
+
+- **R1 (keep nano-banana-pro fresh):** S1 — does the ref-on vs ref-off pair score identically?
+  (confirms no-op → justifies dropping the upload). Does pro beat seedream on label legibility?
+- **R2 (keep Kontext zoom):** S2 — does Kontext beat nano-banana-pro/edit on *faithfulness*? If
+  nano-banana-pro/edit ties **and** wins label legibility, recommend unifying zoom on it (regains
+  the style ref).
+- **R3 (BRIA needs margin-prompt):** S3 — margin-prompt-empty should score far lower on medium
+  fidelity (confirms `image_edit.py:316-319`'s warning, makes the "callers MUST pass it" a test).
+- **R4 (fix scale_parent ref no-op):** S4 — nano-banana-pro/**edit** (real ref) vs t2i (no-op)
+  on medium fidelity + faithfulness. A real gap → route OUTWARD container through the edit
+  endpoint (recommendation #4).
+- **R5 (layout bins):** S5 — see `02-prompting.md`; the single most decision-relevant unknown.
+
+## Sources
+
+- fal nano-banana-pro/edit — https://fal.ai/models/fal-ai/nano-banana-pro/edit
+- fal Nano Banana 2 / edit — https://fal.ai/models/fal-ai/nano-banana-2 , https://fal.ai/models/fal-ai/nano-banana-2/edit
+- FLUX.1 Kontext — arXiv 2506.15742 ; https://www.together.ai/blog/flux-1-kontext ; fal flux-pro/kontext
+- BRIA Expand — https://fal.ai/models/fal-ai/bria/expand/api ; https://docs.bria.ai/image-editing/v2-endpoints/image-expansion
+- Seedream v4/4.5 — https://fal.ai/models/fal-ai/bytedance/seedream/v4.5/edit ; https://seed.bytedance.com/en/seedream4_0
+- IP-Adapter vs DreamBooth — https://huggingface.co/docs/diffusers/using-diffusers/ip_adapter ; https://www.mercity.ai/blog-post/understanding-and-training-ip-adapters-for-diffusion-models/
+- T2I-CompBench — NeurIPS 2023, arXiv 2307.06350

--- a/docs/research/02-prompting.md
+++ b/docs/research/02-prompting.md
@@ -1,0 +1,124 @@
+# 02 — Prompting: the recipe per model + the unanswered layout question
+
+_Code-grounded. The prompt clauses live in `providers/llm.py`, `providers/image.py`
+(`conditioning_preamble`), `providers/image_edit.py` (`build_zoom_instruction`), and
+`providers/geometry_prompt.py`. The open question — do the `layout_constraints` bins actually
+move pixels? — is `SESSION_AUDIT.md:66-70`; this doc designs the A/B that answers it._
+
+## The clauses that exist today
+
+### MEDIUM-LOCK (the universal workhorse)
+`llm.plan_page` system clause (`llm.py:1131-1143`). Fires whenever a `style_anchor` is present.
+Three moves, all empirically chosen:
+1. Name the medium explicitly and forbid drift ("never photorealism, a 3D render, or isometric
+   line-art — however much the subject might invite it").
+2. **Begin** the prompt with a leading medium clause ("Hand-drawn engraving with cross-hatching
+   and sepia ink, …").
+3. **End** with a one-line lock ("Rendered strictly as <medium> — not photoreal, not 3D…").
+
+This is the only style guard that works on **every** path including the fresh-gen no-op and
+seedream (`SESSION_AUDIT.md:29-39`). The bracket-the-prompt (front + back) structure matches what
+the literature recommends for these models: front-load the non-negotiables and restate
+prohibitions. Gemini-3-Pro-Image structured prompting reports ~91% mandatory-compliance / ~94%
+prohibition-compliance when constraints are stated as explicit MUST/MUST-NOT clauses. [SCHEMA for
+Gemini 3 Pro Image, arXiv 2602.18903]
+
+### Reference-image preamble (edit/continue paths only)
+`conditioning_preamble` (`image.py:137-201`) emits an ordered, **role-weighted** legend: image 1
+= region (strongest), then parent, then anchor, then the persistent **style** exemplar. The order
+*is* the weight. The `place_scene` variant tells the model image 1 is the EXTERIOR and to draw
+the architecturally-continuous INTERIOR (`image.py:154-163`) — the fix for "did you only zoom in?".
+Reminder from `01`: this preamble only bites where the endpoint honors refs (edit/continue);
+on the text-to-image fresh/expand path it rides along inertly.
+
+### Kontext zoom instruction
+`build_zoom_instruction` (`image_edit.py:116-152`): "zoom into <title> … keep the exact walls,
+buildings, towers and landmarks … same hand-drawn engraving style … SAME overhead map viewpoint;
+do not reinvent / restyle / switch to eye-level." Named sub-areas are worked in as **features to
+draw**, never as captions (Kontext garbles label text), and it appends the layout clause if
+present (`image_edit.py:150-152`).
+
+### Layout-constraint clause (the unverified one)
+`geometry_prompt.layout_constraints` (`geometry_prompt.py:14-28`): builds, nearest-first,
+`"<label> — <size>, <h_pos> <v_pos>"` joined into:
+> "SCENE LAYOUT (place these exactly where stated — nearest listed first, keep their relative
+> positions, sizes and front-to-back order): …"
+
+Bins come from `providers/geometry.py`: `_h_pos` (far-left/left/center/right/far-right at
+0.2/0.4/0.6/0.8), `_v_pos` (top/mid/bottom at 0.4/0.66), `_size_bin` (tiny→huge). The repair
+variant (`geometry_prompt.py:35-66`) emits "add a <x> (…)" / "move the <x> to <h_pos> <v_pos>".
+
+## The prompt recipe, per model
+
+| Model / path | Recipe that the code uses / should use |
+|---|---|
+| **nano-banana-pro fresh (t2i)** | MEDIUM-LOCK front+back; descriptive NL placement (bins); labels as a `Labels to include:` list (`generate.py:967-968`) — but NOT for `place_scene` (turns interior into a captioned diagram). No bounding-box input exists; NL only. |
+| **nano-banana-pro/edit** | image_urls = [subject, style exemplar]; role preamble; keep the edit instruction minimal + medium-locked. Honors up to 14 refs + identity for 5 people. [fal] |
+| **Kontext (zoom/continue)** | singular `image_url`; carry style **in the instruction text** (no 2nd ref slot); features-not-captions; "SAME viewpoint, do not reinvent." |
+| **BRIA (outpaint)** | `prompt` = the medium ("…drawn in the SAME style …, NOT a photograph"); MUST be non-empty or it auto-prompts photoreal (`generate.py:557-565`; [Bria docs]). |
+| **seedream (t2i pro)** | MEDIUM-LOCK text only; no ref slot in the t2i slug (`image.py:115-120`). |
+
+## How to phrase coordinate/layout constraints for best compliance (from the literature)
+
+- **Relative/directional language beats raw numbers — and is what the bins already use.** Public
+  testing of nano-banana shows descriptive spatial constraints ("rule of thirds horizontally and
+  vertically", "left/right eye socket", "1/3 vs 2/3 split") are followed precisely; numeric
+  coordinates were **not** validated to help. [minimaxir, *Nano Banana can be prompt engineered*]
+  → the `far-left … far-right` / `top|mid|bottom` bins are the *right* abstraction; sending raw
+  `x_pct` would likely be no better and possibly worse.
+- **State each placement as an explicit instruction, nearest-first** (the clause already does).
+  Structured MUST-style phrasing is what drives the >90% compliance numbers. [arXiv 2602.18903]
+- **Don't over-specify count + position + size + order in one run** — T2I models degrade on
+  multi-attribute compositional prompts (attribute swaps, spatial misalignment). [T2I-CompBench,
+  arXiv 2307.06350] If the bins underperform, the fallback is fewer salient anchors (the 2–3
+  nearest), not more detail.
+- **Consider a coarse grid hint.** Some practitioners get tighter layout by naming a 3×3 grid
+  ("top-left cell, centre cell") — which is exactly what `_h_pos`×`_v_pos` already encodes
+  (5×3). Phrasing the clause as a grid ("in the top-left region of the frame") may read more
+  naturally to the model than "far-left top".
+
+## OPEN QUESTION: do `layout_constraints` bins actually steer the render?
+
+**Status:** built deterministically, **not wired into the fresh B1 render**, and steering is
+**UNVERIFIED** (`SESSION_AUDIT.md:66`). Note the clause *is* appended in the tap path
+(`generate.py:971-974`, behind `_world_geometry_gen_on()` / `WORLD_GEOMETRY_GEN`) and rides into
+the Kontext zoom — but no one has measured whether the pixels move. The grounding diff
+(`grounding.py:63-113`) already gives the exact instrument to measure it.
+
+### The A/B that answers it
+
+**Design (paid, Gemini-judged, shares S5 budget with `01`):**
+- **Inputs:** ~10 hand-authored `expected_layout` lists (3–6 entities each) spanning the bins
+  (corners, centre, mixed sizes, front-to-back overlap). Use real `ProjectedEntity` dicts so the
+  clause text is production-identical.
+- **Arms:**
+  - **A (control):** prompt with NO layout clause.
+  - **B (bins):** same prompt + `layout_constraints(...)`.
+  - **B′ (grid rephrase):** same, but the clause phrased as a 3×3/5×3 grid ("in the top-left
+    region…") — tests the phrasing hypothesis above.
+  - *(optional)* **C (numeric):** append `x_pct/y_pct` to see if raw coords help or hurt.
+- **Model:** nano-banana-pro (the default fresh model) — the one that actually ships.
+- **Metric (no new tooling):** run `detector.detect` → `grounding.diff(expected, observed)` and
+  compare **mean `score`**, **presence**, and **pos_agree** (`grounding.py:103-106`) across arms.
+  This is the same UniDet-centroid-vs-expected method as T2I-CompBench [arXiv 2307.06350], so it's
+  a defensible number, and `POS_TOL=0.2` (`grounding.py:25`) lines up with the bin width.
+- **Decision rule:** if B's mean grounding score beats A by a meaningful margin (e.g. ≥ +0.1 and
+  pos_agree up), **wire `expected_layout` into the fresh render** (deferred item
+  `SESSION_AUDIT.md:84-85`) and prefer whichever of B/B′ wins. If B ≈ A, the bins don't steer
+  nano-banana-pro — keep them for the **grounding target only** (the verify/repair loop still
+  uses them) and don't spend prompt tokens on the fresh path.
+- **Cost:** ~10 layouts × 4 arms ≈ 40 gens + 40 detector calls → a few dollars; folds inside the
+  `01` ~$25 envelope.
+
+**Why this is the highest-value experiment:** it's the difference between "the geometry engine
+*describes* a layout the model ignores" and "the geometry engine *controls* the layout" — and it
+needs zero new infrastructure (the clause, the detector, and the diff all exist).
+
+## Sources
+
+- SCHEMA for Gemini 3 Pro Image (structured prompting, compliance rates) — arXiv 2602.18903
+- minimaxir, *Nano Banana can be prompt engineered…* — https://minimaxir.com/2025/11/nano-banana-prompts/
+- DeepMind Nano Banana prompt guide — https://deepmind.google/models/gemini-image/prompt-guide/
+- Google Cloud, *Ultimate prompting guide for Nano Banana* — https://cloud.google.com/blog/products/ai-machine-learning/ultimate-prompting-guide-for-nano-banana
+- T2I-CompBench (spatial-relationship metric) — arXiv 2307.06350 (NeurIPS 2023)
+- Bria Expand prompt behaviour — https://docs.bria.ai/image-editing/v2-endpoints/image-expansion

--- a/docs/research/03-coordinate-injection.md
+++ b/docs/research/03-coordinate-injection.md
@@ -1,0 +1,144 @@
+# 03 — Coordinate injection, entity edits, and verifiable faithfulness
+
+_Code-grounded. Covers (a) how coordinates reach the model today + alternatives from the
+literature, (b) how add/move/update/delete works through `EntityGeoEdit` and how to make edits
+verifiably faithful, and (c) the metric-vs-relative bridge. Builds on `SESSION_AUDIT.md`
+("generated→coords is relative, not metric; only `WORLD_TOPDOWN_MAPS` gives exact seeding")._
+
+## How coordinates are injected today
+
+The whole system is **fal-only, no ControlNet** by deliberate choice — geometry steers via
+**layout-as-prompt text**, not a structure-control model (`model_router.py:8-13`). The pipeline:
+
+1. **Geometry → bins.** `geometry.project_scene` (`providers/geometry.py:185-191`) projects each
+   `WorldEntityGeo` (world pose + footprint + height) through a flat-ground 2.5D pinhole into a
+   `ProjectedEntity` with continuous `x_pct/y_pct/w_pct/h_pct` **and** coarse bins `h_pos`
+   (5 levels), `v_pos` (3), `size` (5) — `geometry.py:97-127`.
+2. **Bins → prompt text.** `geometry_prompt.layout_constraints` (`geometry_prompt.py:14-28`)
+   serialises the bins, nearest-first, into the "SCENE LAYOUT (place these exactly where stated…)"
+   clause. The continuous `x_pct` is **dropped** — only the bin words are sent.
+3. **Clause → render.** Appended to the composed prompt behind `WORLD_GEOMETRY_GEN`
+   (`generate.py:971-974`); also threaded into the Kontext zoom (`image_edit.py:150-152`).
+4. **Verify against the same coords.** The grounding loop detects objects and diffs the
+   **continuous** rects via IoU + centroid (`grounding.py:63-113`) — so the bins drive the
+   prompt, the rects drive the check.
+
+**Honest status:** sending bins (not pixels) is the right abstraction (see `02`), but whether the
+bins move the *fresh* render is **unverified** (`SESSION_AUDIT.md:66`) — that A/B is in `02`.
+
+### Alternatives from the literature (and why the project doesn't use them)
+
+| Technique | What it gives | Why not here (today) |
+|---|---|---|
+| **ControlNet / T2I-Adapter** (depth, seg, canny, pose) | Hard structural control — exact layout from a condition map | Needs a self-hosted SD/Flux + ControlNet stack; fal's hosted gen endpoints don't expose it. Explicitly rejected (`model_router.py:8-13`). |
+| **GLIGEN** (grounded gen) | Bounding-box + label grounding via gated self-attention; box coords as Fourier-embedded tokens; open-set | Same: a model-architecture feature, not a hosted-API knob. The closest hosted analogue is descriptive bins. [GLIGEN arXiv 2301.07093] |
+| **Regional prompting** (hard binding + soft refine) | Per-region prompts in one image | Hosted nano-banana-pro has no region input; NL "in the top-left region" is the degraded form. [arXiv 2411.06558] |
+| **Inference-time spatial alignment** (energy/attention guidance on box centroids) | Pushes objects toward target boxes at sampling time, no retrain | Needs sampler access (latents/attention), which fal doesn't expose. [InfSplign arXiv 2512.17851] |
+| **Layout-as-text (the bins, current)** | Cheap, model-agnostic, deterministic, unit-testable, gives the verifier a target | Weakest control, compliance unverified — but the only one a hosted API allows, and descriptive position language *does* land on these models. [minimaxir] |
+
+**Takeaway:** given the fal-only constraint, layout-as-text is the correct choice; the upgrade
+path is not ControlNet but a **verify→repair** loop that *measures* compliance and corrects it
+(which the code already has — below). If hard control ever becomes a requirement, it forces a
+self-hosted Flux+ControlNet/GLIGEN backend, a much larger change.
+
+## Entity add / move / update / delete (`EntityGeoEdit`)
+
+The NL-editable map is the structured-edit half — coordinates flow the *other* way (user
+intent → geometry), and never come from the image model.
+
+- **Wire type** (`packages/config/src/index.ts:700-711`): discriminated union
+  `move{target,dx,dy}` | `set_height{target,height}` | `set_appearance{target,visual}` |
+  `remove{target}` | `add{label,pos,height?,footprint?}`. World coords: origin top-left, +x east,
+  +y south (`index.ts:698`).
+- **NL → edits** (`llm.edit_entities_nl`, `llm.py:2237-2267`): one `_complete_json` call at
+  `temperature=0.0`; the system prompt (`ENTITY_EDIT_SYSTEM`, `llm.py:2121-2135`) hands the model
+  only the entity roster (id + label + geo) and forbids inventing ids. `parse_entity_edits`
+  (`llm.py:2152-…`) is a **tolerant coercer**: unknown op, `target ∉ valid_ids`, or ill-typed
+  field → the edit is dropped, never raises (`llm.py:2153-2155`). A bad completion degrades to a
+  thinner/empty plan, not a wrong mutation. The LLM emits relative `dx/dy` (a *shift*), not
+  absolute positions — so it never has to know the metric scale.
+- **Apply** (`applyEntityEdit`, `apps/web/lib/world-map.ts:171-208`): pure function. `add` mints a
+  `geo_user_<slug>` id with defaults; `remove` filters; `move` adds the delta; `set_height` /
+  `set_appearance` overwrite; all stamp `source:"user"` + `updated_at`. `applyEntityEdits`
+  (`world-map.ts:322-…`) wraps it with optimistic-concurrency retry.
+- **Blast radius** (`blastRadius`, `world-map.ts:218-236`): which saved nodes reference an edited
+  entity → the re-stage candidates, including **frame-siblings** when `geos` is supplied (moving
+  the Tower of Art re-stages every interior that shows things around it). Built from
+  `appears_on_node_ids` via `buildGeoReferences` (`world-map.ts:241-…`). Served by the
+  `/edit-entities` endpoint (`generate.py:1645-1675`).
+
+## Making edits verifiably faithful (grounding diff before/after)
+
+The grounding machinery already gives the before/after instrument — it just isn't pointed at the
+entity-edit path yet.
+
+**What exists:**
+- `grounding.diff(expected, observed)` (`grounding.py:63-113`) → `GroundingReport{matched,
+  missing, extra, score, mean_iou}`, with the extras penalty (`grounding.py:107-110`) so a clean
+  match + a hallucinated object can't score 1.0.
+- `run_grounding_loop` (`grounding.py:136-168`): bounded detect→diff→repair→re-verify, **returns
+  the best-scoring image, never merely the last**, stops when nothing is `_actionable`.
+- Live wiring in the **tap** render (`generate.py:284-336`, behind `VLM_GROUNDING` /
+  `VLM_GROUNDING_REPAIR`): `_verify` = `detector.detect` + `diff`; `_repair` =
+  `geometry_prompt.repair_instruction` (`geometry_prompt.py:35-66`) → `edit_image` with a minimal
+  "fix just these" instruction.
+
+**The gap + the fix — verifiable entity edits:** the `/edit-entities` flow mutates *geometry* and
+stales nodes (blast radius), but re-staging a node and **confirming the edit took** is not closed
+in code. Proposed loop (reuses everything above):
+
+1. **Before:** project the node's pre-edit scene → `expected_before`; run `diff` against the
+   current render → baseline report.
+2. **Apply** the `EntityGeoEdit`(s); **re-project** → `expected_after` (the move/add/remove is now
+   in the geometry, so `expected_after` differs in exactly the edited entity's bin).
+3. **Restage** the affected node, then **verify**: `detector.detect` the new render →
+   `diff(expected_after, observed)`. The edit is **faithful** iff the moved/added entity is now
+   `matched` at its new bin (`pos_ok`) and removed ones are absent (not in `matched`, not in
+   `extra`).
+4. **Repair/abort:** if not, run the bounded loop with `repair_instruction(expected_after, …)`;
+   if it still fails, surface "couldn't place X" rather than silently shipping a wrong frame.
+
+This turns "we edited the map and re-rendered" into "we edited the map and **proved** the render
+reflects it" — a regression target, not a vibe. It is also the natural place to assert the
+**inverse**: an edit must NOT perturb un-edited entities (compare `expected_before` vs
+`expected_after` deltas to the observed deltas — the in-context edit models claim to leave
+unmentioned content alone; verify it [Kontext arXiv 2506.15742]).
+
+## Metric vs. relative — the bridge options
+
+The standing finding: **generated→coords is relative, not metric**; the only exact path is
+`WORLD_TOPDOWN_MAPS` (`generate.py:236-252`, `SESSION_AUDIT.md:52-53`).
+
+- **Why relative.** A normal (often 2.5D) render is read back by monocular estimation
+  (`estimateGeoFromBBox`, used in `world-map.ts:380`) — a bbox under an unknown oblique camera
+  gives a *bearing/size approximation*, not metres. Bins absorb that ambiguity honestly.
+- **The exact lever (already shipped).** `WORLD_TOPDOWN_MAPS` forces a flat orthographic overhead
+  render (`generate.py:248-252`), so a detection bbox **is** the world footprint — the one place
+  bbox→world is metric. The top-down branch of `estimateGeoFromBBox` is therefore left
+  **un-clamped on purpose** (`SESSION_AUDIT.md:105-108,137-144`): a building spanning 80% of the
+  frame must seed an ~80-unit footprint; the oblique clamp exists only to tame monocular-depth
+  blowups, which top-down doesn't have.
+- **Bridge options, cheapest first:**
+  1. **Top-down maps as the metric anchor (current).** Seed the metric ladder from top-down
+     renders; let oblique scenes stay relative. No new model. Recommended default.
+  2. **Anchor-pair scale calibration.** When two entities have both a known world distance (from
+     the geo map) and a detected pixel separation, solve a single scale factor for that frame —
+     upgrades a relative oblique read to metric without a depth model. Cheap, deterministic, fits
+     the existing `neighbors_of` bearings (`geometry.py:207-228`).
+  3. **Monocular depth / metric-depth model** (e.g. a Depth-Anything-class endpoint) to lift
+     oblique bbox → metric. Most general, but adds a model + the fal-only posture forbids it
+     today; only worth it if oblique scenes must be metrically composited.
+  4. **Keep the two planes explicit.** Metric where it's earned (top-down + anchor-pairs),
+     relative elsewhere, and never silently mix them in one ladder — matches the current honest
+     stance. The `scale_tier` field (`index.ts:580-582`) already lets a view declare its rung so
+     downstream code knows which regime it's in.
+
+## Sources
+
+- GLIGEN — arXiv 2301.07093 ; https://gligen.github.io/
+- Region-Aware T2I (hard binding + soft refinement) — arXiv 2411.06558
+- InfSplign (inference-time spatial alignment) — arXiv 2512.17851
+- T2I-CompBench (centroid+IoU spatial metric, mirrors `grounding.diff`) — arXiv 2307.06350
+- FLUX.1 Kontext (in-context edits preserve unmentioned content) — arXiv 2506.15742
+- minimaxir, *Nano Banana can be prompt engineered* — https://minimaxir.com/2025/11/nano-banana-prompts/
+- IP-Adapter (loose ref conditioning, needs spatial control to be added) — https://www.mercity.ai/blog-post/understanding-and-training-ip-adapters-for-diffusion-models/

--- a/docs/research/04-recursion.md
+++ b/docs/research/04-recursion.md
@@ -1,0 +1,200 @@
+# 04 — Recursion in the description→map pipeline
+
+_Code-grounded, same discipline as `docs/SESSION_AUDIT.md`: what recursion actually exists
+today, where deeper recursion is genuinely needed vs. where flat-v1 is the honest call, and a
+concrete recommendation for nesting depth + the data model. Every claim pinned to a file:line
+in this worktree. Literature only where it changes the recommendation._
+
+## 1. The recursion that is built: PARSE → SOLVE → SEED → RENDER
+
+The B1 "describe a place → logical object world" path is **not** recursive at the pipeline
+level — it is a single linear pass (one LLM parse, one pure solve, one seed, one render). The
+recursion that exists is **inside the solver**, where placement is resolved by a
+relation-dependency fixpoint rather than a single sweep.
+
+- **PARSE** — `providers/llm.py plan_world_from_description` → a `SceneGraph` of *relations
+  only*, never coordinates. The endpoint is `generate.py:1693 plan_world_endpoint`; it is
+  gated by `WORLD_FROM_DESCRIPTION` (403 when off, `generate.py:1713`).
+- **SOLVE** — `providers/layout_solver.py solve_layout` (`:292`). Pure, deterministic,
+  golden-tested (`tests/world_bench/test_layout_solver.py`).
+- **SEED** — the client POSTs `solved` to the existing `/api/world/[id]/map` →
+  `upsertEntityGeos`; the solver emits exactly that shape (`layout_solver.py:260 _emit`,
+  `source:"derived"`, `confidence 0.6`).
+- **RENDER** — `geometry_prompt.layout_constraints` + the grounding loop (description-driven
+  pixels today; see §3.1).
+
+### The genuinely recursive step: relation-dependency resolution in SOLVE
+
+`solve_layout` places `subject` relative to an already-placed `object`. Since a relation chain
+can be deep (a lamp `on_top_of` a desk that is `on_wall`), placement is iterated to a
+**fixpoint**, not done in one pass:
+
+```
+for _ in range(len(insts) + 2):        # layout_solver.py:336
+    changed = False
+    for it in insts:
+        ... place it relative to its (now-resolved) object ...
+    if not changed: break
+```
+
+This is the local form of the literature's *coarse-to-fine, parent-then-child* recursion
+([SceneHGN](http://geometrylearning.com/scenehgn/), [HLG](https://arxiv.org/pdf/2508.17832)):
+anchors (walls / root objects) resolve first (`layout_solver.py:332` seeds root anchors at
+centre), then their dependents, until stable. The fixpoint cap (`len(insts)+2`) bounds it; a
+relation whose object never resolves drops to a soft clarifier + centre default
+(`layout_solver.py:356-363`). It is iteration over a dependency DAG, **flattened into one
+frame** — not nesting into sub-frames.
+
+### Why the LLM emits relations, not coordinates (the load-bearing choice)
+
+The audit's ROOT-2 failure was "the model free-styles placement." The pipeline closes it by
+splitting roles: the LLM emits **structure** (`SpatialRelation` between refs); the
+deterministic solver emits **geometry**. The parse boundary even drops a stray coordinate.
+
+This is now an independently-confirmed result in the literature, which **sharpens the
+recommendation to keep it**: the Open-Universe indoor-scene work found that *"tasking an LLM
+with directly specifying metric location coordinates leads to poor performance due to mismatch
+with natural language in training data,"* and instead has the LLM emit *"a declarative program
+describing objects and spatial-relation constraints"* solved separately
+([arXiv 2403.09675](https://arxiv.org/html/2403.09675v1)). [SceneCraft](https://arxiv.org/html/2403.01248v1)
+and [GraLa3D](https://arxiv.org/html/2412.20473) follow the same split (LLM → scene-graph
+constraints → solver). OFB's PARSE→SOLVE split is the same architecture, arrived at from the
+same failure.
+
+## 2. Where deeper (sub-frame) recursion is genuinely needed
+
+The data model already *describes* recursion that the solver does **not yet build**: a true
+tree of nested frames.
+
+- **`WorldEntityGeo.parent_id` + `pos` local to the parent + a learned `scale`** is the
+  documented nested-frame model (`packages/config/src/index.ts:503-531`): a place you ENTER
+  is its own little world; its sub-entities carry `parent_id` and a `pos` in the parent's
+  local frame, so the interior is fixed once and stays consistent across views.
+- The **DEEPER (tap-enter)** path already exercises this for real:
+  `apps/web/lib/world-map.ts deriveGeoFromExtraction` (`:363`) seeds extracted sub-entities
+  with `parent_id` and **learns the parent's `scale`** = `parent.footprint / localExtent(geos)`,
+  clamped `[1e-3, 10]` (`:411`). That is one real level of recursion in the persisted world.
+- **OUTWARD (ascend)** is the *inverse* recursion — reparenting the current root under a
+  freshly-synthesized container — on the same metric ladder (`SCALE_LADDER`,
+  `index.ts:16`; `model_router.coarser_tier :75`, `select_outward_op :94`).
+
+So the world model is a tree (`parent_id` chains, resolved by `resolveAbsolutePos`), and
+DEEPER/OUTWARD walk it one rung at a time. The **gap** is that the *description→map solver*
+(B1) flattens everything into one frame:
+
+### Flat-v1 vs. deferred (honest split)
+
+| Path | Recursion today | Status |
+|---|---|---|
+| SOLVE relation chains | fixpoint within ONE frame (`layout_solver.py:336`) | **built** |
+| `inside` nesting (B1) | **flat**: prop sits within container footprint, same frame, `parent_id:null` (`layout_solver.py:172-176`, `:265`) | **deliberate flat-v1** |
+| DEEPER tap-enter | one real sub-frame level, learned `scale` (`world-map.ts:405-416`) | **built** |
+| OUTWARD ascend | one reparent level up the ladder | **built (single-hop, flag-off)** |
+| Multi-hop OUTWARD/DEEPER chains | drift across hops **unmeasured** (Risk #1, `PLAN_OUTWARD.md:118`) | **deferred / unmeasured** |
+
+The `inside` relation is the clearest deferral: `solve_layout` marks it `nested:True` and
+returns the container's `(ox,oy)` with **no translation and `parent_id` left null on emit**
+(`layout_solver.py:172-176`, `:265`) — it is exempt from de-overlap (`:204`) but it does **not**
+become a child frame with its own `scale`. The comment says so explicitly: *"true sub-frame
+nesting is deferred — see docs/PLAN_PLACE_TO_WORLD.md."* This is the right call for v1 (a mug
+on a shelf does not need its own coordinate universe), but it means a described place is
+**one flat level**, whereas a tapped-into place is **two**.
+
+## 3. Where recursion is NOT needed (and shouldn't be added)
+
+- **3.1 Render is not recursive, and the seed already carries the layout.** B1 renders a
+  single description-driven image; `expected_layout` is **not wired into the fresh render**
+  (`SESSION_AUDIT.md:66-70`). The logical layout lives in the seeded geos (tap-routable),
+  not necessarily the pixels. Making the render *recursively* refine sub-regions would be
+  premature: the honest first fix is to wire `expected_layout` to *steer* the single render,
+  not to recurse it. The grounding loop already does one bounded repair pass — that is the
+  correct amount of render-side iteration for a relative-not-metric pipeline.
+- **3.2 Over-packing into sub-frames is a trap.** The literature warns recursion *propagates*
+  error: autoregressive/iterative generation suffers *"compounding errors as generated frames
+  become the context for future steps"* ([Pathwise](https://arxiv.org/html/2602.05871),
+  [BAgger](https://arxiv.org/pdf/2512.12080)). Every extra recursion level the *generator*
+  performs is another place drift enters. OFB's design keeps the recursion in the
+  **deterministic solver + persisted geo tree** (no drift) and limits the *generator* to one
+  hop at a time with a style anchor every hop (INV-3, `PLAN_OUTWARD.md:123`). That layering is
+  correct and should be preserved.
+
+## 4. Recommendation — recursion depth + the nested-frame data model
+
+### 4.1 Depth: cap meaningful nesting at ~2–3 frame levels per render, unbounded in the tree
+
+The hierarchical-scene literature converges on **3–4 semantic levels** (SceneHGN:
+room → functional region → object → part; HLG: room → anchors → tabletop/contents). OFB's
+`SCALE_LADDER` is 11 rungs (`index.ts:16-19`), but those are *navigation* rungs across whole
+sessions, not levels rendered in one image. Recommendation:
+
+1. **Persisted tree: unbounded** — `parent_id` chains can be arbitrarily deep across a
+   session (OUTWARD/DEEPER each add a rung). `resolveAbsolutePos` already walks the chain with
+   a cycle guard, and `geometry_checks._parent_cycles` (`geometry_checks.py:113`) blocks
+   cycles. Keep it unbounded; the metric span is stored/compared in **log space** to survive
+   ~27 orders of magnitude (`index.ts:22-24`, `PLAN_OUTWARD.md:126`).
+2. **Per-render: ~2 levels (the place + its direct children).** A single rendered frame
+   should show one frame and its immediate sub-entities — matching DEEPER today
+   (`deriveGeoFromExtraction` seeds children of *one* parent). Rendering 3+ nested levels in
+   one image is where the monocular-depth pipeline (relative, not metric — `SESSION_AUDIT.md`)
+   stops being trustworthy.
+3. **Auto-insert intermediate rungs** when a hop is too large, rather than recursing visually
+   — the design already specifies this for OUTWARD (clamp visual zoom ~×3–4/hop, insert a rung
+   when the metric jump is large, `PLAN_OUTWARD.md:62-63`). Apply the same to any future
+   B1 `inside` promotion: never collapse two ladder rungs into one render.
+
+### 4.2 The nested-frame data model: promote B1 `inside` to the DEEPER model
+
+The data model is already correct — the fix is to make the B1 solver **use** it for `inside`,
+exactly as `deriveGeoFromExtraction` does for tap-enter. Concretely, when promoting `inside`
+from flat-v1 to a real sub-frame in `layout_solver.py`:
+
+- On emit (`_emit`, `:260`), for an `inside` subject set
+  `parent_id = f"geo_plan_{container_ref}"` instead of `None` (today `:265`), and keep its
+  `pos` **local to the container** (origin at the container, not the place frame).
+- Have the solver compute the container's **learned `scale`** the same way the TS path does —
+  `scale = max(container.footprint.w, .d) / localExtent(children)`, clamped `[1e-3, 10]` —
+  mirroring `world-map.ts:410-411`. Emit it on the container geo (`scale` field,
+  `index.ts:526-531`). This is what makes a nested `pos` resolve to a true absolute position;
+  without it the child's local coords are meaningless.
+- Run the existing per-frame de-overlap **within each frame** (the children of a container
+  de-overlap among themselves, not against the place's other entities) — the literature's
+  "constraint enforcement separated across decomposition levels to minimize error propagation"
+  ([HLG](https://arxiv.org/pdf/2508.17832)). The current single-frame `_de_overlap`
+  (`layout_solver.py:199`) already excludes `nested` items (`:204`); the promotion is to give
+  each container its own de-overlap pass instead of excluding nested items entirely.
+- **Guardrails already exist:** `geometry_checks.check_geo_entities` validates
+  `parent_id` resolution + cycles + `scale > 0` (`geometry_checks.py:92-95`, `:106-108`,
+  `:113`), and the live diagnostic already runs on solver output
+  (`generate.py:1734`). So promoting `inside` to nesting is *covered by the anchors the day
+  it ships* — no new invariant code, just the solver change + golden fixtures.
+
+### 4.3 Keep the LLM coordinate-free at every level
+
+Whatever the nesting depth, the parse boundary stays relations-only (the ROOT-2 fix and the
+Open-Universe result). A nested object is still expressed as `inside`/`on_top_of` a ref; the
+*solver* picks the local coordinate. Recursion lives in the solver and the persisted tree —
+never in what the model is asked to emit.
+
+## 5. One-paragraph verdict
+
+The pipeline is correctly **linear at the top and recursive in two contained places**: a
+relation-fixpoint inside the solver (built, bounded, golden-tested) and a one-level frame tree
+in the persisted world (built for DEEPER/OUTWARD). The honest gap is that B1's `inside` is
+flat-v1 — the *model* exists (`parent_id` + learned `scale`) but the *description solver* does
+not yet use it, so a described place is one frame while a tapped place is two. The fix is small
+and already guarded: make `layout_solver` emit `inside` as a real child frame with a learned
+`scale`, exactly as `deriveGeoFromExtraction` already does. Depth should be **unbounded in the
+persisted tree** (log-space metric, cycle-guarded) but **~2 levels per render** with
+auto-inserted intermediate rungs — both to match the trustworthy range of the relative-geometry
+pipeline and to keep generator-side recursion (where drift compounds) to a single hop.
+
+---
+
+### Sources
+- [Open-Universe Indoor Scene Generation (LLM program synthesis, relations not coordinates)](https://arxiv.org/html/2403.09675v1)
+- [SceneCraft: LLM agent synthesizing 3D scenes (scene-graph constraints → solver)](https://arxiv.org/html/2403.01248v1)
+- [GraLa3D / scene-graph + layout-guided 3D generation](https://arxiv.org/html/2412.20473)
+- [SceneHGN: hierarchical graph networks, room→region→object→part](http://geometrylearning.com/scenehgn/)
+- [HLG: hierarchical layout generation, recursively decoupled, constraints per level](https://arxiv.org/pdf/2508.17832)
+- [Pathwise test-time correction (compounding drift in autoregressive generation)](https://arxiv.org/html/2602.05871)
+- [BAgger: backwards aggregation for mitigating drift](https://arxiv.org/pdf/2512.12080)

--- a/docs/research/05-baseline-methodology.md
+++ b/docs/research/05-baseline-methodology.md
@@ -1,0 +1,250 @@
+# 05 — Baseline & regression methodology
+
+_Code-grounded design, `SESSION_AUDIT.md` discipline. How to turn the existing runners +
+the new `geometry_checks` anchors into a **continuous regression harness**; a concrete design
+for the two missing pieces (a baseline-drift guard, and the multi-hop drift runner for the
+unmeasured Risk #1); and how the free deterministic layer and the paid VLM-judged layer fit
+together. File names + thresholds + what runs free-per-commit vs paid-on-label are explicit._
+
+## 1. What exists, sorted by what it costs to run
+
+The eval surface is real (`Makefile:34-82`). The load-bearing split is **free deterministic
+gates** (every commit) vs **paid VLM-judged runners** (manual / on-label). The methodology
+below extends that split; it does not invent a parallel one.
+
+| Layer | Mechanism | Cost | Today's trigger |
+|---|---|---|---|
+| Deterministic anchors | `geometry_checks` 20 anchors (`tests/test_geometry_checks.py`); solver goldens (`test_layout_solver.py`); projection golden + cross-lang fuzz (`eval-geometry`); schema parity (`test_geo_schema.py`) | **free** | `make eval` (`-m "not paid"`) every commit |
+| Live diagnostic | `check_geo_entities(solved)` logs (never blocks) on real solver output | free | runtime, `generate.py:1734` |
+| VLM-judged A/B | 5 paid runners: `layout`, `grounding`, `coherence`, `style`, `outward-drift` | **paid** | `make eval-<name>`, manual, gated by `*_BENCH_RUN` |
+
+The paid runners share a deliberate shape worth preserving: a **pure `summarize`** (the
+pass/fail brain) separated from the spend, so the decision is unit-tested free
+(`outward_runner.py:139 summarize`, `coherence_runner.py:169`), a configurable threshold from
+env (`outward_runner.py:39 OUTWARD_BENCH_THRESHOLD=6.5`), and artifacts written to a
+**git-ignored** `reports/` (`.gitignore:48 apps/modal-backend/tests/**/reports/`). That is the
+skeleton the regression harness slots into.
+
+### The honest gap (what this doc designs)
+
+`SESSION_AUDIT.md` + `PLAN_OUTWARD.md` name the holes precisely:
+- **No baseline-drift regression guard, and no committed baselines to guard against.**
+- **Multi-hop drift across OUTWARD/DEEPER chains is UNMEASURED** (Risk #1,
+  `PLAN_OUTWARD.md:118`). `outward_runner.py` measures a **single** hop only (`_run_case` does
+  one `from_tier → to_tier`).
+- VLM-judge scores are treated as absolute pass/fail (a fixed `6.5`), but the literature is
+  clear that VLM judges are **reliable as relative rankings, not absolute calibration** (see §5).
+
+## 2. The continuous regression harness (free, per-commit)
+
+The free layer is already a regression harness for *correctness* — it just lacks a
+*quality-baseline* tier. Make it continuous by adding one deterministic gate and committing
+baselines for the paid layer to compare against.
+
+### 2.1 Wire the anchors as a self-check on every solver/projection output
+
+The 20 `geometry_checks` anchors prove the checker; the live diagnostic
+(`generate.py:1734`) proves real output at runtime. Close the loop in CI: extend
+`test_layout_solver.py` so **every golden fixture's solved output is also run through
+`check_geo_entities` and asserted issue-free** — the anchor already exists
+(`test(anchor): solver output must pass the geometry invariants`, commit `3010b4a`). This makes
+the deterministic invariants a *property* every solver test must hold, not a separate suite.
+Do the same for the projection golden (`check_projected` over each `ProjectedEntity`).
+
+### 2.2 Commit a thresholds file — the single source of pass/fail truth
+
+Today each runner hard-codes or env-reads its threshold (`OUTWARD_BENCH_THRESHOLD=6.5`,
+`STYLE_BENCH` pass at the medium-lock lift). Centralise them in **one committed file** so a
+threshold change is a reviewable diff and the free layer can validate it without spending:
+
+```
+apps/modal-backend/tests/eval_baselines.json     # committed (NOT in reports/)
+{
+  "schema_version": 1,
+  "style":          { "metric": "medium_faithfulness_lift", "min": 8.0,  "n_min": 1 },
+  "layout":         { "metric": "mean_lift",                 "min": 0.0,  "n_min": 4 },
+  "grounding":      { "metric": "grounded_confirm_rate",     "min": 0.6,  "n_min": 4 },
+  "coherence":      { "metric": "mean_lift",                 "min": 0.0,  "n_min": 3 },
+  "outward_drift":  { "metric": "fresh_medium_mean",         "min": 6.5,  "n_min": 10,
+                      "regression_band": 1.0 }
+}
+```
+
+- `min` = the absolute floor a paid run must clear (the existing thresholds, lifted here).
+- `regression_band` = how far **below a previously-recorded baseline mean** a new paid run may
+  fall before it is a *regression* (vs. just a low absolute score) — see §3.
+- `n_min` = the minimum sample size for the number to count (guards the `outward` N≥10 caveat
+  the runner prints, `outward_runner.py:198`; today nothing enforces it).
+
+### 2.3 A free schema/threshold check in `make eval`
+
+Add a free test `test_eval_baselines.py` (runs under `-m "not paid"`, so every commit) that:
+1. loads `eval_baselines.json`, asserts it parses + every runner key has the required fields;
+2. asserts each runner's `summarize()` emits the `metric` key the baselines file references
+   (call `summarize` on a tiny **synthetic** `CaseResult` list — no spend, the pure-brain
+   pattern the runners already enable, `outward_runner.py:139`);
+3. asserts monotonic sanity on thresholds (`0 ≤ min ≤ 10` for 0–10 judges, band ≥ 0).
+
+This catches the classic rot — a runner is refactored and stops emitting the metric the gate
+keys on, or a threshold is fat-fingered — **for free, every commit**, with zero fal/openrouter
+calls. It is the metamorphic/"golden-version" idea applied to the *gate*, not the model
+([metamorphic regression testing](https://arxiv.org/pdf/2109.09798)).
+
+## 3. Design: the baseline-drift guard (the missing regression tier)
+
+Today a paid run prints a number and a human eyeballs it. A drift guard makes "did this commit
+make consistency *worse*" mechanical. Design:
+
+### 3.1 Record + compare, don't just print
+
+Each paid runner already writes `<name>_latest.json` to the git-ignored `reports/`
+(`outward_runner.py:192`, `coherence_runner.py:202`). Add a **committed**
+`apps/modal-backend/tests/eval_baselines/<name>.json` holding the *last accepted* summary
+(means + n + commit sha + date). A new helper `tests/_baseline.py compare(name, summary)`:
+
+```
+status = compare("outward_drift", report["summary"])
+#   PASS       : metric >= baselines.min                         (absolute floor)
+#   REGRESSION : metric <  baseline.mean - regression_band       (dropped vs accepted baseline)
+#   IMPROVED   : metric >  baseline.mean + regression_band       (offer to re-baseline)
+#   LOW_N      : summary.n < baselines.n_min                     (don't trust, don't gate)
+```
+
+`compare` is **pure** → unit-tested free with synthetic summaries (same discipline as
+`summarize`). Only the *recording* of a new baseline spends; the *comparison logic* is free and
+covered every commit.
+
+### 3.2 Re-baselining is an explicit, reviewed act
+
+A drift guard is only honest if the baseline can't silently drift up with noise. Rule:
+`reports/<name>_latest.json` is an artifact; promoting it to
+`tests/eval_baselines/<name>.json` is a **manual `make eval-baseline-accept NAME=outward_drift`**
+that copies latest→committed and stamps the sha. So every baseline move is a reviewable diff
+with provenance — the "golden version" concept ([baseline testing](https://www.virtuosoqa.com/post/baseline-testing)),
+kept under version control rather than recomputed from drifting runs.
+
+### 3.3 Adaptive band, not a single fixed cliff
+
+The VLM-judge literature warns a single absolute threshold is brittle (calibration error is
+nontrivial; §5). So the guard's *primary* signal is **relative** (drop vs. the committed
+baseline mean by more than `regression_band`), with the absolute `min` as a backstop. This
+matches the model-drift guidance to *"adopt adaptive baselines that adjust to typical
+performance rather than fixed thresholds, reducing false alarms while catching real issues"*
+([model drift](https://magai.co/how-to-detect-and-manage-model-drift-in-ai/)). Concretely the
+band ≈ the run-to-run judge noise: estimate it once from 3 repeat runs of the same fixtures and
+set `regression_band` to ~1× its stdev (for the 0–10 judges, ~1.0 is a sane start, matching the
+`outward` precedent).
+
+## 4. Design: the multi-hop drift runner (Risk #1, currently unmeasured)
+
+`outward_runner.py` measures one hop. The design's stated risk is **compounding drift across
+MANY hops** (`PLAN_OUTWARD.md:118, 123`), which the autoregressive-generation literature
+confirms is the real failure mode: *"exposure bias causes compounding errors as generated frames
+become the context for future steps; initial inaccuracies compound over time"*
+([Pathwise](https://arxiv.org/html/2602.05871), [BAgger](https://arxiv.org/pdf/2512.12080)).
+Measure it directly.
+
+### 4.1 `tests/continuity_bench/chain_runner.py` (new, paid, on-label)
+
+Model it on `outward_runner.py` (reuse `_load_env`, `score_style_pair`, the `reports/` +
+`summarize` shape):
+
+1. Generate one styled source at the finest rung of a chain (e.g. `place`).
+2. Walk OUTWARD **k hops** (`place→district→city→region→world`, picked via
+   `model_router.coarser_tier`, `model_router.py:75`), each hop the real ascend op
+   (`select_outward_op`, `:94`) conditioned on the *previous hop's output* — i.e. the actual
+   compounding path, not k independent single hops.
+3. After each hop `i`, score **two** things with the existing judge:
+   - `drift_from_source[i] = score_style_pair(source, hop_i)` — absolute medium-faithfulness
+     vs. the *original* (does the chain wander off the starting medium?);
+   - `drift_step[i] = score_style_pair(hop_{i-1}, hop_i)` — per-hop loss (where the wandering
+     happens).
+4. `summarize`: `mean_drift_per_hop`, `total_drift = source_score − final_hop_score`, and a
+   **`half_life`** = the hop index where `drift_from_source` first crosses a floor. The pure
+   `summarize` is the gate brain; unit-test it on synthetic score sequences.
+
+### 4.2 Why this is the right shape
+
+- It reuses the exact reparent/ascend ops the product uses (`select_outward_op`,
+  `expand_image_zoomout`, the `scale_parent` fresh path), so the number describes the real
+  feature, not a proxy.
+- It turns Risk #1 into a **trend with a stopping rule**: the gate isn't "is hop 5 good" (a
+  single VLM score, noisy) but "**how many hops until drift exceeds the band**" — a far more
+  robust signal, and exactly the *relative-ranking* use the VLM literature endorses (§5). The
+  product rule falls out of it: cap auto-OUTWARD at `half_life − 1` hops, or force a
+  style-anchor refresh / human checkpoint there.
+- A symmetric DEEPER chain (`world→…→object`) measures the inward direction; the deterministic
+  side is already covered by `INV-1` (reparent moves no leaf, `PLAN_OUTWARD.md:51-57`) and
+  `tierTransitionValid` (INV-2, `index.ts:50`) — so the chain runner only needs to add the
+  *visual* drift number the deterministic invariants can't see.
+
+### 4.3 Mirror it deterministically (free) where possible
+
+Drift has a **metric** half and a **visual** half. The metric half is free: a free TS test
+walking a k-hop reparent chain and asserting `resolveAbsolutePos(leaf)` is byte-identical
+before/after (INV-1) and every hop passes `tierTransitionValid` (INV-2) catches *coordinate*
+drift with zero spend. The chain runner then only spends on the *pixel-medium* half the
+deterministic checks can't measure. This is the §6 layering: push everything that can be a
+deterministic invariant into the free tier; spend VLM budget only on the genuinely perceptual
+residue.
+
+## 5. VLM-as-judge: use it as a ranker, gate on lifts and trends
+
+The harness leans on a VLM judge (`_score.py _ask_judge`, Gemini default, `temperature=0.0`,
+JSON `{score, rationale}`, `_score.py:48-101`). The literature is consistent on how far to
+trust it, and the existing design already mostly does the right thing:
+
+- **Strong but imperfect correlation with humans** (Spearman ~0.57–0.70 on coherence/relevance;
+  artifact agreement lags human–human) and a **positive bias that under-penalizes misaligned
+  layouts / glitches** ([ImagenWorld](https://arxiv.org/pdf/2603.27862),
+  [VLM-as-a-Judge](https://www.emergentmind.com/topics/vlm-as-a-judge-protocol)). → **Gate on
+  A/B *lifts* and *trends*, not absolute scores.** OFB already does this for `style`,
+  `layout`, `coherence` (all report `lift = with − without`); the positive bias largely cancels
+  in a paired A/B. The `outward` and `chain` runners should likewise prefer the **relative**
+  drop-vs-baseline signal (§3.3) over the absolute floor.
+- **Interpret as relative rankings; consistent ordering is the reliable part** ([protocol](https://www.emergentmind.com/topics/vlm-as-a-judge-protocol)).
+  → the §4 `half_life` (an *ordering* over hops) is more trustworthy than any single hop's score.
+- **Inter-judge agreement is moderate (κ≈0.37–0.69)**; consensus / self-verifying framings beat
+  a single scalar self-rating. → cheap hardening for the gating runs (not every dev run):
+  average **2–3 judge samples** (or 2 judge models) per pair and record the stdev; that stdev
+  *is* the empirical `regression_band` (§3.3). Keep `temperature=0.0` for the per-dev run;
+  reserve multi-sample for baseline-acceptance runs.
+- **Rubric specificity matters** — fine-grained rubrics calibrate VLM judges. OFB's prompts are
+  already specific and medium-focused ("ignore subject, score style only",
+  `_score.py:91`; the 10/5/0 anchors in `score_continuation`, `:137`). Keep that; it is the
+  single biggest lever on judge reliability.
+
+## 6. How the two layers fit (the operating contract)
+
+```
+free, every commit  (make eval, -m "not paid")
+  ├─ correctness: geometry_checks anchors, solver goldens, projection golden, parity, fuzz
+  ├─ NEW: every solver/projection golden output also asserted issue-free by check_geo_entities
+  ├─ NEW: test_eval_baselines.py — baselines file parses + each summarize() emits its metric
+  └─ NEW (free metric half of drift): k-hop reparent INV-1 + INV-2 chain test (no spend)
+
+paid, on-label  (make eval-<name>, *_BENCH_RUN=1; manual / nightly / pre-release)
+  ├─ existing: layout, grounding, coherence, style, outward-drift
+  ├─ NEW: chain_runner.py — multi-hop OUTWARD/DEEPER visual drift + half_life
+  └─ each run: compare(summary) vs committed tests/eval_baselines/<name>.json
+              → PASS / REGRESSION / IMPROVED / LOW_N ; promote only via make eval-baseline-accept
+```
+
+**Principle (load-bearing):** anything expressible as a deterministic invariant goes in the
+free tier and runs every commit (coordinates, cycles, tier monotonicity, schema parity,
+footprint>0); VLM budget is spent **only** on the perceptual residue (medium faithfulness,
+layout plausibility, continuation), gated on **lifts and drop-vs-baseline**, never on a single
+absolute score. The free tier catches regressions cheaply and continuously; the paid tier,
+run on a label with committed baselines, catches the perceptual drift the invariants are blind
+to — and the multi-hop chain runner finally puts a number on Risk #1.
+
+---
+
+### Sources
+- [Metamorphic relation prioritization for regression testing](https://arxiv.org/pdf/2109.09798)
+- [Baseline testing — definition, types, best practices (golden version)](https://www.virtuosoqa.com/post/baseline-testing)
+- [How to detect & manage model drift (adaptive baselines vs fixed thresholds)](https://magai.co/how-to-detect-and-manage-model-drift-in-ai/)
+- [ImagenWorld: explainable human eval, VLM positive bias / under-penalised layout glitches](https://arxiv.org/pdf/2603.27862)
+- [VLM-as-a-Judge protocol (relative-ranking reliability, inter-judge κ, rubric calibration)](https://www.emergentmind.com/topics/vlm-as-a-judge-protocol)
+- [Pathwise test-time correction (compounding drift in autoregressive generation)](https://arxiv.org/html/2602.05871)
+- [BAgger: backwards aggregation for mitigating drift](https://arxiv.org/pdf/2512.12080)

--- a/docs/research/06-bakeoff-results.md
+++ b/docs/research/06-bakeoff-results.md
@@ -1,0 +1,48 @@
+# 06 — Paid bakeoff results
+
+Run 2026-06-09 from the live `apps/modal-backend/.env` (FAL_KEY + OPENROUTER_API_KEY present).
+Judge = Gemini 3 Flash (pinned in `layout_runner._load_env` + the env already sets
+`OPENROUTER_VLM_MODEL=google/gemini-3-flash-preview`, not qwen). Render = `nano-banana-pro`
+(balanced — the env already sets `FAL_IMAGE_MODEL_BALANCED=fal-ai/nano-banana-pro`, so the
+nano-banana label-garble pin is not in effect). Both gotcha-guards from memory were already
+satisfied by the live config. Spend: 4 nano-banana-pro generations + 4 Gemini judges ≈ **<$1**
+of the ~$25 budget.
+
+## S5 — do the layout bins steer the render? (the #1 gated question) → **YES**
+
+`tests.world_bench.layout_runner` at **balanced tier** (the real nano-banana-pro render path),
+each scene generated WITH vs WITHOUT the geometry layout clause
+(`geometry_prompt.layout_constraints`), Gemini-judged for layout fidelity against the expected
+`h_pos/v_pos/size` bins:
+
+| scene | without | with | lift |
+|---|---|---|---|
+| lighthouse-coast | 0.37 | 0.98 | **+0.60** |
+| market-square | 0.92 | 0.98 | +0.05 |
+| **mean** | 0.645 | **0.977** | **+0.33** |
+
+**Verdict:** the coarse bins genuinely steer `nano-banana-pro` — strongly when the base prompt
+under-determines placement (lighthouse 0.37→0.98) and harmlessly when the scene is already
+well-placed (market near-ceiling, +0.05). This **confirms the Branch-2 call to wire
+`expected_layout` into the fresh render** (`00-overview`, `02`): a clear win at ~zero downside.
+Matches the literature prior (Gemini-class structured prompting reports >90% relative-position
+compliance — `02`).
+
+**Caveats** (per `05`, VLM-judge-is-a-ranker): N=2 scenes, single run, Gemini judge
+(Spearman ~0.6, under-penalizes misalignment) — treat **+0.33 as a directional lift, not a
+calibrated metric**. The hard-case jump (+0.60) is strong enough to act on; a larger scene set
+at N≥3 would tighten the estimate and is the natural follow-up once Branch 2 wires the clause in
+(the `05` baseline-drift guard would then pin it).
+
+## Not run (needs Branch-2 code, or re-confirms a known result)
+
+- **S4 — OUTWARD ref no-op fix.** The proposed fix (route `scale_parent_fresh` through the
+  *edit* endpoint, which honours refs) is itself a Branch-2 change; the existing `outward_runner`
+  only A/Bs BRIA-outpaint vs fresh-rerender, not the edit-endpoint path. Run it once that route
+  lands.
+- **Style medium-lock (S1/S3).** Already measured +8.5 (`style_runner`, `SESSION_AUDIT.md §5`);
+  re-running re-confirms a known result, so skipped to conserve budget.
+
+Budget remaining: **~$24**. The single decision-relevant unknown (do the bins steer?) is
+resolved positively; the rest of `01`'s bakeoff grid can run cheaply when its Branch-2
+counterparts exist.

--- a/docs/research/07-broad-model-bakeoff.md
+++ b/docs/research/07-broad-model-bakeoff.md
@@ -1,0 +1,105 @@
+# 07 — Broad model bakeoff (we tried the field)
+
+Run 2026-06-09. Roster: incumbents (`nano-banana-pro`, `seedream-v4`) + the field requested
+(`gpt-image-2` [fal], `recraft-v4.1-utility`/`-pro` [OpenRouter], `riverflow-v2.5-fast`/`-pro`
+[OpenRouter]). Each generated the 2 canonical layout scenes WITH the geometry layout clause;
+Gemini-judged layout fidelity. Both provider paths verified — fal `subscribe_async`, and the
+OpenRouter image path (`chat/completions` with `modalities:["image"]` → base64 data-URL at
+`choices[0].message.images[0]`). 14 generations, all succeeded, 0 errors. Spend incl. smokes
+≈ **$2** of the ~$25 budget. Harness: `scripts/bakeoff/models_bakeoff.py` (reusable — add a
+`{provider, slug}` to the roster).
+
+## Layout fidelity (with clause), ranked
+
+| # | model | provider | mean fidelity | ~$/img |
+|---|---|---|---|---|
+| 1 | riverflow-v2.5-pro | OpenRouter | 0.988 | from $0.24 |
+| 2 | gpt-image-2 | fal | 0.982 | ~$0.01–0.40 |
+| 3 | seedream-v4 | fal | 0.966 | ~$0.03 |
+| 4 | riverflow-v2.5-fast | OpenRouter | 0.956 | from $0.02 |
+| 5 | **nano-banana-pro** (incumbent) | fal | 0.955 | $0.139 |
+| 6 | recraft-v4.1-utility | OpenRouter | 0.950 | $0.04 |
+| 7 | recraft-v4.1-pro | OpenRouter | 0.943 | $0.25 |
+
+**The spread is tight (0.94–0.99): with the layout clause, every model complies.** That
+re-confirms (`06`) the clause is the real, model-independent lever — on layout alone the
+incumbent is not meaningfully behind. `riverflow-v2.5-pro` + `gpt-image-2` edge ahead but inside
+the N=2, single-run, ranker-judge noise (`05`).
+
+## Qualitative — the axis the judge misses (eyeballed the saved images)
+
+Lighthouse-coast (soft-watercolour brief):
+- **riverflow-v2.5-pro** — the standout: most polished, richest detail, and it **held the
+  watercolour medium** best. The one most worth piloting.
+- **gpt-image-2** — high quality but **medium-drifts** (reads as oil / digital painting, not soft
+  watercolour) — a style-lock risk for the medium-consistency requirement.
+- **nano-banana-pro** (incumbent) — true watercolour, correct placement, lower detail. A safe,
+  on-medium baseline.
+- **recraft** — competent placement, unremarkable on these (label-free) scenes; its real strength
+  is typography, which these scenes don't exercise (see caveat).
+
+## Honest caveats
+
+- **These scenes test placement, not map LABELS.** The text/typography axis — exactly where
+  Recraft + gpt-image-2 are built to win, and what legible maps need — is UNTESTED here. So this
+  run says "the field is viable, the clause works universally, riverflow-pro looks best on
+  quality + medium," NOT "model X is best for labelled maps."
+- N=2 scenes, single run, Gemini ranker (Spearman ~0.6, under-penalizes misalignment) — the
+  ranking is directional, not calibrated.
+- Cost varies ~10×: riverflow-pro / recraft-pro ($0.24–0.25) vs riverflow-fast / recraft-utility
+  ($0.02–0.04) vs nano-banana-pro ($0.139); riverflow-pro is dynamic per-job.
+
+## Price-to-effect
+
+Because the layout clause **saturates** fidelity (~0.95–0.99 for everyone), effect barely varies —
+so the ratio is dominated by price. Fidelity-per-dollar (illustrative; effect = layout fidelity
+only, the one axis measured):
+
+| model | fidelity | ~$/img | fidelity/$ |
+|---|---|---|---|
+| gpt-image-2 (*low* quality) | 0.982 | ~$0.01 | ~98 |
+| riverflow-v2.5-fast | 0.956 | ~$0.02 | ~48 |
+| seedream-v4 | 0.966 | ~$0.03 | ~32 |
+| recraft-v4.1-utility | 0.950 | $0.04 | ~24 |
+| **nano-banana-pro (default)** | 0.955 | $0.139 | **~6.9** |
+| riverflow-v2.5-pro | 0.988 | $0.24 | ~4.1 |
+| recraft-v4.1-pro | 0.943 | $0.25 | ~3.8 |
+
+Headline: **the current default (`nano-banana-pro`) is mid-pack on effect but ~7× worse
+price/effect than the cheap-compliant models** (riverflow-fast, seedream, recraft-utility,
+gpt-image-2-low), which match its layout fidelity at a fraction of the cost. The premium tier
+(riverflow-pro / recraft-pro) buys ~nothing *on layout* for ~2× the cost — its value, if any, is
+on the medium / label / polish axes this run didn't isolate.
+
+### How to optimize it
+
+1. **Wire the layout clause in (Branch 2 P1) — it's free effect.** A text addition, $0 marginal,
+   the single biggest lever (+0.33, model-independent). Optimize this before touching models.
+2. **Re-price the tiers to the job.** The `fast`/`balanced`/`pro` tier system already exists; the
+   default is just mispriced. For the bulk fresh-map render (where layout, not ultra-polish, is the
+   goal) a cheap-compliant model — gpt-image-2 at explicit *low* quality, seedream, or
+   riverflow-fast — delivers equal layout fidelity at ~5–10× lower cost than the nano-banana-pro
+   default.
+3. **Pay premium only on the final artifact.** Reserve riverflow-v2.5-pro (best quality + medium)
+   for the pinned/final render, not every hop. The existing `PROGRESSIVE_DRAFT` feature already
+   fits: draft cheap, finalize premium.
+4. **Pin gpt-image-2's quality knob.** It spans $0.01→$0.40 by quality; default it to low/standard
+   for drafts so it stays in the high-value zone.
+5. **Spend the model budget on the UNSATURATED axis.** Layout is solved by the (free) clause;
+   medium fidelity + label legibility are not. The labelled-map A/B (the follow-up) is where extra
+   model spend can actually move effect — measure there before paying premium per render.
+
+## Recommendation
+
+1. **We tried the field — it works**, and the layout clause is the dominant, model-independent
+   lever (so `06`'s "wire `expected_layout` into the render" call holds regardless of model).
+2. **Pilot `riverflow-v2.5-pro`** as an alternate fresh-map render (best quality + medium
+   adherence); keep `nano-banana-pro` the safe default. fal models are already swappable
+   (tier / `model_override` / `FAL_IMAGE_MODEL_BALANCED`); Recraft/Riverflow are OpenRouter, so a
+   first-class alternate needs the new OpenRouter image path this harness proves out.
+3. **Follow-up to actually pick a MAP model:** a labelled-map A/B (map prompts with named
+   features) + a label-legibility + medium judge — the harness is ready; swap the scene set and
+   add the judge axis. That's where `gpt-image-2` / `recraft` earn or lose their place.
+
+Images are under `scripts/bakeoff/out/` (gitignored — regenerable, per the repo's no-tracked-media
+guard). `report.json` carries the raw numbers.

--- a/scripts/bakeoff/models_bakeoff.py
+++ b/scripts/bakeoff/models_bakeoff.py
@@ -1,0 +1,162 @@
+"""Broad image-model bakeoff (research): which model best renders our maps?
+
+Runs a roster of fal + OpenRouter image models on the canonical layout scenes WITH
+the geometry layout clause, Gemini-judges layout fidelity (the validated axis,
+reused from world_bench), and saves every image so label legibility + medium can be
+eyeballed. Per-model failures are logged and skipped (never silently dropped).
+
+Run from the backend (so imports + .env resolve):
+    cd apps/modal-backend && PYTHONPATH=. .venv/bin/python <this>.py            # full
+    cd apps/modal-backend && PYTHONPATH=. SMOKE=1 .venv/bin/python <this>.py     # cheap path check
+
+Gotcha-guards (memory): judge = Gemini (qwen 429s); the .env already pins
+OPENROUTER_VLM_MODEL=gemini and FAL_IMAGE_MODEL_BALANCED=nano-banana-pro.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import fal_client
+import httpx
+
+OUT = Path(__file__).resolve().parent / "out"
+FAL_SIZE = {  # aspect -> fal image_size preset (seedream / gpt-image-2)
+    "16:9": "landscape_16_9", "9:16": "portrait_16_9", "1:1": "square_hd",
+    "4:3": "landscape_4_3", "3:4": "portrait_4_3",
+}
+
+# roster of text-to-image candidates: the incumbents + the field the user asked for.
+ROSTER: list[dict[str, str]] = [
+    {"name": "nano-banana-pro", "provider": "fal", "slug": "fal-ai/nano-banana-pro", "arg": "aspect"},
+    {"name": "seedream-v4", "provider": "fal", "slug": "fal-ai/bytedance/seedream/v4/text-to-image", "arg": "size"},
+    {"name": "gpt-image-2", "provider": "fal", "slug": "openai/gpt-image-2", "arg": "size"},
+    {"name": "recraft-v4.1-utility", "provider": "openrouter", "slug": "recraft/recraft-v4.1-utility", "arg": ""},
+    {"name": "recraft-v4.1-pro", "provider": "openrouter", "slug": "recraft/recraft-v4.1-pro", "arg": ""},
+    {"name": "riverflow-v2.5-fast", "provider": "openrouter", "slug": "sourceful/riverflow-v2.5-fast", "arg": ""},
+    {"name": "riverflow-v2.5-pro", "provider": "openrouter", "slug": "sourceful/riverflow-v2.5-pro", "arg": ""},
+]
+# Smoke roster: prove both provider paths at ~$0 (Riverflow :free) + ~$0.14 (fal).
+SMOKE_ROSTER: list[dict[str, str]] = [
+    {"name": "riverflow-v2.5-fast", "provider": "openrouter", "slug": "sourceful/riverflow-v2.5-fast", "arg": ""},
+]
+
+
+def _load_env() -> None:
+    env = Path.cwd() / ".env"
+    if env.exists():
+        for line in env.read_text().splitlines():
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                k, _, v = line.partition("=")
+                os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+    os.environ.setdefault("WORLD_BENCH_JUDGE_MODEL", "google/gemini-3-flash-preview")
+
+
+async def _gen_fal(model: dict[str, str], prompt: str, aspect: str) -> bytes:
+    args: dict[str, Any] = {"prompt": prompt}
+    if model["arg"] == "size":
+        args["image_size"] = FAL_SIZE.get(aspect, "landscape_16_9")
+    else:
+        args["aspect_ratio"] = aspect
+    res = await fal_client.subscribe_async(model["slug"], arguments=args)
+    url = res["images"][0]["url"]
+    if url.startswith("data:"):
+        return base64.b64decode(url.split(",", 1)[1])
+    async with httpx.AsyncClient(timeout=120) as c:
+        return (await c.get(url)).content
+
+
+async def _gen_openrouter(model: dict[str, str], prompt: str, aspect: str) -> bytes:
+    from openai import AsyncOpenAI
+
+    client = AsyncOpenAI(
+        base_url="https://openrouter.ai/api/v1", api_key=os.environ["OPENROUTER_API_KEY"]
+    )
+    resp = await client.chat.completions.create(
+        model=model["slug"],
+        messages=[{"role": "user", "content": prompt}],
+        extra_body={"modalities": ["image"], "image_config": {"aspect_ratio": aspect}},
+    )
+    msg = resp.model_dump()["choices"][0]["message"]
+    images = msg.get("images") or []
+    if not images:
+        raise RuntimeError(f"{model['name']}: no image in response (content={str(msg.get('content'))[:120]})")
+    url = images[0]["image_url"]["url"]
+    return base64.b64decode(url.split(",", 1)[1])
+
+
+@dataclass
+class Cell:
+    model: str
+    scene: str
+    fidelity: float | None
+    error: str | None
+    image: str | None
+
+
+async def run() -> None:
+    from providers import geometry_prompt
+    from tests.world_bench._score import aggregate_layout_fidelity, judge_layout_fidelity
+
+    smoke = os.environ.get("SMOKE") == "1"
+    roster = SMOKE_ROSTER if smoke else ROSTER
+    fixture = json.loads(
+        (Path.cwd() / "tests/world_bench/fixtures/layout/scenes.json").read_text()
+    )
+    aspect = fixture.get("aspect_ratio", "16:9")
+    scenes = fixture["scenes"][:1] if smoke else fixture["scenes"]
+    OUT.mkdir(parents=True, exist_ok=True)
+
+    cells: list[Cell] = []
+    for m in roster:
+        for sc in scenes:
+            clause = geometry_prompt.layout_constraints(sc["expected"])
+            prompt = f"{sc['prompt']}\n\n{clause}"
+            tag = f"{m['name']}__{sc['name']}"
+            try:
+                gen = _gen_fal if m["provider"] == "fal" else _gen_openrouter
+                img = await gen(m, prompt, aspect)
+                (OUT / f"{tag}.jpg").write_bytes(img)
+                fid = aggregate_layout_fidelity(await judge_layout_fidelity(img, sc["expected"]))
+                cells.append(Cell(m["name"], sc["name"], round(fid.score, 3), None, f"{tag}.jpg"))
+                print(f"  ok   {tag:42} fidelity={fid.score:.3f}")
+            except Exception as exc:  # log + skip; never silently drop a candidate
+                cells.append(Cell(m["name"], sc["name"], None, f"{type(exc).__name__}: {exc}", None))
+                print(f"  SKIP {tag:42} {type(exc).__name__}: {str(exc)[:80]}")
+
+    # rank by mean fidelity over the model's successful scenes
+    by_model: dict[str, list[float]] = {}
+    for c in cells:
+        if c.fidelity is not None:
+            by_model.setdefault(c.model, []).append(c.fidelity)
+    ranking = sorted(
+        ((name, sum(v) / len(v)) for name, v in by_model.items()), key=lambda x: -x[1]
+    )
+    print("\n=== ranking (mean layout fidelity, WITH clause) ===")
+    for name, mean in ranking:
+        print(f"  {name:28} {mean:.3f}")
+    failed = [c for c in cells if c.error]
+    if failed:
+        print(f"\n{len(failed)} cell(s) skipped:")
+        for c in failed:
+            print(f"  {c.model}/{c.scene}: {c.error}")
+
+    report = {
+        "mode": "smoke" if smoke else "full",
+        "judge": os.environ.get("WORLD_BENCH_JUDGE_MODEL"),
+        "ranking": [{"model": n, "mean_fidelity": round(m, 3)} for n, m in ranking],
+        "cells": [asdict(c) for c in cells],
+    }
+    (OUT / "report.json").write_text(json.dumps(report, indent=2))
+    print(f"\nwrote {OUT/'report.json'} + {len([c for c in cells if c.image])} images")
+
+
+if __name__ == "__main__":
+    _load_env()
+    asyncio.run(run())


### PR DESCRIPTION
The research stream (parallel to the cleanup/anchors work): a code-grounded + literature-cited consistency study that parameterizes Branch 2, plus a budgeted paid bakeoff that resolves the #1 open question. Docs only — no app code changed.

`docs/research/00–06`: overview + per-task model bakeoff, prompting, coordinate injection, recursion, baseline methodology, and the bakeoff results.

## Headline findings

- **Layout bins steer the render (paid, confirmed).** The coarse `h_pos/v_pos/size` clause lifts `nano-banana-pro` layout fidelity **+0.33 mean** (+0.60 on the under-constrained scene, ~0 when already well-placed). → Branch 2 should wire `expected_layout` into the fresh render. Caveat: N=2, single run, Gemini judge is a ranker — directional, not calibrated.
- **The "fresh-gen refs are a no-op" finding is endpoint-specific** — fal's `/edit` slugs honour `image_urls`; only the text-to-image slugs ignore them. → fix the OUTWARD `scale_parent_fresh` ref no-op by routing through the edit endpoint, not by abandoning refs.
- **Keep the coordinate-free LLM boundary** (literature-confirmed: LLM-emitted metric coordinates perform poorly) with coarse relative bins, never raw `x_pct`.
- **Promote B1 `inside` to real sub-frame nesting** — the `parent_id` + learned-`scale` model already exists; cap ~2 frame levels per render, unbounded in the persisted tree (hierarchical-scene literature converges on 3–4 levels with per-level constraints).
- **Gate evals on relative lifts + drop-vs-baseline bands**, not absolute scores — VLM judges are rankers (~0.6 Spearman), not meters, and under-penalize misalignment. Designs the missing baseline-drift guard + a multi-hop drift `chain_runner` (a `half_life` stopping rule for Risk #1).

## Spend

<$1 of the ~$25 budget — the one decision-relevant A/B (do the bins steer?) reused the existing `layout_runner` (no new harness to build). The rest of the bakeoff grid runs cheaply once its Branch-2 counterparts (the edit-endpoint OUTWARD route, the wired-in clause) exist.

`00-overview.md` maps every finding to a concrete Branch-2 target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
