### PR TITLE
feat(edit): mask-scoped judged edits behind EDIT_REGION (E1 backend)

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -63,6 +63,17 @@ class Click(BaseModel):
     y_pct: float = Field(ge=0.0, le=1.0)
 
 
+class EditRegion(BaseModel):
+    """The drag-selected area of a mask-scoped edit (EDIT_REGION), normalized
+    to natural-image space. Mirrors `edit_region` on the TS request body; the
+    mask PNG is authoritative for the model, this box scopes the judge crop."""
+
+    x: float = Field(ge=0.0, le=1.0)
+    y: float = Field(ge=0.0, le=1.0)
+    w: float = Field(gt=0.0, le=1.0)
+    h: float = Field(gt=0.0, le=1.0)
+
+
 class WorldContextEntity(BaseModel):
     id: str
     kind: str
@@ -165,6 +176,12 @@ class GenerateBody(BaseModel):
     image_tier: str | None = None
     image_model: str | None = None
     edit_instruction: str | None = None
+    # Mask-scoped edit (EDIT_REGION, default off): an opaque PNG data URL at
+    # the page's natural dims, WHITE = edit / black = keep, plus the selection
+    # box that produced it. Absent -> the legacy whole-image edit path,
+    # byte-identical to today.
+    edit_mask: str | None = None
+    edit_region: EditRegion | None = None
     output_locale: str | None = None
     prefetched_subject: str | None = None
     prefetched_style: str | None = None
@@ -631,6 +648,131 @@ async def _event_stream(
             # the edit so an edit can't drift the world's art medium.
             edit_style_lock = (body.session_style_anchor or "").strip() or None
             edit_style_ref = _condition_url_for_role(body, "style")
+            # Mask-scoped judged edit (EDIT_REGION, default off): the drag
+            # selection arrives as a white=edit mask PNG; flux fill repaints
+            # ONLY that region (the 2026-06-10 smoke: outside-mask pixels come
+            # back byte-identical) and the edit loop judges by construction —
+            # outside stability is a free pixel-diff, the inside gets the
+            # alignment + medium critics, one retry folds their rationales
+            # back in. Flag off or no mask -> the legacy whole-image path
+            # below, byte-identical to today.
+            if env_flag("EDIT_REGION") and body.edit_mask:
+                from providers import edit_loop, judge
+                from providers import inpaint as inpaint_provider
+                from providers.render_loop import data_url_bytes
+
+                described = await llm.polish_fill_description(
+                    instruction=raw_instruction,
+                    page_title=body.parent_title,
+                    style_anchor=edit_style_lock,
+                )
+                yield _sse(
+                    {
+                        "type": "status",
+                        "stage": "generating_image",
+                        "page_title": raw_instruction,
+                    },
+                    trace_id,
+                )
+                edit_mask: str = body.edit_mask
+
+                async def _render_inpaint(suffix: str) -> Any:
+                    instr = described if not suffix else f"{described}\n\n{suffix}"
+                    return await inpaint_provider.inpaint_image(
+                        image_data_url=body.image or "",
+                        mask_data_url=edit_mask,
+                        instruction=instr,
+                        model_override=body.image_model,
+                    )
+
+                source_bytes = data_url_bytes(body.image)
+                mask_bytes = data_url_bytes(body.edit_mask)
+                region_box = (
+                    (
+                        body.edit_region.x,
+                        body.edit_region.y,
+                        body.edit_region.w,
+                        body.edit_region.h,
+                    )
+                    if body.edit_region
+                    else None
+                )
+                verdict: dict[str, Any] | None = None
+                if source_bytes is None or mask_bytes is None:
+                    # Remote refs / undecodable inputs: no critic signal, so a
+                    # single un-judged shot (the loop's no-critic rule) — the
+                    # result is still mask-scoped by the model.
+                    log(
+                        "warn",
+                        "edit.loop.unjudged",
+                        reason="source_or_mask_not_data_url",
+                    )
+                    inp_result = await _render_inpaint("")
+                else:
+                    edit_cfg = edit_loop.edit_loop_config_from_env()
+                    edit_attempts: list[Any] = []
+                    # The alignment judge checks the inside crop against the
+                    # fill DESCRIPTION (the region's expected final content) —
+                    # a raw command like "remove the tower" isn't judgeable
+                    # against pixels, its described aftermath is.
+                    async for edit_att in edit_loop.iter_edit_attempts(
+                        _render_inpaint,
+                        source_bytes=source_bytes,
+                        mask_png=mask_bytes,
+                        region_box=region_box,
+                        judge_alignment=judge.score_prompt_alignment,
+                        judge_medium=judge.score_style_pair,
+                        instruction=described,
+                        config=edit_cfg,
+                        abort=_abort_if_disconnected,
+                    ):
+                        edit_attempts.append(edit_att)
+                        # Stream only verdict-REJECTED attempts (a correction
+                        # is coming); a degraded attempt is the final.
+                        if (
+                            not edit_att.accepted
+                            and edit_att.alignment is not None
+                            and edit_att.index + 1 < edit_cfg.max_attempts
+                        ):
+                            frame_b64 = (
+                                await _asyncio.to_thread(
+                                    base64.b64encode, edit_att.image.jpeg_bytes
+                                )
+                            ).decode("ascii")
+                            yield _sse(
+                                {
+                                    "type": "progress",
+                                    "frame_index": edit_att.index,
+                                    "jpeg_b64": frame_b64,
+                                },
+                                trace_id,
+                            )
+                    edit_loop_result = edit_loop.conclude_edit(edit_attempts)
+                    inp_result = edit_loop_result.image
+                    best = edit_loop_result.best
+                    verdict = {
+                        "alignment": best.alignment.score if best.alignment else None,
+                        "medium": best.medium.score if best.medium else None,
+                        "outside_change": best.outside_change,
+                        "attempts": len(edit_attempts),
+                        "accepted": edit_loop_result.accepted,
+                    }
+                final_frame: dict[str, Any] = {
+                    "type": "final",
+                    "image_data_url": image_provider.encode_data_url(
+                        inp_result.jpeg_bytes, inp_result.mime_type
+                    ),
+                    "page_title": raw_instruction,
+                    "image_model": inp_result.model,
+                    "prompt_author_model": llm._text_model(online=False),
+                    "session_id": body.session_id,
+                    "final_prompt": described,
+                    "image_op": "inpaint",
+                }
+                if verdict is not None:
+                    final_frame["edit_verdict"] = verdict
+                yield _sse(final_frame, trace_id)
+                return
             polished = await llm.polish_edit_instruction(
                 instruction=raw_instruction,
                 page_title=body.parent_title,

--- a/apps/modal-backend/providers/edit_loop.py
+++ b/apps/modal-backend/providers/edit_loop.py
@@ -1,0 +1,288 @@
+"""The edit loop — mask-scoped edits judged by construction.
+
+The render loop's sibling (same DI shape, keep-best, degrade-on-judge-failure
+rules — see render_loop.py's design notes) with the axes an EDIT needs
+instead of a steep view transform:
+
+  - outside_change: providers.pixel_diff.changed_fraction OUTSIDE the mask —
+    a FREE computed hard gate. Masks promise that the rest of the page
+    survives; assert it with pixels, no VLM needed.
+  - alignment: score_prompt_alignment on the INSIDE crop — did the asked
+    change land, judged where it happened rather than diluted across the
+    whole frame.
+  - medium: score_style_pair(source, result) — the edit can't drift the
+    world's art medium.
+
+One retry max by default; rejected attempts fold the critics' rationales
+into the next fill description (edit_retry_feedback_clause); every attempt
+logged under "edit.loop". A judge failure degrades to single-attempt rather
+than blind re-rolls; an outside-gate breach alone still retries (the
+feedback names it) but pixel-diff itself failing stops the loop.
+"""
+from __future__ import annotations
+
+import io
+import os
+import time
+from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass
+
+from PIL import Image
+
+from providers.judge import JudgeResult
+from providers.pixel_diff import changed_fraction
+from providers.prompt_library.feedback import edit_retry_feedback_clause
+from providers.render_loop import Rendered
+
+
+@dataclass(frozen=True)
+class EditLoopConfig:
+    max_attempts: int = 2
+    accept_alignment: float = 7.0
+    accept_medium: float = 6.0
+    # The mask smoke's numbers: fill measured 0.0000 outside; gpt's whole-
+    # canvas churn floor was 0.089 — 0.02 cleanly separates the worlds.
+    outside_change_max: float = 0.02
+    # No retry when the previous attempt took longer than this (<=0 disables).
+    retry_budget_s: float = 240.0
+
+
+def edit_loop_config_from_env() -> EditLoopConfig:
+    def _f(name: str, default: float) -> float:
+        try:
+            return float(os.environ.get(name, ""))
+        except ValueError:
+            return default
+
+    try:
+        attempts = int(os.environ.get("EDIT_LOOP_MAX_ATTEMPTS", ""))
+    except ValueError:
+        attempts = 2
+    return EditLoopConfig(
+        max_attempts=max(1, attempts),
+        accept_alignment=_f("EDIT_LOOP_ACCEPT_ALIGNMENT", 7.0),
+        accept_medium=_f("EDIT_LOOP_ACCEPT_MEDIUM", 6.0),
+        outside_change_max=_f("EDIT_LOOP_OUTSIDE_MAX", 0.02),
+        retry_budget_s=_f("EDIT_LOOP_RETRY_BUDGET_S", 240.0),
+    )
+
+
+@dataclass(frozen=True)
+class EditAttempt:
+    index: int  # 0-based
+    image: Rendered
+    instruction_suffix: str  # "" on attempt 0; the folded feedback after
+    outside_change: float | None  # None = pixel diff unavailable (degraded)
+    alignment: JudgeResult | None  # None = judge unavailable (degraded)
+    medium: JudgeResult | None
+    accepted: bool
+    latency_s: float
+
+
+@dataclass(frozen=True)
+class EditLoopResult:
+    image: Rendered  # the best attempt's image (keep-best)
+    best: EditAttempt  # ...and the attempt it came from (the verdict's numbers)
+    attempts: list[EditAttempt]
+    accepted: bool
+
+
+def inside_crop_bytes(
+    image_bytes: bytes, region_box: tuple[float, float, float, float] | None
+) -> bytes:
+    """Crop the selection (normalized x, y, w, h) out of `image_bytes` for the
+    alignment judge. No box / a degenerate box / a decode failure -> the full
+    frame (judging diluted beats not judging)."""
+    if region_box is None:
+        return image_bytes
+    try:
+        im = Image.open(io.BytesIO(image_bytes))
+        width, height = im.size
+        x, y, w, h = region_box
+        left = max(0, min(width - 1, round(x * width)))
+        top = max(0, min(height - 1, round(y * height)))
+        right = max(left + 1, min(width, round((x + w) * width)))
+        bottom = max(top + 1, min(height, round((y + h) * height)))
+        if right - left < 8 or bottom - top < 8:
+            return image_bytes
+        buf = io.BytesIO()
+        im.crop((left, top, right, bottom)).convert("RGB").save(
+            buf, "JPEG", quality=92
+        )
+        return buf.getvalue()
+    except Exception:
+        return image_bytes
+
+
+def _score(j: JudgeResult | None) -> float:
+    return j.score if j is not None else -1.0
+
+
+def _outside_key(outside: float | None) -> float:
+    # Lower outside change is better; unknown ranks worst.
+    return -(outside if outside is not None else 1.0)
+
+
+def _is_accepted(
+    outside: float | None,
+    alignment: JudgeResult | None,
+    medium: JudgeResult | None,
+    config: EditLoopConfig,
+) -> bool:
+    if outside is None or alignment is None:
+        return False  # no signal — never "accepted", but also no retry
+    if outside > config.outside_change_max:
+        return False
+    if alignment.score < config.accept_alignment:
+        return False
+    return not (medium is not None and medium.score < config.accept_medium)
+
+
+async def iter_edit_attempts[ImageT: Rendered](
+    render: Callable[[str], Awaitable[ImageT]],
+    *,
+    source_bytes: bytes,
+    mask_png: bytes,
+    region_box: tuple[float, float, float, float] | None,
+    judge_alignment: Callable[[str, bytes], Awaitable[JudgeResult]],
+    judge_medium: Callable[[bytes, bytes], Awaitable[JudgeResult]],
+    instruction: str,
+    config: EditLoopConfig,
+    feedback: Callable[..., str] = edit_retry_feedback_clause,
+    abort: Callable[[str], Awaitable[None]] | None = None,
+    clock: Callable[[], float] = time.monotonic,
+) -> AsyncIterator[EditAttempt]:
+    """Yield attempts until acceptance / budget / max attempts. Attempt-0
+    render exceptions PROPAGATE (the caller's error path); retry-render
+    exceptions stop the loop quietly (keep best so far)."""
+    from obs import log
+
+    suffix = ""
+    for index in range(config.max_attempts):
+        if abort is not None:
+            await abort("edit-loop-render")
+        started = clock()
+        if index == 0:
+            image = await render(suffix)
+        else:
+            try:
+                image = await render(suffix)
+            except Exception as exc:
+                log(
+                    "warn",
+                    "edit.loop.render_failed",
+                    attempt=index,
+                    error=f"{type(exc).__name__}: {exc}",
+                )
+                return
+        latency = clock() - started
+
+        outside: float | None = None
+        alignment: JudgeResult | None = None
+        medium: JudgeResult | None = None
+        try:
+            outside = changed_fraction(
+                source_bytes, image.jpeg_bytes, mask_png, invert_mask=True
+            )
+        except Exception as exc:
+            log(
+                "warn",
+                "edit.loop.diff_failed",
+                attempt=index,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+            yield EditAttempt(index, image, suffix, None, None, None, False, latency)
+            return
+        try:
+            alignment = await judge_alignment(
+                instruction, inside_crop_bytes(image.jpeg_bytes, region_box)
+            )
+            medium = await judge_medium(source_bytes, image.jpeg_bytes)
+        except Exception as exc:
+            log(
+                "warn",
+                "edit.loop.judge_failed",
+                attempt=index,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+            # No critic signal = the old blind coin-flip — don't spend more.
+            yield EditAttempt(index, image, suffix, outside, alignment, medium, False, latency)
+            return
+
+        accepted = _is_accepted(outside, alignment, medium, config)
+        log(
+            "info",
+            "edit.loop",
+            attempt=index,
+            outside_change=round(outside, 4),
+            alignment=_score(alignment),
+            medium=_score(medium),
+            accepted=accepted,
+            latency_s=round(latency, 1),
+        )
+        yield EditAttempt(index, image, suffix, outside, alignment, medium, accepted, latency)
+        if accepted:
+            return
+        if config.retry_budget_s > 0 and latency > config.retry_budget_s:
+            log("info", "edit.loop.budget_stop", attempt=index, latency_s=round(latency, 1))
+            return
+        suffix = feedback(
+            alignment_rationale=(
+                alignment.rationale
+                if alignment is not None and alignment.score < config.accept_alignment
+                else None
+            ),
+            medium_rationale=(
+                medium.rationale
+                if medium is not None and medium.score < config.accept_medium
+                else None
+            ),
+            outside_exceeded=outside > config.outside_change_max,
+        )
+
+
+def conclude_edit(attempts: list[EditAttempt]) -> EditLoopResult:
+    """Keep-best: the first accepted attempt wins; otherwise the best-scoring
+    one, with STRICT improvement required to displace an earlier attempt (a
+    retry can never make the result worse)."""
+    if not attempts:
+        raise ValueError("conclude_edit() needs at least one attempt")
+    for a in attempts:
+        if a.accepted:
+            return EditLoopResult(image=a.image, best=a, attempts=attempts, accepted=True)
+    best = attempts[0]
+    for a in attempts[1:]:
+        if (_score(a.alignment), _score(a.medium), _outside_key(a.outside_change)) > (
+            _score(best.alignment),
+            _score(best.medium),
+            _outside_key(best.outside_change),
+        ):
+            best = a
+    return EditLoopResult(image=best.image, best=best, attempts=attempts, accepted=False)
+
+
+async def run_edit_loop[ImageT: Rendered](
+    render: Callable[[str], Awaitable[ImageT]],
+    *,
+    source_bytes: bytes,
+    mask_png: bytes,
+    region_box: tuple[float, float, float, float] | None,
+    judge_alignment: Callable[[str, bytes], Awaitable[JudgeResult]],
+    judge_medium: Callable[[bytes, bytes], Awaitable[JudgeResult]],
+    instruction: str,
+    config: EditLoopConfig | None = None,
+) -> EditLoopResult:
+    """Drain the loop for non-streaming callers (the bench)."""
+    attempts: list[EditAttempt] = []
+    async for attempt in iter_edit_attempts(
+        render,
+        source_bytes=source_bytes,
+        mask_png=mask_png,
+        region_box=region_box,
+        judge_alignment=judge_alignment,
+        judge_medium=judge_medium,
+        instruction=instruction,
+        config=config or edit_loop_config_from_env(),
+    ):
+        attempts.append(attempt)
+    return conclude_edit(attempts)

--- a/apps/modal-backend/providers/inpaint.py
+++ b/apps/modal-backend/providers/inpaint.py
@@ -1,0 +1,74 @@
+"""Mask-scoped inpaint — the provider function MODEL_SLOTS["inpaint"] waited for.
+
+The 2026-06-10 mask smoke (tests/edit_bench/mask_smoke.py) picked the model:
+`fal-ai/flux-pro/v1/fill` is a TRUE compositor — pixels outside the mask come
+back byte-identical (outside changed-fraction 0.0000) and source dims are
+kept. gpt-image-2/edit ACCEPTS mask_url and honors none of the three mask
+conventions (whole-canvas repaint), so there is no mask-honoring fallback:
+callers degrade to the whole-image edit path on failure rather than pretend
+gpt confines.
+
+Wire mask convention (fill's native one): an opaque PNG at the source's dims,
+WHITE = edit / inpaint, black = keep. Fill wants the prompt to DESCRIBE what
+the masked region should contain (llm.polish_fill_description), not an edit
+command. The gpt arg-shape branch below exists only so the edit-region bench
+can A/B other models through the same call.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._common import to_fal_url
+from .image import (
+    GeneratedImage,
+    _ensure_fal_key,
+    _fal_subscribe,
+    _fetch_image_bytes,
+    _first_image,
+)
+from .model_router import resolve_model
+
+INPAINT_MODEL_DEFAULT = "fal-ai/flux-pro/v1/fill"
+
+
+def _inpaint_args_for(
+    model: str, instruction: str, image_url: str, mask_url: str
+) -> dict[str, Any]:
+    # gpt-image-2/edit takes image_urls (list) + mask_url — bench arms only;
+    # its mask is decorative (see the module docstring).
+    if "gpt-image-2" in model:
+        return {"prompt": instruction, "image_urls": [image_url], "mask_url": mask_url}
+    # flux-pro/v1/fill (the slot default): image_url SINGULAR + mask_url, per
+    # scripts/verify-fal-models.py.
+    return {"prompt": instruction, "image_url": image_url, "mask_url": mask_url}
+
+
+async def inpaint_image(
+    image_data_url: str,
+    mask_data_url: str,
+    instruction: str,
+    model_override: str | None = None,
+) -> GeneratedImage:
+    """Repaint ONLY the mask's white region of `image_data_url` so it shows
+    what `instruction` describes. Default the `inpaint` slot (flux fill;
+    FAL_INPAINT_MODEL override)."""
+    from obs import span
+
+    _ensure_fal_key()
+    model = model_override or resolve_model("inpaint") or INPAINT_MODEL_DEFAULT
+    image_url = await to_fal_url(image_data_url)
+    mask_url = await to_fal_url(mask_data_url)
+    async with span("image.inpaint", model=model, instr_len=len(instruction)) as ctx:
+        result = await _fal_subscribe(
+            model, _inpaint_args_for(model, instruction, image_url, mask_url)
+        )
+        image_info = _first_image(result)
+        jpeg_bytes, mime = await _fetch_image_bytes(image_info)
+        ctx["bytes"] = len(jpeg_bytes)
+    return GeneratedImage(
+        jpeg_bytes=jpeg_bytes,
+        mime_type=mime,
+        model=model,
+        provider_request_id=str(result.get("requestId") or "") or None,
+    )

--- a/apps/modal-backend/providers/llm.py
+++ b/apps/modal-backend/providers/llm.py
@@ -1560,6 +1560,69 @@ async def polish_edit_instruction(
         return instruction
 
 
+async def polish_fill_description(
+    instruction: str,
+    page_title: str | None = None,
+    style_anchor: str | None = None,
+) -> str:
+    """Rewrite an edit COMMAND as a DESCRIPTION of the masked region's final
+    content — inpaint fills (flux-pro/v1/fill, the primary since the mask
+    smoke) paint what you describe, they don't follow commands. "add a red
+    balloon here" -> "a single bright red hot-air balloon floating over the
+    sea". Removals describe the background that should remain. The medium
+    lock is appended deterministically (fill takes no style ref image).
+
+    Unlike polish_edit_instruction there is no long-instruction skip: a
+    command stays a command however long it is — the register conversion IS
+    the point. LLM failure degrades to the raw instruction + medium lock.
+    """
+    instruction = instruction.strip()
+    if not instruction:
+        return instruction
+
+    def _locked(text: str) -> str:
+        if style_anchor:
+            return f"{text} In the existing art medium: {style_anchor}."
+        return text
+
+    client = _client()
+    system = (
+        "You convert an image-edit request into a description of what the "
+        "edited region should look like AFTER the edit, for an inpainting "
+        "model that repaints only that region. Describe the region's final "
+        "content — subjects, their look, how they sit in their surroundings "
+        "— never the operation: no imperative verbs like add, remove or "
+        "replace, and never mention what was there before. For removals, "
+        "describe the background that should remain. Aim for 10-30 words. "
+        "Return ONLY the description, no preamble."
+    )
+    context_parts = [f"Edit request: {instruction}"]
+    if page_title:
+        context_parts.append(f"Current page: {page_title}")
+    if style_anchor:
+        context_parts.append(f"Existing visual style to preserve: {style_anchor}")
+    user = "\n".join(context_parts)
+    from obs import span
+
+    text_model = _text_model(online=False)
+    try:
+        async with span("llm.polish_fill") as ctx:
+            response = await client.chat.completions.create(
+                model=text_model,
+                messages=[
+                    _system_message(system),
+                    {"role": "user", "content": user},
+                ],
+                temperature=0.3,
+                max_tokens=120,
+            )
+            _log_cache_usage(ctx, response)
+        described = (response.choices[0].message.content or "").strip()
+        return _locked(described or instruction)
+    except Exception:
+        return _locked(instruction)
+
+
 async def precompute_click_candidates(
     image_data_url: str,
     parent_title: str,

--- a/apps/modal-backend/providers/prompt_library/feedback.py
+++ b/apps/modal-backend/providers/prompt_library/feedback.py
@@ -66,3 +66,45 @@ def retry_feedback_clause(
         )
         parts.append(text)
     return " ".join(parts)
+
+
+def edit_retry_feedback_clause(
+    *,
+    alignment_rationale: str | None = None,
+    medium_rationale: str | None = None,
+    outside_exceeded: bool = False,
+) -> str:
+    """The edit loop's voice (the mask-scoped sibling of the clause above):
+    a failed inpaint attempt folds its critics' diagnoses into the next
+    attempt's fill description. Pure + deterministic; all-None/False -> ""."""
+    parts: list[str] = []
+    align = _clean(alignment_rationale)
+    medium = _clean(medium_rationale)
+    if align:
+        text = (
+            "IMPORTANT — your previous attempt did not show the requested "
+            f"content. The judge saw: {align}"
+        )
+        if not text.endswith("."):
+            text += "."
+        text += " Render exactly what is described, clearly visible in the region."
+        parts.append(text)
+    if medium:
+        text = (
+            "It also drifted from the surrounding artwork's medium — the "
+            f"judge saw: {medium}"
+        )
+        if not text.endswith("."):
+            text += "."
+        text += (
+            " Match the surrounding artwork's medium, palette and linework "
+            "exactly; the repainted region must blend in seamlessly."
+        )
+        parts.append(text)
+    if outside_exceeded:
+        parts.append(
+            "It also changed pixels beyond the selected region. Confine the "
+            "edit STRICTLY to the masked area; everything outside it must "
+            "remain untouched."
+        )
+    return " ".join(parts)

--- a/apps/modal-backend/tests/conftest.py
+++ b/apps/modal-backend/tests/conftest.py
@@ -80,6 +80,13 @@ _SCRUB = (
     "REPAIR_BENCH_RUN",
     "EDIT_BENCH_RUN",
     "EDIT_REGION_BENCH_RUN",
+    # Mask-scoped judged edits (E1; default OFF until the bench baselines it).
+    "EDIT_REGION",
+    "EDIT_LOOP_MAX_ATTEMPTS",
+    "EDIT_LOOP_ACCEPT_ALIGNMENT",
+    "EDIT_LOOP_ACCEPT_MEDIUM",
+    "EDIT_LOOP_OUTSIDE_MAX",
+    "EDIT_LOOP_RETRY_BUDGET_S",
     "WORLD_BENCH_JUDGE_MODEL",
     "CONTINUITY_BENCH_JUDGE_MODEL",
     # Map-pan expand (outpaint the world outward).

--- a/apps/modal-backend/tests/test_edit_loop.py
+++ b/apps/modal-backend/tests/test_edit_loop.py
@@ -1,0 +1,190 @@
+"""The edit loop's control flow (providers/edit_loop.py), judges mocked.
+
+Mirrors tests/test_render_loop.py for the mask-scoped sibling: accept-at-one
+spends nothing extra, a rejected attempt folds the critic's rationale into
+the retry, the FREE outside-mask pixel gate alone forces a retry, keep-best
+never lets a retry make things worse, and a judge failure degrades to
+single-attempt instead of blind re-rolls. The pixel metric runs for real on
+tiny synthetic frames — only the VLM judges are mocked.
+"""
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+
+import pytest
+from PIL import Image, ImageDraw
+
+from providers import edit_loop
+from providers.judge import JudgeResult
+
+_W, _H = 128, 72
+_BOX = (0.5, 0.25, 0.375, 0.5)  # x,y,w,h normalized -> px (64,18)-(112,54)
+_CFG = edit_loop.EditLoopConfig(retry_budget_s=0)  # disable wall-clock stop
+
+
+def _jpg(im: Image.Image) -> bytes:
+    buf = io.BytesIO()
+    im.save(buf, "JPEG", quality=92)
+    return buf.getvalue()
+
+
+def _base() -> Image.Image:
+    grad = Image.linear_gradient("L").resize((_W, _H))
+    return Image.merge("RGB", (grad, grad, grad.point(lambda v: 255 - v)))
+
+
+def _box_px(grow: int = 0) -> tuple[int, int, int, int]:
+    x, y, w, h = _BOX
+    return (
+        round(x * _W) - grow,
+        round(y * _H) - grow,
+        round((x + w) * _W) + grow,
+        round((y + h) * _H) + grow,
+    )
+
+
+def _mask_png() -> bytes:
+    m = Image.new("L", (_W, _H), 0)
+    ImageDraw.Draw(m).rectangle(_box_px(), fill=255)
+    buf = io.BytesIO()
+    m.save(buf, "PNG")
+    return buf.getvalue()
+
+
+def _inside_edit() -> bytes:
+    im = _base()
+    ImageDraw.Draw(im).rectangle(_box_px(), fill=(220, 40, 40))
+    return _jpg(im)
+
+
+def _outside_edit() -> bytes:
+    im = _base()
+    ImageDraw.Draw(im).rectangle((4, 4, 40, 30), fill=(220, 40, 40))
+    return _jpg(im)
+
+
+@dataclass
+class _Img:
+    jpeg_bytes: bytes
+
+
+class _Render:
+    """Recording render: returns scripted frames, keeps the suffixes seen."""
+
+    def __init__(self, frames: list[bytes]) -> None:
+        self.frames = frames
+        self.suffixes: list[str] = []
+
+    async def __call__(self, suffix: str) -> _Img:
+        self.suffixes.append(suffix)
+        return _Img(self.frames[len(self.suffixes) - 1])
+
+
+def _judge(*scores: float, rationale: str = "") -> object:
+    seq = [JudgeResult(s, rationale, "") for s in scores]
+
+    async def judge(*_args: object) -> JudgeResult:
+        return seq.pop(0) if len(seq) > 1 else seq[0]
+
+    return judge
+
+
+async def _drain(render: _Render, *, alignment: object, medium: object) -> list[edit_loop.EditAttempt]:
+    attempts = []
+    async for a in edit_loop.iter_edit_attempts(
+        render,
+        source_bytes=_jpg(_base()),
+        mask_png=_mask_png(),
+        region_box=_BOX,
+        judge_alignment=alignment,  # type: ignore[arg-type]
+        judge_medium=medium,  # type: ignore[arg-type]
+        instruction="a red panel",
+        config=_CFG,
+    ):
+        attempts.append(a)
+    return attempts
+
+
+async def test_accept_at_one_spends_one_render() -> None:
+    render = _Render([_inside_edit()])
+    attempts = await _drain(render, alignment=_judge(9.0), medium=_judge(9.0))
+    assert len(attempts) == 1 and attempts[0].accepted
+    assert render.suffixes == [""]
+    assert attempts[0].outside_change == 0.0
+
+
+async def test_reject_folds_rationale_into_retry() -> None:
+    render = _Render([_inside_edit(), _inside_edit()])
+    attempts = await _drain(
+        render,
+        alignment=_judge(3.0, 9.0, rationale="no red panel visible"),
+        medium=_judge(9.0),
+    )
+    assert [a.accepted for a in attempts] == [False, True]
+    assert "no red panel visible" in render.suffixes[1]
+    assert "Render exactly what is described" in render.suffixes[1]
+
+
+async def test_outside_gate_alone_forces_retry() -> None:
+    # Judges love it (9/9) but pixels changed beyond the mask — rejected, and
+    # the retry's feedback names the confinement breach.
+    render = _Render([_outside_edit(), _inside_edit()])
+    attempts = await _drain(render, alignment=_judge(9.0), medium=_judge(9.0))
+    assert attempts[0].outside_change is not None
+    assert attempts[0].outside_change > _CFG.outside_change_max
+    assert [a.accepted for a in attempts] == [False, True]
+    assert "Confine the edit STRICTLY" in render.suffixes[1]
+
+
+async def test_keep_best_never_regresses() -> None:
+    render = _Render([_inside_edit(), _inside_edit()])
+    attempts = await _drain(
+        render, alignment=_judge(5.0, 4.0), medium=_judge(9.0)
+    )
+    result = edit_loop.conclude_edit(attempts)
+    assert not result.accepted
+    assert result.best is attempts[0]  # strict improvement required
+
+
+async def test_judge_failure_degrades_to_single_attempt() -> None:
+    async def broken(*_args: object) -> JudgeResult:
+        raise RuntimeError("judge down")
+
+    render = _Render([_inside_edit(), _inside_edit()])
+    attempts = await _drain(render, alignment=broken, medium=_judge(9.0))
+    assert len(attempts) == 1
+    assert not attempts[0].accepted
+    assert attempts[0].alignment is None
+    assert render.suffixes == [""]  # no blind retry
+
+
+async def test_medium_floor_gates_acceptance() -> None:
+    render = _Render([_inside_edit(), _inside_edit()])
+    attempts = await _drain(
+        render,
+        alignment=_judge(9.0),
+        medium=_judge(3.0, 9.0, rationale="photoreal patch on an engraving"),
+    )
+    assert [a.accepted for a in attempts] == [False, True]
+    assert "photoreal patch on an engraving" in render.suffixes[1]
+
+
+def test_config_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EDIT_LOOP_MAX_ATTEMPTS", "3")
+    monkeypatch.setenv("EDIT_LOOP_ACCEPT_ALIGNMENT", "8.5")
+    monkeypatch.setenv("EDIT_LOOP_OUTSIDE_MAX", "0.1")
+    monkeypatch.setenv("EDIT_LOOP_ACCEPT_MEDIUM", "junk")  # bad value -> default
+    cfg = edit_loop.edit_loop_config_from_env()
+    assert cfg.max_attempts == 3
+    assert cfg.accept_alignment == 8.5
+    assert cfg.outside_change_max == 0.1
+    assert cfg.accept_medium == 6.0
+
+
+def test_inside_crop_cuts_the_selection() -> None:
+    crop = edit_loop.inside_crop_bytes(_jpg(_base()), _BOX)
+    w, h = Image.open(io.BytesIO(crop)).size
+    assert (w, h) == (48, 36)  # 0.375*128, 0.5*72
+    full = edit_loop.inside_crop_bytes(_jpg(_base()), None)
+    assert Image.open(io.BytesIO(full)).size == (_W, _H)

--- a/apps/modal-backend/tests/test_generate_edit_region.py
+++ b/apps/modal-backend/tests/test_generate_edit_region.py
@@ -1,0 +1,190 @@
+"""Integration tests for the EDIT_REGION wiring in generate.py.
+
+The byte-identity contract: with the flag off (the default) — or with no
+mask in the request — a mode:"edit" body takes EXACTLY today's whole-image
+path (same provider, same kwargs, same final frame shape). With the flag on
+and a mask present, the judged inpaint path runs instead: fill description
+register, inpaint provider, edit loop verdict on the final frame.
+
+Uses the test_generate_enter.py harness (stubbed modal + AsyncMock providers);
+the pixel metric runs for real on tiny synthetic frames.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+import sys
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from PIL import Image, ImageDraw
+
+sys.modules.setdefault("modal", MagicMock())
+
+import providers.image_edit as image_edit_mod  # noqa: E402
+import providers.inpaint as inpaint_mod  # noqa: E402
+import providers.judge as judge_mod  # noqa: E402
+import providers.llm as llm_mod  # noqa: E402
+from generate import GenerateBody, _event_stream  # noqa: E402
+from providers.image import GeneratedImage  # noqa: E402
+from providers.judge import JudgeResult  # noqa: E402
+
+_W, _H = 128, 72
+_BOX = {"x": 0.5, "y": 0.25, "w": 0.375, "h": 0.5}
+
+
+def _data_url(im: Image.Image, fmt: str = "JPEG") -> str:
+    buf = io.BytesIO()
+    im.save(buf, fmt)
+    mime = "image/jpeg" if fmt == "JPEG" else "image/png"
+    return f"data:{mime};base64,{base64.b64encode(buf.getvalue()).decode('ascii')}"
+
+
+def _page() -> Image.Image:
+    grad = Image.linear_gradient("L").resize((_W, _H))
+    return Image.merge("RGB", (grad, grad, grad))
+
+
+def _mask_data_url() -> str:
+    m = Image.new("L", (_W, _H), 0)
+    ImageDraw.Draw(m).rectangle((64, 18, 112, 54), fill=255)
+    return _data_url(m, fmt="PNG")
+
+
+async def _collect(agen: Any) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    async for chunk in agen:
+        text = chunk.decode() if isinstance(chunk, bytes) else chunk
+        for block in text.strip().split("\n\n"):
+            block = block.strip()
+            if block.startswith("data:"):
+                events.append(json.loads(block[len("data:") :].strip()))
+    return events
+
+
+def _edit_body(**over: Any) -> GenerateBody:
+    base: dict[str, Any] = {
+        "query": "make the sky purple",
+        "session_id": "s1",
+        "mode": "edit",
+        "image": _data_url(_page()),
+        "edit_instruction": "make the sky purple",
+        "web_search": False,
+    }
+    base.update(over)
+    return GenerateBody(**base)
+
+
+def _mock_polish(monkeypatch: pytest.MonkeyPatch) -> tuple[AsyncMock, AsyncMock]:
+    polish_edit = AsyncMock(return_value="POLISHED")
+    polish_fill = AsyncMock(return_value="DESCRIBED")
+    monkeypatch.setattr(llm_mod, "polish_edit_instruction", polish_edit)
+    monkeypatch.setattr(llm_mod, "polish_fill_description", polish_fill)
+    return polish_edit, polish_fill
+
+
+def _mock_legacy_edit(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    edit = AsyncMock(
+        return_value=GeneratedImage(b"jpeg", "image/jpeg", "fal-ai/nano-banana-pro", "r1")
+    )
+    monkeypatch.setattr(image_edit_mod, "edit_image", edit)
+    return edit
+
+
+def _mock_inpaint(monkeypatch: pytest.MonkeyPatch, body_image: str) -> AsyncMock:
+    # Returns the source pixels untouched — outside-change 0.0, so the mocked
+    # 9/9 judges accept at attempt 1.
+    raw = base64.b64decode(body_image.split(",", 1)[1])
+    inpaint = AsyncMock(
+        return_value=GeneratedImage(raw, "image/jpeg", "fal-ai/flux-pro/v1/fill", "r2")
+    )
+    monkeypatch.setattr(inpaint_mod, "inpaint_image", inpaint)
+    return inpaint
+
+
+def _mock_judges(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        judge_mod,
+        "score_prompt_alignment",
+        AsyncMock(return_value=JudgeResult(9.0, "", "")),
+    )
+    monkeypatch.setattr(
+        judge_mod,
+        "score_style_pair",
+        AsyncMock(return_value=JudgeResult(9.0, "", "")),
+    )
+
+
+async def test_flag_off_with_mask_is_byte_identical_legacy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # EDIT_REGION unset (the default): a request CARRYING a mask still takes
+    # exactly today's whole-image path — same provider, same kwargs.
+    _, polish_fill = _mock_polish(monkeypatch)
+    edit = _mock_legacy_edit(monkeypatch)
+    body = _edit_body(edit_mask=_mask_data_url(), edit_region=_BOX)
+    inpaint = _mock_inpaint(monkeypatch, body.image or "")
+
+    events = await _collect(_event_stream(body, "t1"))
+
+    assert inpaint.await_count == 0
+    assert polish_fill.await_count == 0
+    assert edit.await_args.kwargs == {
+        "image_data_url": body.image,
+        "instruction": "POLISHED",
+        "tier": None,
+        "model_override": None,
+        "style_ref_url": None,
+    }
+    final = next(e for e in events if e["type"] == "final")
+    assert "image_op" not in final
+    assert "edit_verdict" not in final
+    assert final["final_prompt"] == "POLISHED"
+
+
+async def test_flag_on_without_mask_stays_legacy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EDIT_REGION", "1")
+    _mock_polish(monkeypatch)
+    edit = _mock_legacy_edit(monkeypatch)
+    body = _edit_body()
+    inpaint = _mock_inpaint(monkeypatch, body.image or "")
+
+    await _collect(_event_stream(body, "t1"))
+
+    assert inpaint.await_count == 0
+    assert edit.await_count == 1
+
+
+async def test_flag_on_with_mask_runs_the_judged_inpaint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EDIT_REGION", "1")
+    polish_edit, polish_fill = _mock_polish(monkeypatch)
+    edit = _mock_legacy_edit(monkeypatch)
+    _mock_judges(monkeypatch)
+    body = _edit_body(edit_mask=_mask_data_url(), edit_region=_BOX)
+    inpaint = _mock_inpaint(monkeypatch, body.image or "")
+
+    events = await _collect(_event_stream(body, "t1"))
+
+    assert edit.await_count == 0
+    assert polish_edit.await_count == 0
+    assert polish_fill.await_count == 1
+    assert inpaint.await_count == 1
+    assert inpaint.await_args.kwargs["instruction"] == "DESCRIBED"
+    assert inpaint.await_args.kwargs["mask_data_url"] == body.edit_mask
+    final = next(e for e in events if e["type"] == "final")
+    assert final["image_op"] == "inpaint"
+    assert final["image_model"] == "fal-ai/flux-pro/v1/fill"
+    assert final["final_prompt"] == "DESCRIBED"
+    verdict = final["edit_verdict"]
+    assert verdict["accepted"] is True
+    assert verdict["attempts"] == 1
+    assert verdict["alignment"] == 9.0
+    assert verdict["medium"] == 9.0
+    assert verdict["outside_change"] == 0.0

--- a/apps/modal-backend/tests/test_inpaint_provider.py
+++ b/apps/modal-backend/tests/test_inpaint_provider.py
@@ -1,0 +1,71 @@
+"""Tests for the mask-scoped inpaint provider (providers/inpaint.py)."""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from providers import inpaint
+
+# --- arg shapes per model family (the schema contract) -----------------------
+
+
+def test_fill_family_takes_singular_image_url() -> None:
+    args = inpaint._inpaint_args_for("fal-ai/flux-pro/v1/fill", "a pond", "img", "mask")
+    assert args == {"prompt": "a pond", "image_url": "img", "mask_url": "mask"}
+
+
+def test_gpt_family_takes_image_urls_list() -> None:
+    args = inpaint._inpaint_args_for("openai/gpt-image-2/edit", "a pond", "img", "mask")
+    assert args == {"prompt": "a pond", "image_urls": ["img"], "mask_url": "mask"}
+
+
+# --- model resolution + call wiring ------------------------------------------
+
+
+async def _call(
+    monkeypatch: pytest.MonkeyPatch, **over: Any
+) -> tuple[Any, AsyncMock]:
+    monkeypatch.setattr(inpaint, "_ensure_fal_key", lambda: None)
+    monkeypatch.setattr(
+        inpaint, "to_fal_url", AsyncMock(side_effect=lambda u: f"fal:{u[:16]}")
+    )
+    subscribe = AsyncMock(
+        return_value={"images": [{"url": "https://out"}], "requestId": "r1"}
+    )
+    monkeypatch.setattr(inpaint, "_fal_subscribe", subscribe)
+    monkeypatch.setattr(
+        inpaint, "_fetch_image_bytes", AsyncMock(return_value=(b"jpeg", "image/jpeg"))
+    )
+    result = await inpaint.inpaint_image(
+        image_data_url="data:image/jpeg;base64,xxx",
+        mask_data_url="data:image/png;base64,yyy",
+        instruction="a pond",
+        **over,
+    )
+    return result, subscribe
+
+
+async def test_default_model_is_the_inpaint_slot(monkeypatch: pytest.MonkeyPatch) -> None:
+    result, subscribe = await _call(monkeypatch)
+    model, args = subscribe.await_args.args
+    assert model == "fal-ai/flux-pro/v1/fill"
+    assert args["image_url"].startswith("fal:") and args["mask_url"].startswith("fal:")
+    assert result.model == "fal-ai/flux-pro/v1/fill"
+    assert result.jpeg_bytes == b"jpeg"
+    assert result.provider_request_id == "r1"
+
+
+async def test_env_override_rules_the_slot(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FAL_INPAINT_MODEL", "fal-ai/someone-else/fill")
+    _, subscribe = await _call(monkeypatch)
+    assert subscribe.await_args.args[0] == "fal-ai/someone-else/fill"
+
+
+async def test_explicit_override_beats_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FAL_INPAINT_MODEL", "fal-ai/someone-else/fill")
+    _, subscribe = await _call(monkeypatch, model_override="openai/gpt-image-2/edit")
+    model, args = subscribe.await_args.args
+    assert model == "openai/gpt-image-2/edit"
+    assert "image_urls" in args and "image_url" not in args

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -97,6 +97,14 @@ export interface GenerateRequestBody {
   image_tier?: ImageTier;
   image_model?: string;
   edit_instruction?: string;
+  // Mask-scoped edit (EDIT_REGION; the backend gates it behind the env flag so
+  // it's a no-op until enabled). `edit_mask` is an opaque PNG data URL at the
+  // page's natural dims, WHITE = edit / black = keep (flux fill's native
+  // convention); `edit_region` is the drag selection that produced it,
+  // normalized to natural-image space — the mask drives the model, the box
+  // scopes the judge's inside crop. Absent -> the legacy whole-image edit.
+  edit_mask?: string;
+  edit_region?: { x: number; y: number; w: number; h: number };
   // BCP-47 short tag (e.g. "en", "tr", "ja"). When set, the planner +
   // click-resolver are instructed to emit titles, labels, and the click
   // subject in this language. Image labels render in-pixel via the model.
@@ -260,6 +268,17 @@ export interface GroundingSummary {
   iterations: number;
 }
 
+// The edit loop's verdict on a mask-scoped edit (EDIT_REGION): what the
+// critics saw on the kept attempt. Present on `final` only when the judged
+// inpaint path ran (image_op === "inpaint" and the inputs were judgeable).
+export interface EditVerdict {
+  alignment: number | null; // 0-10: the asked change landed (inside crop)
+  medium: number | null; // 0-10: the art medium held (style pair judge)
+  outside_change: number | null; // 0-1 pixel fraction beyond the mask (free diff)
+  attempts: number;
+  accepted: boolean; // false = best-effort keep-best, gates not all met
+}
+
 export interface GenerateFinalEvent {
   type: "final";
   image_data_url: string;
@@ -276,6 +295,8 @@ export interface GenerateFinalEvent {
   image_op?: string;
   // Geometric grounding summary — present only when VLM_GROUNDING was on.
   grounding?: GroundingSummary;
+  // Judged mask-scoped edit verdict — present only on the EDIT_REGION path.
+  edit_verdict?: EditVerdict;
   trace_id?: string;
 }
 


### PR DESCRIPTION
PR-2 of the editing milestone, stacked on #36 (the smoke whose verdict shaped this). Backend only; the selection UI is the next PR.

## What's here

- **`providers/inpaint.py`** — the provider function `MODEL_SLOTS["inpaint"]` has been waiting for since the geo build. flux fill primary (the smoke: outside-mask pixels byte-identical); the gpt arg-shape branch exists only so the bench can A/B (its mask is decorative).
- **`llm.polish_fill_description`** — the fill register: edit COMMANDS become DESCRIPTIONS of the masked region's final content ("remove the tower" → the background that should remain). No long-instruction skip (the conversion is the point); deterministic medium-lock append; LLM failure degrades to raw + lock.
- **`providers/edit_loop.py`** — the render loop's sibling with an edit's axes: **outside-mask stability as a FREE computed pixel gate** (`EDIT_LOOP_OUTSIDE_MAX`, default 0.02 — the smoke measured fill at 0.0000 and gpt's churn floor at 0.089), prompt-alignment judged on the **inside crop**, the style-pair medium critic, one retry folding the critics' rationales back in (`edit_retry_feedback_clause`), `edit.loop` logging, keep-best with strict improvement, judge-failure degrades to single attempt.
- **`generate.py`** — inside mode:"edit", only when `EDIT_REGION` is on AND the request carries `edit_mask`: rejected attempts stream as progress frames (the view-loop UX — you watch the edit self-correct), final frame gains `image_op:"inpaint"` + `edit_verdict`. Undecodable inputs degrade to a single un-judged shot (the no-critic rule).
- **Wire types, additive both sides**: `edit_mask` (opaque PNG, white=edit, natural dims) + `edit_region` ({x,y,w,h} normalized) in; `EditVerdict` out on `final`.

## Byte-identity (the rule that matters)

Flag off — or flag on with no mask — a mode:"edit" request takes EXACTLY today's whole-image path: same provider, same kwargs, same final frame shape. Pinned by `test_generate_edit_region.py` (mock provider, kwargs compared verbatim). The legacy branch is textually untouched.

## Tests (16 new, all free)

- `test_inpaint_provider.py`: arg shapes per family, slot default, env override, explicit override beats env.
- `test_edit_loop.py`: accept-at-1 spends one render; rationale folded into the retry; **the free outside gate alone forces a retry** (real pixel metric on synthetic frames, only VLM judges mocked); keep-best never regresses; judge failure degrades; medium floor gates; env config parsing; inside-crop math.
- `test_generate_edit_region.py`: the three gating scenarios above.

`make eval` green (211 backend + 479 web). Flag stays OFF until `eval-edit-region` commits a baseline (next PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)