### PR TITLE
feat(eval): EDIT_REGION_BENCH_WHOLE — the EDIT_JUDGE arm on the edit bench

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,8 @@ eval-edit-mask-smoke:
 # E5: the mask-scoped edit bench — the asked change LANDS (alignment judge on
 # the inside crop), the edit CONFINES (outside pixel-diff, free, per-case),
 # the MEDIUM holds (style judge). EDIT_REGION_BENCH_MODELS adds A/B arms;
-# EDIT_REGION_BENCH_LOOP=1 measures the production edit loop. PAID (~$1).
+# EDIT_REGION_BENCH_LOOP=1 measures the production edit loop;
+# EDIT_REGION_BENCH_WHOLE=1 adds the EDIT_JUDGE whole-image arm. PAID (~$1).
 eval-edit-region:
 	cd apps/modal-backend && EDIT_REGION_BENCH_RUN=1 .venv/bin/python -m tests.edit_bench.runner
 # The before/after regression sweep: every PAID eval that has a committed

--- a/apps/modal-backend/tests/conftest.py
+++ b/apps/modal-backend/tests/conftest.py
@@ -82,6 +82,7 @@ _SCRUB = (
     "EDIT_REGION_BENCH_RUN",
     "EDIT_REGION_BENCH_MODELS",
     "EDIT_REGION_BENCH_LOOP",
+    "EDIT_REGION_BENCH_WHOLE",
     # Mask-scoped judged edits (E1; default OFF until the bench baselines it).
     "EDIT_REGION",
     # Judged whole-image edits (E3; same loop, no outside gate, default OFF).

--- a/apps/modal-backend/tests/edit_bench/runner.py
+++ b/apps/modal-backend/tests/edit_bench/runner.py
@@ -244,7 +244,56 @@ async def _run_case(case: Case) -> CaseResult:
         )
         for arm, override in _arm_models()
     ]
+    if os.environ.get("EDIT_REGION_BENCH_WHOLE"):
+        arms.append(await _score_whole_image_arm(case, src_bytes, src_url))
     return CaseResult(name=case.name, description=description, arms=arms)
+
+
+async def _score_whole_image_arm(
+    case: Case, src_bytes: bytes, src_url: str
+) -> ArmResult:
+    """EDIT_REGION_BENCH_WHOLE=1: the EDIT_JUDGE axes (E3) on the same cases —
+    the instruction through the WHOLE-IMAGE edit path (polish_edit_instruction
+    register + the edit endpoint, balanced tier), alignment judged on the full
+    frame. `outside` here records the WHOLE-FRAME changed fraction: not a
+    gate (there's no confinement promise), but the honest number next to
+    fill's surgical patch. Reported, never gated (not the production arm)."""
+    from providers import image_edit, judge, llm, pixel_diff
+
+    polished = await llm.polish_edit_instruction(
+        instruction=case.instruction,
+        page_title=case.name.replace("_", " "),
+        style_anchor=case.style,
+    )
+    rendered = None
+    for attempt in range(2):
+        try:
+            rendered = await image_edit.edit_image(src_url, polished)
+            break
+        except Exception as exc:  # bench resilience — reported, not fatal
+            print(f"[edit-bench] {case.name}/whole_image attempt {attempt + 1} failed: {exc}")
+    if rendered is None:
+        return ArmResult(
+            arm="whole_image",
+            model="edit-tier-default",
+            alignment=0.0,
+            outside=1.0,
+            medium=0.0,
+            alignment_rationale="render failed twice (fal)",
+        )
+    out_bytes = rendered.jpeg_bytes
+    (_REPORTS / f"edit_{case.name}_whole_image.jpg").write_bytes(out_bytes)
+    churn = pixel_diff.changed_fraction(src_bytes, out_bytes, None)
+    align = await judge.score_prompt_alignment(polished, out_bytes)
+    medium = await judge.score_style_pair(src_bytes, out_bytes)
+    return ArmResult(
+        arm="whole_image",
+        model=rendered.model,
+        alignment=align.score,
+        outside=round(churn, 4),
+        medium=medium.score,
+        alignment_rationale=align.rationale,
+    )
 
 
 def summarize(results: list[CaseResult]) -> dict[str, Any]:


### PR DESCRIPTION
The follow-up #40 promised: `EDIT_JUDGE` (judged whole-image edits) gets benchable the cheap way — an opt-in `whole_image` arm on the existing `eval-edit-region` runner.

`EDIT_REGION_BENCH_WHOLE=1` runs each case's instruction through the **whole-image** edit path (the `polish_edit_instruction` register + the edit endpoint, balanced tier), scores alignment on the full frame + the medium critic, and records the **whole-frame churn fraction** in the `outside` column — not a gate (no confinement promise), but the honest number to read next to fill's surgical 0.0000s.

Reported, never gated: `summarize()` only gates the production arm, so the committed `edit_region` baseline and the default run are byte-identical. Free suite + ruff + mypy green; conftest scrubs the new env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)