### PR TITLE
feat(web): select-area edits — drag a region, the mask rides the edit (E1 frontend)

### DIFF
--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { ChangeEvent, DragEvent, FormEvent } from "react";
+import type { ChangeEvent, CSSProperties, DragEvent, FormEvent } from "react";
 import type {
   Citation,
   GenerateRequestBody,
@@ -76,6 +76,14 @@ import { ContextMenu } from "@/components/PlayPage/ContextMenu";
 import { HoverCrosshair } from "@/components/PlayPage/HoverCrosshair";
 import { HintPrompt } from "@/components/PlayPage/HintPrompt";
 import { EditForm } from "@/components/PlayPage/EditForm";
+import { RegionSelectOverlay } from "@/components/PlayPage/RegionSelectOverlay";
+import {
+  buildMaskPng,
+  dragToRegion,
+  regionToDisplayRect,
+  type EditRegionBox,
+} from "@/lib/edit-mask";
+import { useContainRect } from "@/hooks/useContainRect";
 import { ImageFailedOverlay } from "@/components/PlayPage/ImageFailedOverlay";
 import { DragDropOverlay } from "@/components/PlayPage/DragDropOverlay";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
@@ -93,6 +101,13 @@ import {
 } from "@/hooks/usePrefetchCache";
 
 type Phase = "idle" | "generating" | "ready" | "error";
+
+// Select-area mask edits (E1). Build-time gate so the UI never offers a drag
+// whose mask a flag-off backend would silently ignore (a whole-image edit
+// after the user drew a box is the worst surprise). Backend twin: EDIT_REGION.
+const EDIT_REGION_ENABLED = ["1", "true", "yes"].includes(
+  (process.env.NEXT_PUBLIC_EDIT_REGION ?? "").toLowerCase()
+);
 
 interface Page {
   nodeId: string | null;
@@ -463,6 +478,61 @@ export default function PlayPage() {
 
   const [editMode, setEditMode] = useState(false);
   const [editInstruction, setEditInstruction] = useState("");
+  // Select-area edit (EDIT_REGION): the committed selection (normalized,
+  // natural-image space), the live drag rect (element px), and the verdict
+  // toast the judged edit's final frame reports. All scoped to editMode.
+  const [editRegion, setEditRegion] = useState<EditRegionBox | null>(null);
+  const [editDragRect, setEditDragRect] = useState<{
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+  } | null>(null);
+  const editDragStartRef = useRef<{ x: number; y: number } | null>(null);
+  const [editToast, setEditToast] = useState<string | null>(null);
+  const containRect = useContainRect(imgRef);
+  const editRegionDisplayRect = useMemo(
+    () =>
+      editRegion && containRect
+        ? regionToDisplayRect(editRegion, containRect)
+        : null,
+    [editRegion, containRect]
+  );
+  // Anchor the edit box just under the selection (clamped into the figure);
+  // no selection -> undefined -> the form keeps its bottom-bar position.
+  const editFormStyle = useMemo<CSSProperties | undefined>(() => {
+    if (!editRegionDisplayRect || !containRect) return undefined;
+    const boxW = containRect.offsetX * 2 + containRect.width;
+    const boxH = containRect.offsetY * 2 + containRect.height;
+    const width = Math.min(320, Math.max(240, editRegionDisplayRect.width));
+    return {
+      left: Math.max(
+        4,
+        Math.min(editRegionDisplayRect.left, boxW - width - 4)
+      ),
+      right: "auto",
+      bottom: "auto",
+      top: Math.min(
+        editRegionDisplayRect.top + editRegionDisplayRect.height + 8,
+        boxH - 44
+      ),
+      width,
+      borderRadius: 9999,
+    };
+  }, [editRegionDisplayRect, containRect]);
+  useEffect(() => {
+    if (!editToast) return;
+    const timer = window.setTimeout(() => setEditToast(null), 6000);
+    return () => window.clearTimeout(timer);
+  }, [editToast]);
+  useEffect(() => {
+    if (!editRegion) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setEditRegion(null);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [editRegion]);
 
   // Style DNA lock — when the user pins a page, every subsequent generate
   // gets `session_style_anchor` set to that page's VLM-described style.
@@ -613,6 +683,15 @@ export default function PlayPage() {
               // Flip the morph gate so the decode-then-reveal effect runs
               // ONLY on the final image, not on streamed progress partials.
               setMorphFx((prev) => (prev ? { ...prev, isFinal: true } : prev));
+              // Judged mask-scoped edit: surface what the critics saw.
+              if (evt.edit_verdict) {
+                const v = evt.edit_verdict;
+                setEditToast(
+                  v.accepted
+                    ? `edit verified ${v.alignment?.toFixed(1) ?? "—"}/10 · medium ${v.medium?.toFixed(1) ?? "—"}/10 · ${v.attempts} attempt${v.attempts === 1 ? "" : "s"}`
+                    : `edit kept best of ${v.attempts} attempt${v.attempts === 1 ? "" : "s"} — verification gates not all met`
+                );
+              }
               void persistNode(
                 {
                   parent_id: body.current_node_id || null,
@@ -1074,10 +1153,29 @@ export default function PlayPage() {
   ]);
 
   const submitEdit = useCallback(
-    (e: FormEvent<HTMLFormElement>) => {
+    async (e: FormEvent<HTMLFormElement>) => {
       e.preventDefault();
       const instruction = editInstruction.trim();
       if (!instruction || !page?.imageDataUrl) return;
+      // Select-area edit: a committed selection rides along as a white=edit
+      // mask PNG at natural dims + the region box (judge crop scope). Mask
+      // build failure falls back to today's whole-image edit.
+      let maskFields: Partial<GenerateRequestBody> = {};
+      const imgEl = imgRef.current;
+      if (EDIT_REGION_ENABLED && editRegion && imgEl?.naturalWidth) {
+        try {
+          maskFields = {
+            edit_mask: await buildMaskPng(
+              imgEl.naturalWidth,
+              imgEl.naturalHeight,
+              editRegion
+            ),
+            edit_region: editRegion,
+          };
+        } catch {
+          /* whole-image fallback */
+        }
+      }
       // Carry the style exemplar (pinned page, else root) so an edit can't drift
       // the art medium. The backend edit path now threads both this "style" ref
       // and the session text lock.
@@ -1111,11 +1209,13 @@ export default function PlayPage() {
             }
           : {}),
         ...(styleAnchor ? { session_style_anchor: styleAnchor.style } : {}),
+        ...maskFields,
       });
       setEditInstruction("");
       setEditMode(false);
+      setEditRegion(null);
     },
-    [editInstruction, page, generate, imageTier, outputLocale, styleAnchor, history]
+    [editInstruction, page, generate, imageTier, outputLocale, styleAnchor, history, editRegion]
   );
 
   const canGoBack = history.trailIdx > 0;
@@ -1908,6 +2008,17 @@ export default function PlayPage() {
         xPx: evt.clientX - rect.left,
         yPx: evt.clientY - rect.top,
       });
+      if (editDragStartRef.current) {
+        const s = editDragStartRef.current;
+        const cur = { x: evt.clientX - rect.left, y: evt.clientY - rect.top };
+        setEditDragRect({
+          left: Math.min(s.x, cur.x),
+          top: Math.min(s.y, cur.y),
+          width: Math.abs(cur.x - s.x),
+          height: Math.abs(cur.y - s.y),
+        });
+        return;
+      }
       if (phase === "generating" || editMode) return;
       if (streamStatus !== "off") return;
       // While a stroke is active, accumulate points instead of prefetching.
@@ -1946,6 +2057,27 @@ export default function PlayPage() {
       }, 450);
     };
     const down = (evt: PointerEvent) => {
+      // Select-area edit: plain drag while editMode is on (every other image
+      // gesture early-returns on editMode, so this is additive by construction).
+      if (
+        EDIT_REGION_ENABLED &&
+        editMode &&
+        evt.pointerType !== "touch" &&
+        phase !== "generating"
+      ) {
+        const rect = img.getBoundingClientRect();
+        editDragStartRef.current = {
+          x: evt.clientX - rect.left,
+          y: evt.clientY - rect.top,
+        };
+        evt.preventDefault();
+        try {
+          img.setPointerCapture(evt.pointerId);
+        } catch {
+          /* no-op */
+        }
+        return;
+      }
       if (!evt.shiftKey) return;
       if (evt.pointerType === "touch") return;
       if (phase === "generating" || editMode) return;
@@ -1969,6 +2101,29 @@ export default function PlayPage() {
       });
     };
     const up = async (evt: PointerEvent) => {
+      if (editDragStartRef.current) {
+        const s = editDragStartRef.current;
+        editDragStartRef.current = null;
+        setEditDragRect(null);
+        try {
+          img.releasePointerCapture(evt.pointerId);
+        } catch {
+          /* no-op */
+        }
+        const rect = img.getBoundingClientRect();
+        // A drag commits a selection; a plain click clears it.
+        setEditRegion(
+          dragToRegion(
+            s,
+            { x: evt.clientX - rect.left, y: evt.clientY - rect.top },
+            rect.width,
+            rect.height,
+            img.naturalWidth,
+            img.naturalHeight
+          )
+        );
+        return;
+      }
       if (!strokeActiveRef.current) return;
       try {
         img.releasePointerCapture(evt.pointerId);
@@ -2461,6 +2616,18 @@ export default function PlayPage() {
               )}
               {strokeState && <StrokeOverlay pxPoints={strokeState.pxPoints} />}
 
+              {editMode && (editDragRect ?? editRegionDisplayRect) && (
+                <RegionSelectOverlay
+                  rect={(editDragRect ?? editRegionDisplayRect)!}
+                />
+              )}
+
+              {editToast && (
+                <div className="pointer-events-none absolute left-1/2 top-3 z-20 -translate-x-1/2 whitespace-nowrap rounded-full bg-black/70 px-3 py-1 text-xs text-white">
+                  {editToast}
+                </div>
+              )}
+
               {imgFailed && <ImageFailedOverlay />}
 
               {hoverPos &&
@@ -2649,6 +2816,8 @@ export default function PlayPage() {
                 onClick={() => {
                   setEditMode((v) => !v);
                   setEditInstruction("");
+                  setEditRegion(null);
+                  setEditDragRect(null);
                 }}
                 disabled={phase === "generating"}
                 aria-pressed={editMode}
@@ -2725,6 +2894,7 @@ export default function PlayPage() {
                 busy={phase === "generating"}
                 placeholder={t.editPlaceholder}
                 applyLabel={t.apply}
+                style={editFormStyle}
               />
             ) : (
               <figcaption className="absolute bottom-0 left-0 right-0 bg-black/50 px-4 py-2 text-sm text-white">

--- a/apps/web/components/PlayPage/EditForm.tsx
+++ b/apps/web/components/PlayPage/EditForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { FormEvent } from "react";
+import type { CSSProperties, FormEvent } from "react";
 
 interface Props {
   instruction: string;
@@ -9,6 +9,9 @@ interface Props {
   busy: boolean;
   placeholder: string;
   applyLabel: string;
+  /** Optional position override — the select-area edit anchors the form just
+   *  under the drag selection; absent, it keeps its bottom-bar position. */
+  style?: CSSProperties | undefined;
 }
 
 /**
@@ -23,10 +26,12 @@ export function EditForm({
   busy,
   placeholder,
   applyLabel,
+  style,
 }: Props) {
   return (
     <form
       onSubmit={onSubmit}
+      style={style}
       className="absolute bottom-0 left-0 right-0 flex items-center gap-2 bg-black/65 px-3 py-2"
     >
       <input

--- a/apps/web/components/PlayPage/RegionSelectOverlay.tsx
+++ b/apps/web/components/PlayPage/RegionSelectOverlay.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+interface Props {
+  /** Image-element pixel-space rect; the parent positions the overlay over
+   *  the image and owns all coordinate math (lib/edit-mask.ts). */
+  rect: { left: number; top: number; width: number; height: number };
+}
+
+/**
+ * The drag-selection marquee for a mask-scoped edit: a dashed rectangle with
+ * everything outside it dimmed (single-div box-shadow scrim, clipped to the
+ * image box). Pure presentational, like StrokeOverlay.
+ */
+export function RegionSelectOverlay({ rect }: Props) {
+  if (rect.width <= 0 || rect.height <= 0) return null;
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none absolute inset-0 z-10 overflow-hidden"
+    >
+      <div
+        className="absolute rounded-sm border-2 border-dashed border-white/95"
+        style={{
+          left: rect.left,
+          top: rect.top,
+          width: rect.width,
+          height: rect.height,
+          boxShadow: "0 0 0 9999px rgba(0,0,0,0.35)",
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/lib/edit-mask.test.ts
+++ b/apps/web/lib/edit-mask.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  dragToRegion,
+  regionToDisplayRect,
+  regionToPixelRect,
+} from "./edit-mask";
+
+// A 16:9 box (800x450) showing a 1600x900 natural image — content fills the
+// box exactly (no letterbox), so display px map 1:2 onto natural px.
+const BOX = { w: 800, h: 450, nw: 1600, nh: 900 };
+
+describe("dragToRegion", () => {
+  it("normalizes a plain drag to natural-image space", () => {
+    const r = dragToRegion(
+      { x: 80, y: 45 },
+      { x: 400, y: 225 },
+      BOX.w,
+      BOX.h,
+      BOX.nw,
+      BOX.nh
+    );
+    expect(r).toEqual({ x: 0.1, y: 0.1, w: 0.4, h: 0.4 });
+  });
+
+  it("accepts drags in any direction", () => {
+    const r = dragToRegion(
+      { x: 400, y: 225 },
+      { x: 80, y: 45 },
+      BOX.w,
+      BOX.h,
+      BOX.nw,
+      BOX.nh
+    );
+    expect(r).toEqual({ x: 0.1, y: 0.1, w: 0.4, h: 0.4 });
+  });
+
+  it("returns null for a click (degenerate drag)", () => {
+    const r = dragToRegion(
+      { x: 100, y: 100 },
+      { x: 104, y: 103 },
+      BOX.w,
+      BOX.h,
+      BOX.nw,
+      BOX.nh
+    );
+    expect(r).toBeNull();
+  });
+
+  it("clamps letterbox-margin points onto the content edge", () => {
+    // A 1:1 natural image in the 16:9 box pillarboxes left/right: content is
+    // 450px wide, offset (800-450)/2 = 175. A drag starting in the left
+    // margin clamps to x=0 of the content.
+    const r = dragToRegion(
+      { x: 10, y: 45 },
+      { x: 400, y: 225 },
+      BOX.w,
+      BOX.h,
+      900,
+      900
+    );
+    expect(r).not.toBeNull();
+    expect(r!.x).toBe(0);
+    expect(r!.x + r!.w).toBeCloseTo((400 - 175) / 450, 5);
+    expect(r!.y).toBeCloseTo(0.1, 5);
+  });
+
+  it("returns null when dimensions are unknown", () => {
+    expect(dragToRegion({ x: 0, y: 0 }, { x: 50, y: 50 }, 0, 0, 0, 0)).toBeNull();
+  });
+});
+
+describe("regionToPixelRect", () => {
+  it("rounds to natural pixels", () => {
+    const r = regionToPixelRect({ x: 0.1, y: 0.1, w: 0.4, h: 0.4 }, 1600, 900);
+    expect(r).toEqual({ sx: 160, sy: 90, sw: 640, sh: 360 });
+  });
+
+  it("clamps an edge-hugging box inside the frame", () => {
+    const r = regionToPixelRect({ x: 0.9, y: 0.9, w: 0.2, h: 0.2 }, 1600, 900);
+    expect(r.sx + r.sw).toBeLessThanOrEqual(1600);
+    expect(r.sy + r.sh).toBeLessThanOrEqual(900);
+    expect(r.sw).toBeGreaterThan(0);
+    expect(r.sh).toBeGreaterThan(0);
+  });
+});
+
+describe("regionToDisplayRect", () => {
+  it("places the box on the letterboxed content, not the wrapper", () => {
+    const content = { offsetX: 175, offsetY: 0, width: 450, height: 450 };
+    const r = regionToDisplayRect({ x: 0.5, y: 0.25, w: 0.2, h: 0.1 }, content);
+    expect(r).toEqual({ left: 400, top: 112.5, width: 90, height: 45 });
+  });
+});

--- a/apps/web/lib/edit-mask.ts
+++ b/apps/web/lib/edit-mask.ts
@@ -1,0 +1,101 @@
+import { objectContainRect, type ContainRect } from "./image-click";
+
+/** A drag-selected edit region, normalized 0..1 in natural-image space —
+ *  the same convention as `cropBox` / entity bboxes. Mirrors `edit_region`
+ *  on the wire (packages/config GenerateRequestBody). */
+export interface EditRegionBox {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/** Below this fraction per axis a "drag" is just a click — no selection. */
+const MIN_DRAG_FRAC = 0.02;
+
+function clamp01(n: number): number {
+  if (Number.isNaN(n)) return 0;
+  if (n < 0) return 0;
+  if (n > 1) return 1;
+  return n;
+}
+
+/**
+ * Convert a drag (element-relative pixel start/end) into a normalized
+ * natural-image region, handling object-fit: contain letterboxing — points
+ * in the letterbox margins clamp onto the content edge. Returns null for
+ * degenerate drags (a click) or when dimensions are unknown.
+ */
+export function dragToRegion(
+  start: { x: number; y: number },
+  end: { x: number; y: number },
+  boxWidth: number,
+  boxHeight: number,
+  naturalWidth: number,
+  naturalHeight: number
+): EditRegionBox | null {
+  const content = objectContainRect(
+    boxWidth,
+    boxHeight,
+    naturalWidth,
+    naturalHeight
+  );
+  if (!content) return null;
+  const nx = (px: number) => clamp01((px - content.offsetX) / content.width);
+  const ny = (py: number) => clamp01((py - content.offsetY) / content.height);
+  const x0 = Math.min(nx(start.x), nx(end.x));
+  const y0 = Math.min(ny(start.y), ny(end.y));
+  const w = Math.max(nx(start.x), nx(end.x)) - x0;
+  const h = Math.max(ny(start.y), ny(end.y)) - y0;
+  if (w < MIN_DRAG_FRAC || h < MIN_DRAG_FRAC) return null;
+  return { x: x0, y: y0, w, h };
+}
+
+/** Natural-pixel rect of a region (for canvas drawing), rounded + clamped. */
+export function regionToPixelRect(
+  box: EditRegionBox,
+  naturalWidth: number,
+  naturalHeight: number
+): { sx: number; sy: number; sw: number; sh: number } {
+  const sx = Math.max(0, Math.round(box.x * naturalWidth));
+  const sy = Math.max(0, Math.round(box.y * naturalHeight));
+  const sw = Math.min(naturalWidth - sx, Math.round(box.w * naturalWidth));
+  const sh = Math.min(naturalHeight - sy, Math.round(box.h * naturalHeight));
+  return { sx, sy, sw: Math.max(1, sw), sh: Math.max(1, sh) };
+}
+
+/** Display-pixel rect of a region on the letterboxed content (for overlays). */
+export function regionToDisplayRect(
+  box: EditRegionBox,
+  content: ContainRect
+): { left: number; top: number; width: number; height: number } {
+  return {
+    left: content.offsetX + box.x * content.width,
+    top: content.offsetY + box.y * content.height,
+    width: box.w * content.width,
+    height: box.h * content.height,
+  };
+}
+
+/**
+ * Build the wire mask: an opaque PNG at the image's NATURAL dims, white =
+ * edit / black = keep (flux fill's native convention — the backend adapts
+ * if its model ever changes). Lossless PNG; a JPEG mask would blur the edge.
+ */
+export async function buildMaskPng(
+  naturalWidth: number,
+  naturalHeight: number,
+  box: EditRegionBox
+): Promise<string> {
+  const canvas = document.createElement("canvas");
+  canvas.width = naturalWidth;
+  canvas.height = naturalHeight;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("canvas 2d context unavailable");
+  ctx.fillStyle = "#000";
+  ctx.fillRect(0, 0, naturalWidth, naturalHeight);
+  const { sx, sy, sw, sh } = regionToPixelRect(box, naturalWidth, naturalHeight);
+  ctx.fillStyle = "#fff";
+  ctx.fillRect(sx, sy, sw, sh);
+  return canvas.toDataURL("image/png");
+}


### PR DESCRIPTION
PR-4 of the editing milestone, stacked on #38. The user-facing half of E1: drag a rectangle in edit mode → the instruction box anchors to it → the edit is mask-scoped and judged.

## The gesture

**Plain drag while editMode is on** — additive by construction: every other image gesture (tap, hover-prefetch, Shift-drag scribble) already early-returns on `editMode`, so there is zero muscle-memory conflict. A click-without-drag or Esc clears the selection; toggling edit mode off resets everything. Touch deferred (same as the stroke).

## What's here

- **`lib/edit-mask.ts`** — all the coordinate math, pure and vitest-pinned (8 tests): `dragToRegion` (element px → normalized natural-image box, letterbox margins clamp onto the content edge via the existing `objectContainRect`), `regionToPixelRect`, `regionToDisplayRect`, and `buildMaskPng` (white=edit, natural dims, lossless PNG — the wire convention the backend's fill model speaks natively).
- **`RegionSelectOverlay`** — dashed marquee + single-div box-shadow scrim, StrokeOverlay's presentational pattern.
- **`page.tsx`** — drag handlers inside the existing pointer effect; selection state lives in the editMode lifecycle; `EditForm` re-anchors just under the selection (a style prop, clamped into the figure — no behavior change to the form itself); `submitEdit` spreads `{edit_mask, edit_region}` when a selection exists (mask-build failure falls back to today's whole-image edit); the final frame's `edit_verdict` surfaces as a 6-second toast: *"edit verified 9.0/10 · medium 10.0/10 · 1 attempt"* (E3 owns the persistent chip later).
- Gate: `NEXT_PUBLIC_EDIT_REGION` (build-time, twin of the backend's `EDIT_REGION`) so a UI never offers a drag whose mask a flag-off backend would silently ignore — a whole-image edit after the user drew a box is the worst surprise.

## Verification

`make eval` green: tsc (with `exactOptionalPropertyTypes`), eslint (no new warnings), 487 web tests (8 new), backend suite untouched. With both flags off the page is byte-identical to today — every new code path is behind `EDIT_REGION_ENABLED && editMode`.

End-to-end (backend `EDIT_REGION=1`, web `NEXT_PUBLIC_EDIT_REGION=1`): Edit → drag over a region → type → only the region changes, verdict toast appears, node persists in history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)