### PR TITLE
feat(eval): the edit-region bench + its first committed baseline (E5)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,12 @@ eval-view-loop:
 # flux-pro/v1/fill slot, scored by pixel-diff only. PAID (~$0.5, no VLM).
 eval-edit-mask-smoke:
 	cd apps/modal-backend && EDIT_REGION_BENCH_RUN=1 .venv/bin/python -m tests.edit_bench.mask_smoke
+# E5: the mask-scoped edit bench — the asked change LANDS (alignment judge on
+# the inside crop), the edit CONFINES (outside pixel-diff, free, per-case),
+# the MEDIUM holds (style judge). EDIT_REGION_BENCH_MODELS adds A/B arms;
+# EDIT_REGION_BENCH_LOOP=1 measures the production edit loop. PAID (~$1).
+eval-edit-region:
+	cd apps/modal-backend && EDIT_REGION_BENCH_RUN=1 .venv/bin/python -m tests.edit_bench.runner
 # The before/after regression sweep: every PAID eval that has a committed
 # baseline band (tests/eval_baselines.json), run back to back. Each prints
 # PASS / REGRESSION / IMPROVED vs its band — run it before AND after a risky

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ eval-baselines:
 	-cd apps/modal-backend && STYLE_BENCH_RUN=1 .venv/bin/python -m tests.continuity_bench.style_runner
 	-cd apps/modal-backend && ENTER_BENCH_RUN=1 .venv/bin/python -m tests.continuity_bench.enter_runner
 	-cd apps/modal-backend && VIEW_BENCH_RUN=1 .venv/bin/python -m tests.continuity_bench.view_runner
+	-cd apps/modal-backend && EDIT_REGION_BENCH_RUN=1 .venv/bin/python -m tests.edit_bench.runner
 # Free coverage report (backend lines + the web view-path files).
 coverage:
 	cd apps/modal-backend && .venv/bin/python -m pytest -q -m "not paid" --cov=providers --cov=generate --cov-report=term | tail -30

--- a/apps/modal-backend/tests/conftest.py
+++ b/apps/modal-backend/tests/conftest.py
@@ -80,6 +80,8 @@ _SCRUB = (
     "REPAIR_BENCH_RUN",
     "EDIT_BENCH_RUN",
     "EDIT_REGION_BENCH_RUN",
+    "EDIT_REGION_BENCH_MODELS",
+    "EDIT_REGION_BENCH_LOOP",
     # Mask-scoped judged edits (E1; default OFF until the bench baselines it).
     "EDIT_REGION",
     "EDIT_LOOP_MAX_ATTEMPTS",

--- a/apps/modal-backend/tests/edit_bench/runner.py
+++ b/apps/modal-backend/tests/edit_bench/runner.py
@@ -1,0 +1,338 @@
+"""EDIT-REGION — the E5 bench: a mask-scoped edit must LAND, CONFINE, and
+keep the MEDIUM.
+
+For each styled case a source page is generated live (balanced tier, the
+bench precedent), the white=edit mask is built from the case's region box,
+the instruction goes through the PRODUCTION fill register
+(llm.polish_fill_description) and the PRODUCTION provider
+(providers.inpaint). Three scores per arm:
+  - alignment: score_prompt_alignment(description, inside crop) — the asked
+    change landed, judged where it happened, not diluted across the frame
+  - outside:   pixel_diff.changed_fraction beyond the mask — FREE, the
+    confinement promise asserted with pixels
+  - medium:    score_style_pair(source, result) — the art medium held
+
+Arms: "production" (the inpaint slot) + EDIT_REGION_BENCH_MODELS extras
+(comma-sep slugs — the ENTER_BENCH_MODELS precedent; how gpt's decorative
+mask was demoted and any future challenger gets judged on the same cases).
+EDIT_REGION_BENCH_LOOP=1 runs arms through the PRODUCTION edit loop (judged
+retries with critic feedback) so the loop's lift is measurable; the default
+stays single-shot so the committed baseline stays comparable.
+
+The committed baseline (tests/eval_baselines.json "edit_region") tracks the
+production arm's alignment_mean; outside-stability is a boolean gate, not a
+band (lower-is-better fractions would invert _baseline.compare).
+
+Paid (~$0.5-1/run: 2 source gens + per-arm inpaints + judges). Self-contained:
+    cd apps/modal-backend && EDIT_REGION_BENCH_RUN=1 \
+      .venv/bin/python -m tests.edit_bench.runner
+or:  make eval-edit-region
+"""
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import os
+import statistics
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+_REPORTS = Path(__file__).resolve().parent / "reports"
+# Production-arm gates (env-tunable for exploration, defaults committed).
+_ALIGN_THRESHOLD = float(os.environ.get("EDIT_REGION_BENCH_THRESHOLD", "6.5"))
+_OUTSIDE_MAX = float(os.environ.get("EDIT_REGION_BENCH_OUTSIDE_MAX", "0.02"))
+_MEDIUM_FLOOR = float(os.environ.get("EDIT_REGION_BENCH_MEDIUM_FLOOR", "6.0"))
+
+
+@dataclass(frozen=True)
+class Case:
+    name: str
+    page_prompt: str
+    style: str
+    region: tuple[float, float, float, float]  # x, y, w, h normalized
+    instruction: str
+    facts: list[str] = field(default_factory=list)
+
+
+# ADD-shaped instructions aimed at areas the prompt pins (south-shore water,
+# vineyards outside the walls) — robust to the layout variance of live
+# generation, unlike remove/replace of a landmark that may drift elsewhere.
+_CASES: list[Case] = [
+    Case(
+        name="engraving_harbor_ship",
+        page_prompt=(
+            "a hand-drawn antique engraving top-down map of a walled harbor "
+            "city: a tall striped lighthouse on the north cliff, a market "
+            "square in the center, wooden docks along the south shore, and a "
+            "stone castle on the east hill; sepia ink, dense cross-hatching, "
+            "aged paper"
+        ),
+        style="hand-drawn antique engraving, sepia ink, dense cross-hatching",
+        region=(0.05, 0.55, 0.24, 0.32),
+        instruction="add a three-masted sailing ship on the water here",
+    ),
+    Case(
+        name="watercolor_hilltown_pond",
+        page_prompt=(
+            "a soft watercolour top-down map of a walled hill town: a market "
+            "hall at the central square, a bell tower just north of it, "
+            "terraced vineyards south of the walls; loose washes, pale pastel "
+            "palette, visible paper texture"
+        ),
+        style="soft watercolour, loose washes, pale pastel palette",
+        region=(0.55, 0.62, 0.28, 0.30),
+        instruction="add a small round pond with ducks among the fields here",
+    ),
+]
+
+
+@dataclass(frozen=True)
+class ArmResult:
+    arm: str  # "production" or the override slug
+    model: str
+    alignment: float
+    outside: float
+    medium: float
+    alignment_rationale: str
+    attempts: int = 1  # >1 only under EDIT_REGION_BENCH_LOOP
+
+
+@dataclass(frozen=True)
+class CaseResult:
+    name: str
+    description: str  # the fill-register text the arms rendered
+    arms: list[ArmResult]
+
+
+def build_mask(size: tuple[int, int], region: tuple[float, float, float, float]) -> bytes:
+    """The wire mask: opaque PNG at source dims, WHITE = edit."""
+    from PIL import Image, ImageDraw
+
+    w, h = size
+    x, y, rw, rh = region
+    m = Image.new("L", size, 0)
+    ImageDraw.Draw(m).rectangle(
+        (round(x * w), round(y * h), round((x + rw) * w), round((y + rh) * h)),
+        fill=255,
+    )
+    buf = io.BytesIO()
+    m.save(buf, "PNG")
+    return buf.getvalue()
+
+
+def _arm_models() -> list[tuple[str, str | None]]:
+    extras = [
+        s.strip()
+        for s in os.environ.get("EDIT_REGION_BENCH_MODELS", "").split(",")
+        if s.strip()
+    ]
+    return [("production", None), *((slug, slug) for slug in extras)]
+
+
+async def _score_arm(
+    arm: str,
+    model_override: str | None,
+    case: Case,
+    description: str,
+    src_bytes: bytes,
+    src_url: str,
+    mask_bytes: bytes,
+    mask_url: str,
+) -> ArmResult:
+    from providers import edit_loop, inpaint, judge, pixel_diff
+
+    loop_mode = bool(os.environ.get("EDIT_REGION_BENCH_LOOP"))
+
+    async def _render(suffix: str) -> Any:
+        instr = description if not suffix else f"{description}\n\n{suffix}"
+        return await inpaint.inpaint_image(
+            image_data_url=src_url,
+            mask_data_url=mask_url,
+            instruction=instr,
+            model_override=model_override,
+        )
+
+    if loop_mode:
+        result = await edit_loop.run_edit_loop(
+            _render,
+            source_bytes=src_bytes,
+            mask_png=mask_bytes,
+            region_box=case.region,
+            judge_alignment=judge.score_prompt_alignment,
+            judge_medium=judge.score_style_pair,
+            instruction=description,
+        )
+        best = result.best
+        out_name = f"edit_{case.name}_{arm.replace('/', '_')}.jpg"
+        (_REPORTS / out_name).write_bytes(result.image.jpeg_bytes)
+        return ArmResult(
+            arm=arm,
+            model=getattr(result.image, "model", model_override or "production"),
+            alignment=best.alignment.score if best.alignment else 0.0,
+            outside=best.outside_change if best.outside_change is not None else 1.0,
+            medium=best.medium.score if best.medium else 0.0,
+            alignment_rationale=best.alignment.rationale if best.alignment else "",
+            attempts=len(result.attempts),
+        )
+
+    # Single-shot (the baseline mode). fal occasionally 422s a valid request —
+    # one bench-level retry, then a zero arm instead of killing the paid run.
+    rendered = None
+    for attempt in range(2):
+        try:
+            rendered = await _render("")
+            break
+        except Exception as exc:  # bench resilience — reported, not fatal
+            print(f"[edit-bench] {case.name}/{arm} attempt {attempt + 1} failed: {exc}")
+    if rendered is None:
+        return ArmResult(
+            arm=arm,
+            model=model_override or "production",
+            alignment=0.0,
+            outside=1.0,
+            medium=0.0,
+            alignment_rationale="render failed twice (fal)",
+        )
+    out_bytes = rendered.jpeg_bytes
+    (_REPORTS / f"edit_{case.name}_{arm.replace('/', '_')}.jpg").write_bytes(out_bytes)
+    outside = pixel_diff.changed_fraction(src_bytes, out_bytes, mask_bytes, invert_mask=True)
+    inside = edit_loop.inside_crop_bytes(out_bytes, case.region)
+    align = await judge.score_prompt_alignment(description, inside)
+    medium = await judge.score_style_pair(src_bytes, out_bytes)
+    return ArmResult(
+        arm=arm,
+        model=rendered.model,
+        alignment=align.score,
+        outside=round(outside, 4),
+        medium=medium.score,
+        alignment_rationale=align.rationale,
+    )
+
+
+async def _run_case(case: Case) -> CaseResult:
+    from PIL import Image
+
+    from providers import image as image_provider
+    from providers import llm
+
+    src = await image_provider.generate_image(
+        prompt=case.page_prompt, aspect_ratio="16:9", tier="balanced"
+    )
+    src_bytes = src.jpeg_bytes
+    src_url = image_provider.encode_data_url(src_bytes)
+    size = Image.open(io.BytesIO(src_bytes)).size
+    mask_bytes = build_mask(size, case.region)
+    mask_url = image_provider.encode_data_url(mask_bytes, "image/png")
+
+    _REPORTS.mkdir(parents=True, exist_ok=True)
+    (_REPORTS / f"edit_{case.name}_src.jpg").write_bytes(src_bytes)
+    (_REPORTS / f"edit_{case.name}_mask.png").write_bytes(mask_bytes)
+
+    # The production register: the command becomes the region's described
+    # final content, medium lock appended — exactly what generate.py sends.
+    description = await llm.polish_fill_description(
+        instruction=case.instruction,
+        page_title=case.name.replace("_", " "),
+        style_anchor=case.style,
+    )
+    arms = [
+        await _score_arm(
+            arm, override, case, description, src_bytes, src_url, mask_bytes, mask_url
+        )
+        for arm, override in _arm_models()
+    ]
+    return CaseResult(name=case.name, description=description, arms=arms)
+
+
+def summarize(results: list[CaseResult]) -> dict[str, Any]:
+    """Per-arm means + the production gates. Pure — unit-tested free."""
+    by_arm: dict[str, dict[str, float]] = {}
+    arm_names = {a.arm for r in results for a in r.arms}
+    for arm in sorted(arm_names):
+        rows = [a for r in results for a in r.arms if a.arm == arm]
+        by_arm[arm] = {
+            "alignment_mean": round(statistics.mean(a.alignment for a in rows), 4),
+            "outside_max": round(max(a.outside for a in rows), 4),
+            "medium_mean": round(statistics.mean(a.medium for a in rows), 4),
+        }
+    prod = [a for r in results for a in r.arms if a.arm == "production"]
+    alignment_mean = (
+        round(statistics.mean(a.alignment for a in prod), 4) if prod else 0.0
+    )
+    return {
+        "n_cases": len(results),
+        "arms": by_arm,
+        "alignment_mean": alignment_mean,
+        # Gate 1: the asked change actually lands in the region.
+        "asked_change_landed": bool(prod) and alignment_mean >= _ALIGN_THRESHOLD,
+        # Gate 2: confinement is a PROMISE — every case, not an average.
+        "outside_stable": bool(prod) and all(a.outside <= _OUTSIDE_MAX for a in prod),
+        # Gate 3: the medium survives the patch.
+        "medium_floor_held": bool(prod)
+        and statistics.mean(a.medium for a in prod) >= _MEDIUM_FLOOR,
+    }
+
+
+async def run_bench() -> dict[str, Any]:
+    results = [await _run_case(c) for c in _CASES]
+    return {
+        "judge_model": os.environ.get("CONTINUITY_BENCH_JUDGE_MODEL"),
+        "started_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "loop": bool(os.environ.get("EDIT_REGION_BENCH_LOOP")),
+        "align_threshold": _ALIGN_THRESHOLD,
+        "outside_max": _OUTSIDE_MAX,
+        "medium_floor": _MEDIUM_FLOOR,
+        "cases": [asdict(r) for r in results],
+        "summary": summarize(results),
+    }
+
+
+def _load_env() -> None:
+    env_path = Path(__file__).resolve().parents[2] / ".env"
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+    os.environ.setdefault("CONTINUITY_BENCH_JUDGE_MODEL", "google/gemini-3-flash-preview")
+    os.environ.setdefault("FAL_IMAGE_MODEL_BALANCED", "fal-ai/nano-banana-pro")
+
+
+def _cli() -> None:
+    if not os.environ.get("EDIT_REGION_BENCH_RUN"):
+        raise SystemExit("set EDIT_REGION_BENCH_RUN=1 to spend on the paid edit-region bench")
+    _load_env()
+    if not os.environ.get("FAL_KEY") or not os.environ.get("OPENROUTER_API_KEY"):
+        raise SystemExit("FAL_KEY + OPENROUTER_API_KEY required (apps/modal-backend/.env)")
+    report = asyncio.run(run_bench())
+    _REPORTS.mkdir(parents=True, exist_ok=True)
+    (_REPORTS / "edit_region_latest.json").write_text(json.dumps(report, indent=2))
+    print(json.dumps(report, indent=2))
+    s = report["summary"]
+    print(
+        f"\nEDIT REGION (production arm) alignment = {s['alignment_mean']} "
+        f"(threshold {_ALIGN_THRESHOLD}); outside stable = {s['outside_stable']} "
+        f"(max {_OUTSIDE_MAX}); medium held = {s['medium_floor_held']} "
+        f"(floor {_MEDIUM_FLOOR})."
+    )
+    from tests._baseline import load_baselines
+
+    if "edit_region" in load_baselines():
+        from tests._baseline import compare
+
+        verdict = compare("edit_region", s["alignment_mean"], s["n_cases"])
+        print(f"baseline: {verdict.status} — {verdict.detail}")
+    else:
+        print(
+            "baseline: none committed yet — add 'edit_region' to "
+            "tests/eval_baselines.json from this run."
+        )
+
+
+if __name__ == "__main__":
+    _cli()

--- a/apps/modal-backend/tests/edit_bench/test_edit_region.py
+++ b/apps/modal-backend/tests/edit_bench/test_edit_region.py
@@ -1,0 +1,81 @@
+"""Free gates for the edit-region bench (tests/edit_bench/runner.py).
+
+The paid runner's pure parts, pinned every commit: cases stay well-formed,
+the mask builder honors the wire convention (white = edit, source dims),
+and summarize()'s three gates flip exactly when they should.
+"""
+from __future__ import annotations
+
+import io
+
+from PIL import Image
+
+from tests.edit_bench import runner
+
+
+def test_cases_well_formed() -> None:
+    assert len(runner._CASES) >= 2
+    names = [c.name for c in runner._CASES]
+    assert len(names) == len(set(names))
+    for c in runner._CASES:
+        x, y, w, h = c.region
+        assert x >= 0.0 and y >= 0.0 and w > 0.0 and h > 0.0
+        assert x + w <= 1.0 and y + h <= 1.0
+        assert c.instruction.strip()
+        assert c.style.strip()
+
+
+def test_build_mask_is_white_rect_at_source_dims() -> None:
+    mask = runner.build_mask((160, 90), (0.25, 0.2, 0.5, 0.6))
+    im = Image.open(io.BytesIO(mask))
+    assert im.size == (160, 90)
+    hist = im.convert("L").histogram()
+    white, total = hist[255], sum(hist)
+    assert abs(white / total - 0.3) < 0.02  # 0.5 * 0.6 of the frame
+    assert hist[0] + white == total  # binary: no grays
+
+
+def _arm(arm: str = "production", alignment: float = 9.0, outside: float = 0.0, medium: float = 9.0) -> runner.ArmResult:
+    return runner.ArmResult(
+        arm=arm, model="m", alignment=alignment, outside=outside,
+        medium=medium, alignment_rationale="",
+    )
+
+
+def _case(name: str, *arms: runner.ArmResult) -> runner.CaseResult:
+    return runner.CaseResult(name=name, description="d", arms=list(arms))
+
+
+def test_summarize_all_gates_pass() -> None:
+    s = runner.summarize([_case("a", _arm()), _case("b", _arm())])
+    assert s["asked_change_landed"] and s["outside_stable"] and s["medium_floor_held"]
+    assert s["alignment_mean"] == 9.0
+    assert s["n_cases"] == 2
+
+
+def test_summarize_alignment_gate_fails_on_low_mean() -> None:
+    s = runner.summarize([_case("a", _arm(alignment=5.0)), _case("b", _arm(alignment=7.0))])
+    assert not s["asked_change_landed"]
+
+
+def test_summarize_outside_gate_is_per_case_not_mean() -> None:
+    # One leaky case must fail the gate even if the average looks fine.
+    s = runner.summarize([_case("a", _arm()), _case("b", _arm(outside=0.3))])
+    assert not s["outside_stable"]
+
+
+def test_summarize_medium_floor() -> None:
+    s = runner.summarize([_case("a", _arm(medium=3.0)), _case("b", _arm(medium=5.0))])
+    assert not s["medium_floor_held"]
+
+
+def test_summarize_extra_arms_reported_but_not_gated() -> None:
+    leaky_extra = _arm(arm="openai/gpt-image-2/edit", outside=0.9, alignment=2.0)
+    s = runner.summarize([_case("a", _arm(), leaky_extra)])
+    assert s["outside_stable"] and s["asked_change_landed"]
+    assert s["arms"]["openai/gpt-image-2/edit"]["outside_max"] == 0.9
+
+
+def test_summarize_empty_production_fails_closed() -> None:
+    s = runner.summarize([])
+    assert not (s["asked_change_landed"] or s["outside_stable"] or s["medium_floor_held"])

--- a/apps/modal-backend/tests/eval_baselines.json
+++ b/apps/modal-backend/tests/eval_baselines.json
@@ -28,6 +28,13 @@
       "regression_band": 2.5,
       "n_min": 2,
       "source": "make eval-view 2026-06-10 (calibrated judge, single-shot bench mode): oblique 10.0, isometric 9.0 (the policy's auto registers); top_down/eye_level 2.5-6 single-shot (nano's aerial attractor). PRODUCTION (steep router + VIEW_LOOP, make eval-view-loop, same date): 9.75 mean \u2014 top_down 10.0, oblique 10.0, isometric 9.0, eye_level 10.0; view_trustworthy TRUE; same_place 9.0-10 every arm; 3/4 steep arms accepted at attempt 1, the 4th self-corrected at attempt 2. This baseline tracks the DEFAULT (single-shot) bench so the loop's lift stays measurable."
+    },
+    "edit_region": {
+      "metric": "alignment_mean",
+      "baseline": 10.0,
+      "regression_band": 2.0,
+      "n_min": 2,
+      "source": "make eval-edit-region first run 2026-06-10 (flux fill, single-shot, production fill register): alignment 10.0 + medium 10.0 on both cases, outside-change 0.0000 per case (the compositor's promise, gated per-case not by mean). Tracks the production arm only; extra A/B arms via EDIT_REGION_BENCH_MODELS report but never gate. Band 2.0 absorbs single judge-noise samples."
     }
   }
 }


### PR DESCRIPTION
PR-3 of the editing milestone, stacked on #37. The bench that earns `EDIT_REGION` its flag — and its first paid run, which came back perfect.

## The bench (`make eval-edit-region`, ~$0.5-1)

`tests/edit_bench/runner.py`, the view-bench shape: two styled cases (engraving harbor / watercolor hill town) generate source pages live, the case region becomes a white=edit mask at source dims, the instruction goes through the **production** fill register (`polish_fill_description`) and the **production** provider (`providers.inpaint`). Three scores per arm:

- **alignment** — `score_prompt_alignment` on the inside crop (judged where the edit happened)
- **outside** — `pixel_diff.changed_fraction` beyond the mask, free, **gated per-case** (one leaky case fails it; confinement is a promise, not an average)
- **medium** — `score_style_pair(source, result)`

`EDIT_REGION_BENCH_MODELS` adds comma-sep A/B arms (reported, never gated — the ENTER_BENCH_MODELS precedent). `EDIT_REGION_BENCH_LOOP=1` runs arms through the production edit loop so its lift stays measurable against the same single-shot baseline.

## First run (2026-06-10, recorded in eval_baselines.json)

| case | alignment | outside | medium |
|---|---|---|---|
| engraving_harbor_ship | 10.0 | 0.0000 | 10.0 |
| watercolor_hilltown_pond | 10.0 | 0.0000 | 10.0 |

All three gates green on the first paid outing — the fill register produced clean region descriptions ("a three-masted wooden sailing ship with billowing sails, rendered in antique sepia ink…") and the compositor kept every outside pixel. Baseline committed: `edit_region` / `alignment_mean` 10.0, band 2.0, n_min 2; the runner joins `eval-baselines`.

Free wrapper (`test_edit_region.py`, 8 tests) pins the cases, the mask builder convention, and the summarize() gate truth table — including "extra arms report but never gate" and "empty production fails closed".

With the baseline committed, the flag-default question is now earned — but the UI lands first (next PR), so the default flip stays a separate one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)