### PR TITLE
feat(edit): the fill register anchors scale — masks are canvases

### DIFF
--- a/apps/modal-backend/providers/llm.py
+++ b/apps/modal-backend/providers/llm.py
@@ -1570,20 +1570,29 @@ async def polish_fill_description(
     smoke) paint what you describe, they don't follow commands. "add a red
     balloon here" -> "a single bright red hot-air balloon floating over the
     sea". Removals describe the background that should remain. The medium
-    lock is appended deterministically (fill takes no style ref image).
+    lock AND a scale anchor are appended deterministically (fill takes no
+    style ref image, and it paints the WHOLE mask — without the anchor a
+    "small ferry" comes out region-sized, the Ankh-Morpork lesson).
 
     Unlike polish_edit_instruction there is no long-instruction skip: a
     command stays a command however long it is — the register conversion IS
-    the point. LLM failure degrades to the raw instruction + medium lock.
+    the point. LLM failure degrades to the raw instruction + the locks.
     """
     instruction = instruction.strip()
     if not instruction:
         return instruction
 
     def _locked(text: str) -> str:
+        # Fill's mask IS its canvas: anchor size to the surroundings or the
+        # subject inflates to fill the selection edge-to-edge.
+        anchored = (
+            f"{text} Drawn to scale with the surrounding scene — nearby "
+            "buildings, figures and objects set the size reference; the "
+            "subject does not fill the region edge-to-edge."
+        )
         if style_anchor:
-            return f"{text} In the existing art medium: {style_anchor}."
-        return text
+            return f"{anchored} In the existing art medium: {style_anchor}."
+        return anchored
 
     client = _client()
     system = (

--- a/apps/modal-backend/tests/test_llm_provider.py
+++ b/apps/modal-backend/tests/test_llm_provider.py
@@ -1125,3 +1125,46 @@ async def test_propose_neighbors_end_to_end(monkeypatch: pytest.MonkeyPatch) -> 
     assert len(out) == 1
     assert out[0].subject == "Factory"
     assert out[0].scale == "container"
+
+
+# --- the fill register (mask-scoped edits, E1/F3) ------------------------------
+
+
+async def test_polish_fill_appends_scale_anchor_and_medium_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Fill paints the WHOLE mask — the deterministic scale anchor is what
+    # keeps a "small ferry" from coming out region-sized (the Ankh-Morpork
+    # lesson), and the medium lock rides after it.
+    fake = _FakeClient([_fake_response(content="a small wooden ferry on the river")])
+    monkeypatch.setattr(llm, "_client", lambda: fake)
+    out = await llm.polish_fill_description(
+        "add a small ferry", style_anchor="aged parchment"
+    )
+    assert out.startswith("a small wooden ferry on the river")
+    assert "Drawn to scale with the surrounding scene" in out
+    assert out.index("Drawn to scale") < out.index("aged parchment")
+    assert out.endswith("In the existing art medium: aged parchment.")
+
+
+async def test_polish_fill_degrades_with_both_locks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeClient([RuntimeError("llm down")])
+    monkeypatch.setattr(llm, "_client", lambda: fake)
+    out = await llm.polish_fill_description(
+        "add a small ferry", style_anchor="aged parchment"
+    )
+    assert out.startswith("add a small ferry")
+    assert "Drawn to scale with the surrounding scene" in out
+    assert "aged parchment" in out
+
+
+async def test_polish_fill_scale_anchor_without_style(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeClient([_fake_response(content="a quiet pond")])
+    monkeypatch.setattr(llm, "_client", lambda: fake)
+    out = await llm.polish_fill_description("add a pond")
+    assert "Drawn to scale with the surrounding scene" in out
+    assert "art medium" not in out

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -1339,10 +1339,12 @@ export default function PlayPage() {
         });
       }
     } else if (contextMenu.clickPct && EDIT_REGION_ENABLED) {
+      // Fill paints the whole mask, so the default region IS the default
+      // object size — keep it modest (the palace-sized ferry lesson).
       const region = cropBox(
         contextMenu.clickPct.x_pct,
         contextMenu.clickPct.y_pct,
-        0.25
+        0.18
       );
       items.push({
         label: "Add something here…",


### PR DESCRIPTION
F3 of the demo post-mortem: flux fill paints the whole mask, so the selection's size IS the subject's size — the demo's *small wooden ferry* came out steamboat-sized. Structural fix, same shape as the medium lock: `polish_fill_description` appends a deterministic **scale anchor** on every path (including LLM-failure degradation), ordered before the medium lock; the context menu's default add-region shrinks 0.25 → 0.18. Three register tests pin the clause order and the degrade path. The `edit_region` baseline's next paid run will confirm alignment holds (band 2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)