### PR TITLE
feat(loop): the medium critic joins the render loop — every enter judged

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -1631,16 +1631,15 @@ async def _event_stream(
             # dispatch: explicit per-request model > the steep-aware router
             # pick (enter_model_slug, resolved above with the view).
             enter_style_ref = _condition_url_for_role(body, "style")
-            # The render loop (VIEW_LOOP, default ON): steep transforms are
-            # the measured ~50% one-shot path — judge each attempt, fold the
-            # critic's rationale into a single retry, keep the best. Aerial
-            # registers + legacy enters keep the zero-overhead one-shot path.
-            view_loop = (
-                enter_view is not None
-                and str(enter_view.get("projection") or "")
-                in model_router.STEEP_ENTER_PROJECTIONS
-                and env_flag("VIEW_LOOP", "true")
-            )
+            # The render loop (VIEW_LOOP, default ON): EVERY deliberate-camera
+            # enter is judged — same-place + medium floors always, conformance
+            # per projection. The loop used to arm on steep projections only
+            # (eye_level/top_down, the measured ~50% one-shot path); the
+            # Ankh-Morpork demo showed an OBLIQUE enter drifting medium and
+            # identity with nothing to catch it — the text medium lock is
+            # advisory to loose-ref models, so the gate has to be a judge.
+            # Legacy (no deliberate view) enters keep the one-shot path.
+            view_loop = enter_view is not None and env_flag("VIEW_LOOP", "true")
             log(
                 "info",
                 "tap.enter_edit",
@@ -1689,6 +1688,9 @@ async def _event_stream(
                     judge_same_place=judge.score_continuation,
                     config=loop_cfg,
                     judge_detail=_judge_detail,
+                    # The medium gate: the entered view must look drawn by the
+                    # same hand as the tapped region (style_pair vs the crop).
+                    judge_medium=judge.score_style_pair,
                     family=enter_family,
                     abort=_abort_if_disconnected,
                 ):

--- a/apps/modal-backend/providers/prompt_library/feedback.py
+++ b/apps/modal-backend/providers/prompt_library/feedback.py
@@ -23,11 +23,13 @@ def retry_feedback_clause(
     conformance_rationale: str | None = None,
     same_place_rationale: str | None = None,
     detail_rationale: str | None = None,
+    medium_rationale: str | None = None,
     family: str | None = None,
 ) -> str:
     conf = _clean(conformance_rationale)
     same = _clean(same_place_rationale)
     det = _clean(detail_rationale)
+    med = _clean(medium_rationale)
     parts: list[str] = []
     if conf:
         reminder = register_reminder(projection, family)
@@ -63,6 +65,18 @@ def retry_feedback_clause(
             " Keep the place's internal structure fully articulated: open "
             "courtyards stay open with their inner buildings drawn; do not "
             "simplify or seal the compound."
+        )
+        parts.append(text)
+    if med:
+        text = (
+            "It also drifted from the reference's ART MEDIUM — the judge saw: "
+            f"{med}"
+        )
+        if not text.endswith("."):
+            text += "."
+        text += (
+            " Match the reference image's medium, palette, linework and paper "
+            "texture exactly; the new view must look drawn by the same hand."
         )
         parts.append(text)
     return " ".join(parts)

--- a/apps/modal-backend/providers/render_loop.py
+++ b/apps/modal-backend/providers/render_loop.py
@@ -45,6 +45,10 @@ class LoopConfig:
     # The richness floor (only when a detail judge is wired): a retry that
     # fixes the camera but seals the place's interior must not be accepted.
     accept_detail: float = 6.0
+    # The medium floor (only when a medium judge is wired): the text medium
+    # lock is advisory to loose-ref models (nano treats refs as inspiration —
+    # the Ankh-Morpork demo drift), so the ART MEDIUM gets a runtime gate too.
+    accept_medium: float = 6.0
     # No retry when the previous attempt took longer than this (<=0 disables).
     retry_budget_s: float = 240.0
 
@@ -65,6 +69,7 @@ def loop_config_from_env() -> LoopConfig:
         accept_conformance=_f("VIEW_LOOP_ACCEPT_CONFORMANCE", 7.0),
         accept_same_place=_f("VIEW_LOOP_ACCEPT_SAME_PLACE", 6.0),
         accept_detail=_f("VIEW_LOOP_ACCEPT_DETAIL", 6.0),
+        accept_medium=_f("VIEW_LOOP_ACCEPT_MEDIUM", 6.0),
         retry_budget_s=_f("VIEW_LOOP_RETRY_BUDGET_S", 240.0),
     )
 
@@ -77,6 +82,7 @@ class Attempt:
     conformance: JudgeResult | None  # None = judge unavailable (degraded)
     same_place: JudgeResult | None  # None = no region bytes, or degraded
     detail: JudgeResult | None  # None = no detail judge wired
+    medium: JudgeResult | None  # None = no medium judge wired / no reference
     accepted: bool
     latency_s: float
 
@@ -107,6 +113,7 @@ def _is_accepted(
     conformance: JudgeResult | None,
     same_place: JudgeResult | None,
     detail: JudgeResult | None,
+    medium: JudgeResult | None,
     config: LoopConfig,
 ) -> bool:
     if conformance is None:
@@ -114,6 +121,8 @@ def _is_accepted(
     if conformance.score < config.accept_conformance:
         return False
     if same_place is not None and same_place.score < config.accept_same_place:
+        return False
+    if medium is not None and medium.score < config.accept_medium:
         return False
     return not (detail is not None and detail.score < config.accept_detail)
 
@@ -127,6 +136,7 @@ async def iter_attempts[ImageT: Rendered](
     judge_same_place: Callable[[bytes, bytes], Awaitable[JudgeResult]],
     config: LoopConfig,
     judge_detail: Callable[[bytes], Awaitable[JudgeResult]] | None = None,
+    judge_medium: Callable[[bytes, bytes], Awaitable[JudgeResult]] | None = None,
     family: str | None = None,
     feedback: Callable[..., str] = retry_feedback_clause,
     abort: Callable[[str], Awaitable[None]] | None = None,
@@ -161,12 +171,15 @@ async def iter_attempts[ImageT: Rendered](
         conformance: JudgeResult | None = None
         same_place: JudgeResult | None = None
         detail: JudgeResult | None = None
+        medium: JudgeResult | None = None
         try:
             conformance = await judge_conformance(image.jpeg_bytes, projection)
             if region_bytes is not None:
                 same_place = await judge_same_place(region_bytes, image.jpeg_bytes)
             if judge_detail is not None:
                 detail = await judge_detail(image.jpeg_bytes)
+            if judge_medium is not None and region_bytes is not None:
+                medium = await judge_medium(region_bytes, image.jpeg_bytes)
         except Exception as exc:
             log(
                 "warn",
@@ -175,10 +188,12 @@ async def iter_attempts[ImageT: Rendered](
                 error=f"{type(exc).__name__}: {exc}",
             )
             # No critic signal = the old blind coin-flip — don't spend more.
-            yield Attempt(index, image, suffix, conformance, same_place, detail, False, latency)
+            yield Attempt(
+                index, image, suffix, conformance, same_place, detail, medium, False, latency
+            )
             return
 
-        accepted = _is_accepted(conformance, same_place, detail, config)
+        accepted = _is_accepted(conformance, same_place, detail, medium, config)
         log(
             "info",
             "view.loop",
@@ -187,10 +202,13 @@ async def iter_attempts[ImageT: Rendered](
             conformance=_score(conformance),
             same_place=_score(same_place),
             detail=_score(detail),
+            medium=_score(medium),
             accepted=accepted,
             latency_s=round(latency, 1),
         )
-        yield Attempt(index, image, suffix, conformance, same_place, detail, accepted, latency)
+        yield Attempt(
+            index, image, suffix, conformance, same_place, detail, medium, accepted, latency
+        )
         if accepted:
             return
         if config.retry_budget_s > 0 and latency > config.retry_budget_s:
@@ -215,6 +233,11 @@ async def iter_attempts[ImageT: Rendered](
                 if detail is not None and detail.score < config.accept_detail
                 else None
             ),
+            medium_rationale=(
+                medium.rationale
+                if medium is not None and medium.score < config.accept_medium
+                else None
+            ),
             family=family,
         )
 
@@ -230,9 +253,15 @@ def conclude(attempts: list[Attempt]) -> LoopResult:
             return LoopResult(image=a.image, attempts=attempts, accepted=True)
     best = attempts[0]
     for a in attempts[1:]:
-        if (_score(a.conformance), _score(a.same_place), _score(a.detail)) > (
+        if (
+            _score(a.conformance),
+            _score(a.same_place),
+            _score(a.medium),
+            _score(a.detail),
+        ) > (
             _score(best.conformance),
             _score(best.same_place),
+            _score(best.medium),
             _score(best.detail),
         ):
             best = a
@@ -248,6 +277,7 @@ async def run_view_loop[ImageT: Rendered](
     judge_same_place: Callable[[bytes, bytes], Awaitable[JudgeResult]],
     config: LoopConfig | None = None,
     judge_detail: Callable[[bytes], Awaitable[JudgeResult]] | None = None,
+    judge_medium: Callable[[bytes, bytes], Awaitable[JudgeResult]] | None = None,
     family: str | None = None,
 ) -> LoopResult:
     """Drain the loop for non-streaming callers (the bench)."""
@@ -260,6 +290,7 @@ async def run_view_loop[ImageT: Rendered](
         judge_same_place=judge_same_place,
         config=config or loop_config_from_env(),
         judge_detail=judge_detail,
+        judge_medium=judge_medium,
         family=family,
     ):
         attempts.append(attempt)

--- a/apps/modal-backend/tests/conftest.py
+++ b/apps/modal-backend/tests/conftest.py
@@ -54,11 +54,13 @@ _SCRUB = (
     "VIEW_GRAMMAR",
     "FAL_ENTER_MODEL",
     "FAL_ENTER_MODEL_STEEP",
-    # The render loop (default ON for steep enters — scrub for hermeticity).
+    # The render loop (default ON for deliberate-camera enters — scrub for
+    # hermeticity).
     "VIEW_LOOP",
     "VIEW_LOOP_MAX_ATTEMPTS",
     "VIEW_LOOP_ACCEPT_CONFORMANCE",
     "VIEW_LOOP_ACCEPT_SAME_PLACE",
+    "VIEW_LOOP_ACCEPT_MEDIUM",
     "VIEW_LOOP_RETRY_BUDGET_S",
     "FAL_EDIT_TIER",
     "FAL_EDIT_MODEL_FAST",

--- a/apps/modal-backend/tests/continuity_bench/view_runner.py
+++ b/apps/modal-backend/tests/continuity_bench/view_runner.py
@@ -173,15 +173,12 @@ async def _run_case(case: Case, aspect: str) -> CaseResult:
             family=family if view is not None else None,
             style_ref=True,
         )
-        # VIEW_BENCH_LOOP=1: steep deliberate arms render through the
-        # PRODUCTION render loop (judged retries with critic feedback) so
+        # VIEW_BENCH_LOOP=1: ALL deliberate arms render through the PRODUCTION
+        # render loop (judged retries with critic feedback — same-place +
+        # medium floors on every camera since the oblique-drift fix) so
         # eval-view-loop measures what users actually get. The default path
         # stays byte-identical (the committed baseline stays comparable).
-        if (
-            loop_mode
-            and view is not None
-            and _ARM_INTENT[arm] in model_router.STEEP_ENTER_PROJECTIONS
-        ):
+        if loop_mode and view is not None:
             from providers import judge as judge_mod
             from providers import render_loop
 
@@ -204,6 +201,7 @@ async def _run_case(case: Case, aspect: str) -> CaseResult:
                 judge_same_place=judge_mod.score_continuation,
                 config=render_loop.LoopConfig(max_attempts=3),
                 judge_detail=_judge_detail,
+                judge_medium=judge_mod.score_style_pair,
             )
             for i, att in enumerate(loop_result.attempts):
                 (_REPORTS / f"view_{case.name}_{arm}_a{i}.jpg").write_bytes(

--- a/apps/modal-backend/tests/test_generate_view.py
+++ b/apps/modal-backend/tests/test_generate_view.py
@@ -343,9 +343,11 @@ def _mock_judges(
     )
     same = AsyncMock(return_value=JudgeResult(score=same_score, rationale="", raw=""))
     detail = AsyncMock(return_value=JudgeResult(score=9.0, rationale="", raw=""))
+    medium = AsyncMock(return_value=JudgeResult(score=9.0, rationale="", raw=""))
     monkeypatch.setattr(judge_mod, "score_view_conformance", conf)
     monkeypatch.setattr(judge_mod, "score_continuation", same)
     monkeypatch.setattr(judge_mod, "score_feature_articulation", detail)
+    monkeypatch.setattr(judge_mod, "score_style_pair", medium)
     return conf, same
 
 
@@ -416,21 +418,75 @@ async def test_view_loop_kill_switch(monkeypatch: pytest.MonkeyPatch) -> None:
     same.assert_not_awaited()
 
 
-async def test_view_loop_aerial_zero_overhead(
+async def test_view_loop_judges_aerial_enters_too(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # The castle -> oblique (aerial register): the loop never engages, the
-    # judges are never called — zero added latency on the common path.
+    # The castle -> oblique: since the Ankh-Morpork drift, EVERY deliberate
+    # camera is judged — the loop used to skip aerial registers and an
+    # unjudged oblique enter walked off the map. Good scores -> a single
+    # attempt and no retry, but the critic DID look.
     _mock_plan(monkeypatch)
     edit = _mock_edit(monkeypatch)
     _mock_fresh(monkeypatch)
-    conf, same = _mock_judges(monkeypatch, [(0.0, "never called")])
+    conf, _same = _mock_judges(monkeypatch, [(9.0, "a clean oblique")])
 
-    await _collect(_event_stream(_tap_body(), "t1"))
+    events = await _collect(_event_stream(_tap_body(), "t1"))
 
     edit.assert_awaited_once()
-    conf.assert_not_awaited()
-    same.assert_not_awaited()
+    assert conf.await_count == 1
+    assert not [e for e in events if e["type"] == "progress"]
+
+
+async def test_view_loop_medium_drift_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The Ankh-Morpork regression, pinned: camera fine, place fine — but the
+    # ART MEDIUM drifted (loose-ref models treat the style ref as
+    # inspiration). The medium critic alone must force the retry, and its
+    # rationale must ride the next instruction.
+    import providers.judge as judge_mod
+    from providers.judge import JudgeResult
+
+    _mock_plan(monkeypatch)
+    edit = _mock_edit(monkeypatch)
+    _mock_fresh(monkeypatch)
+    monkeypatch.setattr(
+        judge_mod,
+        "score_view_conformance",
+        AsyncMock(return_value=JudgeResult(score=9.0, rationale="fine", raw="")),
+    )
+    monkeypatch.setattr(
+        judge_mod,
+        "score_continuation",
+        AsyncMock(return_value=JudgeResult(score=9.0, rationale="", raw="")),
+    )
+    monkeypatch.setattr(
+        judge_mod,
+        "score_feature_articulation",
+        AsyncMock(return_value=JudgeResult(score=9.0, rationale="", raw="")),
+    )
+    monkeypatch.setattr(
+        judge_mod,
+        "score_style_pair",
+        AsyncMock(
+            side_effect=[
+                JudgeResult(
+                    score=2.0,
+                    rationale="smoky industrial engraving, not aged parchment",
+                    raw="",
+                ),
+                JudgeResult(score=9.0, rationale="", raw=""),
+            ]
+        ),
+    )
+
+    events = await _collect(_event_stream(_steep_body(), "t1"))
+
+    assert edit.await_count == 2
+    second_instr = edit.await_args_list[1].args[1]
+    assert "smoky industrial engraving" in second_instr
+    assert "ART MEDIUM" in second_instr
+    assert any(e["type"] == "final" for e in events)
 
 
 async def test_view_loop_judge_failure_degrades(

--- a/apps/modal-backend/tests/test_render_loop.py
+++ b/apps/modal-backend/tests/test_render_loop.py
@@ -248,3 +248,40 @@ async def test_no_detail_judge_ignores_the_axis() -> None:
         config=_cfg(),
     )
     assert attempts[0].accepted and attempts[0].detail is None
+    assert attempts[0].medium is None  # no medium judge wired either
+
+
+async def test_medium_axis_rejects_and_feeds_back() -> None:
+    # The Ankh-Morpork drift fix: camera + place fine, MEDIUM drifted — the
+    # medium critic alone rejects, and its diagnosis rides the retry.
+    render = AsyncMock(side_effect=[_Img(b"a"), _Img(b"b")])
+    conf = AsyncMock(return_value=_j(9.0))
+    same = AsyncMock(return_value=_j(9.0))
+    medium = AsyncMock(side_effect=[_j(2.0, "ink wash became photoreal"), _j(8.5)])
+    attempts = await _drain(
+        render=render, projection="oblique", region_bytes=b"r",
+        judge_conformance=conf, judge_same_place=same, judge_medium=medium,
+        config=_cfg(),
+    )
+    assert len(attempts) == 2 and attempts[1].accepted
+    assert not attempts[0].accepted
+    suffix = render.await_args_list[1].args[0]
+    assert "ink wash became photoreal" in suffix
+    assert "ART MEDIUM" in suffix
+    assert "same hand" in suffix
+
+
+async def test_medium_judge_needs_region_bytes() -> None:
+    # No reference crop -> nothing to compare the medium against; the axis
+    # stays None and never gates.
+    render = AsyncMock(return_value=_Img(b"a"))
+    medium = AsyncMock(return_value=_j(0.0, "never called"))
+    attempts = await _drain(
+        render=render, projection="oblique", region_bytes=None,
+        judge_conformance=AsyncMock(return_value=_j(9.0)),
+        judge_same_place=AsyncMock(return_value=_j(9.0)),
+        judge_medium=medium,
+        config=_cfg(),
+    )
+    assert attempts[0].accepted and attempts[0].medium is None
+    medium.assert_not_awaited()


### PR DESCRIPTION
F1 of the demo post-mortem, fixed at the policy level. The Ankh-Morpork enter drifted because (a) the view loop armed on steep projections only — the oblique enter rendered one-shot and unjudged — and (b) the loop had **no medium axis at all**: the text medium lock is advisory to loose-ref models (nano treats the style ref as inspiration), so a parchment map walked into a smoky industrial engraving with nothing to catch it.

Two structural changes:
1. **The loop arms for every deliberate-camera enter** — same-place + medium floors on all projections, conformance per projection (the judge already speaks all four registers).
2. **`judge_medium` becomes the loop's fourth axis** (style_pair vs the tapped region crop): its own floor (`VIEW_LOOP_ACCEPT_MEDIUM`), feedback voice (*"must look drawn by the same hand"*), keep-best slot, `view.loop` logging. The bench's loop mode follows production.

The old aerial-zero-overhead contract is retired and replaced by its successor (aerial enters ARE judged), and the demo's drift is pinned as a regression test: the medium critic alone forces a retry whose instruction carries its rationale.

**Paid verification** (`eval-view-loop`, post-change): all deliberate arms through the loop, intended conformance mean **9.75** (unchanged vs the pre-change loop run), same-place floor held, 9/10 arms accepted at attempt 1 — the wider gate costs one judge call per enter and no quality. The committed single-shot baseline is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)