### PR TITLE
docs(cost): per-operation cost model + memoize the fal upload

### DIFF
--- a/apps/modal-backend/providers/_common.py
+++ b/apps/modal-backend/providers/_common.py
@@ -6,17 +6,30 @@ Kept tiny on purpose — only consolidates patterns that were duplicated.
 from __future__ import annotations
 
 import base64
+import hashlib
+from collections import OrderedDict
 
 import fal_client
 
+# Memoize data-URL → fal storage URL within the process. The judged loops
+# (edit_loop / render_loop) re-render the SAME source image across retry
+# attempts, and the mask path uploads the same source for both polish and
+# inpaint — each upload is a full-res (1-3MB) round-trip that, on a slow link,
+# measured ~3.5min for one edit. fal storage URLs are stable, so the same
+# bytes need uploading only once. Bounded LRU so long sessions don't grow
+# unbounded; keyed by content hash (identical bytes → one upload).
+_URL_CACHE: OrderedDict[str, str] = OrderedDict()
+_URL_CACHE_MAX = 64
+
 
 async def to_fal_url(image_data_url: str) -> str:
-    """Convert an inline data URL to a fal storage URL.
+    """Convert an inline data URL to a fal storage URL (memoized).
 
     fal's queue endpoints can reject or stall on large data URLs (high-res
     seedream / nano-banana-pro outputs hit 1-3MB easily). Uploading to fal
     storage first sidesteps the limit and is what fal recommends. Pass-through
-    if the input already looks like an http(s) URL.
+    if the input already looks like an http(s) URL. Identical bytes seen again
+    (a retry attempt re-rendering the same source) reuse the cached upload.
     """
     if not image_data_url.startswith("data:"):
         return image_data_url
@@ -25,4 +38,14 @@ async def to_fal_url(image_data_url: str) -> str:
     if ";" in header and ":" in header:
         mime = header.split(":", 1)[1].split(";", 1)[0] or mime
     raw = base64.b64decode(b64)
-    return await fal_client.upload_async(raw, content_type=mime)
+    key = hashlib.sha256(raw).hexdigest()
+    cached = _URL_CACHE.get(key)
+    if cached is not None:
+        _URL_CACHE.move_to_end(key)
+        return cached
+    url = await fal_client.upload_async(raw, content_type=mime)
+    _URL_CACHE[key] = url
+    _URL_CACHE.move_to_end(key)
+    while len(_URL_CACHE) > _URL_CACHE_MAX:
+        _URL_CACHE.popitem(last=False)
+    return url

--- a/apps/modal-backend/tests/test_common_fal_url.py
+++ b/apps/modal-backend/tests/test_common_fal_url.py
@@ -1,0 +1,62 @@
+"""providers/_common.to_fal_url — the upload memoization.
+
+The judged loops re-render the same source across retry attempts; uploading
+the full-res page once per attempt was the slow path (a measured 3.5min edit
+on a hotspot). Identical bytes must upload ONCE; distinct bytes still upload;
+http(s) URLs pass through untouched; the cache is bounded.
+"""
+from __future__ import annotations
+
+import base64
+from unittest.mock import AsyncMock
+
+import pytest
+
+from providers import _common
+
+
+def _data_url(raw: bytes) -> str:
+    return "data:image/png;base64," + base64.b64encode(raw).decode()
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache() -> None:
+    _common._URL_CACHE.clear()
+
+
+async def test_identical_bytes_upload_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    upload = AsyncMock(side_effect=lambda raw, content_type: f"https://fal/{len(raw)}")
+    monkeypatch.setattr(_common.fal_client, "upload_async", upload)
+    url1 = await _common.to_fal_url(_data_url(b"the-same-page-bytes"))
+    url2 = await _common.to_fal_url(_data_url(b"the-same-page-bytes"))
+    assert url1 == url2
+    assert upload.await_count == 1  # the retry reused the upload
+
+
+async def test_distinct_bytes_each_upload(monkeypatch: pytest.MonkeyPatch) -> None:
+    upload = AsyncMock(side_effect=lambda raw, content_type: f"https://fal/{raw.decode()}")
+    monkeypatch.setattr(_common.fal_client, "upload_async", upload)
+    a = await _common.to_fal_url(_data_url(b"page-a"))
+    b = await _common.to_fal_url(_data_url(b"page-b"))
+    assert a != b
+    assert upload.await_count == 2
+
+
+async def test_http_url_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    upload = AsyncMock()
+    monkeypatch.setattr(_common.fal_client, "upload_async", upload)
+    assert await _common.to_fal_url("https://cdn/x.jpg") == "https://cdn/x.jpg"
+    upload.assert_not_awaited()
+
+
+async def test_cache_is_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_common, "_URL_CACHE_MAX", 4)
+    upload = AsyncMock(side_effect=lambda raw, content_type: f"https://fal/{raw.decode()}")
+    monkeypatch.setattr(_common.fal_client, "upload_async", upload)
+    for i in range(10):
+        await _common.to_fal_url(_data_url(f"page-{i}".encode()))
+    assert len(_common._URL_CACHE) <= 4
+    # The oldest (page-0) was evicted, so re-requesting it re-uploads.
+    before = upload.await_count
+    await _common.to_fal_url(_data_url(b"page-0"))
+    assert upload.await_count == before + 1

--- a/docs/COSTS.md
+++ b/docs/COSTS.md
@@ -1,0 +1,112 @@
+# What a tap costs — model prices, per-operation cost, and where the time goes
+
+Prices verified June 2026 (fal model pages + OpenRouter). Token counts are
+real, pulled from this repo's own `prompt_tokens` logs. Two headline facts up
+front:
+
+1. **Image generation is ~99% of the dollars.** Every Gemini call (judge,
+   extraction, planner) is ~$0.001–0.002. Even the enter path's eleven of them
+   add up to ~2¢. The fal image call is the bill.
+2. **The slowness you feel is call COUNT and re-uploads, not price.** An enter
+   fires up to 13 sequential model calls and re-uploads the full-res page to
+   fal storage on every attempt. On a fast link it's hidden; on a hotspot the
+   dead time is the whole video. See "Where the time goes" at the bottom.
+
+## The models we call (slug → price → budget alternative)
+
+### Image (fal) — the dollar driver
+
+| Slot / tier | Default slug | Price | Budget alternative | Budget price |
+|---|---|---|---|---|
+| fresh `fast` | `fal-ai/nano-banana` | **$0.039**/img | — (already the floor) | — |
+| fresh `balanced` (default) | `fal-ai/nano-banana-pro` | **$0.15**/img (1K-2K; 4K $0.30; +$0.015 web search) | `fal-ai/nano-banana-2` | $0.08/img |
+| fresh `pro` | `openrouter:sourceful/riverflow-v2.5-pro` | **~$0.24**/img (+152s) | `nano-banana-pro` | $0.15 |
+| enter (`enter_scene`) | `fal-ai/nano-banana-pro/edit` | **$0.15**/img | `nano-banana-2/edit` | $0.08 |
+| inpaint (`inpaint`) | `fal-ai/flux-pro/v1/fill` | **$0.05/MP** → ~$0.10/edit at 16:9 | none — it's the only true compositor (the mask smoke proved gpt/nano don't honor masks); lower the resolution to drop the MP | scales with px |
+| zoom (`zoom_continue`) | `fal-ai/flux-pro/kontext` | **$0.04**/img | — | — |
+| outpaint (`outpaint`) | `fal-ai/bria/expand` | **~$0.04**/img | — | — |
+
+Every slot already takes an env override (`FAL_*_MODEL`, and the tier keys
+`FAL_IMAGE_MODEL_FAST/BALANCED/PRO`, `FAL_EDIT_MODEL_*`) — the "budget
+alternative" column is just a documented value for those.
+
+### Text / VLM / judge (OpenRouter) — pennies, but they stack up in COUNT
+
+| Role | Default | Price | Budget alternative | Budget price |
+|---|---|---|---|---|
+| planner / instruction polish | `google/gemini-3-flash-preview` | **$0.50/M in · $3/M out** | `google/gemini-3.1-flash-lite-preview` | **$0.25 / $1.50** (½) |
+| VLM (click resolve, extract, detect, view) | same | same | flash-lite | ½ |
+| judges (conformance / same-place / detail / medium / alignment) | same (`CONTINUITY_BENCH_JUDGE_MODEL` override) | same | flash-lite | ½ |
+
+Observed cost per call (from this repo's logged `prompt_tokens`, Gemini 3 Flash):
+- instruction polish (`polish_fill` 164 tok in): **~$0.0003**
+- planner (`plan_page` ~680 in): **~$0.0012**
+- click resolver (`click_to_subject` ~2100 in): **~$0.0017**
+- extraction (`extract_entities` ~2400 in): **~$0.0024**
+- one judge (image + ~1800 in): **~$0.0015**
+
+Switch all of these to flash-lite and the OpenRouter bill halves — but it's
+already <2% of the total, so the win is marginal. The judges' real cost is
+**latency**, not dollars.
+
+## What each operation costs (balanced default, GEOMETRIC_WORLD on)
+
+| Operation | fal calls | OpenRouter calls | ≈ cost | the calls |
+|---|---|---|---|---|
+| **Fresh map** | 1 × $0.15 | 4 | **$0.16** | plan + extract + detect + view |
+| **Enter (1 attempt)** | 1 × $0.15 | 9 | **$0.16** | click + plan + **4 judges** + 3 extraction |
+| **Enter (2 attempts)** | 2 × $0.15 | 13 | **$0.32** | + 1 edit + **4 more judges** |
+| **Mask edit (1 attempt)** | 1 × ~$0.10 | 5 | **$0.11** | polish + **2 judges** + 2 extraction |
+| **Mask edit (2 attempts)** | 2 × ~$0.10 | 7 | **$0.21** | + 1 inpaint + **2 more judges** |
+| **Judged whole-image edit** | 1 × $0.15 | 5 | **$0.16** | polish + 2 judges + 2 extraction |
+| **Extraction (after EVERY final)** | 0 | 1–3 | **~$0.006** | extract (+ detect + view if geo) |
+
+**A full demo run** (map + 1 mask edit + 2 enters, ~1.5 attempts each) ≈
+**$0.6–1.0**. The Ankh-Morpork re-shoot's ~10 takes was ~$6–9 of fal, almost
+all of it nano-banana-pro/edit on the enters.
+
+### A budget profile (env, no code change)
+
+```sh
+# Cheaper images everywhere (≈4× on fresh/edit, the enter is the big one):
+FAL_IMAGE_MODEL_BALANCED=fal-ai/nano-banana-2     # $0.15 -> $0.08
+FAL_EDIT_MODEL_BALANCED=fal-ai/nano-banana-2/edit
+FAL_ENTER_MODEL=fal-ai/nano-banana-2/edit
+# Half-price judges/VLM (marginal $, but flash-lite is also faster):
+CONTINUITY_BENCH_JUDGE_MODEL=google/gemini-3.1-flash-lite-preview
+OPENROUTER_VLM_MODEL=google/gemini-3.1-flash-lite-preview
+# Fewer judged retries (latency + $):
+VIEW_LOOP_MAX_ATTEMPTS=1
+EDIT_LOOP_MAX_ATTEMPTS=1
+```
+That roughly halves both the dollars and the call count — a demo run drops to
+~$0.3–0.5 and noticeably fewer round-trips.
+
+## Where the time goes (the "video is ass" diagnosis)
+
+Dollars are fine; **wall-clock is the product problem**, and it's structural:
+
+1. **Full-res re-upload to fal, every attempt.** `to_fal_url` uploads the
+   ~2-3 MB page (and the mask) to fal storage on each edit/enter *and re-does
+   it per retry attempt* — no memoization. On a hotspot that was a measured
+   **3.5 min** for one ferry edit. **Biggest single win: upload once per
+   request, reuse the URL across attempts.** (Real, mergeable fix.)
+2. **Judges are sequential.** An enter runs 4 judges per attempt, one after
+   another (~2-5s each), up to 2 attempts = up to 8 VLM round-trips before the
+   image is accepted. They could run **concurrently** (they're independent),
+   or be trimmed on a fast tier.
+3. **Extraction blocks the felt-ready moment.** 3 VLM calls (~15-25s) fire
+   after every final before the codex/geo are populated. Already fire-and-
+   forget for the image, but the next interaction's geo isn't ready until it
+   lands.
+
+So the honest fix for a *snappier* demo isn't a cheaper model — it's: cache
+the upload, parallelize the judges, and a one-shot fast mode. The budget
+profile above is the cheap-and-fast lever today; the upload cache + concurrent
+judges are the code wins worth doing next.
+
+Sources: fal model pages (nano-banana-pro $0.15, nano-banana-2 $0.08,
+flux-pro/v1/fill $0.05/MP, flux-pro/kontext $0.04, nano-banana $0.039),
+OpenRouter (gemini-3-flash-preview $0.50/$3, gemini-3.1-flash-lite $0.25/$1.50),
+repo `prompt_tokens` logs + Makefile eval cost anchors (eval-view ~$2.5,
+eval-edit-region ~$1, mask-smoke ~$0.5).


### PR DESCRIPTION
## The accounting you asked for — `docs/COSTS.md`

Verified prices (June 2026, fal model pages + OpenRouter) and per-operation cost from this repo's own `prompt_tokens` logs. Two findings:

- **Image generation is ~99% of the dollars.** Every Gemini call (judge / extraction / planner) is ~$0.001–0.002; even the enter path's 11 of them total ~2¢. The fal image call is the bill: fresh map $0.16, enter $0.16–0.32, mask edit $0.11–0.21, a full demo run $0.6–1.0.
- **The slowness is call COUNT + re-uploads, not price.** An enter fires up to 13 sequential model calls and re-uploads the full-res page to fal storage *on every attempt*.

The doc gives a budget alternative per model (nano-banana-2 at $0.08 vs nano-banana-pro $0.15; gemini-3.1-flash-lite at half the judge cost) and a copy-paste env profile that ~halves both dollars and round-trips — no code change, the slots already take `FAL_*_MODEL` overrides.

## First structural fix — memoize `to_fal_url`

The judged loops re-render the **same source** across retry attempts, and the mask path uploads it twice (polish + inpaint). Each was a full-res 1–3 MB round-trip — **measured 3.5 min for one ferry edit** on the hotspot. `to_fal_url` now memoizes by content hash (bounded LRU), so identical bytes upload once. 4 tests pin it: identical→one upload, distinct→each uploads, http(s) pass-through, bounded eviction.

The doc names the next two wins it doesn't do yet — run the 4 enter judges concurrently (they're independent), and a fast one-shot mode — as the follow-ups worth doing.

`make eval` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)