### PR TITLE
feat(web): E2 — the right-click menu knows what you clicked

### DIFF
--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -17,9 +17,11 @@ import {
   annotateClickPoint,
   annotateStroke,
   normalizeClickOnImage,
+  objectContainRect,
   summarizeStroke,
   type NormalizedClick,
 } from "@/lib/image-click";
+import { entityAtPoint, padBox, type EntityHit } from "@/lib/entity-hit";
 import {
   getWSUrl,
   startLTXStream,
@@ -43,7 +45,7 @@ import { getStrings, resolveOutputLocale } from "@/lib/i18n";
 import { useImageTier, useVideoTier } from "@/hooks/usePersistedTier";
 import { useExpandBloom } from "@/hooks/useExpandBloom";
 import { type Ascended, useAscend } from "@/hooks/useAscend";
-import { buildConditionRefs, orderedRefs } from "@/lib/image-condition";
+import { buildConditionRefs, cropBox, orderedRefs } from "@/lib/image-condition";
 import { enterAsToRenderMode, findRevisitTarget } from "@/lib/world-mode";
 import { usePersistedLocale } from "@/hooks/usePersistedLocale";
 import { usePersistedTheme } from "@/hooks/usePersistedTheme";
@@ -72,7 +74,7 @@ import Breadcrumb from "@/components/PlayPage/Breadcrumb";
 import SpatialPath from "@/components/PlayPage/SpatialPath";
 import { buildBreadcrumb } from "@/lib/breadcrumb";
 import { EntityHoverOverlay } from "@/components/PlayPage/EntityHoverOverlay";
-import { ContextMenu } from "@/components/PlayPage/ContextMenu";
+import { ContextMenu, type ContextMenuItem } from "@/components/PlayPage/ContextMenu";
 import { HoverCrosshair } from "@/components/PlayPage/HoverCrosshair";
 import { HintPrompt } from "@/components/PlayPage/HintPrompt";
 import { EditForm } from "@/components/PlayPage/EditForm";
@@ -403,9 +405,20 @@ export default function PlayPage() {
   // reads the draft as in-progress, not done.
   const [progressiveDraft, setProgressiveDraft] = useState(false);
   const [beaconsHidden, setBeaconsHidden] = useState(false);
+  // Right-click target resolution (E2): the menu is geo-aware — `hit` is the
+  // codex entity under the cursor (per-node bbox containment), `clickPct` the
+  // normalized image point (null when the click landed outside the content,
+  // e.g. on the letterbox). Both null → just the page-level menu items.
   const [contextMenu, setContextMenu] = useState<{
     xPx: number;
     yPx: number;
+    clickPct: NormalizedClick | null;
+    hit: EntityHit | null;
+  } | null>(null);
+  // Seeds the codex's geo editor ("move/resize this…" routes there).
+  const [geoEditPrefill, setGeoEditPrefill] = useState<{
+    text: string;
+    nonce: number;
   } | null>(null);
   const { bindTrace } = useTraceEmitter();
   const { state: worldState, mutate: mutateWorldEntity } =
@@ -1154,25 +1167,26 @@ export default function PlayPage() {
     promptForHint,
   ]);
 
-  const submitEdit = useCallback(
-    async (e: FormEvent<HTMLFormElement>) => {
-      e.preventDefault();
-      const instruction = editInstruction.trim();
+  // The edit primitive: the EditForm submits through it, and the context
+  // menu's one-click actions (fix/redraw, remove) call it directly with a
+  // canned instruction + the target's padded bbox.
+  const runEdit = useCallback(
+    async (instruction: string, region: EditRegionBox | null) => {
       if (!instruction || !page?.imageDataUrl) return;
       // Select-area edit: a committed selection rides along as a white=edit
       // mask PNG at natural dims + the region box (judge crop scope). Mask
       // build failure falls back to today's whole-image edit.
       let maskFields: Partial<GenerateRequestBody> = {};
       const imgEl = imgRef.current;
-      if (EDIT_REGION_ENABLED && editRegion && imgEl?.naturalWidth) {
+      if (EDIT_REGION_ENABLED && region && imgEl?.naturalWidth) {
         try {
           maskFields = {
             edit_mask: await buildMaskPng(
               imgEl.naturalWidth,
               imgEl.naturalHeight,
-              editRegion
+              region
             ),
-            edit_region: editRegion,
+            edit_region: region,
           };
         } catch {
           /* whole-image fallback */
@@ -1217,8 +1231,116 @@ export default function PlayPage() {
       setEditMode(false);
       setEditRegion(null);
     },
-    [editInstruction, page, generate, imageTier, outputLocale, styleAnchor, history, editRegion]
+    [page, generate, imageTier, outputLocale, styleAnchor, history]
   );
+
+  const submitEdit = useCallback(
+    async (e: FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      await runEdit(editInstruction.trim(), editRegion);
+    },
+    [runEdit, editInstruction, editRegion]
+  );
+
+  // The context menu's "Enter {entity}": a synthetic click on the image at
+  // the entity's bbox centre, so the EXISTING tap flow runs verbatim —
+  // revisit check, world-mode routing, condition refs, morph — instead of a
+  // drifting re-implementation.
+  const dispatchTapAt = useCallback((xPct: number, yPct: number) => {
+    const img = imgRef.current;
+    if (!img) return;
+    const rect = img.getBoundingClientRect();
+    const content = objectContainRect(
+      rect.width,
+      rect.height,
+      img.naturalWidth,
+      img.naturalHeight
+    );
+    if (!content) return;
+    img.dispatchEvent(
+      new MouseEvent("click", {
+        clientX: rect.left + content.offsetX + xPct * content.width,
+        clientY: rect.top + content.offsetY + yPct * content.height,
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+  }, []);
+
+  // The geo-aware section of the right-click menu (E2): target-aware actions
+  // routed to the primitives that already exist — runEdit (E1 mask path),
+  // the tap flow, the codex's NL geometry editor. Pure derivation from the
+  // resolved target; the ContextMenu component stays dumb.
+  const contextExtraItems = useMemo<ContextMenuItem[]>(() => {
+    if (!contextMenu || phase === "generating") return [];
+    const items: ContextMenuItem[] = [];
+    const close = () => setContextMenu(null);
+    if (contextMenu.hit) {
+      const { entity, bbox } = contextMenu.hit;
+      items.push({
+        label: `Enter ${entity.name}`,
+        onClick: () => {
+          close();
+          dispatchTapAt(bbox.x_pct + bbox.w_pct / 2, bbox.y_pct + bbox.h_pct / 2);
+        },
+      });
+      if (EDIT_REGION_ENABLED) {
+        items.push({
+          label: `Fix / redraw ${entity.name}`,
+          onClick: () => {
+            close();
+            void runEdit(
+              `redraw the ${entity.name} cleanly, repairing any glitches or artifacts`,
+              padBox(bbox)
+            );
+          },
+        });
+        items.push({
+          label: `Remove ${entity.name}`,
+          danger: true,
+          onClick: () => {
+            close();
+            void runEdit(`remove the ${entity.name}`, padBox(bbox));
+          },
+        });
+      }
+      if (geoMap.entities.length > 0) {
+        items.push({
+          label: `Move / resize ${entity.name}…`,
+          onClick: () => {
+            close();
+            setGeoEditPrefill({ text: `move the ${entity.name} `, nonce: Date.now() });
+            setCodexOpen(true);
+          },
+        });
+      }
+    } else if (contextMenu.clickPct && EDIT_REGION_ENABLED) {
+      const region = cropBox(
+        contextMenu.clickPct.x_pct,
+        contextMenu.clickPct.y_pct,
+        0.25
+      );
+      items.push({
+        label: "Add something here…",
+        onClick: () => {
+          close();
+          setEditMode(true);
+          setEditRegion(region);
+          setEditInstruction("add ");
+        },
+      });
+      items.push({
+        label: "Edit this area",
+        onClick: () => {
+          close();
+          setEditMode(true);
+          setEditRegion(region);
+          setEditInstruction("");
+        },
+      });
+    }
+    return items;
+  }, [contextMenu, phase, dispatchTapAt, runEdit, geoMap.entities.length]);
 
   const canGoBack = history.trailIdx > 0;
   const canGoForward = history.trailIdx < history.trail.length - 1;
@@ -2519,8 +2641,21 @@ export default function PlayPage() {
             if (!page?.imageDataUrl) return;
             e.preventDefault();
             // ContextMenu renders inside a fixed-positioned overlay, so it
-            // anchors to the viewport — pass clientX/Y directly.
-            setContextMenu({ xPx: e.clientX, yPx: e.clientY });
+            // anchors to the viewport — pass clientX/Y directly. Resolve what
+            // is under the cursor while we're here: the menu is geo-aware.
+            const imgEl = imgRef.current;
+            const clickPct = imgEl
+              ? normalizeClickOnImage(e.nativeEvent, imgEl)
+              : null;
+            const hit = clickPct
+              ? entityAtPoint(
+                  worldState.entities,
+                  page?.nodeId ?? null,
+                  clickPct.x_pct,
+                  clickPct.y_pct
+                )
+              : null;
+            setContextMenu({ xPx: e.clientX, yPx: e.clientY, clickPct, hit });
           }}
         >
           {page.sources && page.sources.length > 0 && (
@@ -2999,6 +3134,7 @@ export default function PlayPage() {
         overrideEnabled={worldState.overrideEnabled}
         onMutate={mutateWorldEntity}
         geoEditSessionId={sessionId}
+        geoEditPrefill={geoEditPrefill}
       />
 
       {/* Hide the coach while the Around tray is open — both are pinned to
@@ -3044,6 +3180,7 @@ export default function PlayPage() {
         <ContextMenu
           x={contextMenu.xPx}
           y={contextMenu.yPx}
+          extraItems={contextExtraItems}
           beaconsHidden={beaconsHidden}
           canCopy={!!page?.nodeId}
           canPrune={

--- a/apps/web/components/PlayPage/CodexPanel.tsx
+++ b/apps/web/components/PlayPage/CodexPanel.tsx
@@ -30,6 +30,9 @@ interface Props {
   // NL-editable map section. Omitted → the section is absent (no behaviour
   // change), so this stays additive + opt-in.
   geoEditSessionId?: string;
+  // Seed the geo editor's instruction box (the context menu's "move/resize
+  // this…" routes here). Forwarded verbatim to GeoEditSection.
+  geoEditPrefill?: { text: string; nonce: number } | null | undefined;
 }
 
 interface UndoToastState {
@@ -80,6 +83,7 @@ export function CodexPanel({
   overrideEnabled,
   onMutate,
   geoEditSessionId,
+  geoEditPrefill,
 }: Props) {
   const [tab, setTab] = useState<TabKind>("all");
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
@@ -262,7 +266,7 @@ export function CodexPanel({
               <h3 className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide opacity-60">
                 Map · geometry
               </h3>
-              <GeoEditSection sessionId={geoEditSessionId} />
+              <GeoEditSection sessionId={geoEditSessionId} prefill={geoEditPrefill} />
             </section>
           )}
         </div>

--- a/apps/web/components/PlayPage/ContextMenu.tsx
+++ b/apps/web/components/PlayPage/ContextMenu.tsx
@@ -1,5 +1,13 @@
 "use client";
 
+/** A target-aware action contributed by the parent (the geo-aware section:
+ *  fix/remove/enter THIS entity, add-something-here on empty ground). */
+export interface ContextMenuItem {
+  label: string;
+  onClick: () => void;
+  danger?: boolean;
+}
+
 interface Props {
   x: number;
   y: number;
@@ -12,10 +20,14 @@ interface Props {
   onToggleBeacons: () => void;
   onSavePostcard: () => void;
   onClose: () => void;
+  // Rendered ABOVE the page-level actions, divider-separated. The menu stays
+  // dumb: the parent owns target resolution and what each item does.
+  extraItems?: ContextMenuItem[] | undefined;
 }
 
 /**
- * Right-click page menu: copy permalink, save postcard, toggle beacons,
+ * Right-click page menu: target-aware actions (when the parent resolved what
+ * is under the cursor), then copy permalink, save postcard, toggle beacons,
  * prune branch. Positioned absolutely at the click coordinates; click-outside
  * on the full-screen backdrop dismisses.
  */
@@ -31,6 +43,7 @@ export function ContextMenu({
   onToggleBeacons,
   onSavePostcard,
   onClose,
+  extraItems,
 }: Props) {
   return (
     <div className="fixed inset-0 z-[55]" onClick={onClose}>
@@ -39,6 +52,26 @@ export function ContextMenu({
         style={{ left: x, top: y }}
         onClick={(e) => e.stopPropagation()}
       >
+        {extraItems && extraItems.length > 0 && (
+          <>
+            {extraItems.map((item) => (
+              <button
+                key={item.label}
+                type="button"
+                className={
+                  "block w-full px-3 py-1.5 text-left " +
+                  (item.danger
+                    ? "text-red-700 hover:bg-red-500/10"
+                    : "hover:bg-[var(--color-ink)]/10")
+                }
+                onClick={item.onClick}
+              >
+                {item.label}
+              </button>
+            ))}
+            <div className="my-1 border-t border-[var(--color-edge)]" />
+          </>
+        )}
         <button
           type="button"
           className="block w-full px-3 py-1.5 text-left hover:bg-[var(--color-ink)]/10 disabled:opacity-50"

--- a/apps/web/components/PlayPage/GeoEditPanel.tsx
+++ b/apps/web/components/PlayPage/GeoEditPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import type { EntityEditPlan, WorldEntityGeo } from "@openflipbook/config";
 
@@ -9,6 +9,9 @@ interface Props {
   // Resolve an instruction to a plan. dryRun=true previews (no write); dryRun=false
   // applies. Wired to POST /api/world/:id/edit-entities by the container.
   onSubmit: (instruction: string, dryRun: boolean) => Promise<EntityEditPlan>;
+  // Seed the instruction box from outside (the context menu's "move/resize
+  // this…"); the nonce makes repeat prefills with identical text still land.
+  prefill?: { text: string; nonce: number } | null | undefined;
 }
 
 type Phase = "idle" | "busy" | "confirm";
@@ -17,11 +20,19 @@ type Phase = "idle" | "busy" | "confirm";
 // chip, takes a natural-language edit, previews the structured plan + its
 // blast-radius ("restages N scenes"), then applies on confirm. Presentational —
 // the network lives in onSubmit. Rendered only behind the world-override flag.
-export default function GeoEditPanel({ entities, onSubmit }: Props) {
+export default function GeoEditPanel({ entities, onSubmit, prefill }: Props) {
   const [instruction, setInstruction] = useState("");
   const [plan, setPlan] = useState<EntityEditPlan | null>(null);
   const [phase, setPhase] = useState<Phase>("idle");
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!prefill) return;
+    setInstruction(prefill.text);
+    setPlan(null);
+    setError(null);
+    setPhase("idle");
+  }, [prefill]);
 
   const preview = async () => {
     const instr = instruction.trim();

--- a/apps/web/components/PlayPage/GeoEditSection.tsx
+++ b/apps/web/components/PlayPage/GeoEditSection.tsx
@@ -11,13 +11,14 @@ import GeoEditPanel from "./GeoEditPanel";
 
 interface Props {
   sessionId: string;
+  prefill?: { text: string; nonce: number } | null | undefined;
 }
 
 // Self-contained container for the geometric-world editor: hydrates the session
 // map, wires the NL-edit route (preview via dry_run, then apply), refetches the
 // chips after a write. Drop in behind WORLD_OVERRIDE_ENABLED + GEOMETRIC_WORLD;
 // inert (empty map) when the geo flag is off, so it's safe to mount either way.
-export default function GeoEditSection({ sessionId }: Props) {
+export default function GeoEditSection({ sessionId, prefill }: Props) {
   const { entities, refetch } = useWorldMap(sessionId);
 
   const onSubmit = useCallback(
@@ -41,5 +42,5 @@ export default function GeoEditSection({ sessionId }: Props) {
     [sessionId, refetch],
   );
 
-  return <GeoEditPanel entities={entities} onSubmit={onSubmit} />;
+  return <GeoEditPanel entities={entities} onSubmit={onSubmit} prefill={prefill} />;
 }

--- a/apps/web/lib/entity-hit.test.ts
+++ b/apps/web/lib/entity-hit.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import type { Entity, EntityBBox } from "@openflipbook/config";
+
+import { entityAtPoint, padBox } from "./entity-hit";
+
+function _entity(
+  name: string,
+  bboxes: Record<string, EntityBBox>
+): Entity {
+  return {
+    id: name,
+    kind: "place",
+    name,
+    aliases: [],
+    appearance: "",
+    reference_image_url: null,
+    facts: [],
+    state: {},
+    first_seen_node_id: "n1",
+    last_seen_node_id: "n1",
+    appears_on_node_ids: Object.keys(bboxes),
+    appearance_bboxes: bboxes,
+    pinned_by_user: false,
+    confidence: 1,
+    updated_at: "",
+  };
+}
+
+const HARBOR = _entity("harbor", {
+  n1: { x_pct: 0.1, y_pct: 0.1, w_pct: 0.8, h_pct: 0.8 },
+});
+const LIGHTHOUSE = _entity("lighthouse", {
+  n1: { x_pct: 0.15, y_pct: 0.15, w_pct: 0.1, h_pct: 0.25 },
+});
+
+describe("entityAtPoint", () => {
+  it("returns the entity whose bbox contains the point", () => {
+    const hit = entityAtPoint([HARBOR], "n1", 0.5, 0.5);
+    expect(hit?.entity.name).toBe("harbor");
+  });
+
+  it("prefers the smallest box when bboxes overlap", () => {
+    const hit = entityAtPoint([HARBOR, LIGHTHOUSE], "n1", 0.2, 0.3);
+    expect(hit?.entity.name).toBe("lighthouse");
+  });
+
+  it("ignores entities not localized on this node", () => {
+    expect(entityAtPoint([HARBOR], "other-node", 0.5, 0.5)).toBeNull();
+    expect(entityAtPoint([HARBOR], null, 0.5, 0.5)).toBeNull();
+  });
+
+  it("misses outside every bbox", () => {
+    expect(entityAtPoint([LIGHTHOUSE], "n1", 0.9, 0.9)).toBeNull();
+  });
+});
+
+describe("padBox", () => {
+  it("grows the box by the pad on every side", () => {
+    const r = padBox({ x_pct: 0.3, y_pct: 0.3, w_pct: 0.2, h_pct: 0.2 }, 0.05);
+    expect(r.x).toBeCloseTo(0.25, 10);
+    expect(r.y).toBeCloseTo(0.25, 10);
+    expect(r.w).toBeCloseTo(0.3, 10);
+    expect(r.h).toBeCloseTo(0.3, 10);
+  });
+
+  it("clamps at the frame edges", () => {
+    const r = padBox({ x_pct: 0.0, y_pct: 0.9, w_pct: 0.15, h_pct: 0.1 }, 0.05);
+    expect(r.x).toBe(0);
+    expect(r.y).toBeCloseTo(0.85, 5);
+    expect(r.y + r.h).toBeCloseTo(1, 5);
+  });
+});

--- a/apps/web/lib/entity-hit.ts
+++ b/apps/web/lib/entity-hit.ts
@@ -1,0 +1,54 @@
+import type { Entity, EntityBBox } from "@openflipbook/config";
+
+import type { EditRegionBox } from "./edit-mask";
+
+/** What the right-click landed on: a codex entity localized on THIS page. */
+export interface EntityHit {
+  entity: Entity;
+  bbox: EntityBBox;
+}
+
+/**
+ * Hit-test a normalized image point against the entities localized on the
+ * given node (their per-node `appearance_bboxes`). Plain bbox containment;
+ * when boxes overlap the SMALLEST one wins — right-clicking the lighthouse
+ * shouldn't select the whole harbor it sits in. Works without world mode:
+ * the bboxes come from extraction, not the geo map.
+ */
+export function entityAtPoint(
+  entities: Entity[],
+  nodeId: string | null,
+  xPct: number,
+  yPct: number
+): EntityHit | null {
+  if (!nodeId) return null;
+  let best: EntityHit | null = null;
+  let bestArea = Infinity;
+  for (const entity of entities) {
+    const bbox = entity.appearance_bboxes?.[nodeId];
+    if (!bbox) continue;
+    if (
+      xPct >= bbox.x_pct &&
+      xPct <= bbox.x_pct + bbox.w_pct &&
+      yPct >= bbox.y_pct &&
+      yPct <= bbox.y_pct + bbox.h_pct
+    ) {
+      const area = bbox.w_pct * bbox.h_pct;
+      if (area < bestArea) {
+        best = { entity, bbox };
+        bestArea = area;
+      }
+    }
+  }
+  return best;
+}
+
+/** An entity bbox grown by `pad` per side (clamped) — the edit region for a
+ *  one-click fix/remove, with margin so the seam blends past the subject. */
+export function padBox(bbox: EntityBBox, pad = 0.04): EditRegionBox {
+  const x0 = Math.max(0, bbox.x_pct - pad);
+  const y0 = Math.max(0, bbox.y_pct - pad);
+  const x1 = Math.min(1, bbox.x_pct + bbox.w_pct + pad);
+  const y1 = Math.min(1, bbox.y_pct + bbox.h_pct + pad);
+  return { x: x0, y: y0, w: x1 - x0, h: y1 - y0 };
+}


### PR DESCRIPTION
E2 of the editing milestone: the geo-aware context menu — the discoverability layer over the primitives E1/E3 shipped. Frontend only; zero new backend concepts.

## Target resolution

Right-click on the page resolves what's under the cursor: `lib/entity-hit.ts` hit-tests the click against the codex entities' per-node `appearance_bboxes` (plain containment, **smallest box wins** — clicking the lighthouse shouldn't select the harbor it sits in; vitest-pinned). Works without world mode — the bboxes come from extraction.

## The menu (additive — plain left-tap untouched)

The existing `ContextMenu` gains a dumb `extraItems` section above its page-level actions; the parent owns what each item does:

**On an entity:**
- **Enter {name}** — a synthetic click at the bbox centre, so the *real* tap flow runs verbatim (revisit check, world-mode routing, condition refs, morph) instead of a drifting re-implementation
- **Fix / redraw {name}** / **Remove {name}** — one-click `runEdit` with the padded bbox as the mask region: the E1 inpaint path, judged when `EDIT_REGION` is on (`remove the X` flows through the fill register, which describes the background that should remain)
- **Move / resize {name}…** — prefills the codex's NL geometry editor (new `prefill` prop threaded CodexPanel → GeoEditSection → GeoEditPanel) and opens the codex; shown when the geo map has entities

**On empty ground:** **Add something here…** / **Edit this area** — edit mode with a default region around the click, instruction box focused.

Region-scoped items are gated on `NEXT_PUBLIC_EDIT_REGION` (the menu never offers a mask a flag-off backend would silently ignore); Enter and Move/resize work regardless.

## Plumbing

`submitEdit` refactored over a shared `runEdit(instruction, region)` primitive — the form and the menu's one-click actions now drive the same code path. Menu disabled while generating.

## Verification

`make eval` green: 496 web tests (6 new), tsc, eslint (no new warnings). With no entities localized on the page the menu shows exactly today's items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)