### PR TITLE
feat(graph): relation "edit" — a revision, not a place inside

### DIFF
--- a/apps/web/app/api/nodes/route.ts
+++ b/apps/web/app/api/nodes/route.ts
@@ -19,7 +19,7 @@ interface CreateBody {
   final_prompt?: string | null;
   click_in_parent?: { x_pct: number; y_pct: number } | null;
   sources?: { url: string; title: string | null }[] | null;
-  relation?: "descend" | "expand" | "ascend";
+  relation?: "descend" | "expand" | "ascend" | "edit";
   scale?: "component" | "peer" | "container";
   scale_tier?: ScaleTier | null;
   scene_view?: SceneView | null;

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -160,7 +160,7 @@ interface PersistBody {
   final_prompt: string;
   click_in_parent?: { x_pct: number; y_pct: number } | null;
   sources?: { url: string; title: string | null }[] | null;
-  relation?: "descend" | "expand";
+  relation?: "descend" | "expand" | "edit";
   scale?: "component" | "peer" | "container";
   scale_tier?: ScaleTier;
   scene_view?: SceneView | null;
@@ -720,6 +720,9 @@ export default function PlayPage() {
                   prompt_author_model: evt.prompt_author_model,
                   aspect_ratio: body.aspect_ratio,
                   final_prompt: evt.final_prompt,
+                  // An edit is a REVISION of the current page, not a place
+                  // inside it — the graph chrome renders it as "✎ edited".
+                  ...(body.mode === "edit" ? { relation: "edit" as const } : {}),
                   click_in_parent:
                     body.mode === "tap" && body.click
                       ? {

--- a/apps/web/components/atlas-view.tsx
+++ b/apps/web/components/atlas-view.tsx
@@ -436,7 +436,7 @@ export default function AtlasView({
           <div
             className="flex items-center gap-2 pl-1 opacity-60"
             data-testid="atlas-legend"
-            title="Tile frame colour = view level · ↓ inside (tap-in) · ⤢ expanded (neighbour)"
+            title="Tile frame colour = view level · ↓ inside (tap-in) · ⤢ expanded (neighbour) · ✎ edited (revision)"
           >
             {NODE_KIND_LEGEND.map((lv) => (
               <span key={lv.label} className="flex items-center gap-0.5">
@@ -519,9 +519,11 @@ export default function AtlasView({
                 const delay = reduced ? 0 : childDepth * STAGGER_MS;
                 // Breadth (expand) edges read in teal with a hollow anchor —
                 // no tap happened, the world bloomed outward. Depth (descend)
-                // edges keep the ink line + red tap dot.
-                const isExpand =
-                  (byId.get(c.toNodeId)?.relation ?? "descend") === "expand";
+                // edges keep the ink line + red tap dot. Revision (edit)
+                // edges read in violet tight dots — the same page, changed.
+                const relC = byId.get(c.toNodeId)?.relation ?? "descend";
+                const isExpand = relC === "expand";
+                const isEdit = relC === "edit";
                 // Fade an edge with the node it points at, so it reveals/hides
                 // in lockstep with the LOD band.
                 const lod = lodOn
@@ -534,20 +536,27 @@ export default function AtlasView({
                 return (
                   <g
                     key={c.fromNodeId + "->" + c.toNodeId}
-                    data-relation={isExpand ? "expand" : "descend"}
+                    data-relation={relC}
                     opacity={lod}
                   >
                     <path
                       d={arcPath(c.from, c.to)}
                       fill="none"
-                      stroke={isExpand ? "rgba(13,148,136,0.65)" : "rgba(15,15,15,0.7)"}
+                      stroke={
+                        isEdit
+                          ? "rgba(124,58,237,0.65)"
+                          : isExpand
+                            ? "rgba(13,148,136,0.65)"
+                            : "rgba(15,15,15,0.7)"
+                      }
                       strokeWidth={8}
                       strokeLinecap="round"
                       // A "descend" edge is the zoom path you want to FOLLOW
                       // (City -> place -> sub-part) — draw it as a clear dashed
                       // line, not the near-invisible 2/24 dotting that made the
-                      // nested maps read as detached. "expand" stays subtle.
-                      strokeDasharray={isExpand ? "3 16" : "16 9"}
+                      // nested maps read as detached. "expand" stays subtle;
+                      // "edit" (a revision) reads as violet tight dots.
+                      strokeDasharray={isEdit ? "2 10" : isExpand ? "3 16" : "16 9"}
                       markerEnd={
                         isExpand
                           ? "url(#ofb-atlas-arrow-expand)"
@@ -560,20 +569,22 @@ export default function AtlasView({
                           : { animationDelay: `${delay}ms, ${delay}ms` }
                       }
                     />
-                    <circle
-                      cx={c.from.x}
-                      cy={c.from.y}
-                      r={14}
-                      fill={isExpand ? "none" : "rgba(239,68,68,0.85)"}
-                      stroke={isExpand ? "rgba(13,148,136,0.85)" : "white"}
-                      strokeWidth={4}
-                      className={reduced ? undefined : "ofb-edge-draw"}
-                      style={
-                        reduced
-                          ? undefined
-                          : { animationDelay: `${delay}ms` }
-                      }
-                    />
+                    {!isEdit && (
+                      <circle
+                        cx={c.from.x}
+                        cy={c.from.y}
+                        r={14}
+                        fill={isExpand ? "none" : "rgba(239,68,68,0.85)"}
+                        stroke={isExpand ? "rgba(13,148,136,0.85)" : "white"}
+                        strokeWidth={4}
+                        className={reduced ? undefined : "ofb-edge-draw"}
+                        style={
+                          reduced
+                            ? undefined
+                            : { animationDelay: `${delay}ms` }
+                        }
+                      />
+                    )}
                   </g>
                 );
               })}
@@ -605,7 +616,7 @@ export default function AtlasView({
                 key={p.nodeId}
                 data-tile="1"
                 data-node-id={p.nodeId}
-                data-relation={isExpand ? "expand" : "descend"}
+                data-relation={p.relation ?? "descend"}
                 data-scale-level={scaleLevel}
                 className={
                   "absolute overflow-visible " +
@@ -753,7 +764,13 @@ export default function AtlasView({
                     <div className="text-xs uppercase tracking-wide opacity-50">
                       depth {depth}
                       {p.parentId
-                        ? ` · ${isExpand ? "expanded from" : "child of"} ${truncate(byId.get(p.parentId)?.title ?? "?", 40)}`
+                        ? ` · ${
+                            (p.relation ?? "descend") === "edit"
+                              ? "edited from"
+                              : isExpand
+                                ? "expanded from"
+                                : "child of"
+                          } ${truncate(byId.get(p.parentId)?.title ?? "?", 40)}`
                         : " · root"}
                       {p.scale && p.scale !== "peer" ? ` · ${p.scale}` : ""}
                     </div>

--- a/apps/web/components/world-map.tsx
+++ b/apps/web/components/world-map.tsx
@@ -255,26 +255,38 @@ export default function WorldMap({
               const c1y = c.from.y + dy * 0.33 + py * bend;
               const c2x = c.from.x + dx * 0.67 - px * bend;
               const c2y = c.from.y + dy * 0.67 - py * bend;
-              const isExpand = relById.get(c.toNodeId) === "expand";
+              const rel = relById.get(c.toNodeId) ?? "descend";
+              const isExpand = rel === "expand";
+              // A revision edge: violet, tight dots, no tap anchor — the
+              // child IS the parent, changed, not a place you tapped into.
+              const isEdit = rel === "edit";
               return (
-                <g key={c.fromNodeId + "->" + c.toNodeId}>
+                <g key={c.fromNodeId + "->" + c.toNodeId} data-relation={rel}>
                   <path
                     d={`M ${c.from.x} ${c.from.y} C ${c1x} ${c1y}, ${c2x} ${c2y}, ${c.to.x} ${c.to.y}`}
                     fill="none"
-                    stroke={isExpand ? "rgba(13,148,136,0.6)" : "rgba(15,15,15,0.55)"}
+                    stroke={
+                      isEdit
+                        ? "rgba(124,58,237,0.6)"
+                        : isExpand
+                          ? "rgba(13,148,136,0.6)"
+                          : "rgba(15,15,15,0.55)"
+                    }
                     strokeWidth={8}
                     strokeLinecap="round"
-                    strokeDasharray={isExpand ? "10 16" : "2 22"}
+                    strokeDasharray={isEdit ? "2 10" : isExpand ? "10 16" : "2 22"}
                     markerEnd={isExpand ? "url(#ofb-arrow-expand)" : "url(#ofb-arrow)"}
                   />
-                  <circle
-                    cx={c.from.x}
-                    cy={c.from.y}
-                    r={14}
-                    fill={isExpand ? "rgba(13,148,136,0.85)" : "rgba(239,68,68,0.85)"}
-                    stroke="white"
-                    strokeWidth={4}
-                  />
+                  {!isEdit && (
+                    <circle
+                      cx={c.from.x}
+                      cy={c.from.y}
+                      r={14}
+                      fill={isExpand ? "rgba(13,148,136,0.85)" : "rgba(239,68,68,0.85)"}
+                      stroke="white"
+                      strokeWidth={4}
+                    />
+                  )}
                 </g>
               );
             })}

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -116,7 +116,7 @@ export interface NodeDoc extends Document {
   // M3 scale-space: how this node relates to its parent ("descend" = tap-in /
   // default, "expand" = bloomed neighbour, "ascend" = OUTWARD container) + its
   // size vs the parent's focal subject. Optional + defaulted for back-compat.
-  relation?: "descend" | "expand" | "ascend" | null;
+  relation?: "descend" | "expand" | "ascend" | "edit" | null;
   scale?: "component" | "peer" | "container" | null;
   // B2 scale ladder: the coarse absolute rung this node's frame sits at.
   // Optional + null for pre-B2 rows.
@@ -142,7 +142,7 @@ export interface NodeInsert {
   final_prompt: string | null;
   click_in_parent?: ClickInParent | null;
   sources?: NodeSource[] | null;
-  relation?: "descend" | "expand" | "ascend" | null;
+  relation?: "descend" | "expand" | "ascend" | "edit" | null;
   scale?: "component" | "peer" | "container" | null;
   scale_tier?: ScaleTier | null;
   scene_view?: SceneView | null;
@@ -161,7 +161,7 @@ export interface NodeRow {
   final_prompt: string | null;
   click_in_parent: ClickInParent | null;
   sources: NodeSource[];
-  relation: "descend" | "expand" | "ascend";
+  relation: "descend" | "expand" | "ascend" | "edit";
   scale: "component" | "peer" | "container";
   scale_tier: ScaleTier | null;
   // The observer pose + view level this node was rendered from. Null on

--- a/apps/web/lib/node-kind.test.ts
+++ b/apps/web/lib/node-kind.test.ts
@@ -30,4 +30,12 @@ describe("nodeKind", () => {
     expect(k.levelLabel).toBe("page");
     expect(k.levelColor).toBe("#9ca3af"); // neutral frame for pre-geo nodes
   });
+
+  it("an edit reads as a revision, never as inside", () => {
+    // The Ankh-Morpork atlas bug: the edited map rendered as a child
+    // "inside" the root — two near-identical maps stacked as parent/child.
+    const k = nodeKind({ level: "map", relation: "edit", isRoot: false });
+    expect(k.relGlyph).toBe("✎");
+    expect(k.relLabel).toBe("edited");
+  });
 });

--- a/apps/web/lib/node-kind.ts
+++ b/apps/web/lib/node-kind.ts
@@ -29,7 +29,7 @@ export const NODE_KIND_LEGEND = [LEVELS.map, LEVELS.building, LEVELS.eye];
 // root map don't all read the same. Pure; the data already lives on every node.
 export function nodeKind(opts: {
   level?: ViewLevel | null;
-  relation?: "descend" | "expand" | "ascend" | null;
+  relation?: "descend" | "expand" | "ascend" | "edit" | null;
   isRoot: boolean;
 }): NodeKind {
   const lv = (opts.level && LEVELS[opts.level]) || PAGE_FALLBACK;
@@ -39,7 +39,9 @@ export function nodeKind(opts: {
       ? { glyph: "⤢", label: "expanded" }
       : opts.relation === "ascend"
         ? { glyph: "⤡", label: "container" } // OUTWARD — the synthesized parent
-        : { glyph: "↓", label: "inside" };
+        : opts.relation === "edit"
+          ? { glyph: "✎", label: "edited" } // a REVISION, not a place inside
+          : { glyph: "↓", label: "inside" };
   return {
     levelGlyph: lv.glyph,
     levelLabel: lv.label,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -63,8 +63,10 @@ export function finerTier(t: ScaleTier): ScaleTier {
 
 // How a node relates to its parent: "descend" = went IN (a tap child, the
 // default), "expand" = bloomed OUT (a neighbour from mode:"expand"), "ascend" =
-// zoomed OUT to a synthesized container (the OUTWARD reparent, SCALE_OUTWARD).
-export type NodeRelation = "descend" | "expand" | "ascend";
+// zoomed OUT to a synthesized container (the OUTWARD reparent, SCALE_OUTWARD),
+// "edit" = a REVISION of the parent (mode:"edit") — the same page changed, not
+// a place inside it, so the graph chrome must not read it as a tap-in.
+export type NodeRelation = "descend" | "expand" | "ascend" | "edit";
 
 export type ImageTier = "fast" | "balanced" | "pro";
 


### PR DESCRIPTION
F2 of the demo post-mortem (the Ankh-Morpork atlas bug): edits persisted relation-less, defaulted to `descend`, and the atlas rendered the edited map as a child **↓ inside** its own previous version — two near-identical maps stacked as parent/child.

`NodeRelation` gains `"edit"`, additive end to end: config wire type → the play page persists it on `mode:"edit"` finals → `/api/nodes` → the db layer. The shared `nodeKind` vocabulary renders it **✎ edited** (one fix covers the atlas and the session map), edges become violet tight-dots with **no tap anchor** (an edit has no tap point — the child IS the parent, changed), hover text says *edited from*, and the legend teaches the glyph.

Existing nodes are untouched (absent relation still defaults to descend); 505 web tests green including the pinned regression: *an edit reads as a revision, never as inside*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)