### PR TITLE
feat(edit): E3 — every manual edit judged (EDIT_JUDGE) + the verdict chip with revert

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -786,6 +786,99 @@ async def _event_stream(
                 },
                 trace_id,
             )
+            # Judged whole-image edits (EDIT_JUDGE, default off — E3): the same
+            # edit_loop as the mask path, minus the outside gate (no mask = no
+            # confinement promise): alignment judged on the full frame against
+            # the polished instruction + the medium critic vs the source, one
+            # rationale-folding retry, verdict on the final frame. Undecodable
+            # source (remote ref) falls through to the legacy un-judged call.
+            if env_flag("EDIT_JUDGE"):
+                from providers import edit_loop, judge
+                from providers.render_loop import data_url_bytes
+
+                judge_source = data_url_bytes(body.image)
+                if judge_source is not None:
+
+                    async def _render_judged_edit(suffix: str) -> Any:
+                        instr = polished if not suffix else f"{polished}\n\n{suffix}"
+                        return await image_edit_provider.edit_image(
+                            image_data_url=body.image or "",
+                            instruction=instr,
+                            tier=body.image_tier,
+                            model_override=body.image_model,
+                            style_ref_url=edit_style_ref,
+                        )
+
+                    judge_cfg = edit_loop.edit_loop_config_from_env()
+                    judged_attempts: list[Any] = []
+                    async for judged_att in edit_loop.iter_edit_attempts(
+                        _render_judged_edit,
+                        source_bytes=judge_source,
+                        mask_png=None,
+                        region_box=None,
+                        judge_alignment=judge.score_prompt_alignment,
+                        judge_medium=judge.score_style_pair,
+                        instruction=polished,
+                        config=judge_cfg,
+                        abort=_abort_if_disconnected,
+                    ):
+                        judged_attempts.append(judged_att)
+                        # Stream only verdict-REJECTED attempts (a correction
+                        # is coming); a degraded attempt is the final.
+                        if (
+                            not judged_att.accepted
+                            and judged_att.alignment is not None
+                            and judged_att.index + 1 < judge_cfg.max_attempts
+                        ):
+                            frame_b64 = (
+                                await _asyncio.to_thread(
+                                    base64.b64encode, judged_att.image.jpeg_bytes
+                                )
+                            ).decode("ascii")
+                            yield _sse(
+                                {
+                                    "type": "progress",
+                                    "frame_index": judged_att.index,
+                                    "jpeg_b64": frame_b64,
+                                },
+                                trace_id,
+                            )
+                    judged_result = edit_loop.conclude_edit(judged_attempts)
+                    judged_best = judged_result.best
+                    # The loop types images as the Rendered protocol; this is
+                    # the GeneratedImage our render closure returned.
+                    judged_image: Any = judged_result.image
+                    yield _sse(
+                        {
+                            "type": "final",
+                            "image_data_url": image_provider.encode_data_url(
+                                judged_image.jpeg_bytes,
+                                judged_image.mime_type,
+                            ),
+                            "page_title": raw_instruction,
+                            "image_model": judged_image.model,
+                            "prompt_author_model": llm._text_model(online=False),
+                            "session_id": body.session_id,
+                            "final_prompt": polished,
+                            "edit_verdict": {
+                                "alignment": (
+                                    judged_best.alignment.score
+                                    if judged_best.alignment
+                                    else None
+                                ),
+                                "medium": (
+                                    judged_best.medium.score
+                                    if judged_best.medium
+                                    else None
+                                ),
+                                "outside_change": judged_best.outside_change,
+                                "attempts": len(judged_attempts),
+                                "accepted": judged_result.accepted,
+                            },
+                        },
+                        trace_id,
+                    )
+                    return
             edit_result = await image_edit_provider.edit_image(
                 image_data_url=body.image,
                 instruction=polished,

--- a/apps/modal-backend/providers/edit_loop.py
+++ b/apps/modal-backend/providers/edit_loop.py
@@ -18,6 +18,10 @@ into the next fill description (edit_retry_feedback_clause); every attempt
 logged under "edit.loop". A judge failure degrades to single-attempt rather
 than blind re-rolls; an outside-gate breach alone still retries (the
 feedback names it) but pixel-diff itself failing stops the loop.
+
+mask_png=None is the WHOLE-IMAGE judged edit (E3): no confinement promise to
+assert, so the outside gate is simply not applicable — acceptance rides on
+alignment + medium alone and outside_change stays None throughout.
 """
 from __future__ import annotations
 
@@ -129,9 +133,11 @@ def _is_accepted(
     medium: JudgeResult | None,
     config: EditLoopConfig,
 ) -> bool:
-    if outside is None or alignment is None:
-        return False  # no signal — never "accepted", but also no retry
-    if outside > config.outside_change_max:
+    if alignment is None:
+        return False  # no critic signal — never "accepted", but also no retry
+    # outside=None means the gate isn't applicable (whole-image edit, no
+    # mask); a FAILED diff never reaches here (the loop stops first).
+    if outside is not None and outside > config.outside_change_max:
         return False
     if alignment.score < config.accept_alignment:
         return False
@@ -142,7 +148,7 @@ async def iter_edit_attempts[ImageT: Rendered](
     render: Callable[[str], Awaitable[ImageT]],
     *,
     source_bytes: bytes,
-    mask_png: bytes,
+    mask_png: bytes | None,
     region_box: tuple[float, float, float, float] | None,
     judge_alignment: Callable[[str, bytes], Awaitable[JudgeResult]],
     judge_medium: Callable[[bytes, bytes], Awaitable[JudgeResult]],
@@ -180,19 +186,20 @@ async def iter_edit_attempts[ImageT: Rendered](
         outside: float | None = None
         alignment: JudgeResult | None = None
         medium: JudgeResult | None = None
-        try:
-            outside = changed_fraction(
-                source_bytes, image.jpeg_bytes, mask_png, invert_mask=True
-            )
-        except Exception as exc:
-            log(
-                "warn",
-                "edit.loop.diff_failed",
-                attempt=index,
-                error=f"{type(exc).__name__}: {exc}",
-            )
-            yield EditAttempt(index, image, suffix, None, None, None, False, latency)
-            return
+        if mask_png is not None:
+            try:
+                outside = changed_fraction(
+                    source_bytes, image.jpeg_bytes, mask_png, invert_mask=True
+                )
+            except Exception as exc:
+                log(
+                    "warn",
+                    "edit.loop.diff_failed",
+                    attempt=index,
+                    error=f"{type(exc).__name__}: {exc}",
+                )
+                yield EditAttempt(index, image, suffix, None, None, None, False, latency)
+                return
         try:
             alignment = await judge_alignment(
                 instruction, inside_crop_bytes(image.jpeg_bytes, region_box)
@@ -214,7 +221,7 @@ async def iter_edit_attempts[ImageT: Rendered](
             "info",
             "edit.loop",
             attempt=index,
-            outside_change=round(outside, 4),
+            outside_change=round(outside, 4) if outside is not None else None,
             alignment=_score(alignment),
             medium=_score(medium),
             accepted=accepted,
@@ -237,7 +244,7 @@ async def iter_edit_attempts[ImageT: Rendered](
                 if medium is not None and medium.score < config.accept_medium
                 else None
             ),
-            outside_exceeded=outside > config.outside_change_max,
+            outside_exceeded=outside is not None and outside > config.outside_change_max,
         )
 
 
@@ -265,7 +272,7 @@ async def run_edit_loop[ImageT: Rendered](
     render: Callable[[str], Awaitable[ImageT]],
     *,
     source_bytes: bytes,
-    mask_png: bytes,
+    mask_png: bytes | None,
     region_box: tuple[float, float, float, float] | None,
     judge_alignment: Callable[[str, bytes], Awaitable[JudgeResult]],
     judge_medium: Callable[[bytes, bytes], Awaitable[JudgeResult]],

--- a/apps/modal-backend/tests/conftest.py
+++ b/apps/modal-backend/tests/conftest.py
@@ -84,6 +84,8 @@ _SCRUB = (
     "EDIT_REGION_BENCH_LOOP",
     # Mask-scoped judged edits (E1; default OFF until the bench baselines it).
     "EDIT_REGION",
+    # Judged whole-image edits (E3; same loop, no outside gate, default OFF).
+    "EDIT_JUDGE",
     "EDIT_LOOP_MAX_ATTEMPTS",
     "EDIT_LOOP_ACCEPT_ALIGNMENT",
     "EDIT_LOOP_ACCEPT_MEDIUM",

--- a/apps/modal-backend/tests/test_edit_loop.py
+++ b/apps/modal-backend/tests/test_edit_loop.py
@@ -170,6 +170,45 @@ async def test_medium_floor_gates_acceptance() -> None:
     assert "photoreal patch on an engraving" in render.suffixes[1]
 
 
+async def test_no_mask_skips_the_outside_gate() -> None:
+    # Whole-image judged edit (E3): even a frame that changed EVERYWHERE is
+    # acceptable when the judges pass — there was no confinement promise.
+    render = _Render([_outside_edit()])
+    attempts = []
+    async for a in edit_loop.iter_edit_attempts(
+        render,
+        source_bytes=_jpg(_base()),
+        mask_png=None,
+        region_box=None,
+        judge_alignment=_judge(9.0),  # type: ignore[arg-type]
+        judge_medium=_judge(9.0),  # type: ignore[arg-type]
+        instruction="a red panel",
+        config=_CFG,
+    ):
+        attempts.append(a)
+    assert len(attempts) == 1 and attempts[0].accepted
+    assert attempts[0].outside_change is None
+
+
+async def test_no_mask_still_gates_on_the_judges() -> None:
+    render = _Render([_inside_edit(), _inside_edit()])
+    attempts = []
+    async for a in edit_loop.iter_edit_attempts(
+        render,
+        source_bytes=_jpg(_base()),
+        mask_png=None,
+        region_box=None,
+        judge_alignment=_judge(3.0, 9.0, rationale="missed the ask"),  # type: ignore[arg-type]
+        judge_medium=_judge(9.0),  # type: ignore[arg-type]
+        instruction="a red panel",
+        config=_CFG,
+    ):
+        attempts.append(a)
+    assert [a.accepted for a in attempts] == [False, True]
+    assert "missed the ask" in render.suffixes[1]
+    assert "beyond the selected region" not in render.suffixes[1]
+
+
 def test_config_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("EDIT_LOOP_MAX_ATTEMPTS", "3")
     monkeypatch.setenv("EDIT_LOOP_ACCEPT_ALIGNMENT", "8.5")

--- a/apps/modal-backend/tests/test_generate_edit_judge.py
+++ b/apps/modal-backend/tests/test_generate_edit_judge.py
@@ -1,0 +1,218 @@
+"""Integration tests for the EDIT_JUDGE wiring in generate.py (E3).
+
+Judged WHOLE-IMAGE edits: same edit_loop as the mask path, no outside gate
+(no mask = no confinement promise). The gating contract mirrors EDIT_REGION:
+flag off -> exactly today's un-judged path (same provider, same kwargs, same
+final frame shape); flag on -> the legacy provider runs THROUGH the loop and
+the final frame gains edit_verdict (outside_change null). A masked request
+with both flags on takes the EDIT_REGION inpaint path — region wins.
+
+Uses the test_generate_enter.py harness (stubbed modal + AsyncMock providers).
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+import sys
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from PIL import Image, ImageDraw
+
+sys.modules.setdefault("modal", MagicMock())
+
+import providers.image_edit as image_edit_mod  # noqa: E402
+import providers.inpaint as inpaint_mod  # noqa: E402
+import providers.judge as judge_mod  # noqa: E402
+import providers.llm as llm_mod  # noqa: E402
+from generate import GenerateBody, _event_stream  # noqa: E402
+from providers.image import GeneratedImage  # noqa: E402
+from providers.judge import JudgeResult  # noqa: E402
+
+_W, _H = 128, 72
+
+
+def _data_url(im: Image.Image, fmt: str = "JPEG") -> str:
+    buf = io.BytesIO()
+    im.save(buf, fmt)
+    mime = "image/jpeg" if fmt == "JPEG" else "image/png"
+    return f"data:{mime};base64,{base64.b64encode(buf.getvalue()).decode('ascii')}"
+
+
+def _page() -> Image.Image:
+    grad = Image.linear_gradient("L").resize((_W, _H))
+    return Image.merge("RGB", (grad, grad, grad))
+
+
+def _mask_data_url() -> str:
+    m = Image.new("L", (_W, _H), 0)
+    ImageDraw.Draw(m).rectangle((64, 18, 112, 54), fill=255)
+    return _data_url(m, fmt="PNG")
+
+
+async def _collect(agen: Any) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    async for chunk in agen:
+        text = chunk.decode() if isinstance(chunk, bytes) else chunk
+        for block in text.strip().split("\n\n"):
+            block = block.strip()
+            if block.startswith("data:"):
+                events.append(json.loads(block[len("data:") :].strip()))
+    return events
+
+
+def _edit_body(**over: Any) -> GenerateBody:
+    base: dict[str, Any] = {
+        "query": "make the sky purple",
+        "session_id": "s1",
+        "mode": "edit",
+        "image": _data_url(_page()),
+        "edit_instruction": "make the sky purple",
+        "web_search": False,
+    }
+    base.update(over)
+    return GenerateBody(**base)
+
+
+def _mock_polish(monkeypatch: pytest.MonkeyPatch) -> tuple[AsyncMock, AsyncMock]:
+    polish_edit = AsyncMock(return_value="POLISHED")
+    polish_fill = AsyncMock(return_value="DESCRIBED")
+    monkeypatch.setattr(llm_mod, "polish_edit_instruction", polish_edit)
+    monkeypatch.setattr(llm_mod, "polish_fill_description", polish_fill)
+    return polish_edit, polish_fill
+
+
+def _mock_edit(monkeypatch: pytest.MonkeyPatch, body_image: str) -> AsyncMock:
+    raw = base64.b64decode(body_image.split(",", 1)[1])
+    edit = AsyncMock(
+        return_value=GeneratedImage(raw, "image/jpeg", "fal-ai/nano-banana-pro", "r1")
+    )
+    monkeypatch.setattr(image_edit_mod, "edit_image", edit)
+    return edit
+
+
+def _mock_judges(
+    monkeypatch: pytest.MonkeyPatch, alignment_scores: list[float] | None = None
+) -> None:
+    if alignment_scores is None:
+        align: AsyncMock = AsyncMock(return_value=JudgeResult(9.0, "", ""))
+    else:
+        align = AsyncMock(
+            side_effect=[JudgeResult(s, "no purple sky yet", "") for s in alignment_scores]
+        )
+    monkeypatch.setattr(judge_mod, "score_prompt_alignment", align)
+    monkeypatch.setattr(
+        judge_mod, "score_style_pair", AsyncMock(return_value=JudgeResult(9.0, "", ""))
+    )
+
+
+async def test_flag_off_is_byte_identical_legacy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_polish(monkeypatch)
+    body = _edit_body()
+    edit = _mock_edit(monkeypatch, body.image or "")
+
+    events = await _collect(_event_stream(body, "t1"))
+
+    assert edit.await_count == 1
+    assert edit.await_args.kwargs == {
+        "image_data_url": body.image,
+        "instruction": "POLISHED",
+        "tier": None,
+        "model_override": None,
+        "style_ref_url": None,
+    }
+    final = next(e for e in events if e["type"] == "final")
+    assert "edit_verdict" not in final
+
+
+async def test_flag_on_judges_the_whole_image_edit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EDIT_JUDGE", "1")
+    _mock_polish(monkeypatch)
+    _mock_judges(monkeypatch)
+    body = _edit_body()
+    edit = _mock_edit(monkeypatch, body.image or "")
+
+    events = await _collect(_event_stream(body, "t1"))
+
+    assert edit.await_count == 1
+    assert edit.await_args.kwargs["instruction"] == "POLISHED"
+    final = next(e for e in events if e["type"] == "final")
+    assert "image_op" not in final  # still the edit endpoint, not an op change
+    verdict = final["edit_verdict"]
+    assert verdict["accepted"] is True
+    assert verdict["attempts"] == 1
+    assert verdict["alignment"] == 9.0
+    assert verdict["outside_change"] is None  # whole-image: gate not applicable
+
+
+async def test_rejected_attempt_folds_rationale_and_streams(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EDIT_JUDGE", "1")
+    _mock_polish(monkeypatch)
+    _mock_judges(monkeypatch, alignment_scores=[3.0, 9.0])
+    body = _edit_body()
+    edit = _mock_edit(monkeypatch, body.image or "")
+
+    events = await _collect(_event_stream(body, "t1"))
+
+    assert edit.await_count == 2
+    retry_instruction = edit.await_args_list[1].kwargs["instruction"]
+    assert retry_instruction.startswith("POLISHED\n\n")
+    assert "no purple sky yet" in retry_instruction
+    assert any(e["type"] == "progress" for e in events)
+    final = next(e for e in events if e["type"] == "final")
+    assert final["edit_verdict"]["attempts"] == 2
+    assert final["edit_verdict"]["accepted"] is True
+
+
+async def test_region_path_wins_when_both_flags_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EDIT_JUDGE", "1")
+    monkeypatch.setenv("EDIT_REGION", "1")
+    _, polish_fill = _mock_polish(monkeypatch)
+    _mock_judges(monkeypatch)
+    body = _edit_body(
+        edit_mask=_mask_data_url(),
+        edit_region={"x": 0.5, "y": 0.25, "w": 0.375, "h": 0.5},
+    )
+    edit = _mock_edit(monkeypatch, body.image or "")
+    raw = base64.b64decode((body.image or "").split(",", 1)[1])
+    inpaint = AsyncMock(
+        return_value=GeneratedImage(raw, "image/jpeg", "fal-ai/flux-pro/v1/fill", "r2")
+    )
+    monkeypatch.setattr(inpaint_mod, "inpaint_image", inpaint)
+
+    events = await _collect(_event_stream(body, "t1"))
+
+    assert inpaint.await_count == 1
+    assert edit.await_count == 0
+    assert polish_fill.await_count == 1
+    final = next(e for e in events if e["type"] == "final")
+    assert final["image_op"] == "inpaint"
+
+
+async def test_undecodable_source_degrades_to_legacy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EDIT_JUDGE", "1")
+    _mock_polish(monkeypatch)
+    body = _edit_body(image="https://example.com/page.jpg")
+    edit = AsyncMock(
+        return_value=GeneratedImage(b"jpeg", "image/jpeg", "fal-ai/nano-banana-pro", "r1")
+    )
+    monkeypatch.setattr(image_edit_mod, "edit_image", edit)
+
+    events = await _collect(_event_stream(body, "t1"))
+
+    assert edit.await_count == 1
+    final = next(e for e in events if e["type"] == "final")
+    assert "edit_verdict" not in final

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -84,6 +84,7 @@ import {
   type EditRegionBox,
 } from "@/lib/edit-mask";
 import { useContainRect } from "@/hooks/useContainRect";
+import { formatEditVerdict } from "@/lib/edit-verdict";
 import { ImageFailedOverlay } from "@/components/PlayPage/ImageFailedOverlay";
 import { DragDropOverlay } from "@/components/PlayPage/DragDropOverlay";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
@@ -489,7 +490,12 @@ export default function PlayPage() {
     height: number;
   } | null>(null);
   const editDragStartRef = useRef<{ x: number; y: number } | null>(null);
-  const [editToast, setEditToast] = useState<string | null>(null);
+  // The verdict chip (E3): persists while the edited page is current —
+  // cleared by a new generation, navigation, or its own dismiss/revert.
+  const [editVerdictChip, setEditVerdictChip] = useState<{
+    text: string;
+    revertTo: string | null;
+  } | null>(null);
   const containRect = useContainRect(imgRef);
   const editRegionDisplayRect = useMemo(
     () =>
@@ -520,11 +526,6 @@ export default function PlayPage() {
       borderRadius: 9999,
     };
   }, [editRegionDisplayRect, containRect]);
-  useEffect(() => {
-    if (!editToast) return;
-    const timer = window.setTimeout(() => setEditToast(null), 6000);
-    return () => window.clearTimeout(timer);
-  }, [editToast]);
   useEffect(() => {
     if (!editRegion) return;
     const onKey = (e: KeyboardEvent) => {
@@ -590,6 +591,7 @@ export default function PlayPage() {
       abortRef.current = ac;
       setPhase("generating");
       setError(null);
+      setEditVerdictChip(null);
       setStatusMsg(
         body.mode === "tap" ? "Resolving what you tapped…" : "Planning page…"
       );
@@ -683,14 +685,14 @@ export default function PlayPage() {
               // Flip the morph gate so the decode-then-reveal effect runs
               // ONLY on the final image, not on streamed progress partials.
               setMorphFx((prev) => (prev ? { ...prev, isFinal: true } : prev));
-              // Judged mask-scoped edit: surface what the critics saw.
+              // Judged edit: surface what the critics saw, with a one-click
+              // path back to the pre-edit node (undo, made felt).
               if (evt.edit_verdict) {
-                const v = evt.edit_verdict;
-                setEditToast(
-                  v.accepted
-                    ? `edit verified ${v.alignment?.toFixed(1) ?? "—"}/10 · medium ${v.medium?.toFixed(1) ?? "—"}/10 · ${v.attempts} attempt${v.attempts === 1 ? "" : "s"}`
-                    : `edit kept best of ${v.attempts} attempt${v.attempts === 1 ? "" : "s"} — verification gates not all met`
-                );
+                setEditVerdictChip({
+                  text: formatEditVerdict(evt.edit_verdict),
+                  revertTo:
+                    body.mode === "edit" ? body.current_node_id || null : null,
+                });
               }
               void persistNode(
                 {
@@ -1250,12 +1252,14 @@ export default function PlayPage() {
   };
 
   const goBack = useCallback(() => {
+    setEditVerdictChip(null);
     setHistory((prev) =>
       prev.trailIdx <= 0 ? prev : navigateToTrailIdx(prev, prev.trailIdx - 1)
     );
   }, []);
 
   const goForward = useCallback(() => {
+    setEditVerdictChip(null);
     setHistory((prev) =>
       prev.trailIdx >= prev.trail.length - 1
         ? prev
@@ -1264,6 +1268,7 @@ export default function PlayPage() {
   }, []);
 
   const selectFromMap = useCallback((nodeId: string) => {
+    setEditVerdictChip(null);
     setHistory((prev) => {
       const target = prev.items.find((p) => p.nodeId === nodeId);
       if (!target) return prev;
@@ -2622,9 +2627,31 @@ export default function PlayPage() {
                 />
               )}
 
-              {editToast && (
-                <div className="pointer-events-none absolute left-1/2 top-3 z-20 -translate-x-1/2 whitespace-nowrap rounded-full bg-black/70 px-3 py-1 text-xs text-white">
-                  {editToast}
+              {editVerdictChip && (
+                <div className="absolute left-1/2 top-3 z-20 flex -translate-x-1/2 items-center gap-2 whitespace-nowrap rounded-full bg-black/70 px-3 py-1 text-xs text-white">
+                  <span>{editVerdictChip.text}</span>
+                  {editVerdictChip.revertTo && (
+                    <button
+                      type="button"
+                      className="rounded-full bg-white/15 px-2 py-0.5 hover:bg-white/25"
+                      title="Go back to the page as it was before this edit"
+                      onClick={() => {
+                        const id = editVerdictChip.revertTo;
+                        setEditVerdictChip(null);
+                        if (id) selectFromMap(id);
+                      }}
+                    >
+                      ↩ revert
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    aria-label="Dismiss edit verdict"
+                    className="opacity-60 hover:opacity-100"
+                    onClick={() => setEditVerdictChip(null)}
+                  >
+                    ✕
+                  </button>
                 </div>
               )}
 

--- a/apps/web/lib/edit-verdict.test.ts
+++ b/apps/web/lib/edit-verdict.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { formatEditVerdict } from "./edit-verdict";
+
+describe("formatEditVerdict", () => {
+  it("reports an accepted edit with its scores", () => {
+    expect(
+      formatEditVerdict({
+        alignment: 9.0,
+        medium: 10.0,
+        outside_change: 0,
+        attempts: 1,
+        accepted: true,
+      })
+    ).toBe("edit verified 9.0/10 · medium 10.0/10 · 1 attempt");
+  });
+
+  it("pluralizes attempts and admits a kept-best fallback", () => {
+    expect(
+      formatEditVerdict({
+        alignment: 5.5,
+        medium: 8.0,
+        outside_change: null,
+        attempts: 2,
+        accepted: false,
+      })
+    ).toBe("edit kept best of 2 attempts — verification gates not all met");
+  });
+
+  it("renders degraded (null) scores as an em dash", () => {
+    expect(
+      formatEditVerdict({
+        alignment: 9.0,
+        medium: null,
+        outside_change: null,
+        attempts: 1,
+        accepted: true,
+      })
+    ).toBe("edit verified 9.0/10 · medium —/10 · 1 attempt");
+  });
+});

--- a/apps/web/lib/edit-verdict.ts
+++ b/apps/web/lib/edit-verdict.ts
@@ -1,0 +1,12 @@
+import type { EditVerdict } from "@openflipbook/config";
+
+/** The verdict chip's text — what the judges saw on the kept attempt.
+ *  Null scores (a degraded judge, or the not-applicable outside gate on
+ *  whole-image edits) render as an em dash rather than pretending. */
+export function formatEditVerdict(v: EditVerdict): string {
+  const n = (x: number | null) => (x == null ? "—" : x.toFixed(1));
+  const attempts = `${v.attempts} attempt${v.attempts === 1 ? "" : "s"}`;
+  return v.accepted
+    ? `edit verified ${n(v.alignment)}/10 · medium ${n(v.medium)}/10 · ${attempts}`
+    : `edit kept best of ${attempts} — verification gates not all met`;
+}


### PR DESCRIPTION
E3 of the editing milestone (docs/PLAN_EDITING.md), straight after the E1+E5 stack (#36–#39). The old edit box gets the treatment the enter path got.

## Backend — `EDIT_JUDGE` (default off)

Whole-image edits run through the **same `edit_loop`** as the mask path, with the outside gate simply *not applicable* (`mask_png=None` — no mask means no confinement promise to assert):

- **alignment** judged on the full frame against the polished instruction
- **medium** via the style-pair critic vs the source
- one rationale-folding retry, rejected attempts streamed as progress frames (the view-loop UX), every attempt under `edit.loop`
- `edit_verdict` on the final frame with `outside_change: null`

Gating contract, pinned by tests: flag off → byte-identical legacy (same provider, same kwargs verbatim); undecodable source (remote ref) → degrades to the legacy un-judged call; **both flags on + a mask → the EDIT_REGION inpaint path wins** (region precedence).

## Frontend — the verdict chip, undo made felt

The E1 toast grows up: a **persistent chip** (`lib/edit-verdict.ts` formatter, vitest-pinned — including the degraded-judge em-dash case) that stays while the edited page is current, with **↩ revert** jumping back to the pre-edit node via the existing `selectFromMap` (every edit is already a node — now the way back is one click instead of implicit). Clears on new generation, navigation, dismiss. Data-driven: renders only when the backend sends `edit_verdict`, so no new frontend flag.

## Tests

18 backend (edit-loop no-mask semantics: outside gate skipped but judges still gate; the five EDIT_JUDGE gating scenarios) + 3 web. `make eval` green (490 web / full backend suite).

Flag stays OFF: per the house rule it earns default-on through a bench — the cheap path is a no-mask arm on the existing `eval-edit-region` runner, noted for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)