### PR TITLE
Speed preset + live cost chip; concurrent judges (the demo slowness fix)

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -175,6 +175,12 @@ class GenerateBody(BaseModel):
     click_hint: str | None = None
     image_tier: str | None = None
     image_model: str | None = None
+    # Per-request loop control (the speed preset). Absent -> today's env
+    # defaults, byte-identical. verify=False skips the judged loops for this
+    # request (the proven one-shot paths, user-chosen); max_attempts clamps
+    # to the loops' hard cap server-side.
+    max_attempts: int | None = None
+    verify: bool | None = None
     edit_instruction: str | None = None
     # Mask-scoped edit (EDIT_REGION, default off): an opaque PNG data URL at
     # the page's natural dims, WHITE = edit / black = keep, plus the selection
@@ -698,18 +704,24 @@ async def _event_stream(
                     else None
                 )
                 verdict: dict[str, Any] | None = None
-                if source_bytes is None or mask_bytes is None:
-                    # Remote refs / undecodable inputs: no critic signal, so a
-                    # single un-judged shot (the loop's no-critic rule) — the
-                    # result is still mask-scoped by the model.
-                    log(
-                        "warn",
-                        "edit.loop.unjudged",
-                        reason="source_or_mask_not_data_url",
-                    )
+                if (
+                    body.verify is False
+                    or source_bytes is None
+                    or mask_bytes is None
+                ):
+                    # Remote refs / undecodable inputs (or the user opted out
+                    # of verification): a single un-judged shot (the loop's
+                    # no-critic rule) — the result is still mask-scoped by
+                    # the model.
+                    if body.verify is not False:
+                        log(
+                            "warn",
+                            "edit.loop.unjudged",
+                            reason="source_or_mask_not_data_url",
+                        )
                     inp_result = await _render_inpaint("")
                 else:
-                    edit_cfg = edit_loop.edit_loop_config_from_env()
+                    edit_cfg = edit_loop.edit_loop_config_from_env(body.max_attempts)
                     edit_attempts: list[Any] = []
                     # The alignment judge checks the inside crop against the
                     # fill DESCRIPTION (the region's expected final content) —
@@ -792,7 +804,7 @@ async def _event_stream(
             # the polished instruction + the medium critic vs the source, one
             # rationale-folding retry, verdict on the final frame. Undecodable
             # source (remote ref) falls through to the legacy un-judged call.
-            if env_flag("EDIT_JUDGE"):
+            if env_flag("EDIT_JUDGE") and body.verify is not False:
                 from providers import edit_loop, judge
                 from providers.render_loop import data_url_bytes
 
@@ -809,7 +821,7 @@ async def _event_stream(
                             style_ref_url=edit_style_ref,
                         )
 
-                    judge_cfg = edit_loop.edit_loop_config_from_env()
+                    judge_cfg = edit_loop.edit_loop_config_from_env(body.max_attempts)
                     judged_attempts: list[Any] = []
                     async for judged_att in edit_loop.iter_edit_attempts(
                         _render_judged_edit,
@@ -1639,7 +1651,11 @@ async def _event_stream(
             # identity with nothing to catch it — the text medium lock is
             # advisory to loose-ref models, so the gate has to be a judge.
             # Legacy (no deliberate view) enters keep the one-shot path.
-            view_loop = enter_view is not None and env_flag("VIEW_LOOP", "true")
+            view_loop = (
+                enter_view is not None
+                and env_flag("VIEW_LOOP", "true")
+                and body.verify is not False
+            )
             log(
                 "info",
                 "tap.enter_edit",
@@ -1678,7 +1694,7 @@ async def _event_stream(
                         img_bytes, detail_title, detail_features
                     )
 
-                loop_cfg = render_loop.loop_config_from_env()
+                loop_cfg = render_loop.loop_config_from_env(body.max_attempts)
                 loop_attempts: list[Any] = []
                 async for loop_att in render_loop.iter_attempts(
                     _render_enter,

--- a/apps/modal-backend/providers/edit_loop.py
+++ b/apps/modal-backend/providers/edit_loop.py
@@ -36,7 +36,7 @@ from PIL import Image
 from providers.judge import JudgeResult
 from providers.pixel_diff import changed_fraction
 from providers.prompt_library.feedback import edit_retry_feedback_clause
-from providers.render_loop import Rendered
+from providers.render_loop import Rendered, judge_concurrently
 
 
 @dataclass(frozen=True)
@@ -200,17 +200,21 @@ async def iter_edit_attempts[ImageT: Rendered](
                 )
                 yield EditAttempt(index, image, suffix, None, None, None, False, latency)
                 return
-        try:
-            alignment = await judge_alignment(
+        # Both critics look at the same result independently — judged
+        # concurrently (see render_loop.judge_concurrently).
+        judged, failure = await judge_concurrently(
+            judge_alignment(
                 instruction, inside_crop_bytes(image.jpeg_bytes, region_box)
-            )
-            medium = await judge_medium(source_bytes, image.jpeg_bytes)
-        except Exception as exc:
+            ),
+            judge_medium(source_bytes, image.jpeg_bytes),
+        )
+        alignment, medium = judged
+        if failure is not None:
             log(
                 "warn",
                 "edit.loop.judge_failed",
                 attempt=index,
-                error=f"{type(exc).__name__}: {exc}",
+                error=f"{type(failure).__name__}: {failure}",
             )
             # No critic signal = the old blind coin-flip — don't spend more.
             yield EditAttempt(index, image, suffix, outside, alignment, medium, False, latency)

--- a/apps/modal-backend/providers/edit_loop.py
+++ b/apps/modal-backend/providers/edit_loop.py
@@ -36,7 +36,7 @@ from PIL import Image
 from providers.judge import JudgeResult
 from providers.pixel_diff import changed_fraction
 from providers.prompt_library.feedback import edit_retry_feedback_clause
-from providers.render_loop import Rendered, judge_concurrently
+from providers.render_loop import MAX_ATTEMPTS_CAP, Rendered, judge_concurrently
 
 
 @dataclass(frozen=True)
@@ -51,7 +51,7 @@ class EditLoopConfig:
     retry_budget_s: float = 240.0
 
 
-def edit_loop_config_from_env() -> EditLoopConfig:
+def edit_loop_config_from_env(max_attempts: int | None = None) -> EditLoopConfig:
     def _f(name: str, default: float) -> float:
         try:
             return float(os.environ.get(name, ""))
@@ -62,6 +62,8 @@ def edit_loop_config_from_env() -> EditLoopConfig:
         attempts = int(os.environ.get("EDIT_LOOP_MAX_ATTEMPTS", ""))
     except ValueError:
         attempts = 2
+    if max_attempts is not None:
+        attempts = min(MAX_ATTEMPTS_CAP, max_attempts)
     return EditLoopConfig(
         max_attempts=max(1, attempts),
         accept_alignment=_f("EDIT_LOOP_ACCEPT_ALIGNMENT", 7.0),

--- a/apps/modal-backend/providers/render_loop.py
+++ b/apps/modal-backend/providers/render_loop.py
@@ -54,7 +54,13 @@ class LoopConfig:
     retry_budget_s: float = 240.0
 
 
-def loop_config_from_env() -> LoopConfig:
+# The per-request attempts ceiling: a client may ask for fewer attempts than
+# the env default (the Fast preset's one-shot) or a couple more (Quality),
+# never an unbounded spend.
+MAX_ATTEMPTS_CAP = 4
+
+
+def loop_config_from_env(max_attempts: int | None = None) -> LoopConfig:
     def _f(name: str, default: float) -> float:
         try:
             return float(os.environ.get(name, ""))
@@ -65,6 +71,8 @@ def loop_config_from_env() -> LoopConfig:
         attempts = int(os.environ.get("VIEW_LOOP_MAX_ATTEMPTS", ""))
     except ValueError:
         attempts = 2
+    if max_attempts is not None:
+        attempts = min(MAX_ATTEMPTS_CAP, max_attempts)
     return LoopConfig(
         max_attempts=max(1, attempts),
         accept_conformance=_f("VIEW_LOOP_ACCEPT_CONFORMANCE", 7.0),

--- a/apps/modal-backend/providers/render_loop.py
+++ b/apps/modal-backend/providers/render_loop.py
@@ -22,6 +22,7 @@ rejected attempt as a progress frame between iterations.
 """
 from __future__ import annotations
 
+import asyncio
 import base64
 import os
 import time
@@ -109,6 +110,28 @@ def _score(j: JudgeResult | None) -> float:
     return j.score if j is not None else -1.0
 
 
+async def _no_judge() -> None:
+    """Placeholder for a judge axis that isn't applicable this attempt —
+    keeps the gathered result shape positional."""
+    return None
+
+
+async def judge_concurrently(
+    *coros: Awaitable[JudgeResult | None],
+) -> tuple[list[JudgeResult | None], Exception | None]:
+    """Run independent judge calls concurrently — each is a 2-5s VLM
+    round-trip, and run back-to-back they dominated an attempt's wall-clock.
+    Returns (results, first_failure) with failed slots as None; cancellation
+    propagates exactly as it would from a bare await."""
+    gathered = await asyncio.gather(*coros, return_exceptions=True)
+    for r in gathered:
+        if isinstance(r, BaseException) and not isinstance(r, Exception):
+            raise r
+    results = [None if isinstance(r, BaseException) else r for r in gathered]
+    failure = next((r for r in gathered if isinstance(r, Exception)), None)
+    return results, failure
+
+
 def _is_accepted(
     conformance: JudgeResult | None,
     same_place: JudgeResult | None,
@@ -168,24 +191,30 @@ async def iter_attempts[ImageT: Rendered](
                 return
         latency = clock() - started
 
-        conformance: JudgeResult | None = None
-        same_place: JudgeResult | None = None
-        detail: JudgeResult | None = None
-        medium: JudgeResult | None = None
-        try:
-            conformance = await judge_conformance(image.jpeg_bytes, projection)
-            if region_bytes is not None:
-                same_place = await judge_same_place(region_bytes, image.jpeg_bytes)
-            if judge_detail is not None:
-                detail = await judge_detail(image.jpeg_bytes)
-            if judge_medium is not None and region_bytes is not None:
-                medium = await judge_medium(region_bytes, image.jpeg_bytes)
-        except Exception as exc:
+        # The four axes are independent verdicts on the same image — judged
+        # concurrently (the Ankh-Morpork re-shoot: sequential judging alone
+        # cost 10-20s per attempt).
+        judged, failure = await judge_concurrently(
+            judge_conformance(image.jpeg_bytes, projection),
+            (
+                judge_same_place(region_bytes, image.jpeg_bytes)
+                if region_bytes is not None
+                else _no_judge()
+            ),
+            judge_detail(image.jpeg_bytes) if judge_detail is not None else _no_judge(),
+            (
+                judge_medium(region_bytes, image.jpeg_bytes)
+                if judge_medium is not None and region_bytes is not None
+                else _no_judge()
+            ),
+        )
+        conformance, same_place, detail, medium = judged
+        if failure is not None:
             log(
                 "warn",
                 "view.loop.judge_failed",
                 attempt=index,
-                error=f"{type(exc).__name__}: {exc}",
+                error=f"{type(failure).__name__}: {failure}",
             )
             # No critic signal = the old blind coin-flip — don't spend more.
             yield Attempt(

--- a/apps/modal-backend/tests/test_edit_loop.py
+++ b/apps/modal-backend/tests/test_edit_loop.py
@@ -248,3 +248,11 @@ async def test_edit_judges_run_concurrently() -> None:
     render = _Render([_inside_edit()])
     attempts = await _drain(render, alignment=alignment, medium=medium)
     assert len(attempts) == 1 and attempts[0].accepted
+
+
+def test_edit_config_per_request_attempts_clamped() -> None:
+    # Mirrors render_loop: the per-request ask wins inside [1, cap].
+    assert edit_loop.edit_loop_config_from_env(max_attempts=1).max_attempts == 1
+    assert edit_loop.edit_loop_config_from_env(max_attempts=99).max_attempts == 4
+    assert edit_loop.edit_loop_config_from_env(max_attempts=0).max_attempts == 1
+    assert edit_loop.edit_loop_config_from_env().max_attempts == 2

--- a/apps/modal-backend/tests/test_edit_loop.py
+++ b/apps/modal-backend/tests/test_edit_loop.py
@@ -227,3 +227,24 @@ def test_inside_crop_cuts_the_selection() -> None:
     assert (w, h) == (48, 36)  # 0.375*128, 0.5*72
     full = edit_loop.inside_crop_bytes(_jpg(_base()), None)
     assert Image.open(io.BytesIO(full)).size == (_W, _H)
+
+
+async def test_edit_judges_run_concurrently() -> None:
+    # Alignment + medium are independent verdicts and must overlap (the same
+    # latency fix as the render loop). Alignment blocks until medium STARTS —
+    # sequential execution times out instead of accepting.
+    import asyncio
+
+    started = asyncio.Event()
+
+    async def alignment(_instr: str, _img: bytes) -> JudgeResult:
+        await asyncio.wait_for(started.wait(), timeout=2.0)
+        return JudgeResult(9.0, "", "")
+
+    async def medium(_src: bytes, _out: bytes) -> JudgeResult:
+        started.set()
+        return JudgeResult(9.0, "", "")
+
+    render = _Render([_inside_edit()])
+    attempts = await _drain(render, alignment=alignment, medium=medium)
+    assert len(attempts) == 1 and attempts[0].accepted

--- a/apps/modal-backend/tests/test_generate_edit_judge.py
+++ b/apps/modal-backend/tests/test_generate_edit_judge.py
@@ -216,3 +216,21 @@ async def test_undecodable_source_degrades_to_legacy(
     assert edit.await_count == 1
     final = next(e for e in events if e["type"] == "final")
     assert "edit_verdict" not in final
+
+
+async def test_verify_false_skips_the_judged_edit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # EDIT_JUDGE on but the request says verify:false -> exactly the legacy
+    # un-judged whole-image edit, no critics, no verdict.
+    monkeypatch.setenv("EDIT_JUDGE", "1")
+    _mock_polish(monkeypatch)
+    _mock_judges(monkeypatch)
+    body = _edit_body(verify=False)
+    edit = _mock_edit(monkeypatch, body.image or "")
+
+    events = await _collect(_event_stream(body, "t1"))
+
+    assert edit.await_count == 1
+    final = next(e for e in events if e["type"] == "final")
+    assert "edit_verdict" not in final

--- a/apps/modal-backend/tests/test_generate_edit_region.py
+++ b/apps/modal-backend/tests/test_generate_edit_region.py
@@ -188,3 +188,29 @@ async def test_flag_on_with_mask_runs_the_judged_inpaint(
     assert verdict["alignment"] == 9.0
     assert verdict["medium"] == 9.0
     assert verdict["outside_change"] == 0.0
+
+
+async def test_mask_edit_verify_false_single_unjudged_inpaint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # verify:false on the mask path: still mask-scoped (the inpaint runs),
+    # but ONE un-judged shot — no critics, no verdict on the final frame.
+    monkeypatch.setenv("EDIT_REGION", "1")
+    _mock_polish(monkeypatch)
+    edit = _mock_legacy_edit(monkeypatch)
+    align = AsyncMock(return_value=JudgeResult(9.0, "", ""))
+    medium = AsyncMock(return_value=JudgeResult(9.0, "", ""))
+    monkeypatch.setattr(judge_mod, "score_prompt_alignment", align)
+    monkeypatch.setattr(judge_mod, "score_style_pair", medium)
+    body = _edit_body(edit_mask=_mask_data_url(), edit_region=_BOX, verify=False)
+    inpaint = _mock_inpaint(monkeypatch, body.image or "")
+
+    events = await _collect(_event_stream(body, "t1"))
+
+    assert edit.await_count == 0
+    assert inpaint.await_count == 1
+    align.assert_not_awaited()
+    medium.assert_not_awaited()
+    final = next(e for e in events if e["type"] == "final")
+    assert final["image_op"] == "inpaint"
+    assert "edit_verdict" not in final

--- a/apps/modal-backend/tests/test_generate_view.py
+++ b/apps/modal-backend/tests/test_generate_view.py
@@ -509,3 +509,38 @@ async def test_view_loop_judge_failure_degrades(
 
     edit.assert_awaited_once()
     assert any(e["type"] == "final" for e in events)
+
+
+async def test_view_loop_verify_false_takes_one_shot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The Fast preset's request-level opt-out: verify:false rides the same
+    # proven one-shot path as the env kill-switch — per request, no judges.
+    _mock_plan(monkeypatch)
+    edit = _mock_edit(monkeypatch)
+    _mock_fresh(monkeypatch)
+    conf, same = _mock_judges(monkeypatch, [(0.0, "never called")])
+
+    events = await _collect(_event_stream(_steep_body(verify=False), "t1"))
+
+    edit.assert_awaited_once()
+    conf.assert_not_awaited()
+    same.assert_not_awaited()
+    assert any(e["type"] == "final" for e in events)
+
+
+async def test_view_loop_per_request_max_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # max_attempts:1 -> a rejected first attempt is NOT retried (the env
+    # default would); keep-best still finals the rejected image.
+    _mock_plan(monkeypatch)
+    edit = _mock_edit(monkeypatch)
+    _mock_fresh(monkeypatch)
+    conf, _ = _mock_judges(monkeypatch, [(3.0, "looks wrong")])
+
+    events = await _collect(_event_stream(_steep_body(max_attempts=1), "t1"))
+
+    edit.assert_awaited_once()
+    assert conf.await_count == 1
+    assert any(e["type"] == "final" for e in events)

--- a/apps/modal-backend/tests/test_render_loop.py
+++ b/apps/modal-backend/tests/test_render_loop.py
@@ -206,6 +206,16 @@ def test_loop_config_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     assert cfg2.retry_budget_s == 0.0
 
 
+def test_loop_config_per_request_attempts_clamped() -> None:
+    # The speed preset's per-request ask beats the env default, inside
+    # [1, MAX_ATTEMPTS_CAP] — never an unbounded spend.
+    assert loop_config_from_env(max_attempts=1).max_attempts == 1
+    assert loop_config_from_env(max_attempts=3).max_attempts == 3
+    assert loop_config_from_env(max_attempts=99).max_attempts == 4
+    assert loop_config_from_env(max_attempts=0).max_attempts == 1
+    assert loop_config_from_env(max_attempts=None).max_attempts == 2  # env default
+
+
 async def test_run_view_loop_drains_and_concludes() -> None:
     render = AsyncMock(side_effect=[_Img(b"a"), _Img(b"b")])
     result = await run_view_loop(

--- a/apps/modal-backend/tests/test_render_loop.py
+++ b/apps/modal-backend/tests/test_render_loop.py
@@ -271,6 +271,46 @@ async def test_medium_axis_rejects_and_feeds_back() -> None:
     assert "same hand" in suffix
 
 
+async def test_judges_run_concurrently() -> None:
+    # The demo latency fix: the four verdicts are independent VLM calls and
+    # must overlap. Conformance blocks until same_place STARTS — sequential
+    # execution times out (degraded, unaccepted) instead of passing.
+    import asyncio
+
+    started = asyncio.Event()
+
+    async def conf(_img: bytes, _proj: str) -> JudgeResult:
+        await asyncio.wait_for(started.wait(), timeout=2.0)
+        return _j(9.0)
+
+    async def same(_region: bytes, _img: bytes) -> JudgeResult:
+        started.set()
+        return _j(9.0)
+
+    attempts = await _drain(
+        render=AsyncMock(return_value=_Img(b"a")), projection="top_down",
+        region_bytes=b"r", judge_conformance=conf, judge_same_place=same,
+        config=_cfg(),
+    )
+    assert len(attempts) == 1 and attempts[0].accepted
+
+
+async def test_sibling_judge_failure_still_degrades() -> None:
+    # A failure in ANY concurrent judge keeps the no-critic rule: one attempt,
+    # never accepted, the surviving verdicts retained.
+    render = AsyncMock(return_value=_Img(b"a"))
+    conf = AsyncMock(return_value=_j(9.0))
+    same = AsyncMock(side_effect=RuntimeError("429"))
+    attempts = await _drain(
+        render=render, projection="top_down", region_bytes=b"r",
+        judge_conformance=conf, judge_same_place=same, config=_cfg(),
+    )
+    assert len(attempts) == 1 and not attempts[0].accepted
+    assert attempts[0].conformance is not None  # the survivor kept
+    assert attempts[0].same_place is None  # the failed slot degraded
+    render.assert_awaited_once()
+
+
 async def test_medium_judge_needs_region_bytes() -> None:
     # No reference crop -> nothing to compare the medium against; the axis
     # stays None and never gates.

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/lib/trace";
 import { getStrings, resolveOutputLocale } from "@/lib/i18n";
 import { useImageTier, useVideoTier } from "@/hooks/usePersistedTier";
+import { useLoopKnobs, wireFields } from "@/hooks/useSpeedPreset";
 import { useExpandBloom } from "@/hooks/useExpandBloom";
 import { type Ascended, useAscend } from "@/hooks/useAscend";
 import { buildConditionRefs, cropBox, orderedRefs } from "@/lib/image-condition";
@@ -487,6 +488,10 @@ export default function PlayPage() {
   // hydration; the per-effect firstRun guards keep these effects from
   // overwriting that initial paint with the default values on mount.
   const [imageTier, setImageTier] = useImageTier();
+  const [loopKnobs, setLoopKnobs] = useLoopKnobs();
+  // The speed preset's wire half — spread into every generate() body next to
+  // image_tier. Balanced knobs produce {} (byte-identity with today).
+  const loopWire = useMemo(() => wireFields(loopKnobs), [loopKnobs]);
   const [videoTier, setVideoTier] = useVideoTier();
   const [outputLocale, setOutputLocale] = usePersistedLocale();
   const [theme, setTheme] = usePersistedTheme();
@@ -888,6 +893,7 @@ export default function PlayPage() {
       parent_query: page.query,
       parent_title: page.title,
       image_tier: imageTier,
+      ...loopWire,
       output_locale: resolveOutputLocale(outputLocale),
       ...(condition.urls.length
         ? {
@@ -906,6 +912,7 @@ export default function PlayPage() {
     bloom,
     startBloom,
     imageTier,
+    loopWire,
     outputLocale,
     styleAnchor,
     history,
@@ -1035,11 +1042,12 @@ export default function PlayPage() {
         current_node_id: page?.nodeId ?? "",
         mode: "query",
         image_tier: imageTier,
+        ...loopWire,
         output_locale: resolveOutputLocale(outputLocale),
         ...(styleAnchor ? { session_style_anchor: styleAnchor.style } : {}),
       });
     },
-    [input, sessionId, page, generate, imageTier, outputLocale, styleAnchor]
+    [input, sessionId, page, generate, imageTier, loopWire, outputLocale, styleAnchor]
   );
 
   // B1 — "Describe a place": turn the input description into a logical object
@@ -1133,6 +1141,7 @@ export default function PlayPage() {
         current_node_id: page?.nodeId ?? "",
         mode: "query",
         image_tier: imageTier,
+        ...loopWire,
         output_locale: resolveOutputLocale(outputLocale),
         world_mode: true,
         render_mode: "place_submap",
@@ -1167,6 +1176,7 @@ export default function PlayPage() {
     page,
     generate,
     imageTier,
+    loopWire,
     outputLocale,
     styleAnchor,
     promptForHint,
@@ -1222,6 +1232,7 @@ export default function PlayPage() {
         parent_query: page.query,
         parent_title: page.title,
         image_tier: imageTier,
+        ...loopWire,
         output_locale: resolveOutputLocale(outputLocale),
         ...(editCondition.urls.length
           ? {
@@ -1236,7 +1247,7 @@ export default function PlayPage() {
       setEditMode(false);
       setEditRegion(null);
     },
-    [page, generate, imageTier, outputLocale, styleAnchor, history]
+    [page, generate, imageTier, loopWire, outputLocale, styleAnchor, history]
   );
 
   const submitEdit = useCallback(
@@ -2076,6 +2087,7 @@ export default function PlayPage() {
         parent_title: page.title,
         click,
         image_tier: imageTier,
+        ...loopWire,
         output_locale: resolveOutputLocale(outputLocale),
         ...(condition.urls.length
           ? {
@@ -2371,6 +2383,7 @@ export default function PlayPage() {
         click,
         click_hint: strokeHint,
         image_tier: imageTier,
+        ...loopWire,
         output_locale: resolveOutputLocale(outputLocale),
         ...(strokeCondition.urls.length
           ? {
@@ -2412,7 +2425,7 @@ export default function PlayPage() {
       inflight.clear();
       prefetchCurrentKeyRef.current = null;
     };
-  }, [page, phase, generate, imageTier, editMode, outputLocale, bucketKey, streamStatus, styleAnchor, promptForHint, worldEnabled, worldAutonomy, history, selectFromMap]);
+  }, [page, phase, generate, imageTier, loopWire, editMode, outputLocale, bucketKey, streamStatus, styleAnchor, promptForHint, worldEnabled, worldAutonomy, history, selectFromMap]);
 
   // When the page changes, tear down any running stream.
   useEffect(() => {
@@ -2438,10 +2451,11 @@ export default function PlayPage() {
       current_node_id: "",
       mode: "query",
       image_tier: imageTier,
+      ...loopWire,
       output_locale: resolveOutputLocale(outputLocale),
       ...(styleAnchor ? { session_style_anchor: styleAnchor.style } : {}),
     });
-  }, [generate, sessionId, imageTier, outputLocale, styleAnchor]);
+  }, [generate, sessionId, imageTier, loopWire, outputLocale, styleAnchor]);
 
   const animateAbortRef = useRef<AbortController | null>(null);
   const disconnectStream = useCallback(() => {
@@ -2541,6 +2555,8 @@ export default function PlayPage() {
         setTheme={setTheme}
         imageTier={imageTier}
         setImageTier={setImageTier}
+        loopKnobs={loopKnobs}
+        setLoopKnobs={setLoopKnobs}
         worldMode={worldEnabled}
         setWorldMode={setWorldEnabled}
         autonomy={worldAutonomy}

--- a/apps/web/components/PlayPage/QueryToolbar.tsx
+++ b/apps/web/components/PlayPage/QueryToolbar.tsx
@@ -5,6 +5,8 @@ import type { Autonomy, ImageTier } from "@openflipbook/config";
 
 import { SUPPORTED_LOCALES, type SupportedLocale, type LocaleStrings } from "@/lib/i18n";
 import { THEMES, type Theme } from "@/hooks/usePersistedTheme";
+import type { LoopKnobs } from "@/hooks/useSpeedPreset";
+import { SpeedPreset } from "./SpeedPreset";
 
 const TIERS: readonly ImageTier[] = ["fast", "balanced", "pro"] as const;
 
@@ -22,6 +24,8 @@ interface Props {
   setTheme: (t: Theme) => void;
   imageTier: ImageTier;
   setImageTier: (t: ImageTier) => void;
+  loopKnobs: LoopKnobs;
+  setLoopKnobs: (k: LoopKnobs) => void;
   worldMode: boolean;
   setWorldMode: (on: boolean) => void;
   autonomy: Autonomy;
@@ -42,6 +46,8 @@ export function QueryToolbar({
   setTheme,
   imageTier,
   setImageTier,
+  loopKnobs,
+  setLoopKnobs,
   worldMode,
   setWorldMode,
   autonomy,
@@ -135,6 +141,13 @@ export function QueryToolbar({
             </button>
           ))}
         </div>
+        <SpeedPreset
+          busy={busy}
+          imageTier={imageTier}
+          setImageTier={setImageTier}
+          knobs={loopKnobs}
+          setKnobs={setLoopKnobs}
+        />
         <div
           role="group"
           aria-label="World Mode"

--- a/apps/web/components/PlayPage/SpeedPreset.test.tsx
+++ b/apps/web/components/PlayPage/SpeedPreset.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { SpeedPreset } from "./SpeedPreset";
+
+const BALANCED = { maxAttempts: 2, verify: true };
+
+function setup(over: Partial<Parameters<typeof SpeedPreset>[0]> = {}) {
+  const setImageTier = vi.fn();
+  const setKnobs = vi.fn();
+  render(
+    <SpeedPreset
+      busy={false}
+      imageTier="balanced"
+      setImageTier={setImageTier}
+      knobs={BALANCED}
+      setKnobs={setKnobs}
+      {...over}
+    />,
+  );
+  return { setImageTier, setKnobs };
+}
+
+describe("SpeedPreset", () => {
+  it("highlights the preset the current tier+knobs amount to", () => {
+    setup();
+    expect(
+      screen.getByRole("button", { name: "balanced" }).getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(
+      screen.getByRole("button", { name: "fast" }).getAttribute("aria-pressed"),
+    ).toBe("false");
+  });
+
+  it("a preset click sets BOTH stores — tier and loop knobs", () => {
+    const { setImageTier, setKnobs } = setup();
+    fireEvent.click(screen.getByRole("button", { name: "quality" }));
+    expect(setImageTier).toHaveBeenCalledWith("pro");
+    expect(setKnobs).toHaveBeenCalledWith({ maxAttempts: 3, verify: true });
+  });
+
+  it("an off-bundle combo reads as custom", () => {
+    setup({ knobs: { maxAttempts: 1, verify: true } });
+    expect(screen.getByText("custom")).toBeTruthy();
+  });
+
+  it("the chip projects the balanced tap range from docs/COSTS.md", () => {
+    setup();
+    expect(screen.getByTestId("cost-chip").textContent).toContain(
+      "$0.16–0.32",
+    );
+  });
+
+  it("the chip collapses for the fast un-judged shot", () => {
+    setup({ imageTier: "fast", knobs: { maxAttempts: 1, verify: false } });
+    expect(screen.getByTestId("cost-chip").textContent).toMatch(/\$0\.05\/tap/);
+  });
+
+  it("the ⚙ popover exposes the knobs", () => {
+    const { setKnobs } = setup();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Advanced loop controls" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "off" }));
+    expect(setKnobs).toHaveBeenCalledWith({ maxAttempts: 2, verify: false });
+    fireEvent.click(screen.getByRole("button", { name: "3" }));
+    expect(setKnobs).toHaveBeenCalledWith({ maxAttempts: 3, verify: true });
+  });
+});

--- a/apps/web/components/PlayPage/SpeedPreset.tsx
+++ b/apps/web/components/PlayPage/SpeedPreset.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useState } from "react";
+import type { ImageTier } from "@openflipbook/config";
+
+import { formatCostRange, projectCost } from "@/lib/cost-estimate";
+import {
+  type LoopKnobs,
+  PRESET_BUNDLES,
+  presetFor,
+  SPEED_PRESETS,
+  type SpeedPreset as Preset,
+} from "@/hooks/useSpeedPreset";
+
+interface Props {
+  busy: boolean;
+  imageTier: ImageTier;
+  setImageTier: (t: ImageTier) => void;
+  knobs: LoopKnobs;
+  setKnobs: (k: LoopKnobs) => void;
+}
+
+// The 3-stop speed/quality preset + the live cost chip — the projected spend
+// shown BEFORE you spend it. A preset is a shortcut that sets the image tier
+// (the existing toggle stays in sync — it's the same store) plus the loop
+// knobs; the ⚙ popover exposes the knobs directly, and any hand-tuned combo
+// reads as "custom". Presentational; the page owns the state.
+export function SpeedPreset({
+  busy,
+  imageTier,
+  setImageTier,
+  knobs,
+  setKnobs,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const active = presetFor(imageTier, knobs);
+  const bundle = { tier: imageTier, ...knobs };
+  const tap = formatCostRange(projectCost(bundle, "tap"));
+  const edit = formatCostRange(projectCost(bundle, "edit"));
+  const fresh = formatCostRange(projectCost(bundle, "query"));
+
+  const applyPreset = (p: Preset) => {
+    const b = PRESET_BUNDLES[p];
+    setImageTier(b.tier);
+    setKnobs({ maxAttempts: b.maxAttempts, verify: b.verify });
+  };
+
+  const knobButton = (pressed: boolean, onClick: () => void, label: string) => (
+    <button
+      key={label}
+      type="button"
+      onClick={onClick}
+      disabled={busy}
+      aria-pressed={pressed}
+      className={
+        "rounded-full px-2.5 py-1 transition-colors disabled:opacity-40 " +
+        (pressed
+          ? "bg-[var(--color-ink)] text-[var(--color-canvas)]"
+          : "hover:bg-[var(--color-ink)]/5")
+      }
+    >
+      {label}
+    </button>
+  );
+
+  return (
+    <div className="relative flex items-center gap-1.5 text-xs">
+      <div
+        role="group"
+        aria-label="Speed / quality preset"
+        className="flex items-center overflow-hidden rounded-full border border-[var(--color-edge)]"
+        title="Speed/quality preset — fast (one cheap un-judged shot), balanced (default), quality (premium image + deeper judged retries)"
+      >
+        <span className="px-2 py-1 opacity-60">speed</span>
+        {SPEED_PRESETS.map((p) => (
+          <button
+            key={p}
+            type="button"
+            onClick={() => applyPreset(p)}
+            disabled={busy}
+            aria-pressed={active === p}
+            className={
+              "px-2.5 py-1 transition-colors disabled:opacity-40 " +
+              (active === p
+                ? "bg-[var(--color-ink)] text-[var(--color-canvas)]"
+                : "hover:bg-[var(--color-ink)]/5")
+            }
+          >
+            {p}
+          </button>
+        ))}
+        {active === "custom" && (
+          <span className="bg-[var(--color-ink)] px-2.5 py-1 text-[var(--color-canvas)]">
+            custom
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={() => setOpen(!open)}
+          aria-expanded={open}
+          aria-label="Advanced loop controls"
+          title="Advanced — retry attempts + verification"
+          className="px-2 py-1 transition-colors hover:bg-[var(--color-ink)]/5"
+        >
+          ⚙
+        </button>
+      </div>
+      <span
+        data-testid="cost-chip"
+        className="whitespace-nowrap opacity-60"
+        title={`Projected spend per action — tap ${tap} · edit ${edit} · new page ${fresh}. Ranges span retries; see docs/COSTS.md.`}
+      >
+        ≈ {tap}/tap
+      </span>
+      {open && (
+        <div className="absolute left-0 top-full z-20 mt-2 w-60 rounded-xl border border-[var(--color-edge)] bg-[var(--color-canvas)] p-3 shadow-md">
+          <div className="mb-2 flex items-center justify-between">
+            <span className="opacity-60">attempts</span>
+            <div role="group" aria-label="Max judged attempts" className="flex gap-1">
+              {([1, 2, 3] as const).map((n) =>
+                knobButton(
+                  knobs.maxAttempts === n,
+                  () => setKnobs({ ...knobs, maxAttempts: n }),
+                  String(n),
+                ),
+              )}
+            </div>
+          </div>
+          <div className="mb-2 flex items-center justify-between">
+            <span className="opacity-60">verify</span>
+            <div role="group" aria-label="Judged verification" className="flex gap-1">
+              {knobButton(knobs.verify, () => setKnobs({ ...knobs, verify: true }), "on")}
+              {knobButton(!knobs.verify, () => setKnobs({ ...knobs, verify: false }), "off")}
+            </div>
+          </div>
+          <p className="mt-2 border-t border-[var(--color-edge)] pt-2 opacity-60">
+            tap {tap} · edit {edit} · new page {fresh}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/hooks/useSpeedPreset.test.tsx
+++ b/apps/web/hooks/useSpeedPreset.test.tsx
@@ -1,0 +1,91 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  PRESET_BUNDLES,
+  presetFor,
+  useLoopKnobs,
+  wireFields,
+} from "./useSpeedPreset";
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe("preset → bundle map", () => {
+  it("balanced puts NOTHING on the wire — the byte-identity stop", () => {
+    expect(wireFields(PRESET_BUNDLES.balanced)).toEqual({});
+  });
+
+  it("fast asks for one un-judged shot", () => {
+    expect(wireFields(PRESET_BUNDLES.fast)).toEqual({
+      max_attempts: 1,
+      verify: false,
+    });
+  });
+
+  it("quality asks for the deeper judged pass, verify omitted (it's the default)", () => {
+    expect(wireFields(PRESET_BUNDLES.quality)).toEqual({ max_attempts: 3 });
+  });
+
+  it("each bundle round-trips through presetFor", () => {
+    for (const preset of ["fast", "balanced", "quality"] as const) {
+      const { tier, ...knobs } = PRESET_BUNDLES[preset];
+      expect(presetFor(tier, knobs)).toBe(preset);
+    }
+  });
+
+  it("a hand-flipped knob or tier reads as custom", () => {
+    expect(presetFor("balanced", { maxAttempts: 1, verify: true })).toBe(
+      "custom",
+    );
+    expect(presetFor("pro", { maxAttempts: 2, verify: true })).toBe("custom");
+  });
+});
+
+describe("useLoopKnobs", () => {
+  it("defaults to the balanced bundle", () => {
+    const { result } = renderHook(() => useLoopKnobs());
+    expect(result.current[0]).toEqual({ maxAttempts: 2, verify: true });
+  });
+
+  it("hydrates from localStorage on mount", () => {
+    window.localStorage.setItem(
+      "openflipbook.loopKnobs",
+      JSON.stringify({ maxAttempts: 1, verify: false }),
+    );
+    const { result } = renderHook(() => useLoopKnobs());
+    expect(result.current[0]).toEqual({ maxAttempts: 1, verify: false });
+  });
+
+  it("ignores garbage and out-of-range stored values", () => {
+    window.localStorage.setItem("openflipbook.loopKnobs", "not json");
+    expect(renderHook(() => useLoopKnobs()).result.current[0]).toEqual({
+      maxAttempts: 2,
+      verify: true,
+    });
+    window.localStorage.setItem(
+      "openflipbook.loopKnobs",
+      JSON.stringify({ maxAttempts: 99, verify: false }),
+    );
+    expect(renderHook(() => useLoopKnobs()).result.current[0]).toEqual({
+      maxAttempts: 2,
+      verify: true,
+    });
+  });
+
+  it("writes back on change but not on the first mount", () => {
+    window.localStorage.setItem(
+      "openflipbook.loopKnobs",
+      JSON.stringify({ maxAttempts: 3, verify: true }),
+    );
+    const { result } = renderHook(() => useLoopKnobs());
+    expect(
+      window.localStorage.getItem("openflipbook.loopKnobs"),
+    ).toContain('"maxAttempts":3');
+    act(() => result.current[1]({ maxAttempts: 1, verify: false }));
+    expect(
+      JSON.parse(window.localStorage.getItem("openflipbook.loopKnobs") ?? ""),
+    ).toEqual({ maxAttempts: 1, verify: false });
+  });
+});

--- a/apps/web/hooks/useSpeedPreset.ts
+++ b/apps/web/hooks/useSpeedPreset.ts
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { ImageTier } from "@openflipbook/config";
+
+// The speed preset — one control that bundles {image tier, judged-loop
+// attempts, verify} so "I just want it fast and cheap right now" is a single
+// tap instead of a server flag. The preset is a SHORTCUT over two stores:
+// the image tier keeps living in useImageTier (openflipbook.tier — the
+// existing toggle stays the source of truth), this hook owns the loop knobs.
+// Both are global localStorage: a per-session preset wrapping a global tier
+// would desync the moment you switch sessions.
+
+const KNOBS_KEY = "openflipbook.loopKnobs";
+
+export type SpeedPreset = "fast" | "balanced" | "quality";
+
+export const SPEED_PRESETS: readonly SpeedPreset[] = [
+  "fast",
+  "balanced",
+  "quality",
+] as const;
+
+export interface LoopKnobs {
+  /** Judged-loop attempts; the server clamps to [1, 4]. */
+  maxAttempts: number;
+  /** false -> skip the judged loops (a fast, un-judged single shot). */
+  verify: boolean;
+}
+
+export interface SpeedBundle extends LoopKnobs {
+  tier: ImageTier;
+}
+
+// The three stops. Balanced is exactly today's defaults — it puts NOTHING
+// new on the wire (see wireFields), so the default path stays byte-identical.
+export const PRESET_BUNDLES: Record<SpeedPreset, SpeedBundle> = {
+  fast: { tier: "fast", maxAttempts: 1, verify: false },
+  balanced: { tier: "balanced", maxAttempts: 2, verify: true },
+  quality: { tier: "pro", maxAttempts: 3, verify: true },
+};
+
+const DEFAULT_KNOBS: LoopKnobs = {
+  maxAttempts: PRESET_BUNDLES.balanced.maxAttempts,
+  verify: PRESET_BUNDLES.balanced.verify,
+};
+
+/** Which preset the current {tier, knobs} amount to — "custom" when the
+ * advanced knobs (or a hand-flipped tier) left the three stops. */
+export function presetFor(
+  tier: ImageTier,
+  knobs: LoopKnobs,
+): SpeedPreset | "custom" {
+  for (const preset of SPEED_PRESETS) {
+    const b = PRESET_BUNDLES[preset];
+    if (
+      b.tier === tier &&
+      b.maxAttempts === knobs.maxAttempts &&
+      b.verify === knobs.verify
+    )
+      return preset;
+  }
+  return "custom";
+}
+
+/** The request-body fields the knobs put on the wire. Balanced values are
+ * OMITTED (absent -> the backend's env defaults, byte-identical to today). */
+export function wireFields(knobs: LoopKnobs): {
+  max_attempts?: number;
+  verify?: boolean;
+} {
+  return {
+    ...(knobs.maxAttempts !== PRESET_BUNDLES.balanced.maxAttempts
+      ? { max_attempts: knobs.maxAttempts }
+      : {}),
+    ...(knobs.verify ? {} : { verify: false }),
+  };
+}
+
+function isKnobs(v: unknown): v is LoopKnobs {
+  if (typeof v !== "object" || v === null) return false;
+  const k = v as Record<string, unknown>;
+  return (
+    typeof k.maxAttempts === "number" &&
+    k.maxAttempts >= 1 &&
+    k.maxAttempts <= 4 &&
+    typeof k.verify === "boolean"
+  );
+}
+
+/**
+ * Loop knobs persisted to localStorage; mirrors useImageTier (the first
+ * effect run after mount is skipped so a fresh hydration isn't clobbered by
+ * the default before the load-from-storage effect runs).
+ */
+export function useLoopKnobs(): readonly [LoopKnobs, (k: LoopKnobs) => void] {
+  const [knobs, setKnobs] = useState<LoopKnobs>(DEFAULT_KNOBS);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = window.localStorage.getItem(KNOBS_KEY);
+    if (!stored) return;
+    try {
+      const parsed: unknown = JSON.parse(stored);
+      if (isKnobs(parsed))
+        setKnobs({ maxAttempts: parsed.maxAttempts, verify: parsed.verify });
+    } catch {
+      // garbage in storage -> keep the default
+    }
+  }, []);
+
+  const firstRun = useRef(true);
+  useEffect(() => {
+    if (firstRun.current) {
+      firstRun.current = false;
+      return;
+    }
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(KNOBS_KEY, JSON.stringify(knobs));
+  }, [knobs]);
+
+  return [knobs, setKnobs] as const;
+}

--- a/apps/web/lib/cost-estimate.test.ts
+++ b/apps/web/lib/cost-estimate.test.ts
@@ -1,0 +1,63 @@
+// Pins the projection to docs/COSTS.md's headline per-operation numbers
+// (the table under "What each operation costs"). If fal/OpenRouter prices
+// move, update the doc AND the constants — this test is the drift alarm.
+import { describe, expect, it } from "vitest";
+
+import { type CostBundle, formatCostRange, projectCost } from "./cost-estimate";
+
+const BALANCED: CostBundle = { tier: "balanced", maxAttempts: 2, verify: true };
+const FAST: CostBundle = { tier: "fast", maxAttempts: 1, verify: false };
+const QUALITY: CostBundle = { tier: "pro", maxAttempts: 3, verify: true };
+
+describe("projectCost vs docs/COSTS.md", () => {
+  it("balanced tap ≈ $0.16 (1 attempt) – $0.32 (2 attempts)", () => {
+    const { low, high } = projectCost(BALANCED, "tap");
+    expect(low).toBeCloseTo(0.16, 1);
+    expect(high).toBeCloseTo(0.32, 1);
+  });
+
+  it("balanced mask edit ≈ $0.11 – $0.21", () => {
+    const { low, high } = projectCost(BALANCED, "edit");
+    expect(low).toBeCloseTo(0.11, 2);
+    expect(high).toBeCloseTo(0.21, 2);
+  });
+
+  it("balanced fresh map ≈ $0.16, never looped", () => {
+    const { low, high } = projectCost(BALANCED, "query");
+    expect(low).toBeCloseTo(0.16, 2);
+    expect(high).toBe(low);
+  });
+
+  it("fast un-judged tap ≈ $0.04–0.05 — the Fast preset's whole point", () => {
+    const { low, high } = projectCost(FAST, "tap");
+    expect(high).toBe(low);
+    expect(low).toBeGreaterThan(0.039); // never cheaper than the image itself
+    expect(low).toBeLessThan(0.05);
+  });
+
+  it("verify:false collapses the range even with retries configured", () => {
+    const r = projectCost({ ...BALANCED, verify: false }, "tap");
+    expect(r.high).toBe(r.low);
+    expect(r.low).toBeLessThan(projectCost(BALANCED, "tap").low);
+  });
+
+  it("quality tap scales with attempts and the pro image price", () => {
+    const { low, high } = projectCost(QUALITY, "tap");
+    expect(low).toBeCloseTo(0.25, 1);
+    expect(high).toBeGreaterThan(0.7); // 3 × $0.24 + the judges
+  });
+
+  it("clamps absurd attempt asks to the server cap", () => {
+    const capped = projectCost({ ...BALANCED, maxAttempts: 99 }, "tap");
+    expect(capped.high).toBe(
+      projectCost({ ...BALANCED, maxAttempts: 4 }, "tap").high,
+    );
+  });
+});
+
+describe("formatCostRange", () => {
+  it("renders a range and collapses points", () => {
+    expect(formatCostRange({ low: 0.1635, high: 0.3195 })).toBe("$0.16–0.32");
+    expect(formatCostRange({ low: 0.0465, high: 0.0465 })).toBe("$0.05");
+  });
+});

--- a/apps/web/lib/cost-estimate.ts
+++ b/apps/web/lib/cost-estimate.ts
@@ -1,0 +1,90 @@
+// The cost projection behind the speed preset's chip — the number you see
+// BEFORE you spend it. Price constants are mirrored from docs/COSTS.md
+// (June 2026, fal model pages + OpenRouter); the vitest next door pins the
+// projections to that doc's headline per-operation numbers so the two can't
+// silently drift apart. Honest ranges, not false precision: `low` is the
+// accept-at-one outcome, `high` is every retry spent.
+
+import type { ImageTier } from "@openflipbook/config";
+
+export type CostAction = "tap" | "edit" | "query";
+
+export interface CostBundle {
+  tier: ImageTier;
+  /** Judged-loop attempts, clamped server-side to [1, 4]. */
+  maxAttempts: number;
+  /** false -> the judged loops are skipped (one un-judged shot). */
+  verify: boolean;
+}
+
+export interface CostRange {
+  low: number;
+  high: number;
+}
+
+// fal — the dollar driver (docs/COSTS.md "The models we call").
+const IMAGE_PRICE: Record<ImageTier, number> = {
+  fast: 0.039, // nano-banana
+  balanced: 0.15, // nano-banana-pro
+  pro: 0.24, // riverflow-v2.5-pro
+};
+// flux-pro/v1/fill $0.05/MP ≈ $0.10 per mask edit at 16:9.
+const INPAINT_PRICE = 0.1;
+// One Gemini Flash round-trip (judge / VLM / planner) — pennies that stack
+// up in COUNT, not dollars.
+const VLM_CALL = 0.0015;
+
+// Per-operation call counts (docs/COSTS.md "What each operation costs").
+const TAP_VLM_FIRST = 9; // click + plan + 4 judges + 3 extraction
+const TAP_VLM_RETRY = 4; // 4 more judges per extra attempt
+const TAP_VLM_UNJUDGED = 5; // click + plan + 3 extraction, no judges
+const EDIT_VLM_FIRST = 5; // polish + 2 judges + 2 extraction
+const EDIT_VLM_RETRY = 2; // 2 more judges per extra attempt
+const EDIT_VLM_UNJUDGED = 3; // polish + 2 extraction
+const QUERY_VLM = 4; // plan + extract + detect + view
+
+/** Projected dollar range for one action under the bundle. The fresh `query`
+ * path is never looped, so its range collapses to a point. */
+export function projectCost(bundle: CostBundle, action: CostAction): CostRange {
+  const attempts = bundle.verify
+    ? Math.max(1, Math.min(4, Math.round(bundle.maxAttempts)))
+    : 1;
+  const image = IMAGE_PRICE[bundle.tier];
+  switch (action) {
+    case "query":
+      return point(image + QUERY_VLM * VLM_CALL);
+    case "tap": {
+      if (!bundle.verify) return point(image + TAP_VLM_UNJUDGED * VLM_CALL);
+      const low = image + TAP_VLM_FIRST * VLM_CALL;
+      const high =
+        attempts * image +
+        (TAP_VLM_FIRST + (attempts - 1) * TAP_VLM_RETRY) * VLM_CALL;
+      return { low, high };
+    }
+    case "edit": {
+      if (!bundle.verify)
+        return point(INPAINT_PRICE + EDIT_VLM_UNJUDGED * VLM_CALL);
+      const low = INPAINT_PRICE + EDIT_VLM_FIRST * VLM_CALL;
+      const high =
+        attempts * INPAINT_PRICE +
+        (EDIT_VLM_FIRST + (attempts - 1) * EDIT_VLM_RETRY) * VLM_CALL;
+      return { low, high };
+    }
+  }
+}
+
+/** "$0.16–0.32", or "$0.05" when the range collapses. Two decimals — the
+ * projection is honest to about a cent, no further. */
+export function formatCostRange(range: CostRange): string {
+  const lo = dollars(range.low);
+  const hi = dollars(range.high);
+  return lo === hi ? `$${lo}` : `$${lo}–${hi}`;
+}
+
+function point(value: number): CostRange {
+  return { low: value, high: value };
+}
+
+function dollars(value: number): string {
+  return value.toFixed(2);
+}

--- a/docs/COSTS.md
+++ b/docs/COSTS.md
@@ -91,10 +91,12 @@ Dollars are fine; **wall-clock is the product problem**, and it's structural:
    it per retry attempt* — no memoization. On a hotspot that was a measured
    **3.5 min** for one ferry edit. **Biggest single win: upload once per
    request, reuse the URL across attempts.** (Real, mergeable fix.)
-2. **Judges are sequential.** An enter runs 4 judges per attempt, one after
+2. **Judges are sequential.** ~~An enter runs 4 judges per attempt, one after
    another (~2-5s each), up to 2 attempts = up to 8 VLM round-trips before the
-   image is accepted. They could run **concurrently** (they're independent),
-   or be trimmed on a fast tier.
+   image is accepted.~~ **Shipped:** `judge_concurrently()` gathers them
+   (render_loop + edit_loop) — judge wall-clock per attempt is now the
+   slowest single judge, not the sum. And the speed preset's `verify:false`
+   skips them entirely per request.
 3. **Extraction blocks the felt-ready moment.** 3 VLM calls (~15-25s) fire
    after every final before the codex/geo are populated. Already fire-and-
    forget for the image, but the next interaction's geo isn't ready until it

--- a/docs/PLAN_CONTROLS.md
+++ b/docs/PLAN_CONTROLS.md
@@ -1,5 +1,16 @@
 # PLAN — speed/budget/model controls in the UI, with live cost projection
 
+> **Status: shipped** (June 2026). All four steps landed, plus the concurrent
+> judges (step 4 was promoted from optional — it was the demo's wall-clock
+> pain). Names settled as **fast / balanced / quality**; the chip shows real
+> dollar ranges (`lib/cost-estimate.ts`, vitest-pinned to `docs/COSTS.md`);
+> the 3-stop preset sits inline next to the tier toggle with the granular
+> knobs (attempts, verify) behind the ⚙ popover. One deviation from the text
+> below: `max_attempts` clamps to a hard server cap of 4 rather than the env
+> ceiling (the env default of 2 would have made Quality's 3 attempts
+> unreachable), and the preset store is global localStorage, not per-session
+> (it drives the global image tier — per-session would desync).
+
 ## Context
 
 The Ankh-Morpork re-shoot made the problem visible: the default path is

--- a/docs/PLAN_CONTROLS.md
+++ b/docs/PLAN_CONTROLS.md
@@ -1,0 +1,141 @@
+# PLAN — speed/budget/model controls in the UI, with live cost projection
+
+## Context
+
+The Ankh-Morpork re-shoot made the problem visible: the default path is
+heavy (an enter fires up to 13 sequential model calls + judged retries + a
+full-res re-upload), and the user has **no way to say "I just want it fast and
+cheap right now"** beyond the existing `fast/balanced/pro` image-tier toggle —
+which only changes the image model, not the judging or the retries. And there
+is **no cost feedback at all**: you can't tell that one tap costs ~$0.16 and a
+2-attempt enter ~$0.32 until the bill arrives. `docs/COSTS.md` is the
+accounting; this plan surfaces it as a control you can turn, with the number
+shown before you spend it.
+
+Goal: one **Economy ↔ Balanced ↔ Quality** preset that bundles
+{image model, retry attempts, verification on/off, judge model} and shows the
+**projected cost per action** live — plus an advanced expander for granular
+control. Additive, per-session, flag-free (it's user preference, not a kill
+switch).
+
+## What already exists (reuse, don't rebuild)
+
+- **Image tier** (`fast/balanced/pro`) already flows per-request:
+  `useImageTier()` (localStorage `openflipbook.tier`) → toolbar toggle
+  (`QueryToolbar.tsx:113-137`) → `image_tier` on every `generate()` call →
+  backend `_resolve_model` (`providers/image.py`). `pro` already warns once
+  ("slower + pricier"). This is the exact pattern to extend.
+- **Persisted-preference hook pattern**: `usePersistedTier.ts` (SSR-safe,
+  hydration-deferred, `[value, setter]`) — mirror it for the new preset.
+- **Per-request model override** `image_model` exists on the wire but is never
+  set from the UI — the budget-alternative slugs (`docs/COSTS.md`) can ride it.
+- **`world_mode` / `autonomy`** already flow per-request (the toggle pattern).
+- **`docs/COSTS.md`** — the cost source of truth (prices + per-op + token
+  counts). The TS projection table mirrors its numbers.
+
+## The gaps to close
+
+1. **Retry attempts are env-only.** `VIEW_LOOP_MAX_ATTEMPTS` /
+   `EDIT_LOOP_MAX_ATTEMPTS` are read from `os.environ` in `render_loop.py` /
+   `edit_loop.py`. No per-request control → a user can't pick "one shot, no
+   retries" for a fast pass.
+2. **Verification is all-or-nothing by env flag.** `VIEW_LOOP` / `EDIT_JUDGE`
+   are deployer kill-switches, not per-request. Economy mode wants "skip the
+   judges this time" without flipping a server flag.
+3. **No cost feedback.** Nothing shows the projected spend of the current
+   config before you act.
+
+## The design — one preset, three stops
+
+A **Speed/Quality preset** in the toolbar (next to the image-tier toggle),
+persisted per session, that sets a bundle and projects cost:
+
+| Preset | Image | Retries | Verify (judges) | Judge model | ≈ per tap / per edit |
+|---|---|---|---|---|---|
+| **Economy** | fast (`nano-banana` $0.039) | 1 | off | — | **~$0.04 / ~$0.04** |
+| **Balanced** (default) | balanced (`nano-banana-pro` $0.15) | up to 2 | on | flash | **~$0.16–0.32 / ~$0.11–0.21** |
+| **Quality** | pro (`riverflow` $0.24) | up to 3 | on | flash | **~$0.25–0.5 / ~$0.2–0.4** |
+
+The projection number is computed, not hard-coded — `lib/cost-estimate.ts`
+holds the price constants (mirrored from `docs/COSTS.md`) and a
+`projectCost(preset, action)` that returns a `{low, high}` range. The toolbar
+renders a small chip: **"≈ $0.04 per tap · fast, no verify"** that updates as
+the preset (or the advanced knobs) change. Honest ranges, not false precision.
+
+**Advanced expander** (a small popover, mirror the existing tier-toggle
+markup): granular control over the four axes above, for power users — the
+preset is just a shortcut that sets all four. Changing an advanced knob shows
+"Custom" as the preset and re-projects.
+
+## Wire changes (additive, backwards-compat)
+
+`packages/config/src/index.ts` `GenerateRequestBody`:
+```ts
+// Per-request loop control (absent → today's env defaults). Economy sets
+// max_attempts:1 + verify:false for a fast, un-judged pass.
+max_attempts?: number;   // clamps to [1, env max] server-side
+verify?: boolean;        // false → skip the judged loop this request
+```
+`image_model` already exists — Economy/Quality can set the budget/premium slug
+through it (or keep using `image_tier`; the preset decides).
+
+Backend threading (small, localized):
+- `generate.py` reads `body.max_attempts` / `body.verify`, passes them into
+  `render_loop.loop_config_from_env()` / `edit_loop.edit_loop_config_from_env()`
+  as overrides (the configs already centralize attempts — add an optional
+  `max_attempts_override` param, clamp to the env ceiling so a deployer cap
+  still wins).
+- `verify:false` → skip the loop branch entirely (the existing one-shot path
+  the loop already falls back to when `enter_view is None`), so it's the
+  proven zero-overhead route, just user-chosen.
+- Byte-identity: absent fields → exactly today's behavior.
+
+## UI surface
+
+- `components/PlayPage/SpeedPreset.tsx`: the 3-stop segmented control + the
+  cost chip + the advanced popover. Presentational; the page owns state.
+- `hooks/useSpeedPreset.ts`: persisted per session (mirror `useWorldMode`),
+  returns `{preset, custom, setPreset, setCustom}` where `custom` holds the
+  four advanced axes.
+- `lib/cost-estimate.ts`: pure price table + `projectCost()` — vitest-pinned
+  against the `docs/COSTS.md` numbers so they can't silently drift.
+- `app/play/page.tsx`: read the preset, spread `{max_attempts, verify}` (and
+  `image_tier`/`image_model` per the preset) into every `generate()` body —
+  the same spots `image_tier` already goes.
+
+## Build sequence (PR-sized)
+
+1. **Backend per-request loop control**: `max_attempts` + `verify` on the wire
+   + the config overrides in `generate.py`/render_loop/edit_loop, clamped to
+   env ceilings. Tests: a request with `max_attempts:1 verify:false` takes the
+   one-shot path (no judge calls); absent → env default (byte-identity).
+2. **`lib/cost-estimate.ts`** + vitest: the price table mirrored from
+   `docs/COSTS.md`, `projectCost(preset, action)` ranges, a test that fails if
+   the constants drift from the doc's headline numbers.
+3. **`useSpeedPreset` + `SpeedPreset.tsx`** + the cost chip, wired into the
+   toolbar and the `generate()` bodies. Vitest on the pure preset→bundle map.
+4. (optional) **Concurrent judges** — the latency win named in `docs/COSTS.md`:
+   run the 4 enter judges with `asyncio.gather` instead of sequentially. Pure
+   backend, no UI; cuts an enter's judge time ~4×. Worth doing alongside.
+
+## Verification
+
+- Free: `make eval` — the new wire fields' byte-identity test, the cost-table
+  drift test, the preset→bundle map test.
+- Manual: pick Economy → the chip reads ~$0.04, a tap does one un-judged fast
+  render (confirm in the backend log: no `view.loop` markers, `fast` model);
+  pick Quality → the chip jumps, the log shows judged retries. Confirm the
+  projection range brackets the real per-action spend over a few actions.
+- The cost numbers trace to `docs/COSTS.md`; if fal/OpenRouter prices move,
+  update the doc and the test catches the drift.
+
+## Open questions for you
+
+- **Preset names**: Economy/Balanced/Quality, or Fast/Default/Best, or a
+  literal "$ / $$ / $$$"? (I'd lean Fast/Balanced/Quality — verbs, not money.)
+- **Show dollars or relative?** A real "$0.04" chip is honest but ties the UI
+  to live prices; a "~3× cheaper" relative chip ages better. (I'd show the
+  dollar range with a tooltip linking the breakdown.)
+- **Where**: in the always-visible toolbar (one more control) vs behind a
+  small ⚙ settings popover (keeps the toolbar clean). (I'd put the 3-stop
+  preset inline and the advanced axes in the popover.)

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -98,6 +98,12 @@ export interface GenerateRequestBody {
   click_hint?: string;
   image_tier?: ImageTier;
   image_model?: string;
+  // Per-request loop control (the speed preset). Absent -> the backend's env
+  // defaults, byte-identical to today. `verify: false` skips the judged
+  // render/edit loops for this request (a fast, un-judged single shot);
+  // `max_attempts` clamps server-side to the loops' hard cap.
+  max_attempts?: number;
+  verify?: boolean;
   edit_instruction?: string;
   // Mask-scoped edit (EDIT_REGION; the backend gates it behind the env flag so
   // it's a no-op until enabled). `edit_mask` is an opaque PNG data URL at the


### PR DESCRIPTION
Executes docs/PLAN_CONTROLS.md (carried in on this branch) and fixes the demo's wall-clock problem in the same stroke.

## What

- **Concurrent judges** — the 4 enter judges and 2 edit judges are independent verdicts on the same image but ran back-to-back (~2–5s each, 10–20s/attempt of pure serial judging — the Ankh-Morpork re-shoot's pain). `judge_concurrently()` gathers them; failure in any slot keeps the exact degraded-single-attempt rule, cancellation propagates as before. Pinned by tests that deadlock-then-timeout if the judges ever go sequential again.
- **Per-request loop control on the wire** — `max_attempts` + `verify` on `GenerateBody`/`GenerateRequestBody`. Absent → byte-identical to today (tested). `verify:false` rides the proven one-shot paths per request; `max_attempts` clamps to a hard cap of 4.
- **`lib/cost-estimate.ts`** — docs/COSTS.md as code: `projectCost(bundle, action)` → honest `{low, high}` ranges, vitest-pinned to the doc's headline numbers (balanced tap $0.16–0.32, mask edit $0.11–0.21) so prices can't silently drift.
- **The speed preset UI** — a `fast / balanced / quality` 3-stop in the toolbar next to the tier toggle, with a live cost chip ("≈ $0.16–0.32/tap") and a ⚙ popover for the granular knobs (attempts, verify). The preset is a shortcut over two stores: tier stays in the existing toggle (they sync), `useLoopKnobs` owns the loop axes; hand-tuning reads as "custom". **Balanced spreads nothing onto the wire** — the default path is untouched.

## Why

The default path is heavy: an enter fires up to 13 sequential model calls + judged retries, and there was no way to say "fast and cheap right now" and no cost feedback at all. The upload re-do was fixed in #49; this lands the other two named wins (concurrent judges, one-shot fast mode) plus the projection that shows the spend before you spend it.

## Tests

- backend: 603 passed (new: judge-concurrency deadlock pins, verify/max_attempts gates on enter + mask edit + judged whole-image edit, clamp tests, byte-identity)
- web: 528 passed (new: cost-table drift pin, preset→bundle map, hook hydration, component behavior), tsc clean, build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)