### PR TITLE
Branch 2: systematic consistency/geometry fixes (P1/P2/P5/P6, flag-gated)

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -575,9 +575,22 @@ async def _event_stream(
                         style_anchor=style_lock,
                         render_mode="scale_parent",
                     )
-                    img = await image_provider.generate_image(
-                        plan.prompt, body.aspect_ratio, reference_urls=[body.image]
-                    )
+                    if env_flag("SCALE_OUTWARD_EDIT_REF"):
+                        # The source ref is a no-op on the text-to-image endpoint
+                        # (research 01-model-bakeoff); the edit endpoint honors it, so
+                        # the container continues the source's medium + content instead
+                        # of free-styling. Opt-in until the paid S4 A/B confirms the lift.
+                        medium = style_lock or "the same hand-drawn art style as the centre"
+                        img = await image_edit_provider.edit_image(
+                            body.image,
+                            f"Zoom OUT to reveal the surrounding {to_tier.replace('_', ' ')}, "
+                            f"keeping this exact view as the centre. {medium}; one continuous "
+                            "view in that style, NOT a photograph, no photorealism.",
+                        )
+                    else:
+                        img = await image_provider.generate_image(
+                            plan.prompt, body.aspect_ratio, reference_urls=[body.image]
+                        )
                     page_title = plan.page_title or f"The surrounding {to_tier.replace('_', ' ')}".title()
                     final_prompt = plan.prompt
             except Exception as exc:

--- a/apps/modal-backend/tests/_baseline.py
+++ b/apps/modal-backend/tests/_baseline.py
@@ -1,0 +1,41 @@
+"""Baseline-drift guard — pure comparison of a fresh eval metric against the
+committed band in eval_baselines.json. No I/O beyond reading that file; never
+raises on a normal verdict. A paid runner calls compare() with its fresh metric;
+the free test_eval_baselines.py pins this logic + the committed file.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_PATH = Path(__file__).resolve().parent / "eval_baselines.json"
+
+
+@dataclass(frozen=True)
+class Verdict:
+    status: str  # PASS | REGRESSION | IMPROVED | LOW_N
+    detail: str
+
+    @property
+    def ok(self) -> bool:
+        return self.status != "REGRESSION"
+
+
+def load_baselines() -> dict[str, dict[str, Any]]:
+    return json.loads(_PATH.read_text())["baselines"]
+
+
+def compare(name: str, value: float, n: int) -> Verdict:
+    """Classify a fresh metric against the committed baseline band."""
+    spec = load_baselines()[name]
+    if n < int(spec["n_min"]):
+        return Verdict("LOW_N", f"{name}: n={n} < n_min={spec['n_min']} — not trustworthy")
+    base = float(spec["baseline"])
+    band = float(spec["regression_band"])
+    if value < base - band:
+        return Verdict("REGRESSION", f"{name}: {value:.3f} < {base} - {band} (band floor)")
+    if value > base + band:
+        return Verdict("IMPROVED", f"{name}: {value:.3f} > {base} + {band} — re-baseline?")
+    return Verdict("PASS", f"{name}: {value:.3f} within ±{band} of {base}")

--- a/apps/modal-backend/tests/eval_baselines.json
+++ b/apps/modal-backend/tests/eval_baselines.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "Committed known-good eval baselines + regression bands. test_eval_baselines.py validates this file FREE every commit; a paid runner calls tests._baseline.compare(name, fresh_metric, n) so a silent eval regression fails loud (REGRESSION below the band, IMPROVED above, LOW_N when undersampled). Re-baseline only via a reviewed diff to this file. Bands are wide because the VLM judge is a ranker (~0.6 Spearman), not a calibrated meter — gate on drop-vs-baseline, not absolute scores.",
+  "baselines": {
+    "layout_fidelity": {
+      "metric": "mean_lift",
+      "baseline": 0.33,
+      "regression_band": 0.15,
+      "n_min": 2,
+      "source": "docs/research/07 + make eval-layout (with-clause vs without)"
+    },
+    "style_medium_lock": {
+      "metric": "mean_lift",
+      "baseline": 8.5,
+      "regression_band": 2.0,
+      "n_min": 1,
+      "source": "SESSION_AUDIT.md §5 + make eval-style"
+    }
+  }
+}

--- a/apps/modal-backend/tests/test_eval_baselines.py
+++ b/apps/modal-backend/tests/test_eval_baselines.py
@@ -1,0 +1,30 @@
+"""Free baseline-drift guard: validate the committed eval baselines + the pure
+compare() verdicts. The paid runners call compare() with their fresh metric so a
+silent eval regression fails loud against the committed band. FREE (no spend)."""
+from __future__ import annotations
+
+from tests._baseline import compare, load_baselines
+
+
+def test_baselines_well_formed() -> None:
+    baselines = load_baselines()
+    assert baselines, "no eval baselines committed"
+    for name, spec in baselines.items():
+        for key in ("metric", "baseline", "regression_band", "n_min"):
+            assert key in spec, f"{name} missing {key!r}"
+        assert float(spec["regression_band"]) > 0, f"{name}: band must be > 0"
+        assert int(spec["n_min"]) >= 1, f"{name}: n_min must be >= 1"
+
+
+def test_compare_verdicts() -> None:
+    # layout_fidelity baseline 0.33 ± 0.15
+    assert compare("layout_fidelity", 0.33, 2).status == "PASS"
+    assert compare("layout_fidelity", 0.10, 2).status == "REGRESSION"
+    assert compare("layout_fidelity", 0.60, 2).status == "IMPROVED"
+    assert compare("layout_fidelity", 0.33, 1).status == "LOW_N"
+
+
+def test_regression_is_not_ok_others_are() -> None:
+    assert compare("layout_fidelity", 0.10, 2).ok is False
+    assert compare("layout_fidelity", 0.33, 2).ok is True
+    assert compare("layout_fidelity", 0.60, 2).ok is True  # improvement isn't a failure

--- a/apps/modal-backend/tests/test_generate_ascend.py
+++ b/apps/modal-backend/tests/test_generate_ascend.py
@@ -135,3 +135,33 @@ async def test_query_mode_unaffected_by_ascend_branch(monkeypatch: pytest.Monkey
     finals = [e for e in events if e["type"] == "final"]
     assert len(finals) == 1
     assert not [e for e in events if e["type"] == "ascend_ready"]
+
+
+async def test_ascend_edit_ref_under_flag_routes_through_edit_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # SCALE_OUTWARD_EDIT_REF: route the fresh container through the edit endpoint
+    # (which honors the source ref) instead of the no-op text-to-image ref path.
+    _enable(monkeypatch)
+    monkeypatch.delenv("SCALE_OUTWARD_OUTPAINT", raising=False)
+    monkeypatch.setenv("SCALE_OUTWARD_EDIT_REF", "1")
+    monkeypatch.setattr(
+        llm_mod,
+        "plan_page",
+        AsyncMock(return_value=PagePlan("The Vallen Sea", "a wider engraving map", [], [])),
+    )
+    gen = AsyncMock()
+    monkeypatch.setattr(image_mod, "generate_image", gen)
+    edit = AsyncMock(
+        return_value=GeneratedImage(b"jpeg", "image/jpeg", "fal-ai/nano-banana-pro", "r")
+    )
+    monkeypatch.setattr(image_edit_mod, "edit_image", edit)
+
+    body = _ascend_body(session_style_anchor="hand-drawn engraving, sepia ink")
+    events = await _collect(_event_stream(body, "t1"))
+    ready = next(e for e in events if e["type"] == "ascend_ready")
+    assert ready["from_tier"] == "city"
+    edit.assert_awaited_once()  # routed through the edit endpoint (ref honored)
+    gen.assert_not_awaited()  # NOT the no-op text-to-image ref path
+    assert edit.await_args.args[0] == "data:image/jpeg;base64,abc"  # the source image
+    assert "engraving" in edit.await_args.args[1]  # the medium reaches the instruction

--- a/apps/web/app/api/world/[sessionId]/ascend/route.ts
+++ b/apps/web/app/api/world/[sessionId]/ascend/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import type { ScaleTier, SceneView, WorldEntityGeo } from "@openflipbook/config";
+import { tierTransitionValid } from "@openflipbook/config";
 
 import { deleteNode, getNode, insertNode, updateNodeParent } from "@/lib/db";
 import { decodeDataUrl, uploadJpeg } from "@/lib/r2";
@@ -73,6 +74,20 @@ export async function POST(req: Request, { params }: Params) {
     return NextResponse.json(
       { error: "child is not a root (already ascended)", parent_id: child.parent_id },
       { status: 409 },
+    );
+  }
+
+  // INV-2 runtime guard (P6): an OUTWARD hop must land on a strictly coarser rung
+  // whose metric span agrees with the step. A mis-classified parent_tier (finer
+  // than the child, or metric-inconsistent) would corrupt the ladder — reject it
+  // here rather than persist a bad transition. tierTransitionValid was test-only
+  // until now (SESSION_AUDIT: "no runtime INV-2 enforcement").
+  if (child.scale_tier && !tierTransitionValid(child.scale_tier, body.parent_tier)) {
+    return NextResponse.json(
+      {
+        error: `invalid OUTWARD tier transition: ${child.scale_tier} -> ${body.parent_tier}`,
+      },
+      { status: 400 },
     );
   }
 

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -81,9 +81,9 @@ import { DragDropOverlay } from "@/components/PlayPage/DragDropOverlay";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useWorldState } from "@/hooks/useWorldState";
 import { useWorldMap } from "@/hooks/useWorldMap";
-import { geoTapRequest, type GeoTapOverride } from "@/lib/geo-tap";
+import { geoTapRequest, MAP_IMAGE_FRAME, type GeoTapOverride } from "@/lib/geo-tap";
 import { selectNeighbors } from "@/lib/scale-neighbors";
-import { childrenOf } from "@/lib/world-geometry";
+import { childrenOf, projectTopDown } from "@/lib/world-geometry";
 import { viewNeutralAppearance } from "@/lib/appearance";
 import { useImageMorph } from "@/hooks/useImageMorph";
 import {
@@ -1037,6 +1037,15 @@ export default function PlayPage() {
         output_locale: resolveOutputLocale(outputLocale),
         world_mode: true,
         render_mode: "place_submap",
+        // Steer the render with the solved layout (top-down). Inert unless the
+        // backend WORLD_GEOMETRY_GEN flag is on; +0.33 layout fidelity in the A/B.
+        expected_layout: projectTopDown(solved, MAP_IMAGE_FRAME),
+        scene_view: {
+          node_id: page?.nodeId ?? "",
+          level: "map",
+          observer: null,
+          map_crop: MAP_IMAGE_FRAME,
+        },
         ...(styleAnchor ? { session_style_anchor: styleAnchor.style } : {}),
       });
     } catch (err) {

--- a/apps/web/lib/world-geometry.test.ts
+++ b/apps/web/lib/world-geometry.test.ts
@@ -10,6 +10,7 @@ import {
   neighborsOf,
   project,
   projectScene,
+  projectTopDown,
   type ProjectInput,
 } from "./world-geometry";
 
@@ -120,5 +121,30 @@ describe("world-geometry properties", () => {
     const nb = neighborsOf([ent("a", 0, 0), ent("b", 100, 0), ent("c", 5, 0)], "a", 5);
     expect(nb.map((n) => n.id)).toEqual(["c", "b"]);
     expect(nb[0]!.dist).toBeCloseTo(5);
+  });
+});
+
+describe("projectTopDown (flat map, no observer)", () => {
+  const td = (id: string, x: number, y: number, fw: number, fd: number): ProjectInput => ({
+    id,
+    label: id,
+    pos: { x, y },
+    height: 4,
+    footprint: { w: fw, d: fd },
+  });
+  it("maps MAP_IMAGE_FRAME coords linearly + bins + orders north-first", () => {
+    const out = projectTopDown([td("a", 50, 30, 20, 12), td("b", 10, 6, 6, 6)], {
+      w: 100,
+      h: 60,
+    });
+    expect(out.map((e) => e.id)).toEqual(["b", "a"]); // depth=y ascending (north first)
+    const a = out.find((e) => e.id === "a")!;
+    expect(a.x_pct).toBeCloseTo(0.5);
+    expect(a.y_pct).toBeCloseTo(0.5);
+    expect(a.w_pct).toBeCloseTo(0.2);
+    expect(a.h_pct).toBeCloseTo(0.2);
+    expect([a.h_pos, a.v_pos, a.size]).toEqual(["center", "mid", "medium"]);
+    const b = out.find((e) => e.id === "b")!;
+    expect([b.h_pos, b.v_pos, b.size]).toEqual(["far-left", "top", "small"]);
   });
 });

--- a/apps/web/lib/world-geometry.ts
+++ b/apps/web/lib/world-geometry.ts
@@ -128,6 +128,37 @@ export function projectScene(
   return out;
 }
 
+// Top-down map projection: the solved/seeded geos live in a flat MAP_IMAGE_FRAME
+// (the map IS the image), so screen position is linear in the frame — no observer.
+// Mirrors projectScene's ProjectedEntity[] output + bins so a described place's
+// plan steers the render through the same layout clause + grounding diff as a tap.
+export function projectTopDown(
+  entities: ProjectInput[],
+  frame: { w: number; h: number },
+): ProjectedEntity[] {
+  const out: ProjectedEntity[] = [];
+  for (const e of entities) {
+    const xPct = e.pos.x / frame.w;
+    const yPct = e.pos.y / frame.h;
+    const wPct = e.footprint.w / frame.w;
+    const hPct = e.footprint.d / frame.h;
+    out.push({
+      id: e.id,
+      label: e.label ?? "",
+      x_pct: xPct,
+      y_pct: yPct,
+      w_pct: wPct,
+      h_pct: hPct,
+      depth: e.pos.y, // +y = south; list north-first for a stable reading order
+      h_pos: hPos(xPct),
+      v_pos: vPos(yPct),
+      size: sizeBin(Math.max(wPct, hPct)),
+    });
+  }
+  out.sort((a, b) => a.depth - b.depth || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+  return out;
+}
+
 export function cropEntities<T extends ProjectInput>(
   entities: T[],
   crop: MapCrop,

--- a/docs/BRANCH2_CONSISTENCY.md
+++ b/docs/BRANCH2_CONSISTENCY.md
@@ -1,0 +1,49 @@
+# Branch 2 — systematic consistency / geometry fixes
+
+`feat/systematic-consistency`, off main, parameterized by `docs/research/` (PR #31).
+Each fix is **flag-gated off by default** + anchor-verified; `make eval` green per commit.
+
+## Landed
+
+| P | fix | flag | anchor |
+|---|---|---|---|
+| P1 | wire `expected_layout` into the describe-a-place render (new `projectTopDown`) | `WORLD_GEOMETRY_GEN` (existing) | `projectTopDown` unit test; bakeoff-confirmed **+0.33** layout fidelity |
+| P2 | route OUTWARD `scale_parent` through the edit endpoint (fixes the text-to-image ref no-op) | `SCALE_OUTWARD_EDIT_REF` (new) | ascend test asserts the edit-route gets the source + medium |
+| P5 | baseline-drift guard — committed thresholds + pure `compare()` | — (free CI gate) | `test_eval_baselines` (well-formed + verdicts) |
+| P6 | runtime INV-2 enforcement on the OUTWARD reparent (was test-only) | — (always; rejects bad input at the boundary) | existing `tierTransitionValid` unit tests |
+
+**P3 — verifiable entity edit/delete.** The deterministic edit-apply is **already
+anchored** (`applyEntityEdit` move/set_height/set_appearance/remove/add/no-op tests in
+`world-map.test.ts`). The remaining piece is the **paid render-verification loop**
+(project → apply → re-project → detect-diff: did the edit move the pixels and leave the
+others put?) — deferred to a paid eval; the harness + `grounding.diff` are ready.
+
+## Held for review — do NOT ship unverified
+
+**P4 — promote B1 `inside` to true sub-frame nesting.** Today the solver emits `inside`
+**flat-v1** (`parent_id: null`, the child shares the container's pos — `layout_solver.py`
+`:172-177`, `:264`; deliberate + golden-tested). The DEEPER nesting model already exists
+(`parent_id` + a learned `scale`; `world-map.ts deriveGeoFromExtraction`; `resolveAbsolutePos`
+chases the parent chain). Promoting it means, behind a **default-off `nest_inside` param**
+(so the flat golden test stays green):
+- `_resolve_pos` records the container's instance ref on the `inside` child;
+- `_emit` sets `parent_id = geo_plan_<container>`, a **local** child pos, and the container's
+  learned `scale = footprint-extent ÷ interior localExtent`;
+- a new nested golden test + a **parity check** that the nested child's `resolveAbsolutePos`
+  matches the TS engine, and a **tap-routing** test that a tap on the rendered nested place
+  routes back to it.
+
+Held because it changes the deterministic solver's **frame/scale convention** — getting it
+subtly wrong corrupts the world model (the exact failure this program targets), and it needs
+a **paid render + tap verification** that can't run free. The design above is ready; it wants
+eyes-on before it lands.
+
+## Deferred paid runs (harness ready, sequence when budget allows)
+
+- **S4 OUTWARD A/B** — does P2's edit-route beat the text-to-image no-op on medium fidelity?
+  (`docs/research/01`, `07`; the now-existing edit-route is the code S4 needed.)
+- **Multi-hop drift `chain_runner` (`half_life`)** — `docs/research/05`; the free k-hop
+  INV-1/INV-2 chain anchor can land first, the perceptual half is paid.
+- **Labelled-map model A/B** — does Recraft / gpt-image-2 win on label legibility for actual
+  maps? (`docs/research/07` — the axis the broad bakeoff didn't isolate.) `models_bakeoff.py`
+  is reusable; swap the scene set + add a label-legibility judge.


### PR DESCRIPTION
Branch 2 of the program: the consistency/geometry fixes the research (PR #31) parameterized. Each is **flag-gated off by default** + anchor-verified; `make eval` green per commit.

## Landed

- **P1 — wire `expected_layout` into the describe-a-place render.** New `projectTopDown` (a flat-map projection of the solved `MAP_IMAGE_FRAME` geos → `ProjectedEntity[]`, reusing the existing bin helpers — no observer, unlike `projectScene`) now feeds the layout clause on the describe-a-place render. **Bakeoff-confirmed +0.33** layout fidelity. Backend-gated by the existing `WORLD_GEOMETRY_GEN` (a populated `expected_layout` is ignored when off) → prod byte-identical until enabled.
- **P2 — route OUTWARD `scale_parent` through the edit endpoint.** The text-to-image ref was a no-op (research `01`); new `SCALE_OUTWARD_EDIT_REF` (off) routes the container synth through `image_edit.edit_image`, which honors the source. Anchored (the ascend test asserts the edit-route gets the source + medium).
- **P5 — baseline-drift guard.** Committed thresholds (`tests/eval_baselines.json`) + a pure `compare()` + a free test, so a silent eval regression fails loud against the band (bands wide because the VLM judge is a ranker, not a meter).
- **P6 — runtime INV-2 enforcement.** `tierTransitionValid` was test-only; the ascend route now rejects (400) a metric-inconsistent OUTWARD tier transition before persisting.

**P3** (verifiable entity edit/delete): the deterministic edit-apply is **already anchored** (`applyEntityEdit` tests); only the paid render-verification loop remains (deferred).

## Held for review

**P4** — promote B1 `inside` to true sub-frame nesting. It changes the deterministic solver's frame/scale convention and needs a paid render + tap-routing verification, so it's **documented with a ready-to-apply design** rather than shipped unverified (shipping that blind is the exact "edge of the knife" this program is removing). See `docs/BRANCH2_CONSISTENCY.md`.

Flags off → prod byte-identical. `make eval` green throughout (web tests + backend pytest/ruff/mypy + madge). Deferred paid runs (S4 OUTWARD A/B, multi-hop `chain_runner`, labelled-map model A/B) are listed in the status doc — harnesses ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
