### PR TITLE
Enter-via-edit: tap-to-ENTER renders are finally conditioned on the map (+ the bakeoff models wired live)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,15 +58,32 @@ OPENROUTER_ENABLE_WEB_SEARCH=true
 # --- Image generation tier (fast | balanced | pro) ---
 # Per-request override available in body.image_tier from the frontend.
 FAL_IMAGE_TIER=balanced
-# Per-tier slug overrides (optional — only set if pinning a non-default model).
-FAL_IMAGE_MODEL_FAST=fal-ai/nano-banana
-FAL_IMAGE_MODEL_BALANCED=fal-ai/nano-banana-pro
-FAL_IMAGE_MODEL_PRO=fal-ai/bytedance/seedream/v4/text-to-image
-# Edit-mode tier defaults
+# Per-tier slug overrides (optional — leave UNSET to track the code defaults:
+# fast=fal-ai/nano-banana, balanced=fal-ai/nano-banana-pro,
+# pro=openrouter:sourceful/riverflow-v2.5-pro — the bakeoff quality winner,
+# docs/research/07; it rides OPENROUTER_API_KEY and takes 1-3 MINUTES/image,
+# so the fast draft race doubles as the keep-alive while it renders).
+# Verified alternates (scripts/verify-fal-models.py + scripts/bakeoff):
+#   fal-ai/bytedance/seedream/v4/text-to-image   (the old pro default)
+#   openai/gpt-image-2                           (fal-hosted, image_size+quality)
+#   fal-ai/nano-banana-2
+#   openrouter:sourceful/riverflow-v2.5-fast     (~$0.02/image)
+#   openrouter:recraft/recraft-v4.1-utility | openrouter:recraft/recraft-v4.1-pro
+# FAL_IMAGE_MODEL_FAST=fal-ai/nano-banana
+# FAL_IMAGE_MODEL_BALANCED=fal-ai/nano-banana-pro
+# FAL_IMAGE_MODEL_PRO=fal-ai/bytedance/seedream/v4/text-to-image
+# OPENROUTER_IMAGE_TIMEOUT_S=240
+# Edit-mode tier defaults (optional overrides; unset tracks the code).
+# FAL_EDIT_MODEL_FAST=fal-ai/nano-banana/edit
+# FAL_EDIT_MODEL_BALANCED=fal-ai/nano-banana-pro
+# FAL_EDIT_MODEL_PRO=fal-ai/flux-pro/kontext
 FAL_EDIT_TIER=balanced
-FAL_EDIT_MODEL_FAST=fal-ai/nano-banana/edit
-FAL_EDIT_MODEL_BALANCED=fal-ai/nano-banana-pro
-FAL_EDIT_MODEL_PRO=fal-ai/flux-pro/kontext
+# Enter-via-edit: tap-to-ENTER renders go through the edit endpoint so the
+# region crop actually conditions the scene (default ON; kill-switch below).
+# Ref-honouring alternates for the enter model: fal-ai/flux-pro/kontext (strict),
+# openai/gpt-image-2/edit, fal-ai/nano-banana-2/edit.
+# ENTER_EDIT_REF=true
+# FAL_ENTER_MODEL=fal-ai/nano-banana-pro/edit
 
 # --- Web (apps/web/.env.local) ---
 # Cloudflare R2 (S3-compatible)

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,15 @@ eval-style:
 #   make eval-outward-drift
 eval-outward-drift:
 	cd apps/modal-backend && OUTWARD_BENCH_RUN=1 .venv/bin/python -m tests.continuity_bench.outward_runner
+# ENTER-consistency A/B: tap a landmark on a styled map and render the entered
+# scene the OLD way (fresh text-to-image, refs ignored) vs the NEW way (edit
+# endpoint on the region crop) → "same place?" judge vs the tapped region → the
+# LIFT. THE metric for cross-hop visual consistency. Optional extra arms:
+#   ENTER_BENCH_MODELS=fal-ai/flux-pro/kontext,openai/gpt-image-2/edit \
+#     make eval-enter-drift
+# PAID (fal gens + Gemini judge); self-contained, no session needed.
+eval-enter-drift:
+	cd apps/modal-backend && ENTER_BENCH_RUN=1 .venv/bin/python -m tests.continuity_bench.enter_runner
 # The full paid sweep (spends fal/openrouter on the tiny golden set).
 eval-paid:
 	cd apps/modal-backend && LAYOUT_BENCH_RUN=1 GROUNDING_BENCH_RUN=1 REPAIR_BENCH_RUN=1 EDIT_BENCH_RUN=1 .venv/bin/python -m pytest -m paid -q

--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -575,11 +575,12 @@ async def _event_stream(
                         style_anchor=style_lock,
                         render_mode="scale_parent",
                     )
-                    if env_flag("SCALE_OUTWARD_EDIT_REF"):
+                    if env_flag("SCALE_OUTWARD_EDIT_REF", "true"):
                         # The source ref is a no-op on the text-to-image endpoint
                         # (research 01-model-bakeoff); the edit endpoint honors it, so
                         # the container continues the source's medium + content instead
-                        # of free-styling. Opt-in until the paid S4 A/B confirms the lift.
+                        # of free-styling. Default ON (kill-switch =false) — the inert
+                        # ref path exists only as the revert.
                         medium = style_lock or "the same hand-drawn art style as the centre"
                         img = await image_edit_provider.edit_image(
                             body.image,

--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -1013,11 +1013,23 @@ async def _event_stream(
                     break
             if region_ref is None:
                 region_ref = body.condition_image_urls[0]
-        # The model router owns the op decision (same result as before: a
-        # place_submap entry with a region crop zoom-continues, else fresh gen).
-        use_continuation = (
-            model_router.select_operation(render_mode, region_ref is not None)
-            == "zoom_continue"
+        # The model router owns the op decision: a place_submap entry with a
+        # region crop zoom-continues; a place_scene entry routes through the
+        # edit endpoint; everything else is a fresh gen.
+        image_op = model_router.select_operation(render_mode, region_ref is not None)
+        use_continuation = image_op == "zoom_continue"
+        # Enter-via-edit (ENTER_EDIT_REF, default ON — a kill-switch, not an
+        # opt-in): the edit endpoint is the only path where the source ref
+        # actually bites (research/01: text-to-image accepts-but-IGNORES refs,
+        # which made every entered place an unconditioned reinvention). Source
+        # = the clean region crop the client already sends in the condition
+        # stack; body.image only as a last resort — it is the marker-ANNOTATED
+        # parent (play page annotateClickPoint).
+        enter_source: str | None = region_ref or body.image
+        use_enter_edit = (
+            image_op == "enter_scene"
+            and env_flag("ENTER_EDIT_REF", "true")
+            and enter_source is not None
         )
         # The Kontext zoom keeps the crop's LOOK faithful; feed it the system's
         # KNOWLEDGE too — the planner's named sub-areas (plan.facts) + the
@@ -1026,6 +1038,17 @@ async def _event_stream(
         # it through the world model and geometry.
         zoom_instruction = image_edit_provider.build_zoom_instruction(
             plan.page_title, plan.facts, layout_clause
+        )
+        # The enter edit is a view CHANGE on the SAME place: the region crop
+        # carries the look, this text carries the move inside + everything the
+        # system knows (identity, neighbours-by-bearing, medium, geometry).
+        enter_instruction = image_edit_provider.build_enter_instruction(
+            plan.page_title,
+            plan.facts,
+            style_anchor=style_anchor,
+            subject_context=subject_context,
+            surroundings=surroundings_for_plan,
+            layout_clause=layout_clause,
         )
 
         # 3. Image gen — with progressive fast-tier draft.
@@ -1049,6 +1072,10 @@ async def _event_stream(
             # Sub-map continuation is a single Kontext call on the region crop;
             # a nano-banana text draft would just be an unrelated preview.
             and not use_continuation
+            # Same for the enter edit: a text-only draft can't preview a
+            # conditioned edit — it would be a SECOND unconditioned reinvention
+            # flashing before the faithful render (the draft≠final complaint).
+            and not use_enter_edit
         )
         draft_task: _asyncio.Task | None = None
         if wants_draft:
@@ -1080,6 +1107,28 @@ async def _event_stream(
             main_task = _asyncio.create_task(
                 image_edit_provider.continue_image(
                     region_ref, zoom_instruction, model_override=body.image_model
+                )
+            )
+        elif use_enter_edit and enter_source is not None:
+            # Explicit per-request model wins (mirrors the continuation call);
+            # else the router's enter_scene slot (FAL_ENTER_MODEL override).
+            enter_model = body.image_model or model_router.resolve_model(
+                "enter_scene"
+            )
+            enter_style_ref = _condition_url_for_role(body, "style")
+            log(
+                "info",
+                "tap.enter_edit",
+                model=enter_model,
+                source="region" if region_ref else "parent_image",
+                style_ref=bool(enter_style_ref),
+            )
+            main_task = _asyncio.create_task(
+                image_edit_provider.edit_image(
+                    enter_source,
+                    enter_instruction,
+                    model_override=enter_model,
+                    style_ref_url=enter_style_ref,
                 )
             )
         else:
@@ -1181,9 +1230,27 @@ async def _event_stream(
             "image_model": result.model,
             "prompt_author_model": text_model,
             "session_id": body.session_id,
-            "final_prompt": zoom_instruction if use_continuation else composed_prompt,
+            "final_prompt": (
+                zoom_instruction
+                if use_continuation
+                else enter_instruction
+                if use_enter_edit
+                else composed_prompt
+            ),
             "sources": sources_payload,
         }
+        # Which non-fresh op actually rendered the image — additive, absent on
+        # the fresh path (unchanged wire shape). Lets the demo trace / A-B
+        # drivers machine-check the route instead of inferring from the model.
+        executed_op = (
+            "zoom_continue"
+            if use_continuation
+            else "enter_scene"
+            if use_enter_edit
+            else "fresh"
+        )
+        if executed_op != "fresh":
+            final_payload["image_op"] = executed_op
         # Geometric grounding summary rides on `final` only when produced (flag
         # off → key absent → unchanged wire shape).
         if grounding_summary is not None:

--- a/apps/modal-backend/providers/image.py
+++ b/apps/modal-backend/providers/image.py
@@ -1,13 +1,16 @@
-"""fal-ai image generation with quality tiers.
+"""Image generation with quality tiers (fal + OpenRouter slugs).
 
-Three tiers map to fal model slugs (verified 2026-04). Each tier is overridable
-via env (`FAL_IMAGE_MODEL_FAST` / `..._BALANCED` / `..._PRO`). A request may
-also pass an explicit `tier` or `model_override` per call. Resolution order:
-explicit override > per-request tier > FAL_IMAGE_MODEL legacy env > default.
+Three tiers map to model slugs (fal verified 2026-04; OpenRouter added 2026-06
+after the broad bakeoff, docs/research/07). Each tier is overridable via env
+(`FAL_IMAGE_MODEL_FAST` / `..._BALANCED` / `..._PRO`). A request may also pass
+an explicit `tier` or `model_override` per call. Resolution order: explicit
+override > per-request tier > FAL_IMAGE_MODEL legacy env > default.
 
-`_args_for` keeps the per-model arg-shape divergence localised — seedream uses
-`image_size`, nano-banana uses `aspect_ratio`. Add new entries here as more
-models join.
+Slugs prefixed `openrouter:` route through OpenRouter's image-modality chat API
+(riverflow, recraft, …) instead of fal — same GeneratedImage out, provenance
+kept in the model string. `_args_for` keeps the per-model arg-shape divergence
+localised — seedream/gpt-image-2 use `image_size`, nano-banana family uses
+`aspect_ratio`. Add new entries here as more models join.
 """
 
 from __future__ import annotations
@@ -19,6 +22,8 @@ from typing import Any, cast
 
 import fal_client
 import httpx
+import openai
+from openai import AsyncOpenAI
 from tenacity import (
     AsyncRetrying,
     retry_if_exception,
@@ -26,10 +31,18 @@ from tenacity import (
     wait_exponential,
 )
 
+# OpenRouter-served image models (bakeoff field: sourceful/riverflow-v2.5-*,
+# recraft/recraft-v4.1-*). The prefix keeps fal slugs unambiguous and shows
+# provider provenance in final.image_model.
+OPENROUTER_IMAGE_PREFIX = "openrouter:"
+
 TIER_MODELS: dict[str, str] = {
     "fast":     "fal-ai/nano-banana",
     "balanced": "fal-ai/nano-banana-pro",
-    "pro":      "fal-ai/bytedance/seedream/v4/text-to-image",
+    # Bakeoff quality winner (docs/research/07): best medium adherence; layout
+    # fidelity is saturated across the field so this is the "I want the best
+    # one" tier. Revert knob: FAL_IMAGE_MODEL_PRO (e.g. back to seedream-v4).
+    "pro":      "openrouter:sourceful/riverflow-v2.5-pro",
 }
 TIER_ENV_KEYS: dict[str, str] = {
     "fast":     "FAL_IMAGE_MODEL_FAST",
@@ -112,8 +125,10 @@ def _args_for(
     aspect_ratio: str,
     reference_urls: list[str] | None = None,
 ) -> dict[str, Any]:
-    if "seedream" in model:
-        # seedream is text-to-image only here — no reference conditioning.
+    if "seedream" in model or "gpt-image" in model:
+        # seedream + fal-hosted gpt-image-2 take `image_size` presets (same
+        # enum) and are text-to-image only here — no reference conditioning
+        # (verified via scripts/verify-fal-models.py: no image_urls on either).
         return {
             "prompt": prompt,
             "image_size": SEEDREAM_SIZE_MAP.get(aspect_ratio, "landscape_16_9"),
@@ -273,8 +288,23 @@ async def generate_image(
             ctx["bytes"] = len(generated.jpeg_bytes)
         return generated
 
-    _ensure_fal_key()
     model = _resolve_model(tier, model_override)
+    if model.startswith(OPENROUTER_IMAGE_PREFIX):
+        # OpenRouter image-modality slug (riverflow / recraft / …): needs only
+        # OPENROUTER_API_KEY (already required for the planner), not FAL_KEY.
+        # Text-to-image semantics — refs would be ignored, same as seedream.
+        slug = model.removeprefix(OPENROUTER_IMAGE_PREFIX)
+        async with span(
+            "image.generate",
+            model=model,
+            prompt_len=len(prompt),
+            provider="openrouter",
+        ) as ctx:
+            generated = await _openrouter_image(slug, prompt, aspect_ratio)
+            ctx["bytes"] = len(generated.jpeg_bytes)
+        return generated
+
+    _ensure_fal_key()
     # Reference conditioning: upload each data URL to fal storage (queue
     # endpoints choke on multi-MB inline data URLs) and pass them as image_urls.
     # Only nano-banana accepts refs; other fal models stay text-only.
@@ -412,18 +442,108 @@ async def _openai_compatible_image(
     raise RuntimeError("image provider returned neither b64_json nor url")
 
 
+_OPENROUTER_CLIENT: AsyncOpenAI | None = None
+
+
+def _openrouter_client() -> AsyncOpenAI:
+    """Module-level singleton for `openrouter:` image slugs.
+
+    Pinned to the OpenRouter base URL on purpose — NOT llm._client(), whose
+    LLM_PROVIDER seam may point at Ollama/LM Studio, which can't serve image
+    modalities. Explicit generous timeout: riverflow-pro takes 1-3 MINUTES
+    with no bytes on the wire (152s measured live, 2026-06-10), and an
+    unbounded await would hang the SSE worker.
+    """
+    global _OPENROUTER_CLIENT
+    if _OPENROUTER_CLIENT is None:
+        api_key = os.environ.get("OPENROUTER_API_KEY", "").strip()
+        if not api_key:
+            raise RuntimeError(
+                "OPENROUTER_API_KEY is not set (required for openrouter: image models)"
+            )
+        _OPENROUTER_CLIENT = AsyncOpenAI(
+            base_url="https://openrouter.ai/api/v1",
+            api_key=api_key,
+            timeout=float(os.environ.get("OPENROUTER_IMAGE_TIMEOUT_S", "240")),
+            default_headers={
+                "HTTP-Referer": os.environ.get(
+                    "OPENROUTER_REFERER", "https://github.com/eren23/openflipbook"
+                ),
+                "X-Title": "Endless Canvas",
+            },
+        )
+    return _OPENROUTER_CLIENT
+
+
+async def _openrouter_image(
+    slug: str, prompt: str, aspect_ratio: str
+) -> GeneratedImage:
+    """One image via OpenRouter's image-modality chat API (riverflow/recraft).
+
+    Request shape proven by the bakeoff harness (scripts/bakeoff): a chat
+    completion with `modalities: ["image"]`; the image comes back base64 in
+    `message.images[0].image_url.url` (or, defensively, an http(s) URL).
+    """
+    client = _openrouter_client()
+    async for attempt in AsyncRetrying(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=0.5, min=0.5, max=4),
+        retry=retry_if_exception(_is_retryable),
+        reraise=True,
+    ):
+        with attempt:
+            resp = await client.chat.completions.create(
+                model=slug,
+                messages=[{"role": "user", "content": prompt}],
+                extra_body={
+                    "modalities": ["image"],
+                    "image_config": {"aspect_ratio": aspect_ratio},
+                },
+            )
+            msg = (resp.model_dump().get("choices") or [{}])[0].get("message") or {}
+            images = msg.get("images") or []
+            if not images:
+                # Malformed/empty responses fail fast (RuntimeError is not
+                # retryable) — mirrors _first_image on the fal path.
+                content = str(msg.get("content"))[:160]
+                raise RuntimeError(
+                    f"openrouter image model returned no image (content={content!r})"
+                )
+            url = str((images[0].get("image_url") or {}).get("url") or "")
+            if url.startswith("data:"):
+                header, _, b64 = url.partition(",")
+                mime = header.removeprefix("data:").split(";")[0] or "image/png"
+                raw = base64.b64decode(b64)
+            elif url.startswith("http"):
+                raw, mime = await _fetch_url_bytes(url)
+            else:
+                raise RuntimeError("openrouter image url malformed")
+            return GeneratedImage(
+                jpeg_bytes=raw,
+                mime_type=mime or "image/png",
+                model=f"{OPENROUTER_IMAGE_PREFIX}{slug}",
+                provider_request_id=str(getattr(resp, "id", "") or "") or None,
+            )
+    raise RuntimeError("unreachable")  # pragma: no cover
+
+
 def _is_retryable(exc: BaseException) -> bool:
-    """fal/transport transients worth retrying. 4xx-other should fail fast.
+    """fal/openai/transport transients worth retrying. 4xx-other fails fast.
 
     fal_client raises its own exception hierarchy (`FalClientHTTPError`,
     `FalClientTimeoutError`) for queue/HTTP failures — NOT bare httpx
-    exceptions — so the classifier checks those first. Falls back to httpx
-    exceptions for the post-fal CDN download path.
+    exceptions — so the classifier checks those first. The openai SDK (the
+    `openrouter:` image path) likewise wraps transport errors in its own
+    types. Falls back to httpx exceptions for the post-fal CDN download path.
     """
     if isinstance(exc, fal_client.FalClientHTTPError):
         code = exc.status_code
         return code == 429 or 500 <= code < 600
     if isinstance(exc, fal_client.FalClientTimeoutError):
+        return True
+    if isinstance(exc, openai.APIStatusError):  # RateLimitError subclasses this
+        return exc.status_code == 429 or 500 <= exc.status_code < 600
+    if isinstance(exc, openai.APIConnectionError):  # APITimeoutError subclasses this
         return True
     if isinstance(exc, httpx.TransportError):
         return True

--- a/apps/modal-backend/providers/image_edit.py
+++ b/apps/modal-backend/providers/image_edit.py
@@ -152,6 +152,61 @@ def build_zoom_instruction(
     return text.strip()
 
 
+def build_enter_instruction(
+    page_title: str,
+    facts: list[str],
+    *,
+    style_anchor: str | None = None,
+    subject_context: str | None = None,
+    surroundings: str | None = None,
+    layout_clause: str = "",
+) -> str:
+    """Compose the enter-edit instruction: a VIEW CHANGE that keeps the place.
+
+    The reference (the tapped region crop) carries the place's look — walls,
+    shapes, materials, palette; this text carries the move pixels can't show:
+    step from the overhead map to ground level INSIDE the same place. Fidelity
+    is the contract — the same architecture and landmarks the crop shows, seen
+    from within — not a fresh invention (the old text-to-image path, where refs
+    were a no-op) and not a plain zoom (the submap path). The medium clause is
+    load-bearing when FAL_ENTER_MODEL points at Kontext, which takes no second
+    style ref. Empty inputs degrade cleanly — no dangling separators.
+    """
+    title = page_title.strip() or "this place"
+    anchor = f'"{title}"'
+    if subject_context and subject_context.strip():
+        anchor += f" ({subject_context.strip()})"
+    text = (
+        f"Step INSIDE {anchor} — the place this image shows — and draw the view "
+        "from ground level within it. This is the SAME place seen from the "
+        "inside, not a new one and not the overhead map view: keep the exact "
+        "architecture, walls, towers, materials, colours and landmarks the "
+        "image shows, and reveal what they enclose"
+    )
+    named = [f.strip() for f in facts if f and f.strip()]
+    if named:
+        # Features to SHOW, not captions — same garble guard as the zoom path.
+        text += ", working in what belongs here: " + "; ".join(named[:8])
+    text += "."
+    if surroundings and surroundings.strip():
+        text += (
+            " Through openings and beyond the walls, keep the neighbours where "
+            f"the map placed them: {surroundings.strip()}"
+        )
+        if not text.endswith("."):
+            text += "."
+    text += " Keep the exact art medium of the reference"
+    if style_anchor and style_anchor.strip():
+        text += f" — {style_anchor.strip()} —"
+    text += (
+        " same palette and line work; NOT a photograph, no photorealism. "
+        "Keep any lettering sparse and legible — no garbled text."
+    )
+    if layout_clause.strip():
+        text += "\n\n" + layout_clause.strip()
+    return text.strip()
+
+
 async def continue_image(
     image_data_url: str,
     instruction: str,

--- a/apps/modal-backend/providers/model_router.py
+++ b/apps/modal-backend/providers/model_router.py
@@ -1,9 +1,10 @@
 """Per-operation image-model router.
 
 Every image operation has a default model and an env override, and a pure
-`select_operation` decides which op a tap generation uses: entering a place or a
-sub-map with a region crop zoom-continues (a faithful Kontext zoom of the map);
-everything else is a fresh generation.
+`select_operation` decides which op a tap generation uses: a sub-map with a
+region crop zoom-continues (a faithful Kontext zoom of the map); entering a
+place routes through an EDIT endpoint (the only path where the parent-region
+ref actually bites); everything else is a fresh generation.
 
 `outpaint`/`inpaint`/`upscale` slots are declared for the verify→repair loop
 (and map-pan reuse) but only activate once their FAL_*_MODEL is set AND a
@@ -19,6 +20,11 @@ import os
 MODEL_SLOTS: dict[str, tuple[str | None, str | None]] = {
     "fresh": (None, None),  # tier-based via image.py (FAL_IMAGE_MODEL_*)
     "zoom_continue": ("fal-ai/flux-pro/kontext", "FAL_CONTINUE_MODEL"),
+    # Entering a place: an instruction-driven EDIT of the tapped region crop —
+    # nano edit slugs honour image_urls (verified via scripts/verify-fal-models.py)
+    # and tolerate a view change, where Kontext strict-zooms. The enter eval
+    # (tests/continuity_bench/enter_runner.py) A/Bs the candidates.
+    "enter_scene": ("fal-ai/nano-banana-pro/edit", "FAL_ENTER_MODEL"),
     "outpaint": ("fal-ai/bria/expand", "FAL_OUTPAINT_MODEL"),
     # B2 OUTWARD: a centered BRIA outpaint (reuses the bria slot) paints the
     # container around the source; the medium-flip hop is a tier-based fresh gen.
@@ -52,16 +58,22 @@ def select_operation(render_mode: str | None, has_region: bool) -> str:
     — a faithful, style-preserving closer MAP of the SAME walls/buildings the map
     shows, from the same overhead viewpoint.
 
-    Stepping INSIDE a place (`place_scene`) is a view CHANGE — exterior to interior
-    — which a strict zoom can't do (Kontext just zooms the crop, the "did you only
-    zoom in?" failure). So a scene is a FRESH, reference-conditioned generation: it
-    renders the interior while the region crop + the place's appearance keep its
-    architecture, materials and style continuous with the map.
+    Stepping INSIDE a place (`place_scene`) is a view CHANGE — overhead map to
+    ground level — routed through an EDIT endpoint conditioned on the tapped
+    region crop. Fresh text-to-image is NOT an option here: fal's text-to-image
+    endpoints accept-but-ignore reference images (research/01), so a "fresh,
+    reference-conditioned" scene was really an unconditioned reinvention —
+    different walls/shapes every time. The edit endpoint is where refs bite;
+    the instruction (build_enter_instruction) carries the view change. The call
+    site still needs a source image, hence no has_region condition here — it
+    falls back to fresh only when there is nothing to condition on.
 
     Everything else is a fresh generation. (outpaint/inpaint/upscale are invoked
     explicitly by callers — the repair loop — not chosen here.)"""
     if render_mode == "place_submap" and has_region:
         return "zoom_continue"
+    if render_mode == "place_scene":
+        return "enter_scene"
     return "fresh"
 
 

--- a/apps/modal-backend/scripts/verify-fal-models.py
+++ b/apps/modal-backend/scripts/verify-fal-models.py
@@ -7,9 +7,13 @@ run it by hand when wiring a new slot or before trusting a param like
 
 Findings as of 2026-06 (the reason image._args_for sends no negative_prompt and
 why fresh-gen conditioning is best-effort):
-  - nano-banana / nano-banana-pro (text-to-image): NO negative_prompt, NO image_urls
+  - nano-banana / nano-banana-pro / nano-banana-2 (text-to-image):
+                                                   NO negative_prompt, NO image_urls
+  - nano-banana(-pro/-2)/edit:                     take image_urls (list) + aspect_ratio
   - flux-pro/kontext (edit/continue):              NO negative_prompt, takes image_url (singular)
   - seedream v4 (text-to-image):                   text-only (image_size, no refs)
+  - openai/gpt-image-2:                            image_size + quality, NO refs
+  - openai/gpt-image-2/edit:                       image_urls (list) + image_size/quality/mask_url
   - bria/expand (outpaint):                        takes image_url + expansion box
 => No image model in use accepts a negative_prompt, so we never send one; the
    MEDIUM LOCK in the prompt text is the model-agnostic style guard. Image refs
@@ -31,9 +35,14 @@ SLUGS = [
     "fal-ai/nano-banana",
     "fal-ai/nano-banana-pro",
     "fal-ai/nano-banana/edit",
+    "fal-ai/nano-banana-pro/edit",
+    "fal-ai/nano-banana-2",
+    "fal-ai/nano-banana-2/edit",
     "fal-ai/bytedance/seedream/v4/text-to-image",
     "fal-ai/flux-pro/kontext",
     "fal-ai/bria/expand",
+    "openai/gpt-image-2",
+    "openai/gpt-image-2/edit",
 ]
 PROBE = ["prompt", "image_url", "image_urls", "negative_prompt", "aspect_ratio", "guidance_scale"]
 

--- a/apps/modal-backend/tests/conftest.py
+++ b/apps/modal-backend/tests/conftest.py
@@ -47,6 +47,14 @@ _SCRUB = (
     # World Mode (tap enters a place; gated off by default).
     "WORLD_MODE",
     "FAL_CONTINUE_MODEL",
+    # Enter-via-edit (default ON — scrub so a host kill-switch can't silently
+    # flip the routing tests) + the edit-tier knobs it can interact with.
+    "ENTER_EDIT_REF",
+    "FAL_ENTER_MODEL",
+    "FAL_EDIT_TIER",
+    "FAL_EDIT_MODEL_FAST",
+    "FAL_EDIT_MODEL_BALANCED",
+    "FAL_EDIT_MODEL_PRO",
     # Geometric world model (numeric map, observer poses, grounded gen).
     "GEOMETRIC_WORLD",
     "WORLD_GEOMETRY_GEN",

--- a/apps/modal-backend/tests/conftest.py
+++ b/apps/modal-backend/tests/conftest.py
@@ -74,6 +74,15 @@ _SCRUB = (
     # Map-pan expand (outpaint the world outward).
     "EXPAND_MAP_PAN",
     "FAL_EXPAND_MODEL",
+    # B2 scale-ladder nav — the root .env turns these on for local demos; the
+    # OUTWARD edit-ref default is ON so scrubbing keeps the routing tests
+    # deterministic either way.
+    "SCALE_LADDER_NAV",
+    "SCALE_OUTWARD",
+    "SCALE_OUTWARD_OUTPAINT",
+    "SCALE_OUTWARD_EDIT_REF",
+    "SCALE_OUTWARD_RERENDER",
+    "SCALE_AROUND_LOGICAL",
     "SENTRY_DSN",
 )
 

--- a/apps/modal-backend/tests/continuity_bench/enter_runner.py
+++ b/apps/modal-backend/tests/continuity_bench/enter_runner.py
@@ -1,0 +1,335 @@
+"""ENTER-CONSISTENCY — the A/B for the metric the owner actually cares about:
+does the ENTERED place look like the place you tapped on the map?
+
+For each styled top-down map we tap a named landmark and render the entered
+scene BOTH ways:
+  - FRESH (the shipped bug, byte-faithful): conditioning preamble + scene
+    prompt -> generate_image(reference_urls=[region, map, map]) — fal's
+    text-to-image accepts-but-IGNORES those refs (research/01), so this arm is
+    an unconditioned reinvention. This was the live path until ENTER_EDIT_REF.
+  - EDIT (the fix): build_enter_instruction -> edit_image(region crop, style
+    ref) on the router's enter_scene model — the path where refs bite.
+Optional extra arms via ENTER_BENCH_MODELS (comma-sep ref-honouring slugs,
+e.g. fal-ai/flux-pro/kontext,openai/gpt-image-2/edit,fal-ai/nano-banana-2/edit)
+decide the enter_scene default empirically.
+
+`score_continuation(region_crop, candidate)` is the judge: 0-10 "is this the
+SAME place seen closer?" (it was built for exactly this and never pointed at
+the broken path). `score_style_pair(map, candidate)` seconds it on medium.
+LIFT = edit_mean - fresh_mean; the committed baseline (eval_baselines.json,
+"enter_same_place") guards it against regression once measured.
+
+Paid (fal gens + Gemini judge). Self-contained — no session / web needed:
+    cd apps/modal-backend && ENTER_BENCH_RUN=1 \
+      .venv/bin/python -m tests.continuity_bench.enter_runner
+or:  make eval-enter-drift
+The judge + text model default to Gemini (qwen 429s — memory
+project_qwen_ratelimit); the balanced image model is forced to nano-banana-pro.
+"""
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import os
+import statistics
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from ._score import score_continuation, score_style_pair
+from .coherence_runner import crop_box
+
+_REPORTS = Path(__file__).resolve().parent / "reports"
+# Below this mean, the edit-routed enter still isn't a trustworthy continuation
+# of the tapped region — iterate the instruction/model before trusting it.
+_PASS_THRESHOLD = float(os.environ.get("ENTER_BENCH_THRESHOLD", "6.5"))
+
+
+@dataclass(frozen=True)
+class Case:
+    name: str
+    # The styled top-down map; the prompt PLACES the landmark so `tap` can aim.
+    map_prompt: str
+    style: str
+    # Normalised tap point aimed at the named landmark on the map.
+    tap: tuple[float, float]
+    # What the tap resolves to (the prefetched_subject / page title analogue).
+    place_label: str
+    subject_context: str
+    surroundings: str
+    facts: list[str] = field(default_factory=list)
+
+
+_CASES: list[Case] = [
+    Case(
+        name="engraving_harbor_castle",
+        map_prompt=(
+            "a hand-drawn antique engraving top-down map of a walled harbor "
+            "city: a tall striped lighthouse on the north cliff, a market "
+            "square in the center, wooden docks along the south shore, and a "
+            "stone castle on the east hill; sepia ink, dense cross-hatching, "
+            "aged paper"
+        ),
+        style="hand-drawn antique engraving, sepia ink, dense cross-hatching",
+        tap=(0.78, 0.42),
+        place_label="The Stone Castle",
+        subject_context="a stone castle with towers and walls on a hill east of the harbor",
+        surroundings=(
+            "to the west, the market square and the harbor; to the north-west, "
+            "the striped lighthouse on the cliffs"
+        ),
+        facts=["the inner bailey", "the east gatehouse"],
+    ),
+    Case(
+        name="watercolor_hilltown_market",
+        map_prompt=(
+            "a soft watercolour top-down map of a walled hill town: a market "
+            "hall at the central square, a bell tower just north of it, "
+            "terraced vineyards south of the walls; loose washes, pale pastel "
+            "palette, visible paper texture"
+        ),
+        style="soft watercolour, loose washes, pale pastel palette",
+        tap=(0.5, 0.5),
+        place_label="The Market Hall",
+        subject_context="a timber market hall on the town's central square",
+        surroundings="just north, the bell tower; south beyond the walls, terraced vineyards",
+        facts=["the cloth stalls", "the well"],
+    ),
+    Case(
+        name="infographic_workshop_bench",
+        map_prompt=(
+            "a flat vector infographic top-down floor plan of a clockmaker's "
+            "workshop: a long workbench along the north wall, a brass lathe in "
+            "the center, a parts cabinet on the east wall; clean flat colours, "
+            "minimal palette, crisp outlines"
+        ),
+        style="flat vector infographic, clean flat colours, crisp outlines",
+        tap=(0.5, 0.22),
+        place_label="The Workbench",
+        subject_context="the clockmaker's long workbench along the north wall",
+        surroundings="behind it, the brass lathe at the room's center; to the east, the parts cabinet",
+        facts=["the escapement jig", "rows of tiny drawers"],
+    ),
+]
+
+
+@dataclass(frozen=True)
+class CaseResult:
+    name: str
+    fresh_score: float
+    edit_score: float
+    fresh_rationale: str
+    edit_rationale: str
+    # Medium-faithfulness of the edit arm vs the map (style second opinion).
+    edit_medium_score: float
+    # Optional extra arms: model slug -> same-place score.
+    extra_models: dict[str, float] = field(default_factory=dict)
+
+    @property
+    def lift(self) -> float:
+        # >0 = the edit-routed enter continues the tapped region better.
+        return round(self.edit_score - self.fresh_score, 4)
+
+
+def _crop_region(map_bytes: bytes, tap: tuple[float, float]) -> bytes:
+    """Pillow mirror of the client's cropRegion (frac via crop_box) — the same
+    region ref the frontend would send for this tap. Test-only dep (Pillow is
+    not in the backend runtime)."""
+    from PIL import Image
+
+    img = Image.open(io.BytesIO(map_bytes)).convert("RGB")
+    bx, by, bw, bh = crop_box(tap[0], tap[1])
+    w, h = img.size
+    crop = img.crop(
+        (round(bx * w), round(by * h), round((bx + bw) * w), round((by + bh) * h))
+    )
+    buf = io.BytesIO()
+    crop.save(buf, format="JPEG", quality=90)
+    return buf.getvalue()
+
+
+async def _run_case(case: Case, aspect: str) -> CaseResult:
+    from providers import image as image_provider
+    from providers import image_edit as image_edit_provider
+    from providers import llm, model_router
+
+    # 1. The styled top-down map (what the user generated, then tapped).
+    src = await image_provider.generate_image(
+        prompt=case.map_prompt, aspect_ratio=aspect, tier="balanced"
+    )
+    map_url = image_provider.encode_data_url(src.jpeg_bytes)
+    region_bytes = _crop_region(src.jpeg_bytes, case.tap)
+    region_url = image_provider.encode_data_url(region_bytes)
+
+    # 2. One plan shared by both arms (same knowledge, different render route —
+    #    a fair A/B). Exactly what generate.py's tap branch asks the planner.
+    plan = await llm.plan_page(
+        query=case.place_label,
+        web_search=False,
+        style_anchor=case.style,
+        subject_context=case.subject_context,
+        render_mode="place_scene",
+        surroundings=case.surroundings,
+    )
+    facts = list(plan.facts or case.facts)
+
+    # 3a. FRESH — the shipped bug, byte-faithful: preamble + styled prompt with
+    #     the (inert) reference stack on text-to-image.
+    fresh_prompt = (
+        image_provider.conditioning_preamble(["region", "parent", "style"], "place_scene")
+        + f"Style: {case.style}\n\n{plan.prompt}"
+    )
+    fresh = await image_provider.generate_image(
+        fresh_prompt,
+        aspect,
+        tier="balanced",
+        reference_urls=[region_url, map_url, map_url],
+    )
+
+    # 3b. EDIT — the fix: the region crop is the edit source, refs bite.
+    instruction = image_edit_provider.build_enter_instruction(
+        plan.page_title or case.place_label,
+        facts,
+        style_anchor=case.style,
+        subject_context=case.subject_context,
+        surroundings=case.surroundings,
+    )
+    edited = await image_edit_provider.edit_image(
+        region_url,
+        instruction,
+        model_override=model_router.resolve_model("enter_scene"),
+        style_ref_url=map_url,
+    )
+
+    # 3c. Optional extra ref-honouring arms (decide the enter default).
+    extra: dict[str, float] = {}
+    extra_blobs: dict[str, bytes] = {}
+    for slug in [
+        s.strip() for s in os.environ.get("ENTER_BENCH_MODELS", "").split(",") if s.strip()
+    ]:
+        alt = await image_edit_provider.edit_image(
+            region_url, instruction, model_override=slug, style_ref_url=map_url
+        )
+        alt_j = await score_continuation(region_bytes, alt.jpeg_bytes)
+        extra[slug] = alt_j.score
+        extra_blobs[slug] = alt.jpeg_bytes
+
+    # 4. Judge both arms against the tapped region.
+    fresh_j = await score_continuation(region_bytes, fresh.jpeg_bytes)
+    edit_j = await score_continuation(region_bytes, edited.jpeg_bytes)
+    edit_style_j = await score_style_pair(src.jpeg_bytes, edited.jpeg_bytes)
+
+    _REPORTS.mkdir(parents=True, exist_ok=True)
+    (_REPORTS / f"enter_{case.name}_map.jpg").write_bytes(src.jpeg_bytes)
+    (_REPORTS / f"enter_{case.name}_region.jpg").write_bytes(region_bytes)
+    (_REPORTS / f"enter_{case.name}_fresh.jpg").write_bytes(fresh.jpeg_bytes)
+    (_REPORTS / f"enter_{case.name}_edit.jpg").write_bytes(edited.jpeg_bytes)
+    for slug, blob in extra_blobs.items():
+        safe = slug.replace("/", "_").replace(":", "_")
+        (_REPORTS / f"enter_{case.name}_{safe}.jpg").write_bytes(blob)
+
+    return CaseResult(
+        name=case.name,
+        fresh_score=fresh_j.score,
+        edit_score=edit_j.score,
+        fresh_rationale=fresh_j.rationale,
+        edit_rationale=edit_j.rationale,
+        edit_medium_score=edit_style_j.score,
+        extra_models=extra,
+    )
+
+
+def summarize(results: list[CaseResult]) -> dict[str, Any]:
+    """Aggregate the A/B: per-arm same-place means, the LIFT, the trust gate,
+    and per-extra-model means. Pure, so the decision is unit-tested free."""
+    fresh_mean = round(statistics.mean(r.fresh_score for r in results), 4)
+    edit_mean = round(statistics.mean(r.edit_score for r in results), 4)
+    extra_means: dict[str, float] = {}
+    slugs = {s for r in results for s in r.extra_models}
+    for slug in sorted(slugs):
+        vals = [r.extra_models[slug] for r in results if slug in r.extra_models]
+        extra_means[slug] = round(statistics.mean(vals), 4)
+    return {
+        "n_cases": len(results),
+        "fresh_same_place_mean": fresh_mean,
+        "edit_same_place_mean": edit_mean,
+        # >0 → the edit route continues the tapped place better than the old
+        # text-to-image path. THE number for the owner's complaint.
+        "mean_lift": round(edit_mean - fresh_mean, 4),
+        "edit_medium_mean": round(
+            statistics.mean(r.edit_medium_score for r in results), 4
+        ),
+        "extra_model_same_place_means": extra_means,
+        "edit_trustworthy": edit_mean >= _PASS_THRESHOLD,
+    }
+
+
+async def run_bench() -> dict[str, Any]:
+    results = [await _run_case(c, "16:9") for c in _CASES]
+    from dataclasses import asdict
+
+    return {
+        "judge_model": os.environ.get("CONTINUITY_BENCH_JUDGE_MODEL"),
+        "enter_model": _enter_model(),
+        "started_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "threshold": _PASS_THRESHOLD,
+        "cases": [asdict(r) | {"lift": r.lift} for r in results],
+        "summary": summarize(results),
+    }
+
+
+def _enter_model() -> str:
+    from providers import model_router
+
+    return model_router.resolve_model("enter_scene") or "unset"
+
+
+def _load_env() -> None:
+    """Load apps/modal-backend/.env, force nano-banana-pro for the balanced tier
+    (the .env pins plain nano-banana — memory project_fal_model_pin) and pin the
+    judge + text model to Gemini (the .env's qwen rate-limits)."""
+    env_path = Path(__file__).resolve().parents[2] / ".env"
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+    os.environ.setdefault("CONTINUITY_BENCH_JUDGE_MODEL", "google/gemini-3-flash-preview")
+    os.environ.setdefault("FAL_IMAGE_MODEL_BALANCED", "fal-ai/nano-banana-pro")
+
+
+def _cli() -> None:
+    if not os.environ.get("ENTER_BENCH_RUN"):
+        raise SystemExit("set ENTER_BENCH_RUN=1 to spend on the paid ENTER-consistency A/B")
+    _load_env()
+    if not os.environ.get("FAL_KEY") or not os.environ.get("OPENROUTER_API_KEY"):
+        raise SystemExit("FAL_KEY + OPENROUTER_API_KEY required (apps/modal-backend/.env)")
+    report = asyncio.run(run_bench())
+    _REPORTS.mkdir(parents=True, exist_ok=True)
+    (_REPORTS / "enter_latest.json").write_text(json.dumps(report, indent=2))
+    print(json.dumps(report, indent=2))
+    summary = report["summary"]
+    print(
+        f"\nLIFT (edit - fresh, same-place 0-10) = {summary['mean_lift']}; "
+        f"edit trustworthy = {summary['edit_trustworthy']} (threshold {_PASS_THRESHOLD})."
+    )
+    from tests._baseline import load_baselines
+
+    if "enter_same_place" in load_baselines():
+        from tests._baseline import compare
+
+        verdict = compare("enter_same_place", summary["mean_lift"], summary["n_cases"])
+        print(f"baseline: {verdict.status} — {verdict.detail}")
+    else:
+        print(
+            "baseline: none committed yet — add 'enter_same_place' to "
+            "tests/eval_baselines.json from this run."
+        )
+
+
+if __name__ == "__main__":
+    _cli()

--- a/apps/modal-backend/tests/continuity_bench/test_enter.py
+++ b/apps/modal-backend/tests/continuity_bench/test_enter.py
@@ -1,0 +1,75 @@
+"""Free (unpaid) tests for the ENTER-consistency A/B — the cases + the gate's brain.
+
+The paid run (`enter_runner._cli`, gated on ENTER_BENCH_RUN) spends on fal gens
++ the Gemini judge. These cover the parts that don't: the cases are well-formed,
+the crop mirrors the client, and `summarize` computes the LIFT + flips
+`edit_trustworthy` at the threshold — the "did the fix actually fix it" decision
+is itself unit-tested.
+"""
+from __future__ import annotations
+
+from tests.continuity_bench.enter_runner import (
+    _CASES,
+    CaseResult,
+    summarize,
+)
+
+
+def _result(
+    name: str,
+    fresh: float,
+    edit: float,
+    extra: dict[str, float] | None = None,
+) -> CaseResult:
+    return CaseResult(
+        name=name,
+        fresh_score=fresh,
+        edit_score=edit,
+        fresh_rationale="",
+        edit_rationale="",
+        edit_medium_score=8.0,
+        extra_models=extra or {},
+    )
+
+
+def test_cases_are_well_formed() -> None:
+    assert len(_CASES) >= 2, "need >= 2 cases for a trustworthy mean (n_min)"
+    for c in _CASES:
+        assert c.map_prompt.strip() and c.style.strip() and c.place_label.strip()
+        assert c.subject_context.strip() and c.surroundings.strip()
+        x, y = c.tap
+        assert 0.0 <= x <= 1.0 and 0.0 <= y <= 1.0
+        # The map prompt must PLACE the tapped landmark so the tap can aim.
+        anchor = c.place_label.removeprefix("The ").split()[0].lower()
+        assert anchor in c.map_prompt.lower()
+
+
+def test_lift_is_edit_minus_fresh() -> None:
+    # The old fresh path scored 3 on "same place?"; the edit route scored 8.
+    assert _result("x", 3.0, 8.0).lift == 5.0
+
+
+def test_summarize_lift_and_trust() -> None:
+    s = summarize([_result("a", 3.0, 8.0), _result("b", 4.0, 7.0)])
+    assert s["fresh_same_place_mean"] == 3.5
+    assert s["edit_same_place_mean"] == 7.5
+    assert s["mean_lift"] == 4.0
+    assert s["edit_trustworthy"] is True  # 7.5 >= 6.5
+
+
+def test_summarize_distrusts_a_weak_edit() -> None:
+    # Even with a positive lift, a low absolute mean means the enter still
+    # isn't a faithful continuation — don't celebrate a lift over garbage.
+    s = summarize([_result("a", 2.0, 5.0), _result("b", 3.0, 6.0)])
+    assert s["mean_lift"] == 3.0
+    assert s["edit_trustworthy"] is False  # 5.5 < 6.5
+
+
+def test_summarize_aggregates_extra_model_arms() -> None:
+    s = summarize(
+        [
+            _result("a", 3.0, 8.0, {"fal-ai/flux-pro/kontext": 6.0}),
+            _result("b", 4.0, 7.0, {"fal-ai/flux-pro/kontext": 7.0}),
+        ]
+    )
+    assert s["extra_model_same_place_means"] == {"fal-ai/flux-pro/kontext": 6.5}

--- a/apps/modal-backend/tests/eval_baselines.json
+++ b/apps/modal-backend/tests/eval_baselines.json
@@ -14,6 +14,13 @@
       "regression_band": 2.0,
       "n_min": 1,
       "source": "SESSION_AUDIT.md §5 + make eval-style"
+    },
+    "enter_same_place": {
+      "metric": "mean_lift",
+      "baseline": 2.33,
+      "regression_band": 2.0,
+      "n_min": 2,
+      "source": "make eval-enter-drift first run 2026-06-10: fresh 6.67 -> edit 9.0 same-place (medium 9.33); arms: nano-banana-2/edit 9.33, gpt-image-2/edit 8.67, kontext 3.33 (rejected for enter)"
     }
   }
 }

--- a/apps/modal-backend/tests/test_generate_ascend.py
+++ b/apps/modal-backend/tests/test_generate_ascend.py
@@ -71,10 +71,19 @@ def _mock_fresh(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
     return gen
 
 
-async def test_ascend_fresh_container_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_ascend_container_continues_source_via_edit_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # SCALE_OUTWARD_EDIT_REF defaults ON: the container render goes through the
+    # edit endpoint (the only path where the source ref bites) — not the inert
+    # text-to-image ref path, and not the outpaint.
     _enable(monkeypatch)
     monkeypatch.delenv("SCALE_OUTWARD_OUTPAINT", raising=False)
     gen = _mock_fresh(monkeypatch)
+    edit = AsyncMock(
+        return_value=GeneratedImage(b"jpeg", "image/jpeg", "fal-ai/nano-banana-pro", "r")
+    )
+    monkeypatch.setattr(image_edit_mod, "edit_image", edit)
     outpaint = AsyncMock()
     monkeypatch.setattr(image_edit_mod, "expand_image_zoomout", outpaint)
 
@@ -83,8 +92,27 @@ async def test_ascend_fresh_container_by_default(monkeypatch: pytest.MonkeyPatch
     assert ready["scale_tier"] == "region"  # one rung coarser than city
     assert ready["from_tier"] == "city"
     assert ready["page_title"] == "The Vallen Sea and Coastline"
-    gen.assert_awaited_once()  # the fresh scale_parent container
+    edit.assert_awaited_once()  # the ref-honouring edit container
+    assert edit.await_args.args[0] == "data:image/jpeg;base64,abc"  # the source
+    gen.assert_not_awaited()  # NOT the no-op text-to-image ref path
     outpaint.assert_not_awaited()  # NOT the outpaint
+
+
+async def test_ascend_edit_ref_kill_switch_reverts_to_fresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # SCALE_OUTWARD_EDIT_REF=false: byte-identical to the old fresh container.
+    _enable(monkeypatch)
+    monkeypatch.setenv("SCALE_OUTWARD_EDIT_REF", "false")
+    gen = _mock_fresh(monkeypatch)
+    edit = AsyncMock()
+    monkeypatch.setattr(image_edit_mod, "edit_image", edit)
+
+    events = await _collect(_event_stream(_ascend_body(), "t1"))
+    ready = next(e for e in events if e["type"] == "ascend_ready")
+    assert ready["page_title"] == "The Vallen Sea and Coastline"
+    gen.assert_awaited_once()  # the fresh scale_parent container
+    edit.assert_not_awaited()
 
 
 async def test_ascend_outpaint_under_flag_steers_the_medium(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/apps/modal-backend/tests/test_generate_enter.py
+++ b/apps/modal-backend/tests/test_generate_enter.py
@@ -1,0 +1,246 @@
+"""Integration tests for enter-via-edit: place_scene taps route through the
+EDIT endpoint (where the region-crop ref actually bites) instead of the no-op
+text-to-image ref path that reinvented every entered place (research/01).
+
+ENTER_EDIT_REF is a default-ON kill-switch: off must be byte-identical to the
+old fresh path. The conftest scrubs the flag so host config can't flip these.
+
+generate.py imports `modal` at module level (deploy-only); stub it before import.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.modules.setdefault("modal", MagicMock())
+
+import providers.image as image_mod  # noqa: E402
+import providers.image_edit as image_edit_mod  # noqa: E402
+import providers.llm as llm_mod  # noqa: E402
+from generate import GenerateBody, _event_stream  # noqa: E402
+from providers import model_router  # noqa: E402
+from providers.image import GeneratedImage  # noqa: E402
+from providers.llm import PagePlan  # noqa: E402
+
+
+async def _collect(agen: Any) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    async for chunk in agen:
+        text = chunk.decode() if isinstance(chunk, bytes) else chunk
+        for block in text.strip().split("\n\n"):
+            block = block.strip()
+            if block.startswith("data:"):
+                events.append(json.loads(block[len("data:") :].strip()))
+    return events
+
+
+def _tap_body(**over: Any) -> GenerateBody:
+    """A world-mode tap entering a place, exactly as the geo-tap client sends
+    it: explicit place_scene framing, prefetched hints, and the condition
+    stack with the clean region crop first."""
+    base: dict[str, Any] = {
+        "query": "a walled harbor city",
+        "session_id": "s1",
+        "mode": "tap",
+        "image": "data:image/jpeg;base64,annotated-parent",
+        "click": {"x_pct": 0.6, "y_pct": 0.4},
+        "web_search": False,
+        "render_mode": "place_scene",
+        "prefetched_subject": "The Stone Castle",
+        "prefetched_subject_context": "a stone castle with concentric walls",
+        "prefetched_surroundings": "to the north, the striped lighthouse.",
+        "session_style_anchor": "hand-drawn engraving, sepia ink",
+        "condition_image_urls": ["data:r", "data:p", "data:s"],
+        "condition_roles": ["region", "parent", "style"],
+    }
+    base.update(over)
+    return GenerateBody(**base)
+
+
+def _mock_plan(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        llm_mod,
+        "plan_page",
+        AsyncMock(
+            return_value=PagePlan(
+                "The Stone Castle", "an interior scene", ["The Inner Bailey"], []
+            )
+        ),
+    )
+
+
+def _mock_edit(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    edit = AsyncMock(
+        return_value=GeneratedImage(
+            b"jpeg", "image/jpeg", "fal-ai/nano-banana-pro/edit", "r1"
+        )
+    )
+    monkeypatch.setattr(image_edit_mod, "edit_image", edit)
+    return edit
+
+
+def _mock_fresh(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    gen = AsyncMock(
+        return_value=GeneratedImage(b"jpeg", "image/jpeg", "fal-ai/nano-banana-pro", "r2")
+    )
+    monkeypatch.setattr(image_mod, "generate_image", gen)
+    return gen
+
+
+async def test_enter_routes_through_edit_with_region_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The default path: the CLEAN region crop is the edit source, the style
+    # exemplar rides as the second ref, and the router's enter model is used.
+    _mock_plan(monkeypatch)
+    edit = _mock_edit(monkeypatch)
+    gen = _mock_fresh(monkeypatch)
+
+    events = await _collect(_event_stream(_tap_body(), "t1"))
+
+    edit.assert_awaited_once()
+    gen.assert_not_awaited()  # NOT the no-op text-to-image ref path (and no draft)
+    assert edit.await_args.args[0] == "data:r"  # region crop, not the annotated parent
+    instruction = edit.await_args.args[1]
+    assert "The Stone Castle" in instruction
+    assert "engraving" in instruction  # the medium lock reaches the edit text
+    assert "lighthouse" in instruction  # neighbours stay where the map put them
+    assert edit.await_args.kwargs["style_ref_url"] == "data:s"
+    assert edit.await_args.kwargs["model_override"] == model_router.resolve_model(
+        "enter_scene"
+    )
+    assert any(e["type"] == "final" for e in events)
+
+
+async def test_enter_kill_switch_reverts_to_fresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # ENTER_EDIT_REF=false must be byte-identical to the old behaviour: fresh
+    # text-to-image with the (inert) reference stack.
+    monkeypatch.setenv("ENTER_EDIT_REF", "false")
+    monkeypatch.setenv("PROGRESSIVE_DRAFT", "false")
+    _mock_plan(monkeypatch)
+    edit = _mock_edit(monkeypatch)
+    gen = _mock_fresh(monkeypatch)
+
+    events = await _collect(_event_stream(_tap_body(), "t1"))
+
+    edit.assert_not_awaited()
+    gen.assert_awaited_once()
+    assert gen.await_args.kwargs["reference_urls"] == ["data:r", "data:p", "data:s"]
+    final = next(e for e in events if e["type"] == "final")
+    assert "image_op" not in final  # fresh path: additive key stays absent
+
+
+async def test_enter_skips_progressive_draft(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A text-only nano draft can't preview a conditioned edit — it would be a
+    # second unconditioned reinvention flashing before the faithful render.
+    monkeypatch.setenv("PROGRESSIVE_DRAFT", "true")
+    _mock_plan(monkeypatch)
+    edit = _mock_edit(monkeypatch)
+    gen = _mock_fresh(monkeypatch)
+
+    events = await _collect(_event_stream(_tap_body(image_tier="balanced"), "t1"))
+
+    edit.assert_awaited_once()
+    gen.assert_not_awaited()  # the draft would have used generate_image
+    assert not [e for e in events if e["type"] == "progress"]
+
+
+async def test_enter_without_source_falls_back_to_fresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # place_scene framing but nothing to condition on (no click image, no
+    # condition stack) → the defensive fresh fallback, never a broken edit call.
+    monkeypatch.setenv("PROGRESSIVE_DRAFT", "false")
+    _mock_plan(monkeypatch)
+    edit = _mock_edit(monkeypatch)
+    gen = _mock_fresh(monkeypatch)
+
+    body = _tap_body(
+        mode="query",
+        image=None,
+        click=None,
+        condition_image_urls=None,
+        condition_roles=None,
+        prefetched_subject=None,
+    )
+    await _collect(_event_stream(body, "t1"))
+
+    edit.assert_not_awaited()
+    gen.assert_awaited_once()
+
+
+async def test_enter_final_event_shows_edit_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The final event must make the route machine-checkable: the edit model,
+    # the enter instruction as final_prompt, and the additive image_op key.
+    _mock_plan(monkeypatch)
+    _mock_edit(monkeypatch)
+    _mock_fresh(monkeypatch)
+
+    events = await _collect(_event_stream(_tap_body(), "t1"))
+
+    final = next(e for e in events if e["type"] == "final")
+    assert final["image_model"] == "fal-ai/nano-banana-pro/edit"
+    assert final["image_op"] == "enter_scene"
+    assert "Step INSIDE" in final["final_prompt"]
+    assert "ground level" in final["final_prompt"]
+
+
+async def test_enter_explicit_image_model_wins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A per-request model override beats the router slot (mirrors continuation).
+    _mock_plan(monkeypatch)
+    edit = _mock_edit(monkeypatch)
+    _mock_fresh(monkeypatch)
+
+    await _collect(
+        _event_stream(_tap_body(image_model="fal-ai/flux-pro/kontext"), "t1")
+    )
+
+    assert edit.await_args.kwargs["model_override"] == "fal-ai/flux-pro/kontext"
+
+
+async def test_submap_zoom_continue_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Regression lock: the place_submap path still strict-zooms via Kontext.
+    _mock_plan(monkeypatch)
+    edit = _mock_edit(monkeypatch)
+    cont = AsyncMock(
+        return_value=GeneratedImage(b"jpeg", "image/jpeg", "fal-ai/flux-pro/kontext", "r3")
+    )
+    monkeypatch.setattr(image_edit_mod, "continue_image", cont)
+    gen = _mock_fresh(monkeypatch)
+
+    await _collect(_event_stream(_tap_body(render_mode="place_submap"), "t1"))
+
+    cont.assert_awaited_once()
+    assert cont.await_args.args[0] == "data:r"
+    edit.assert_not_awaited()
+    gen.assert_not_awaited()
+
+
+async def test_explainer_tap_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression lock: a plain explainer tap (no render_mode) keeps today's
+    # fresh, reference-stack generation.
+    monkeypatch.setenv("PROGRESSIVE_DRAFT", "false")
+    _mock_plan(monkeypatch)
+    edit = _mock_edit(monkeypatch)
+    gen = _mock_fresh(monkeypatch)
+
+    await _collect(_event_stream(_tap_body(render_mode=None), "t1"))
+
+    edit.assert_not_awaited()
+    gen.assert_awaited_once()
+    assert gen.await_args.kwargs["reference_urls"] == ["data:r", "data:p", "data:s"]

--- a/apps/modal-backend/tests/test_image_continue.py
+++ b/apps/modal-backend/tests/test_image_continue.py
@@ -74,6 +74,44 @@ def test_build_zoom_instruction_degrades_without_knowledge() -> None:
     assert s == s.strip()
 
 
+def test_build_enter_instruction_changes_viewpoint_keeps_place() -> None:
+    # Entering is a VIEW CHANGE on the SAME place: the instruction must demand
+    # ground level (not the map view) while locking architecture, neighbours,
+    # medium and the geometry clause to the reference crop.
+    s = image_edit.build_enter_instruction(
+        "Sentinel's Rise",
+        ["The Inner Bailey", "The Watch Bell"],
+        style_anchor="hand-drawn engraving, sepia ink",
+        subject_context="a stone castle with concentric walls",
+        surroundings="to the north-east, the striped lighthouse on the cliffs",
+        layout_clause="Place the Inner Bailey at the centre.",
+    )
+    low = s.lower()
+    assert "sentinel's rise" in low
+    assert "ground level" in low and "inside" in low       # the view change
+    assert "same place" in low and "exact" in low          # fidelity lock
+    assert "a stone castle with concentric walls" in s     # identity descriptor
+    assert "The Inner Bailey" in s and "The Watch Bell" in s
+    assert "hand-drawn engraving, sepia ink" in s          # medium rides the text (Kontext)
+    assert "striped lighthouse" in s                       # neighbours stay where mapped
+    assert "Place the Inner Bailey at the centre." in s    # geometry reaches the edit
+    assert "garbled" in low                                # no label bait
+    assert "photograph" in low                             # photoreal-drift guard
+
+
+def test_build_enter_instruction_degrades_without_knowledge() -> None:
+    # First enter with nothing seeded: still a faithful view change, no dangling
+    # enumerations or separators.
+    s = image_edit.build_enter_instruction("The Tower", [])
+    low = s.lower()
+    assert "the tower" in low
+    assert "ground level" in low and "same place" in low
+    assert "belongs here" not in low
+    assert "neighbours" not in low
+    assert "photograph" in low  # the medium guard holds even without an anchor
+    assert s == s.strip()
+
+
 async def test_continue_image_respects_env_override(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/apps/modal-backend/tests/test_image_provider.py
+++ b/apps/modal-backend/tests/test_image_provider.py
@@ -11,6 +11,7 @@ import base64
 
 import fal_client
 import httpx
+import openai
 import pytest
 
 from providers import image
@@ -407,3 +408,153 @@ async def test_generate_image_stays_on_fal_by_default(
     assert out.jpeg_bytes == b"jpeg"
     assert out.model == image.TIER_MODELS["balanced"]
     assert out.provider_request_id == "r1"
+
+
+# ---------- OpenRouter image slugs (openrouter: prefix) -------------------
+
+
+class _FakeORResponse:
+    id = "gen-123"
+
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+
+    def model_dump(self) -> dict:
+        return self._payload
+
+
+def _fake_or_client(payload: dict, captured: dict) -> object:
+    from types import SimpleNamespace
+
+    async def create(**kwargs: object) -> _FakeORResponse:
+        captured.update(kwargs)
+        return _FakeORResponse(payload)
+
+    return SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create))
+    )
+
+
+def _or_payload(url: str) -> dict:
+    return {"choices": [{"message": {"images": [{"image_url": {"url": url}}]}}]}
+
+
+def test_args_for_gpt_image_uses_image_size_and_never_refs() -> None:
+    # fal-hosted gpt-image-2: image_size presets, refs must never leak
+    # (verify-fal-models.py: no image_urls on its text-to-image schema).
+    args = image._args_for("openai/gpt-image-2", "p", "16:9", ["u1"])
+    assert args["image_size"] == "landscape_16_9"
+    assert "aspect_ratio" not in args
+    assert "image_urls" not in args
+
+
+def test_pro_tier_defaults_to_riverflow_on_openrouter() -> None:
+    # The bakeoff pick is the LIVE default, not a recommendation in a doc.
+    assert image._resolve_model("pro", None) == "openrouter:sourceful/riverflow-v2.5-pro"
+    assert image.TIER_MODELS["pro"].startswith(image.OPENROUTER_IMAGE_PREFIX)
+
+
+async def test_generate_image_routes_openrouter_prefix_without_fal_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # An openrouter: slug must dispatch off the fal path entirely — no FAL_KEY
+    # demanded (conftest scrubs it) — and strip the prefix for the wire call.
+    sentinel = image.GeneratedImage(
+        jpeg_bytes=b"x",
+        mime_type="image/png",
+        model="openrouter:sourceful/riverflow-v2.5-pro",
+        provider_request_id=None,
+    )
+    seen: dict[str, str] = {}
+
+    async def fake_or(slug: str, prompt: str, aspect: str) -> image.GeneratedImage:
+        seen["slug"] = slug
+        seen["aspect"] = aspect
+        return sentinel
+
+    monkeypatch.setattr(image, "_openrouter_image", fake_or)
+    out = await image.generate_image("a map", "16:9", tier="pro")
+    assert out is sentinel
+    assert seen["slug"] == "sourceful/riverflow-v2.5-pro"  # prefix stripped
+    assert seen["aspect"] == "16:9"
+
+
+async def test_openrouter_image_parses_data_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    b64 = base64.b64encode(b"PNGDATA").decode("ascii")
+    captured: dict = {}
+    fake = _fake_or_client(_or_payload(f"data:image/png;base64,{b64}"), captured)
+    monkeypatch.setattr(image, "_OPENROUTER_CLIENT", fake)
+
+    out = await image._openrouter_image("sourceful/riverflow-v2.5-pro", "a map", "16:9")
+
+    assert out.jpeg_bytes == b"PNGDATA"
+    assert out.mime_type == "image/png"
+    assert out.model == "openrouter:sourceful/riverflow-v2.5-pro"
+    assert out.provider_request_id == "gen-123"
+    # The proven bakeoff request shape: image modality + aspect via image_config.
+    assert captured["model"] == "sourceful/riverflow-v2.5-pro"
+    assert captured["extra_body"]["modalities"] == ["image"]
+    assert captured["extra_body"]["image_config"]["aspect_ratio"] == "16:9"
+
+
+async def test_openrouter_image_fetches_http_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict = {}
+    fake = _fake_or_client(_or_payload("http://cdn/img.jpg"), captured)
+    monkeypatch.setattr(image, "_OPENROUTER_CLIENT", fake)
+
+    async def fake_fetch(url: str) -> tuple[bytes, str]:
+        assert url == "http://cdn/img.jpg"
+        return b"JPEGDATA", "image/jpeg"
+
+    monkeypatch.setattr(image, "_fetch_url_bytes", fake_fetch)
+    out = await image._openrouter_image("recraft/recraft-v4.1-pro", "p", "1:1")
+    assert out.jpeg_bytes == b"JPEGDATA"
+    assert out.mime_type == "image/jpeg"
+
+
+async def test_openrouter_image_no_image_fails_fast(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict = {}
+    fake = _fake_or_client(
+        {"choices": [{"message": {"content": "cannot draw that"}}]}, captured
+    )
+    monkeypatch.setattr(image, "_OPENROUTER_CLIENT", fake)
+    with pytest.raises(RuntimeError, match="no image"):
+        await image._openrouter_image("sourceful/riverflow-v2.5-fast", "p", "1:1")
+
+
+def test_openrouter_client_requires_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(image, "_OPENROUTER_CLIENT", None)
+    with pytest.raises(RuntimeError, match="OPENROUTER_API_KEY"):
+        image._openrouter_client()
+
+
+def _openai_status_error(status: int) -> openai.APIStatusError:
+    req = httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions")
+    resp = httpx.Response(status, request=req)
+    return openai.APIStatusError("boom", response=resp, body=None)
+
+
+def test_retryable_openai_rate_limit() -> None:
+    assert image._is_retryable(_openai_status_error(429)) is True
+
+
+@pytest.mark.parametrize("code", [500, 502, 503])
+def test_retryable_openai_5xx(code: int) -> None:
+    assert image._is_retryable(_openai_status_error(code)) is True
+
+
+@pytest.mark.parametrize("code", [400, 401, 403, 404, 422])
+def test_not_retryable_openai_4xx_other(code: int) -> None:
+    assert image._is_retryable(_openai_status_error(code)) is False
+
+
+def test_retryable_openai_connection_error() -> None:
+    req = httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions")
+    err = openai.APIConnectionError(request=req)
+    assert image._is_retryable(err) is True

--- a/apps/modal-backend/tests/test_model_router.py
+++ b/apps/modal-backend/tests/test_model_router.py
@@ -13,18 +13,18 @@ def test_submap_with_region_zoom_continues() -> None:
     assert model_router.select_operation("place_submap", True) == "zoom_continue"
 
 
-def test_scene_is_fresh_conditioned_not_a_zoom() -> None:
-    # Stepping INSIDE a place is a view CHANGE (exterior -> interior), not a strict
-    # zoom of the crop — Kontext can only zoom it ("just a zoom"). So a scene is a
-    # fresh, reference-conditioned gen that keeps the place's architecture/style
-    # from the crop while actually going within.
-    assert model_router.select_operation("place_scene", True) == "fresh"
+def test_scene_enters_via_edit_op() -> None:
+    # Stepping INSIDE a place is a view CHANGE (overhead -> ground level) that
+    # must stay VISUALLY conditioned on the tapped region. Text-to-image ignores
+    # refs (research/01), so the scene routes through the edit endpoint — with or
+    # without a region crop (the call site falls back to the parent image).
+    assert model_router.select_operation("place_scene", True) == "enter_scene"
+    assert model_router.select_operation("place_scene", False) == "enter_scene"
 
 
-def test_no_region_falls_back_to_fresh() -> None:
+def test_submap_without_region_falls_back_to_fresh() -> None:
     # No region crop to continue from → a fresh generation.
     assert model_router.select_operation("place_submap", False) == "fresh"
-    assert model_router.select_operation("place_scene", False) == "fresh"
 
 
 @pytest.mark.parametrize("rm", ["explainer", None])
@@ -36,6 +36,8 @@ def test_resolve_model_defaults() -> None:
     assert "kontext" in (model_router.resolve_model("zoom_continue") or "")
     assert "bria" in (model_router.resolve_model("outpaint") or "")
     assert "fill" in (model_router.resolve_model("inpaint") or "")
+    # The enter op must resolve to an EDIT endpoint — refs are a no-op anywhere else.
+    assert "/edit" in (model_router.resolve_model("enter_scene") or "")
     assert model_router.resolve_model("fresh") is None
     assert model_router.resolve_model("unknown") is None
 
@@ -45,6 +47,8 @@ def test_resolve_model_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
     assert model_router.resolve_model("zoom_continue") == "fal-ai/custom/kontext2"
     monkeypatch.setenv("FAL_OUTPAINT_MODEL", "fal-ai/custom/expand2")
     assert model_router.resolve_model("outpaint") == "fal-ai/custom/expand2"
+    monkeypatch.setenv("FAL_ENTER_MODEL", "fal-ai/flux-pro/kontext")
+    assert model_router.resolve_model("enter_scene") == "fal-ai/flux-pro/kontext"
 
 
 # ── B2 OUTWARD op selection (pure, by tier delta) ────────────────────────────

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -271,6 +271,9 @@ export interface GenerateFinalEvent {
   // Web-search citations the planner used. Empty when web search is off
   // or the model returned none. Already domain-deduped, capped at ~3.
   sources?: Citation[];
+  // Which non-fresh image operation rendered this page ("zoom_continue",
+  // "enter_scene"). Absent on the fresh path — additive, backwards-compat.
+  image_op?: string;
   // Geometric grounding summary — present only when VLM_GROUNDING was on.
   grounding?: GroundingSummary;
   trace_id?: string;

--- a/scripts/ab-proof/ab_enter.py
+++ b/scripts/ab-proof/ab_enter.py
@@ -1,0 +1,198 @@
+"""A/B proof for the ENTER consistency fix (enter-via-edit).
+
+The kill-switch IS the "before": the SAME code runs on two local backends that
+differ only in one env flag —
+  :8788 = ENTER_EDIT_REF=false  (the old path: fresh text-to-image, refs ignored)
+  :8789 = ENTER_EDIT_REF=true   (the fix: edit endpoint on the region crop)
+
+One map is generated once; the region crop at the tap point is computed here
+exactly like the client (crop_box frac mirror); the IDENTICAL tap body goes to
+both backends. The script machine-asserts the routing from the final events
+(image_op / image_model) and composes a 3-panel: tapped region | BEFORE | AFTER.
+
+Run (two terminals, from apps/modal-backend, both with WORLD_MODE=1):
+  ENTER_EDIT_REF=false PORT=8788 python local_server.py
+  ENTER_EDIT_REF=true  PORT=8789 python local_server.py
+then:
+  .venv/bin/python ../../scripts/ab-proof/ab_enter.py
+Artifacts: /tmp/ab_enter_{map,region,before,after}.jpg + /tmp/ab_enter_3panel.png
+"""
+import base64
+import io
+import json
+import sys
+
+import httpx
+from PIL import Image, ImageDraw, ImageFont
+
+BEFORE = "http://localhost:8788/sse/generate"
+AFTER = "http://localhost:8789/sse/generate"
+SID = "ab-enter-proof"
+FONT = "/System/Library/Fonts/Supplemental/Arial.ttf"
+
+STYLE = "hand-drawn antique engraving, sepia ink, dense cross-hatching, woodcut linework"
+MAP_QUERY = (
+    "a hand-drawn antique engraving top-down map of a walled harbor city: a tall "
+    "striped lighthouse on the north cliff, a market square in the center, wooden "
+    "docks along the south shore, and a stone castle on the east hill; sepia ink, "
+    "dense cross-hatching, aged paper"
+)
+TAP = (0.78, 0.42)  # the stone castle, east hill
+SUBJECT = "The Stone Castle"
+SURROUNDINGS = (
+    "to the west, the market square and the harbor; to the north-west, the striped "
+    "lighthouse on the cliffs"
+)
+
+
+def sse_generate(url: str, body: dict, timeout: float = 300.0) -> dict:
+    final = None
+    with httpx.stream("POST", url, json=body, timeout=timeout) as r:
+        r.raise_for_status()
+        for line in r.iter_lines():
+            if not line or not line.startswith("data:"):
+                continue
+            try:
+                evt = json.loads(line[5:].strip())
+            except json.JSONDecodeError:
+                continue
+            if evt.get("type") == "error":
+                raise RuntimeError(f"backend error: {evt.get('message')}")
+            if evt.get("type") == "final":
+                final = evt
+    if not final:
+        raise RuntimeError("no final event")
+    return final
+
+
+def save(data_url: str, path: str) -> bytes:
+    raw = base64.b64decode(data_url.split(",", 1)[1])
+    with open(path, "wb") as f:
+        f.write(raw)
+    return raw
+
+
+def crop_region(map_bytes: bytes, x_pct: float, y_pct: float, frac: float = 0.42) -> bytes:
+    """Pure mirror of lib/image-condition.ts cropBox — the client's region ref."""
+    img = Image.open(io.BytesIO(map_bytes)).convert("RGB")
+    w = min(max(frac, 0.0), 1.0)
+    x = min(max(x_pct - w / 2, 0.0), 1.0 - w)
+    y = min(max(y_pct - w / 2, 0.0), 1.0 - w)
+    pw, ph = img.size
+    crop = img.crop((round(x * pw), round(y * ph), round((x + w) * pw), round((y + w) * ph)))
+    buf = io.BytesIO()
+    crop.save(buf, format="JPEG", quality=90)
+    return buf.getvalue()
+
+
+def tap_body(map_data_url: str, region_data_url: str) -> dict:
+    return {
+        "query": SUBJECT,
+        "session_id": SID,
+        "aspect_ratio": "16:9",
+        "image_tier": "balanced",
+        "mode": "tap",
+        "image": map_data_url,
+        "parent_query": MAP_QUERY,
+        "parent_title": "The Harbor City",
+        "click": {"x_pct": TAP[0], "y_pct": TAP[1]},
+        "world_mode": True,
+        "render_mode": "place_scene",
+        # Identical resolved subject on both backends (skips the VLM resolver).
+        "prefetched_subject": SUBJECT,
+        "prefetched_style": STYLE,
+        "prefetched_subject_context": "a stone castle with towers and walls on a hill east of the harbor",
+        "prefetched_surroundings": SURROUNDINGS,
+        "web_search": False,
+        # The exact stack the client sends: region crop -> parent map -> style.
+        "condition_image_urls": [region_data_url, map_data_url, map_data_url],
+        "condition_roles": ["region", "parent", "style"],
+        "session_style_anchor": STYLE,
+    }
+
+
+def labeled(raw: bytes, caption: str, barcolor: str, w: int = 520, h: int = 390) -> Image.Image:
+    barh = 56
+    im = Image.open(io.BytesIO(raw)).convert("RGB").resize((w, h))
+    canvas = Image.new("RGB", (w, h + barh), barcolor)
+    canvas.paste(im, (0, 0))
+    d = ImageDraw.Draw(canvas)
+    f = ImageFont.truetype(FONT, 22)
+    tw = d.textlength(caption, font=f)
+    d.text(((w - tw) // 2, h + (barh - 26) // 2), caption, font=f, fill="white")
+    return canvas
+
+
+def three_panel(panels: list[Image.Image], title: str, out: str) -> None:
+    gap, titleh = 12, 64
+    W = sum(p.width for p in panels) + gap * (len(panels) - 1)
+    H = max(p.height for p in panels) + titleh
+    canvas = Image.new("RGB", (W, H), "white")
+    d = ImageDraw.Draw(canvas)
+    f = ImageFont.truetype(FONT, 22)
+    tw = d.textlength(title, font=f)
+    d.text(((W - tw) // 2, (titleh - 26) // 2), title, font=f, fill="black")
+    x = 0
+    for p in panels:
+        canvas.paste(p, (x, titleh))
+        x += p.width + gap
+    if canvas.width % 2 or canvas.height % 2:
+        canvas = canvas.crop((0, 0, canvas.width - canvas.width % 2, canvas.height - canvas.height % 2))
+    canvas.save(out)
+    print("wrote", out, canvas.size)
+
+
+def main() -> None:
+    print("[1/4] generating the source map once (AFTER backend)...", file=sys.stderr)
+    m = sse_generate(
+        AFTER,
+        {
+            "query": MAP_QUERY,
+            "session_id": SID,
+            "aspect_ratio": "16:9",
+            "image_tier": "balanced",
+            "mode": "query",
+            "web_search": False,
+            "session_style_anchor": STYLE,
+        },
+    )
+    map_url = m["image_data_url"]
+    map_bytes = save(map_url, "/tmp/ab_enter_map.jpg")
+
+    print("[2/4] cropping the tapped region (client mirror)...", file=sys.stderr)
+    region_bytes = crop_region(map_bytes, *TAP)
+    with open("/tmp/ab_enter_region.jpg", "wb") as f:
+        f.write(region_bytes)
+    region_url = "data:image/jpeg;base64," + base64.b64encode(region_bytes).decode()
+
+    body = tap_body(map_url, region_url)
+    print("[3/4] identical tap to BOTH backends...", file=sys.stderr)
+    before = sse_generate(BEFORE, dict(body))
+    after = sse_generate(AFTER, dict(body))
+    save(before["image_data_url"], "/tmp/ab_enter_before.jpg")
+    save(after["image_data_url"], "/tmp/ab_enter_after.jpg")
+
+    # Machine-check the routing — the proof is in the trace, not vibes.
+    assert "image_op" not in before, f"BEFORE unexpectedly edit-routed: {before.get('image_op')}"
+    assert after.get("image_op") == "enter_scene", f"AFTER not edit-routed: {after.get('image_op')}"
+    assert "/edit" in after.get("image_model", ""), f"AFTER model: {after.get('image_model')}"
+    print(
+        f"routing OK — before: {before.get('image_model')} (fresh, refs inert) | "
+        f"after: {after.get('image_model')} (op={after.get('image_op')})",
+        file=sys.stderr,
+    )
+
+    print("[4/4] composing the 3-panel...", file=sys.stderr)
+    three_panel(
+        [
+            labeled(region_bytes, "the tapped map region", "#444444"),
+            labeled(open("/tmp/ab_enter_before.jpg", "rb").read(), "BEFORE — refs silently ignored", "#B00020"),
+            labeled(open("/tmp/ab_enter_after.jpg", "rb").read(), "AFTER — edit-conditioned on the crop", "#0B7A33"),
+        ],
+        "openflipbook — tap-to-ENTER consistency — identical request, only ENTER_EDIT_REF differs",
+        "/tmp/ab_enter_3panel.png",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/record-demo/record-fresh-nav.ts
+++ b/scripts/record-demo/record-fresh-nav.ts
@@ -1,0 +1,229 @@
+/**
+ * Records a FRESH world-mode navigation clip by actually driving the live app:
+ *   enable World Mode  →  describe a place  →  the solved top-down map renders
+ *   →  geo coordinate overlay  →  TAP IN to a place (the geometry box, not a
+ *   blind coordinate)  →  step back via the breadcrumb  →  OUTWARD (zoom out
+ *   to the surrounding container)  →  Around (map-pan bloom)  →  atlas.
+ *
+ * Needs the stack on localhost:3000 with the world flags on (WORLD_MODE,
+ * GEOMETRIC_WORLD, WORLD_GEOMETRY_GEN, WORLD_FROM_DESCRIPTION, SCALE_LADDER_NAV,
+ * SCALE_OUTWARD, EXPAND_MAP_PAN).
+ *
+ *   DEMO_BASE_URL=http://localhost:3000 DEMO_TAP_LABEL=castle pnpm tsx record-fresh-nav.ts
+ *
+ * The two CORE beats (map render, enter render) fail LOUD — a dead stack exits
+ * 1 with a screenshot instead of producing a junk mp4. The tour beats
+ * (outward / around / atlas) soft-skip with a warning.
+ *
+ * Output: scripts/record-demo/fresh-nav-demo.mp4
+ */
+import { spawn } from "node:child_process";
+import { mkdir, readdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium, type Locator, type Page } from "playwright";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ARTIFACTS = path.join(HERE, "artifacts-fresh-nav");
+const MP4_OUT = path.join(HERE, "fresh-nav-demo.mp4");
+const BASE = process.env.DEMO_BASE_URL ?? "http://localhost:3000";
+const TAP_LABEL = (process.env.DEMO_TAP_LABEL ?? "castle").toLowerCase();
+const GEN_TIMEOUT = Number(process.env.DEMO_GEN_TIMEOUT_MS ?? 180_000);
+const VIEWPORT = { width: 1280, height: 800 };
+const DESC =
+  "A walled harbor city seen from above: a tall striped lighthouse on the north cliff, " +
+  "a market square in the center, wooden docks with fishing boats along the south shore, " +
+  "and a stone castle on the east hill.";
+
+const wait = (p: Page, ms: number) => p.waitForTimeout(ms);
+const log = (m: string) => console.log(`[fresh-nav] ${m}`);
+
+function run(cmd: string, args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const c = spawn(cmd, args, { stdio: "inherit" });
+    c.on("close", (code) => (code === 0 ? resolve() : reject(new Error(`${cmd} ${code}`))));
+    c.on("error", reject);
+  });
+}
+
+/** A CORE generation wait: on timeout, screenshot + exit 1 — never a junk mp4. */
+async function mustHappen(page: Page, what: string, fn: () => Promise<unknown>): Promise<void> {
+  try {
+    await fn();
+  } catch (e) {
+    const shot = path.join(ARTIFACTS, `FAILED-${what.replace(/\W+/g, "-")}.png`);
+    await page.screenshot({ path: shot }).catch(() => {});
+    console.error(`[fresh-nav] FAILED waiting for ${what} — screenshot: ${shot}`);
+    throw e instanceof Error ? e : new Error(String(e));
+  }
+}
+
+/** Tap target: the geometry overlay's box for TAP_LABEL (the entity's REAL
+ * detected coordinates), falling back to the prompt's expected spot. */
+async function tapPoint(page: Page, img: Locator): Promise<{ x: number; y: number }> {
+  const boxes = page.locator('[data-testid="geo-box"]');
+  const n = await boxes.count();
+  for (let i = 0; i < n; i++) {
+    const b = boxes.nth(i);
+    const label = ((await b.locator("span").first().textContent()) ?? "").toLowerCase();
+    if (label.includes(TAP_LABEL)) {
+      const bb = await b.boundingBox();
+      if (bb) {
+        log(`tapping the geometry box "${label.trim()}"`);
+        return { x: bb.x + bb.width / 2, y: bb.y + bb.height / 2 };
+      }
+    }
+  }
+  log(`WARN: no geo-box matching "${TAP_LABEL}" — falling back to the fixed east-hill spot`);
+  const bb = await img.boundingBox();
+  if (!bb) throw new Error("map image has no bounding box");
+  return { x: bb.x + bb.width * 0.72, y: bb.y + bb.height * 0.34 };
+}
+
+async function main(): Promise<void> {
+  await rm(ARTIFACTS, { recursive: true, force: true });
+  await mkdir(ARTIFACTS, { recursive: true });
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    viewport: VIEWPORT,
+    deviceScaleFactor: 2,
+    recordVideo: { dir: ARTIFACTS, size: VIEWPORT },
+  });
+  const page = await context.newPage();
+
+  log("open /play");
+  await page.goto(`${BASE}/play`, { waitUntil: "networkidle" });
+  await wait(page, 1500);
+
+  log("enable World Mode");
+  await page.getByRole("button", { name: "world" }).first().click();
+  await wait(page, 800);
+
+  log("type the place description");
+  await page.getByRole("textbox").first().fill(DESC);
+  await wait(page, 600);
+
+  log("lock a Woodcut style");
+  await page.getByRole("button", { name: "Woodcut" }).first().click().catch(() => {});
+  await wait(page, 800);
+
+  log("Describe a place → solve + render the map");
+  await page.getByRole("button", { name: /Describe a place/ }).first().click();
+  const img = page.locator('img[alt^="Generated illustration"]').first();
+  // CORE beat: the map must actually render.
+  await mustHappen(page, "map-render", async () => {
+    await page.waitForURL(/\/n\//, { timeout: GEN_TIMEOUT });
+    await img.waitFor({ state: "visible", timeout: GEN_TIMEOUT });
+  });
+  await wait(page, 4000);
+
+  log("geo coordinate overlay");
+  const geo = page.getByRole("button", { name: /geo$/ }).first();
+  if (await geo.count()) {
+    await geo.click().catch(() => {});
+    await wait(page, 4500);
+  }
+
+  log(`TAP IN — enter "${TAP_LABEL}"`);
+  const mapUrl = page.url();
+  const pt = await tapPoint(page, img);
+  await page.mouse.move(pt.x, pt.y);
+  await wait(page, 900);
+  await page.mouse.click(pt.x, pt.y);
+  // CORE beat: entering must resolve + render a NEW node (the conditioned
+  // enter-edit — the consistency fix this clip exists to show).
+  await mustHappen(page, "enter-render", async () => {
+    await page.waitForURL((u) => u.toString() !== mapUrl && /\/n\//.test(u.toString()), {
+      timeout: GEN_TIMEOUT,
+    });
+    await page
+      .locator('img[alt^="Generated illustration"]')
+      .first()
+      .waitFor({ state: "visible", timeout: GEN_TIMEOUT });
+  });
+  log("entered the place — holding so the continuity reads on camera");
+  await wait(page, 7000);
+
+  log("step back to the map via the breadcrumb");
+  const crumb = page.getByTestId("breadcrumb").locator("button").first();
+  if (await crumb.count()) {
+    await crumb.click().catch(() => {});
+    await wait(page, 4500);
+  } else {
+    log("WARN: no breadcrumb — skipping step-back");
+  }
+
+  log("OUTWARD — zoom out to the surrounding container (edit-routed)");
+  const outward = page.getByRole("button", { name: /zoom out|step back/i }).first();
+  if (await outward.count()) {
+    const beforeOut = page.url();
+    await outward.click().catch(() => {});
+    const moved = await page
+      .waitForURL((u) => u.toString() !== beforeOut, { timeout: GEN_TIMEOUT })
+      .then(() => true)
+      .catch(() => false);
+    if (moved) {
+      await page
+        .locator('img[alt^="Generated illustration"]')
+        .first()
+        .waitFor({ state: "visible", timeout: GEN_TIMEOUT })
+        .catch(() => {});
+      await wait(page, 6000);
+    } else {
+      log("WARN: OUTWARD didn't navigate — continuing the tour");
+    }
+  } else {
+    log("WARN: no OUTWARD button (root-only) — skipping");
+  }
+
+  log("Around — bloom the world around this page (map-pan)");
+  const around = page.getByRole("button", { name: /Around/ }).first();
+  if (await around.count()) {
+    await around.click().catch(() => {});
+    // The bloom streams panels into the tray; hold long enough for the first
+    // pan(s) to land on camera, then move on.
+    await wait(page, 28_000);
+  } else {
+    log("WARN: no Around button — skipping");
+  }
+
+  log("atlas — the nested world, zoom out then in");
+  const atlas = page.getByRole("button", { name: /^atlas$/i }).first();
+  if (await atlas.count()) {
+    await atlas.click().catch(() => {});
+    await wait(page, 3500);
+    await page.mouse.move(VIEWPORT.width * 0.45, VIEWPORT.height * 0.45);
+    for (let i = 0; i < 6; i++) {
+      await page.mouse.wheel(0, -120);
+      await wait(page, 140);
+    }
+    await wait(page, 2500);
+    for (let i = 0; i < 6; i++) {
+      await page.mouse.wheel(0, 120);
+      await wait(page, 140);
+    }
+    await wait(page, 2500);
+  }
+
+  await page.close();
+  await context.close();
+  await browser.close();
+
+  const webm = (await readdir(ARTIFACTS)).find((f) => f.endsWith(".webm"));
+  if (!webm) throw new Error("no webm captured");
+  log(`transcoding ${webm} → mp4 (1.6x)`);
+  await run("ffmpeg", [
+    "-y", "-i", path.join(ARTIFACTS, webm),
+    "-filter:v", "setpts=0.625*PTS",
+    "-c:v", "libx264", "-pix_fmt", "yuv420p", "-crf", "23", "-preset", "slow",
+    "-movflags", "+faststart", "-an",
+    MP4_OUT,
+  ]);
+  log(`done → ${MP4_OUT}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## What this fixes

Tap-to-enter a place was a **fresh text-to-image call passing reference images fal silently ignores** — so every entered place was an unconditioned reinvention (different walls/shapes/surroundings from the map you just tapped). The region crop the client already sends was wasted on a no-op path. Meanwhile the bakeoff's "new models" were only ever A/B'd in a throwaway script.

## What changed

- **`enter_scene` op + routing (default ON, `ENTER_EDIT_REF` kill-switch):** `place_scene` taps now render through `edit_image()` conditioned on the clean region crop (+ style ref), with `build_enter_instruction` carrying the view change, identity, neighbours-by-bearing, medium lock and geometry clause. Progressive draft skipped on this path (also kills the draft≠final flash). Still inside the `WORLD_MODE` gate — prod unchanged.
- **`SCALE_OUTWARD_EDIT_REF` defaults ON** (within the off-by-default `SCALE_OUTWARD`): the P2 lever actually runs now.
- **The bakeoff field is live, not a recommendation:** `openrouter:` slug prefix (riverflow-v2.5-fast/pro, recraft-v4.1-*) with retries/timeouts; **pro tier default → `openrouter:sourceful/riverflow-v2.5-pro`** (live-smoked: superb engraved map, 152s/image — the fast-draft race keeps the UI alive); `openai/gpt-image-2(/edit)` arg shapes; `nano-banana-2(/edit)` verified compatible. `.env.example` documents the whole verified menu and un-pins the tier lines.
- **The metric that was missing:** `make eval-enter-drift` — old path vs new path judged "is this the SAME place you tapped?" against the region crop. First run (n=3): **fresh 6.67 → edit 9.0, lift +2.33**, medium 9.33. Model arms picked the default empirically: nano-banana-pro/edit 9.0 (kept), nano-banana-2/edit 9.33, gpt-image-2/edit 8.67, **Kontext 3.33 — rejected for enter** (a strict zoom can't do the view change). Baseline committed.
- **Demo tooling:** `record-fresh-nav.ts` committed + hardened (geometry-box tap targeting, loud-fail core waits, OUTWARD/Around beats); `scripts/ab-proof/ab_enter.py` proves the fix with the kill-switch as the "before" and machine-asserts the routing from `final.image_op` / `image_model` (new additive wire key).

## Proof

- Live demo trace: `tap.enter_edit` → `fal-ai/nano-banana-pro/edit`, `source=region`, zero errors; no text-to-image on the enter path.
- A/B 3-panel (tapped region | BEFORE | AFTER): the before arm reinvented the tapped castle as an unrelated floor plan; the after arm is the same four-towered castle from ground level, neighbours where the map placed them.
- Eval artifacts under `tests/continuity_bench/reports/` (gitignored), report JSON + demo clip + panels on the owner's Desktop (`~/Desktop/ofb-demo-2026-06-10/`).

## Out of scope

P4 sub-frame nesting, AROUND logical-neighbour backlog, metric bridge (geometry backlog). The balanced **edit-tier** slug (`fal-ai/nano-banana-pro` without `/edit`) being potentially ref-blind on user edits is a noted follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)