### PR TITLE
feat(web): E4 — pixels and world model finally talking

### DIFF
--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ChangeEvent, CSSProperties, DragEvent, FormEvent } from "react";
 import type {
   Citation,
+  EntityEditPlan,
   GenerateRequestBody,
   GenerateEvent,
   MapCrop,
@@ -22,6 +23,7 @@ import {
   type NormalizedClick,
 } from "@/lib/image-click";
 import { entityAtPoint, padBox, type EntityHit } from "@/lib/entity-hit";
+import { applyPlanInstruction } from "@/lib/geo-to-edit";
 import {
   getWSUrl,
   startLTXStream,
@@ -1242,6 +1244,24 @@ export default function PlayPage() {
     [runEdit, editInstruction, editRegion]
   );
 
+  // E4 apply-to-image: a just-landed geo plan becomes ONE page edit in the
+  // repair register ("keep everything else exactly as it is — only adjust:
+  // move the lighthouse north"). Coordinates moved; the pixels follow —
+  // judged by the edit loop when its flags are on.
+  const geoApplyToImage = useCallback(
+    (plan: EntityEditPlan, entitiesAtApply: WorldEntityGeo[]) => {
+      const frame =
+        geoMap.bounds.w > 0 && geoMap.bounds.h > 0
+          ? { w: geoMap.bounds.w, h: geoMap.bounds.h }
+          : { w: 100, h: 60 };
+      const instruction = applyPlanInstruction(plan.edits, entitiesAtApply, frame);
+      if (!instruction) return;
+      setCodexOpen(false);
+      void runEdit(instruction, null);
+    },
+    [geoMap.bounds, runEdit]
+  );
+
   // The context menu's "Enter {entity}": a synthetic click on the image at
   // the entity's bbox centre, so the EXISTING tap flow runs verbatim —
   // revisit check, world-mode routing, condition refs, morph — instead of a
@@ -1301,6 +1321,10 @@ export default function PlayPage() {
           onClick: () => {
             close();
             void runEdit(`remove the ${entity.name}`, padBox(bbox));
+            // E4: the pixels go AND the world model follows — soft delete
+            // with the codex's existing 10s undo; the edited page's
+            // re-extraction won't re-add what's no longer drawn.
+            void mutateWorldEntity({ op: "delete", id: entity.id });
           },
         });
       }
@@ -1340,7 +1364,7 @@ export default function PlayPage() {
       });
     }
     return items;
-  }, [contextMenu, phase, dispatchTapAt, runEdit, geoMap.entities.length]);
+  }, [contextMenu, phase, dispatchTapAt, runEdit, geoMap.entities.length, mutateWorldEntity]);
 
   const canGoBack = history.trailIdx > 0;
   const canGoForward = history.trailIdx < history.trail.length - 1;
@@ -3135,6 +3159,7 @@ export default function PlayPage() {
         onMutate={mutateWorldEntity}
         geoEditSessionId={sessionId}
         geoEditPrefill={geoEditPrefill}
+        onGeoApplyToImage={geoApplyToImage}
       />
 
       {/* Hide the coach while the Around tray is open — both are pinned to

--- a/apps/web/components/PlayPage/CodexPanel.tsx
+++ b/apps/web/components/PlayPage/CodexPanel.tsx
@@ -3,7 +3,9 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type {
   Entity,
+  EntityEditPlan,
   EntityKind,
+  WorldEntityGeo,
   WorldEntityMutation,
 } from "@openflipbook/config";
 
@@ -33,6 +35,10 @@ interface Props {
   // Seed the geo editor's instruction box (the context menu's "move/resize
   // this…" routes here). Forwarded verbatim to GeoEditSection.
   geoEditPrefill?: { text: string; nonce: number } | null | undefined;
+  // E4 apply-to-image: after a geo plan lands, let the pixels follow.
+  onGeoApplyToImage?:
+    | ((plan: EntityEditPlan, entitiesAtApply: WorldEntityGeo[]) => void)
+    | undefined;
 }
 
 interface UndoToastState {
@@ -84,6 +90,7 @@ export function CodexPanel({
   onMutate,
   geoEditSessionId,
   geoEditPrefill,
+  onGeoApplyToImage,
 }: Props) {
   const [tab, setTab] = useState<TabKind>("all");
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
@@ -266,7 +273,11 @@ export function CodexPanel({
               <h3 className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide opacity-60">
                 Map · geometry
               </h3>
-              <GeoEditSection sessionId={geoEditSessionId} prefill={geoEditPrefill} />
+              <GeoEditSection
+                sessionId={geoEditSessionId}
+                prefill={geoEditPrefill}
+                onApplyToImage={onGeoApplyToImage}
+              />
             </section>
           )}
         </div>

--- a/apps/web/components/PlayPage/GeoEditPanel.tsx
+++ b/apps/web/components/PlayPage/GeoEditPanel.tsx
@@ -12,6 +12,14 @@ interface Props {
   // Seed the instruction box from outside (the context menu's "move/resize
   // this…"); the nonce makes repeat prefills with identical text still land.
   prefill?: { text: string; nonce: number } | null | undefined;
+  // E4 apply-to-image: offered after a successful apply — the coordinates
+  // moved, this lets the PIXELS follow (parent turns the plan into a page
+  // edit). `entitiesAtApply` is the pre-apply snapshot, so a removed
+  // entity's label is still resolvable after the map refetches. Omitted →
+  // no affordance (the panel stays usable standalone).
+  onApplyToImage?:
+    | ((plan: EntityEditPlan, entitiesAtApply: WorldEntityGeo[]) => void)
+    | undefined;
 }
 
 type Phase = "idle" | "busy" | "confirm";
@@ -20,9 +28,20 @@ type Phase = "idle" | "busy" | "confirm";
 // chip, takes a natural-language edit, previews the structured plan + its
 // blast-radius ("restages N scenes"), then applies on confirm. Presentational —
 // the network lives in onSubmit. Rendered only behind the world-override flag.
-export default function GeoEditPanel({ entities, onSubmit, prefill }: Props) {
+export default function GeoEditPanel({
+  entities,
+  onSubmit,
+  prefill,
+  onApplyToImage,
+}: Props) {
   const [instruction, setInstruction] = useState("");
   const [plan, setPlan] = useState<EntityEditPlan | null>(null);
+  // The last plan that LANDED on the map + the entity snapshot it applied
+  // against — the apply-to-image offer's subject.
+  const [appliedPlan, setAppliedPlan] = useState<{
+    plan: EntityEditPlan;
+    entities: WorldEntityGeo[];
+  } | null>(null);
   const [phase, setPhase] = useState<Phase>("idle");
   const [error, setError] = useState<string | null>(null);
 
@@ -30,6 +49,7 @@ export default function GeoEditPanel({ entities, onSubmit, prefill }: Props) {
     if (!prefill) return;
     setInstruction(prefill.text);
     setPlan(null);
+    setAppliedPlan(null);
     setError(null);
     setPhase("idle");
   }, [prefill]);
@@ -59,6 +79,7 @@ export default function GeoEditPanel({ entities, onSubmit, prefill }: Props) {
     setError(null);
     try {
       await onSubmit(instruction.trim(), false);
+      setAppliedPlan(plan ? { plan, entities: [...entities] } : null);
       setPlan(null);
       setInstruction("");
       setPhase("idle");
@@ -170,6 +191,33 @@ export default function GeoEditPanel({ entities, onSubmit, prefill }: Props) {
             </div>
           </div>
         )
+      )}
+
+      {appliedPlan && onApplyToImage && phase === "idle" && !plan && (
+        <div
+          className="flex items-center gap-2 rounded border border-emerald-200 bg-emerald-50 p-2 text-xs text-stone-700"
+          data-testid="apply-to-image"
+        >
+          <span>✓ map updated — the page's pixels haven't moved yet.</span>
+          <button
+            type="button"
+            className="rounded bg-emerald-600 px-2 py-1 text-white"
+            onClick={() => {
+              const p = appliedPlan;
+              setAppliedPlan(null);
+              onApplyToImage(p.plan, p.entities);
+            }}
+          >
+            Apply to image
+          </button>
+          <button
+            type="button"
+            className="rounded px-1.5 py-1 text-stone-500"
+            onClick={() => setAppliedPlan(null)}
+          >
+            Skip
+          </button>
+        </div>
       )}
 
       {error && (

--- a/apps/web/components/PlayPage/GeoEditSection.tsx
+++ b/apps/web/components/PlayPage/GeoEditSection.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback } from "react";
 
-import type { EntityEditPlan } from "@openflipbook/config";
+import type { EntityEditPlan, WorldEntityGeo } from "@openflipbook/config";
 
 import { useWorldMap } from "@/hooks/useWorldMap";
 import { TRACE_HEADER, newTraceId } from "@/lib/trace";
@@ -12,13 +12,16 @@ import GeoEditPanel from "./GeoEditPanel";
 interface Props {
   sessionId: string;
   prefill?: { text: string; nonce: number } | null | undefined;
+  onApplyToImage?:
+    | ((plan: EntityEditPlan, entitiesAtApply: WorldEntityGeo[]) => void)
+    | undefined;
 }
 
 // Self-contained container for the geometric-world editor: hydrates the session
 // map, wires the NL-edit route (preview via dry_run, then apply), refetches the
 // chips after a write. Drop in behind WORLD_OVERRIDE_ENABLED + GEOMETRIC_WORLD;
 // inert (empty map) when the geo flag is off, so it's safe to mount either way.
-export default function GeoEditSection({ sessionId, prefill }: Props) {
+export default function GeoEditSection({ sessionId, prefill, onApplyToImage }: Props) {
   const { entities, refetch } = useWorldMap(sessionId);
 
   const onSubmit = useCallback(
@@ -42,5 +45,12 @@ export default function GeoEditSection({ sessionId, prefill }: Props) {
     [sessionId, refetch],
   );
 
-  return <GeoEditPanel entities={entities} onSubmit={onSubmit} prefill={prefill} />;
+  return (
+    <GeoEditPanel
+      entities={entities}
+      onSubmit={onSubmit}
+      prefill={prefill}
+      onApplyToImage={onApplyToImage}
+    />
+  );
 }

--- a/apps/web/lib/geo-to-edit.test.ts
+++ b/apps/web/lib/geo-to-edit.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import type { WorldEntityGeo } from "@openflipbook/config";
+
+import { applyPlanInstruction, compassFor } from "./geo-to-edit";
+
+const FRAME = { w: 100, h: 60 };
+
+function _geo(id: string, label: string, height = 10): WorldEntityGeo {
+  return {
+    id,
+    entity_id: null,
+    kind: "place",
+    label,
+    pos: { x: 50, y: 30 },
+    height,
+    footprint: { w: 8, d: 8 },
+  } as WorldEntityGeo;
+}
+
+const ENTITIES = [_geo("g1", "lighthouse"), _geo("g2", "stone castle", 15)];
+
+describe("compassFor", () => {
+  it("names the cardinal directions (+x east, +y south)", () => {
+    expect(compassFor(0, -10)).toBe("north");
+    expect(compassFor(10, 0)).toBe("east");
+    expect(compassFor(-10, 10)).toBe("south-west");
+  });
+
+  it("drops a noise minor axis", () => {
+    expect(compassFor(10, 1)).toBe("east");
+  });
+});
+
+describe("applyPlanInstruction", () => {
+  it("phrases a move with magnitude and direction", () => {
+    const text = applyPlanInstruction(
+      [{ op: "move", target: "g1", dx: 0, dy: -40 }],
+      ENTITIES,
+      FRAME
+    );
+    expect(text).toContain("move the lighthouse far north");
+    expect(text).toContain("Keep the existing scene");
+    expect(text.endsWith(".")).toBe(true);
+  });
+
+  it("phrases small moves as slight", () => {
+    const text = applyPlanInstruction(
+      [{ op: "move", target: "g1", dx: 4, dy: 0 }],
+      ENTITIES,
+      FRAME
+    );
+    expect(text).toContain("move the lighthouse slightly east");
+  });
+
+  it("phrases add with frame-third bins and remove by label", () => {
+    const text = applyPlanInstruction(
+      [
+        { op: "add", label: "windmill", pos: { x: 90, y: 10 } },
+        { op: "remove", target: "g2" },
+      ],
+      ENTITIES,
+      FRAME
+    );
+    expect(text).toContain("add a windmill on the right, toward the top of the frame");
+    expect(text).toContain("remove the stone castle");
+    expect(text).toContain("; ");
+  });
+
+  it("compares set_height against the current entity", () => {
+    const taller = applyPlanInstruction(
+      [{ op: "set_height", target: "g2", height: 30 }],
+      ENTITIES,
+      FRAME
+    );
+    expect(taller).toContain("make the stone castle taller");
+    const shorter = applyPlanInstruction(
+      [{ op: "set_height", target: "g2", height: 5 }],
+      ENTITIES,
+      FRAME
+    );
+    expect(shorter).toContain("make the stone castle shorter");
+  });
+
+  it("falls back to the raw target id when the entity is unknown", () => {
+    const text = applyPlanInstruction(
+      [{ op: "remove", target: "ghost-9" }],
+      ENTITIES,
+      FRAME
+    );
+    expect(text).toContain("remove the ghost-9");
+  });
+
+  it("returns empty for an empty plan", () => {
+    expect(applyPlanInstruction([], ENTITIES, FRAME)).toBe("");
+  });
+});

--- a/apps/web/lib/geo-to-edit.ts
+++ b/apps/web/lib/geo-to-edit.ts
@@ -1,0 +1,96 @@
+import type { EntityGeoEdit, WorldEntityGeo } from "@openflipbook/config";
+
+/**
+ * E4's apply-to-image: a just-applied geo edit plan becomes ONE image-edit
+ * instruction for the current page, in the proven repair_instruction register
+ * (providers/prompt_library/layout.py — "keep everything else exactly as it
+ * is, only adjust: …"). Coordinates moved; now the pixels follow.
+ *
+ * Pure text building — directions come from the plan's own deltas (world
+ * frame is map-aligned: +x east, +y south on a north-up map), magnitudes
+ * from the delta relative to the frame. Returns "" for a plan with nothing
+ * an image edit can express.
+ */
+
+/** Compass phrase for a world-space delta (+x east, +y south). */
+export function compassFor(dx: number, dy: number): string {
+  const parts: string[] = [];
+  const ax = Math.abs(dx);
+  const ay = Math.abs(dy);
+  // Drop the minor axis when it's noise next to the major one.
+  if (ay > 0 && ay >= ax * 0.4) parts.push(dy < 0 ? "north" : "south");
+  if (ax > 0 && ax >= ay * 0.4) parts.push(dx < 0 ? "west" : "east");
+  return parts.join("-") || "in place";
+}
+
+function magnitudeFor(dx: number, dy: number, frame: { w: number; h: number }): string {
+  const f = Math.max(
+    Math.abs(dx) / Math.max(1e-6, frame.w),
+    Math.abs(dy) / Math.max(1e-6, frame.h)
+  );
+  if (f < 0.1) return "slightly ";
+  if (f > 0.3) return "far ";
+  return "";
+}
+
+function labelFor(target: string, entities: WorldEntityGeo[]): string {
+  return entities.find((e) => e.id === target)?.label ?? target;
+}
+
+function positionPhrase(
+  pos: { x: number; y: number },
+  frame: { w: number; h: number }
+): string {
+  const x = pos.x / Math.max(1e-6, frame.w);
+  const y = pos.y / Math.max(1e-6, frame.h);
+  const h = x < 1 / 3 ? "on the left" : x > 2 / 3 ? "on the right" : "in the center";
+  const v = y < 1 / 3 ? "toward the top" : y > 2 / 3 ? "toward the bottom" : "at mid-height";
+  return `${h}, ${v} of the frame`;
+}
+
+export function applyPlanInstruction(
+  edits: EntityGeoEdit[],
+  entities: WorldEntityGeo[],
+  frame: { w: number; h: number }
+): string {
+  const parts: string[] = [];
+  for (const edit of edits) {
+    switch (edit.op) {
+      case "move":
+        parts.push(
+          `move the ${labelFor(edit.target, entities)} ${magnitudeFor(
+            edit.dx,
+            edit.dy,
+            frame
+          )}${compassFor(edit.dx, edit.dy)}`
+        );
+        break;
+      case "remove":
+        parts.push(`remove the ${labelFor(edit.target, entities)}`);
+        break;
+      case "add":
+        parts.push(`add a ${edit.label} ${positionPhrase(edit.pos, frame)}`);
+        break;
+      case "set_height": {
+        const current = entities.find((e) => e.id === edit.target);
+        const taller = !current || edit.height >= current.height;
+        parts.push(
+          `make the ${labelFor(edit.target, entities)} ${taller ? "taller" : "shorter"}`
+        );
+        break;
+      }
+      case "set_appearance":
+        parts.push(
+          `change the ${labelFor(edit.target, entities)} so it looks like: ${edit.visual}`
+        );
+        break;
+    }
+  }
+  if (parts.length === 0) return "";
+  return (
+    "Keep the existing scene, its art medium, colour palette and everything " +
+    "else exactly as they are — only adjust: " +
+    parts.join("; ") +
+    "."
+  );
+}


### PR DESCRIPTION
E4 of the editing milestone — the last feature letter. Two directions, both closing loops that have been open since the geo build:

## Geo → pixels: "Apply to image"

After an NL geo edit lands (`move the lighthouse north` — coordinates moved, pixels didn't), the geo panel now offers **Apply to image**: `lib/geo-to-edit.ts` turns the applied plan into one page edit in the proven repair register (*"Keep the existing scene, its art medium, colour palette and everything else exactly as they are — only adjust: move the lighthouse far north."*). Compass comes from the plan's own deltas (+x east, +y south on the north-up map), magnitude from the delta vs the frame (`slightly`/`far`), add-ops binned by frame thirds. Pure and vitest-pinned (8 tests). The panel snapshots its entities at apply time so a removed entity's label survives the post-apply refetch; the page runs the instruction through `runEdit` — whole-image, judged when `EDIT_JUDGE` is on, verdict chip + revert for free.

## Pixels → geo: removal that sticks

The context menu's **Remove {entity}** now soft-deletes the codex entity alongside the pixel edit, via the existing mutation machinery (10-second undo toast included) — an edited-away tower leaves the world model. Re-extraction (already wired for every final, edits included) won't re-add what's no longer drawn.

## Plumbing

`onApplyToImage` threaded GeoEditPanel → GeoEditSection → CodexPanel → page (all optional props — the panel stays usable standalone); the post-apply offer renders as a small "✓ map updated — the page's pixels haven't moved yet" row with Apply/Skip.

## Verification

`make eval` green: 504 web tests (8 new), tsc, eslint clean of new warnings. Every addition is behind an optional prop or an existing flag — byte-identical UX when unused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)