### PR TITLE
Wave 1: tap crash fix, spatial continuity + zoom-cut, legible generation

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -90,6 +90,11 @@ class WorldContextEntity(BaseModel):
     # Mirrors the TS `footprint?: {w,d}` / `height?` (schema-parity gated).
     footprint: dict[str, float] | None = None
     height: float | None = None
+    # Compass phrase from the entity's top-level map geo ("the north-west of
+    # the map") — the spatial half of continuity. Rendered as a fixed-position
+    # instruction so landmarks stop relocating between pages (the palace-on-
+    # the-riverbank drift). Omitted → appearance-only continuity, as today.
+    location_hint: str | None = None
 
 
 # Geometric world model — Pydantic mirrors of the packages/config TS shapes.

--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -1781,6 +1781,17 @@ async def _event_stream(
                 except Exception:
                     draft_result = None
                 if draft_result is not None:
+                    # Name the phase honestly: what lands next is a fast-tier
+                    # DRAFT the main render will replace — the banner and the
+                    # waterfall both label it so the swap isn't a mystery.
+                    yield _sse(
+                        {
+                            "type": "status",
+                            "stage": "draft",
+                            "image_model": draft_result.model,
+                        },
+                        trace_id,
+                    )
                     # Encode in a thread so the event loop stays free for
                     # main_task progress. Sync b64encode of a 1-3MB JPEG
                     # otherwise stalls the loop for ~5-15ms — small per call,

--- a/apps/modal-backend/providers/judge.py
+++ b/apps/modal-backend/providers/judge.py
@@ -51,6 +51,10 @@ def _parse_judgement(raw: str) -> JudgeResult:
     rationale = ""
     try:
         parsed = json.loads(cleaned[cleaned.find("{") : cleaned.rfind("}") + 1])
+        if isinstance(parsed, list):  # list-wrapped reply (see llm._coerce_json_dict)
+            parsed = next((p for p in parsed if isinstance(p, dict)), {})
+        if not isinstance(parsed, dict):
+            raise ValueError("non-object judge reply")
         rationale = str(parsed.get("rationale", ""))[:300]
         if "score" in parsed:
             score = float(parsed["score"])

--- a/apps/modal-backend/providers/llm.py
+++ b/apps/modal-backend/providers/llm.py
@@ -2185,17 +2185,30 @@ def _coerce_bbox(raw: Any) -> dict[str, float] | None:
     return {"x_pct": x, "y_pct": y, "w_pct": w, "h_pct": h}
 
 
+def _coerce_json_dict(parsed: Any) -> dict[str, Any] | None:
+    """A reply that should be one object sometimes arrives list-wrapped
+    ([{...}]) — gemini does this occasionally even under response_format
+    json_object, and it took the whole click path down in prod. Unwrap to
+    the first dict; anything else is a miss."""
+    if isinstance(parsed, list):
+        parsed = next((p for p in parsed if isinstance(p, dict)), None)
+    return cast(dict[str, Any], parsed) if isinstance(parsed, dict) else None
+
+
 def _safe_json(raw: str) -> dict[str, Any]:
     try:
-        return cast(dict[str, Any], json.loads(raw))
+        coerced = _coerce_json_dict(json.loads(raw))
+        if coerced is not None:
+            return coerced
     except json.JSONDecodeError:
-        start = raw.find("{")
-        end = raw.rfind("}")
-        if start >= 0 and end > start:
-            try:
-                return cast(dict[str, Any], json.loads(raw[start : end + 1]))
-            except json.JSONDecodeError:
-                return {}
+        pass
+    start = raw.find("{")
+    end = raw.rfind("}")
+    if start >= 0 and end > start:
+        try:
+            return _coerce_json_dict(json.loads(raw[start : end + 1])) or {}
+        except json.JSONDecodeError:
+            return {}
     return {}
 
 
@@ -2435,6 +2448,9 @@ def parse_scene_graph(payload: Any) -> SceneGraph:
     capped at 2. Never raises — a weak completion degrades to a thinner graph."""
     from .layout_solver import EmptyRegion, PlannedEntity, PlannedRelation, SceneGraph
 
+    if isinstance(payload, list):
+        # The same list-wrapping drift _safe_json tolerates — unwrap, don't discard.
+        payload = next((p for p in payload if isinstance(p, dict)), None)
     if not isinstance(payload, dict):
         payload = {}
     kind = str(payload.get("place_kind", "place")).strip().lower()

--- a/apps/modal-backend/providers/llm.py
+++ b/apps/modal-backend/providers/llm.py
@@ -1325,6 +1325,12 @@ def _format_world_context_clause(
         # scale across pages (a place rendered large once shouldn't come back
         # tiny). Best-effort; absent → no hint.
         line += _world_size_hint(entry)
+        # The spatial half of continuity: where the world map pins this entity
+        # ("the north-west of the map"). Without it the model relocates
+        # landmarks to fit the composition — the palace-on-the-riverbank drift.
+        location = str(entry.get("location_hint", "") or "").strip()
+        if location:
+            line += f"; fixed position: {location}"
         lines.append(line)
     if not lines:
         return ""
@@ -1338,7 +1344,17 @@ def _format_world_context_clause(
         "Keep each entity at a CONSISTENT RELATIVE SCALE across pages — where a "
         "size is given below (footprint/height in world units), respect those "
         "proportions so a place drawn large once is not shrunk later. "
-        "If an entity is NOT relevant to this page, simply omit it; do not "
+        + (
+            # Additive: the position rule only enters the prompt when at least
+            # one entity actually carries a hint (no hints -> byte-identical).
+            "Where a `fixed position` is given, the entity LIVES at that "
+            "position of the established world — keep it there relative to "
+            "the other landmarks; do NOT relocate it to suit this page's "
+            "composition. "
+            if any("fixed position:" in line for line in lines)
+            else ""
+        )
+        + "If an entity is NOT relevant to this page, simply omit it; do not "
         "force entities into the scene.\n\n"
         "CAUSALITY (CRITICAL): each entity's `state=` flags below describe "
         "the CURRENT condition of the entity from prior pages. The "

--- a/apps/modal-backend/tests/test_generate_enter.py
+++ b/apps/modal-backend/tests/test_generate_enter.py
@@ -247,3 +247,26 @@ async def test_explainer_tap_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
     edit.assert_not_awaited()
     gen.assert_awaited_once()
     assert gen.await_args.kwargs["reference_urls"] == ["data:r", "data:p", "data:s"]
+
+
+async def test_world_off_submap_request_still_zoom_continues(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The wideRegionCut contract: a classic (world OFF) tap that the client
+    # routed as place_submap rides the same Kontext cut as a world-mode submap
+    # tap — the river page is a faithful crop-zoom, not a re-imagined city.
+    _mock_plan(monkeypatch)
+    edit = _mock_edit(monkeypatch)
+    cont = AsyncMock(
+        return_value=GeneratedImage(b"jpeg", "image/jpeg", "fal-ai/flux-pro/kontext", "r3")
+    )
+    monkeypatch.setattr(image_edit_mod, "continue_image", cont)
+    gen = _mock_fresh(monkeypatch)
+
+    await _collect(
+        _event_stream(_tap_body(render_mode="place_submap", world_mode=False), "t1")
+    )
+
+    cont.assert_awaited_once()
+    edit.assert_not_awaited()
+    gen.assert_not_awaited()

--- a/apps/modal-backend/tests/test_llm_provider.py
+++ b/apps/modal-backend/tests/test_llm_provider.py
@@ -1168,3 +1168,37 @@ async def test_polish_fill_scale_anchor_without_style(
     out = await llm.polish_fill_description("add a pond")
     assert "Drawn to scale with the surrounding scene" in out
     assert "art medium" not in out
+
+
+def test_safe_json_unwraps_list_wrapped_objects() -> None:
+    # gemini sometimes returns [{...}] despite response_format json_object —
+    # the shape drift that 502'd every tap (err.resolve_click in prod).
+    assert llm._safe_json('[{"subject": "The River Ankh"}]') == {
+        "subject": "The River Ankh"
+    }
+    assert llm._safe_json('[null, {"a": 1}]') == {"a": 1}
+    assert llm._safe_json("[]") == {}
+    assert llm._safe_json('["just", "strings"]') == {}
+    assert llm._safe_json('"a scalar"') == {}
+    assert llm._safe_json('{"already": "fine"}') == {"already": "fine"}
+    # prose-wrapped object still slices out
+    assert llm._safe_json('Sure! {"x": 2} hope that helps') == {"x": 2}
+
+
+def test_parse_scene_graph_unwraps_list_payload() -> None:
+    # bounds_hint only survives if the list-wrapped payload was unwrapped
+    # rather than discarded to {}.
+    graph = llm.parse_scene_graph(
+        [{"place_kind": "place", "bounds_hint": {"w": 12, "h": 8}}]
+    )
+    assert graph.bounds_hint == {"w": 12.0, "h": 8.0}
+
+
+def test_judge_parse_tolerates_list_wrapped_reply() -> None:
+    from providers.judge import _parse_judgement
+
+    result = _parse_judgement('[{"score": 7.5, "rationale": "fine"}]')
+    # the {-to-} slice grabs the inner object; either way no crash and the
+    # score survives
+    assert result.score == 7.5
+    assert "fine" in result.rationale

--- a/apps/modal-backend/tests/test_llm_provider.py
+++ b/apps/modal-backend/tests/test_llm_provider.py
@@ -1202,3 +1202,40 @@ def test_judge_parse_tolerates_list_wrapped_reply() -> None:
     # score survives
     assert result.score == 7.5
     assert "fine" in result.rationale
+
+
+def test_world_context_clause_renders_fixed_position() -> None:
+    out = llm._format_world_context_clause(
+        [
+            {
+                "name": "The Patrician's Palace",
+                "appearance": "grand marble palace with columns",
+                "kind": "place",
+                "location_hint": "the north of the map",
+            },
+            {
+                "name": "The Mended Drum",
+                "appearance": "a notorious low-beamed tavern",
+                "kind": "place",
+            },
+        ]
+    )
+    assert "fixed position: the north of the map" in out
+    assert "do NOT relocate" in out
+    # absent hint -> the entity line carries no position claim
+    drum_line = next(line for line in out.splitlines() if "Mended Drum" in line)
+    assert "fixed position" not in drum_line
+
+
+def test_world_context_clause_without_hints_is_byte_identical() -> None:
+    # The spatial half is strictly additive: no location_hint anywhere ->
+    # the clause must not change at all (header included).
+    entities = [
+        {
+            "name": "Mira",
+            "appearance": "a wiry engineer in a patched coat",
+            "kind": "person",
+        }
+    ]
+    out = llm._format_world_context_clause(entities)
+    assert "fixed position" not in out

--- a/apps/web/app/api/generate-page/route.ts
+++ b/apps/web/app/api/generate-page/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import type { GenerateRequestBody } from "@openflipbook/config";
+import { locationPhrase } from "@/lib/location-phrase";
 import { resolveEntitiesForPrompt } from "@/lib/world";
 import { getWorldMap } from "@/lib/world-map";
 import { modalUrl as joinModalUrl } from "@/lib/modal";
@@ -59,12 +60,25 @@ export async function POST(req: Request) {
                 { footprint: g.footprint, height: g.height },
               ])
           );
+          // Spatial half of continuity: a compass phrase from the TOP-LEVEL
+          // geos only (a nested geo's pos is in its parent's local frame —
+          // a phrase from it would claim the wrong place on the city map).
+          const hintById = new Map(
+            geo.entities
+              .filter((g) => g.entity_id && !g.parent_id)
+              .map((g) => [
+                g.entity_id as string,
+                locationPhrase(g, geo.bounds),
+              ])
+          );
           for (const wc of world_context) {
             const s = sizeById.get(wc.id);
             if (s) {
               wc.footprint = s.footprint;
               wc.height = s.height;
             }
+            const hint = hintById.get(wc.id);
+            if (hint) wc.location_hint = hint;
           }
         } catch {
           // size enrichment is best-effort; never block generation

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -666,11 +666,22 @@ export default function PlayPage() {
               } else if (evt.stage === "planning") {
                 setStatusMsg("Planning page…");
               } else if (evt.stage === "generating_image") {
+                // The pro model has no fast draft to show (OpenRouter path)
+                // and routinely takes minutes — say so instead of leaving a
+                // silent spinner (the 3-minute-riverflow mystery). Read the
+                // tier off the REQUEST body: this callback is deliberately
+                // dependency-free, so component state here would be stale.
+                const proNote =
+                  body.image_tier === "pro"
+                    ? " (pro model — usually 2–3 min)"
+                    : "";
                 setStatusMsg(
                   evt.page_title
-                    ? `Drawing "${evt.page_title}"…`
-                    : "Drawing image…"
+                    ? `Drawing "${evt.page_title}"…${proNote}`
+                    : `Drawing image…${proNote}`
                 );
+              } else if (evt.stage === "draft") {
+                setStatusMsg("Draft preview — the full render is refining…");
               }
             } else if (evt.type === "progress") {
               lastImage = `data:image/jpeg;base64,${evt.jpeg_b64}`;
@@ -2829,7 +2840,10 @@ export default function PlayPage() {
                     }
                     setMorphFx((prev) => {
                       if (!prev || prev.phase !== "reveal") return prev;
-                      hudEmit("morph:end", { duration_ms: nowMs() - prev.startedAt });
+                      hudEmit("morph:end", {
+                        duration_ms: nowMs() - prev.startedAt,
+                        t: nowMs(),
+                      });
                       return null;
                     });
                   }}

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -95,7 +95,12 @@ import { DragDropOverlay } from "@/components/PlayPage/DragDropOverlay";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useWorldState } from "@/hooks/useWorldState";
 import { useWorldMap } from "@/hooks/useWorldMap";
-import { geoTapRequest, MAP_IMAGE_FRAME, type GeoTapOverride } from "@/lib/geo-tap";
+import {
+  geoTapRequest,
+  MAP_IMAGE_FRAME,
+  wideRegionCut,
+  type GeoTapOverride,
+} from "@/lib/geo-tap";
 import { selectNeighbors } from "@/lib/scale-neighbors";
 import { childrenOf, projectTopDown } from "@/lib/world-geometry";
 import { viewNeutralAppearance } from "@/lib/appearance";
@@ -2075,6 +2080,18 @@ export default function PlayPage() {
               page.sceneView,
             )
           : null;
+      // World OFF + a wide mapped region (the river): a fresh re-composition
+      // relocates landmarks, so zoom-cut the map instead (see wideRegionCut).
+      const wideCut =
+        !worldEnabled && geoEntities.length > 0
+          ? wideRegionCut(
+              { entities: geoEntities, bounds: geoBounds },
+              page.nodeId ?? "",
+              { x_pct: click.x_pct, y_pct: click.y_pct },
+              16 / 9,
+              page.sceneView,
+            )
+          : null;
       void generate({
         query: page.query,
         aspect_ratio: "16:9",
@@ -2163,6 +2180,25 @@ export default function PlayPage() {
               // the VLM-invented surroundings above (geoTap is spread last → wins).
               ...(geoTap.surroundings
                 ? { prefetched_surroundings: geoTap.surroundings }
+                : {}),
+            }
+          : {}),
+        // The world-off zoom-cut: same submap continuation a world-mode submap
+        // tap rides (Kontext on the region crop), so the river page is a CUT of
+        // the map, not a re-imagined city. Spread last so the subject wins.
+        ...(wideCut
+          ? {
+              render_mode: "place_submap",
+              prefetched_subject: wideCut.focus_label,
+              ...(viewNeutralAppearance(wideCut.focus_visual)
+                ? {
+                    prefetched_subject_context: viewNeutralAppearance(
+                      wideCut.focus_visual,
+                    ),
+                  }
+                : {}),
+              ...(wideCut.surroundings
+                ? { prefetched_surroundings: wideCut.surroundings }
                 : {}),
             }
           : {}),

--- a/apps/web/components/waterfall-hud.tsx
+++ b/apps/web/components/waterfall-hud.tsx
@@ -2,17 +2,12 @@
 
 import { useEffect, useState } from "react";
 import { on, type HudEventName } from "@/lib/trace";
-
-type StageKey =
-  | "request"
-  | "click_resolving"
-  | "click_resolved"
-  | "planning"
-  | "generating_image"
-  | "verifying"
-  | "final"
-  | "decode"
-  | "morph";
+import {
+  buildSegments,
+  marksForEndReportedStage,
+  type WaterfallMark as Mark,
+  type WaterfallStage as StageKey,
+} from "@/lib/waterfall-segments";
 
 interface StageInfo {
   label: string;
@@ -25,17 +20,13 @@ const STAGE_INFO: Record<StageKey, StageInfo> = {
   click_resolved: { label: "tap → subject", color: "rgba(59,130,246,0.85)" },
   planning: { label: "planner", color: "rgba(34,197,94,0.85)" },
   generating_image: { label: "image gen", color: "rgba(234,88,12,0.85)" },
+  draft: { label: "draft preview", color: "rgba(245,158,11,0.85)" },
   verifying: { label: "vlm: verify", color: "rgba(20,184,166,0.85)" },
   final: { label: "final", color: "rgba(239,68,68,0.9)" },
   decode: { label: "decode", color: "rgba(168,85,247,0.85)" },
+  idle: { label: "idle (tab hidden?)", color: "rgba(120,120,120,0.35)" },
   morph: { label: "reveal", color: "rgba(217,70,239,0.85)" },
 };
-
-interface Mark {
-  stage: StageKey;
-  t: number;
-  hint?: string;
-}
 
 interface RunState {
   traceId: string | null;
@@ -120,27 +111,38 @@ export default function WaterfallHUD() {
     });
 
     sub("image:decode", (p: unknown) => {
-      const v = p as { ms?: number };
+      // End-reported: the event arrives when the browser decode RESOLVES,
+      // carrying its measured ms + its start time. A backgrounded tab defers
+      // the decode by minutes — that gap renders as `idle`, never as a
+      // 100s+ "decode" bar (the 184813ms incident).
+      const v = p as { ms?: number; t0?: number };
       const ms = typeof v?.ms === "number" ? v.ms : 0;
       setRun((prev) => {
         const lastT = prev.marks[prev.marks.length - 1]?.t ?? 0;
+        const start = typeof v?.t0 === "number" ? v.t0 : lastT;
         return {
           ...prev,
-          marks: [...prev.marks, { stage: "decode", t: lastT + ms }],
-          active: "decode",
+          marks: marksForEndReportedStage(prev.marks, "decode", start, ms),
+          active: null,
         };
       });
     });
 
     sub("morph:end", (p: unknown) => {
-      const v = p as { duration_ms?: number };
-      const ms = typeof v?.duration_ms === "number" ? v.duration_ms : 0;
+      // The reveal runs from the decode's end to this event's arrival; the
+      // legacy duration_ms (measured since CLICK) is ignored for the bar.
+      const v = p as { t?: number; duration_ms?: number };
       setRun((prev) => {
-        const lastT = prev.marks[prev.marks.length - 1]?.t ?? 0;
+        const last = prev.marks[prev.marks.length - 1];
+        const lastEnd = last == null ? 0 : (last.end ?? last.t);
+        const endT = typeof v?.t === "number" ? v.t : lastEnd;
         return {
           ...prev,
-          marks: [...prev.marks, { stage: "morph", t: lastT + ms }],
-          endedAt: lastT + ms,
+          marks: [
+            ...prev.marks,
+            { stage: "morph", t: lastEnd, end: Math.max(endT, lastEnd) },
+          ],
+          endedAt: Math.max(endT, lastEnd),
           active: null,
         };
       });
@@ -173,21 +175,10 @@ export default function WaterfallHUD() {
   if (!hasShown) return null;
 
   const { startedAt, marks, active, traceId } = run;
-  const segments: Array<{ stage: StageKey; start: number; end: number }> = [];
-  if (startedAt != null) {
-    for (let i = 0; i < marks.length; i++) {
-      const m = marks[i]!;
-      const next = marks[i + 1];
-      const start = m.t - startedAt;
-      const end =
-        next != null
-          ? next.t - startedAt
-          : active != null && active === m.stage
-            ? Math.max(start + 1, performanceNow() - startedAt)
-            : start + 1;
-      segments.push({ stage: m.stage, start, end });
-    }
-  }
+  const segments =
+    startedAt != null
+      ? buildSegments(marks, startedAt, active, performanceNow())
+      : [];
   const totalMs =
     segments.length > 0 ? Math.max(1, segments[segments.length - 1]!.end) : 1;
 

--- a/apps/web/hooks/useImageMorph.ts
+++ b/apps/web/hooks/useImageMorph.ts
@@ -42,7 +42,10 @@ export function useImageMorph(currentImageDataUrl: string | null | undefined) {
     const decodeStart = nowMs();
     const finish = () => {
       if (cancelled) return;
-      hudEmit("image:decode", { ms: nowMs() - decodeStart });
+      // t0 lets the HUD place the decode bar where it actually ran — a
+      // backgrounded tab defers this promise by minutes, and without the
+      // start time that stall painted as a 100s+ "decode" segment.
+      hudEmit("image:decode", { ms: nowMs() - decodeStart, t0: decodeStart });
       setMorphFx((prev) =>
         prev && prev.phase === "wait" ? { ...prev, nextImg: url, phase: "reveal" } : prev,
       );

--- a/apps/web/lib/geo-tap.test.ts
+++ b/apps/web/lib/geo-tap.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { MapCrop, SceneView, WorldEntityGeo } from "@openflipbook/config";
 
-import { describeSurroundings, geoTapRequest } from "./geo-tap";
+import { describeSurroundings, geoTapRequest, wideRegionCut } from "./geo-tap";
 
 function geo(
   id: string,
@@ -309,4 +309,69 @@ describe("geoTapRequest (close the geometric tap loop)", () => {
     expect(auto.scene_view.view).toBeUndefined();
   });
 
+});
+
+describe("wideRegionCut (world-off coherence net)", () => {
+  const river = geo("river", "The River Ankh", 50, 30, {
+    footprint: { w: 90, d: 8 },
+    visual: "a wide silty brown river",
+  });
+  const palace = geo("palace", "The Patrician's Palace", 20, 10, {
+    height: 14,
+  });
+  const map = { entities: [river, palace], bounds: CROP };
+
+  it("a tap on a frame-spanning region answers with the zoom-cut subject", () => {
+    const cut = wideRegionCut(map, "n1", { x_pct: 0.5, y_pct: 0.5 }, 16 / 9);
+    expect(cut).not.toBeNull();
+    expect(cut!.focus_label).toBe("The River Ankh");
+    expect(cut!.focus_visual).toBe("a wide silty brown river");
+  });
+
+  it("a narrow entity keeps the classic topical tap", () => {
+    const cut = wideRegionCut(
+      map,
+      "n1",
+      { x_pct: 20 / 100, y_pct: 10 / 60 },
+      16 / 9,
+    );
+    expect(cut).toBeNull();
+  });
+
+  it("inside an entered place the cut never fires", () => {
+    const inside: SceneView = {
+      node_id: "n2",
+      level: "street",
+      observer: {
+        pos: { x: 0, y: 0 },
+        eye_height: 1.7,
+        gaze: 0,
+        pitch: 0,
+        fov: 1.2,
+      },
+      map_crop: null,
+    };
+    const cut = wideRegionCut(
+      map,
+      "n2",
+      { x_pct: 0.5, y_pct: 0.5 },
+      16 / 9,
+      inside,
+    );
+    expect(cut).toBeNull();
+  });
+
+  it("nested geos (a child frame's wide floor) never claim the city map", () => {
+    const nestedWide = geo("hall", "The Great Hall", 50, 30, {
+      footprint: { w: 90, d: 8 },
+      parent_id: "palace",
+    });
+    const cut = wideRegionCut(
+      { entities: [nestedWide, palace], bounds: CROP },
+      "n1",
+      { x_pct: 0.5, y_pct: 0.5 },
+      16 / 9,
+    );
+    expect(cut).toBeNull();
+  });
 });

--- a/apps/web/lib/geo-tap.ts
+++ b/apps/web/lib/geo-tap.ts
@@ -224,3 +224,43 @@ export function geoTapRequest(
     surroundings: describeSurroundings(route.focus_id, map.entities),
   };
 }
+
+export interface WideRegionCut {
+  focus_label: string;
+  focus_visual: string | null;
+  surroundings: string;
+}
+
+/** World-OFF coherence net. A classic tap on a WIDE mapped region (a river, a
+ * wall, a district spanning the frame) re-composes the whole scene on the
+ * fresh path, and with nothing pinning the geography the model relocates
+ * landmarks to fit the new composition — the palace-on-the-riverbank drift.
+ * Detect exactly that case and answer with the same place_submap zoom-cut a
+ * world-mode submap tap uses (Kontext continuation of the region crop — a
+ * faithful CUT of the map, not a reinvention). Narrow entities, nested
+ * frames, and unmapped taps all keep the classic topical tap. */
+export function wideRegionCut(
+  map: { entities: WorldEntityGeo[]; bounds: MapCrop },
+  nodeId: string,
+  click: ClickPoint,
+  aspect: number,
+  currentView?: SceneView | null,
+  minFrameFrac = 0.5,
+): WideRegionCut | null {
+  // Only at the top-level map frame — inside an entered place the classic
+  // tap stands (its frame isn't the city map the cut would continue).
+  if (currentView && currentView.level !== "map") return null;
+  const tap = geoTapRequest(map, nodeId, click, aspect, undefined, currentView ?? null);
+  if (!tap?.focus_id || !tap.focus_label) return null;
+  const focus = map.entities.find((e) => e.id === tap.focus_id);
+  if (!focus || (focus.parent_id ?? null) !== null) return null;
+  const wide =
+    focus.footprint.w >= MAP_IMAGE_FRAME.w * minFrameFrac ||
+    focus.footprint.d >= MAP_IMAGE_FRAME.h * minFrameFrac;
+  if (!wide) return null;
+  return {
+    focus_label: tap.focus_label,
+    focus_visual: tap.focus_visual,
+    surroundings: tap.surroundings,
+  };
+}

--- a/apps/web/lib/location-phrase.test.ts
+++ b/apps/web/lib/location-phrase.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { locationPhrase } from "./location-phrase";
+
+const FRAME = { x: 0, y: 0, w: 100, h: 60 };
+const geo = (x: number, y: number, w = 6, d = 6) => ({
+  pos: { x, y },
+  footprint: { w, d },
+});
+
+describe("locationPhrase", () => {
+  it("maps the 3×3 compass grid (+y = south)", () => {
+    expect(locationPhrase(geo(10, 5), FRAME)).toBe("the north-west of the map");
+    expect(locationPhrase(geo(50, 5), FRAME)).toBe("the north of the map");
+    expect(locationPhrase(geo(90, 55), FRAME)).toBe(
+      "the south-east of the map",
+    );
+    expect(locationPhrase(geo(50, 30), FRAME)).toBe("the center of the map");
+    expect(locationPhrase(geo(90, 30), FRAME)).toBe("the east of the map");
+  });
+
+  it("calls out edge-spanning entities (the river case)", () => {
+    expect(locationPhrase(geo(50, 30, 95, 8), FRAME)).toBe(
+      "spanning the map east–west across its middle",
+    );
+    expect(locationPhrase(geo(50, 8, 95, 8), FRAME)).toBe(
+      "spanning the map east–west across its north",
+    );
+    expect(locationPhrase(geo(20, 30, 8, 58), FRAME)).toBe(
+      "spanning the map north–south through its west",
+    );
+    expect(locationPhrase(geo(50, 30, 80, 50), FRAME)).toBe(
+      "spanning the whole map",
+    );
+  });
+
+  it("makes no claim for out-of-frame or degenerate inputs", () => {
+    expect(locationPhrase(geo(140, 30), FRAME)).toBeNull();
+    expect(locationPhrase(geo(50, -20), FRAME)).toBeNull();
+    expect(locationPhrase(geo(50, 30), { x: 0, y: 0, w: 0, h: 0 })).toBeNull();
+    expect(locationPhrase(geo(Number.NaN, 30), FRAME)).toBeNull();
+  });
+});

--- a/apps/web/lib/location-phrase.ts
+++ b/apps/web/lib/location-phrase.ts
@@ -1,0 +1,32 @@
+import type { MapCrop, WorldEntityGeo } from "@openflipbook/config";
+
+// Geo → compass phrase for the world-continuity prompt ("fixed position: the
+// north-west of the map"). The spatial half of continuity: world_context has
+// always locked APPEARANCE while leaving the model free to relocate landmarks
+// (the Patrician's-Palace-on-the-riverbank incident); this phrase pins them.
+// +y = south in the map frame (see world-geometry.ts); thirds give a 3×3
+// compass grid, and edge-spanning entities (rivers, walls) are called out as
+// spans rather than cells.
+
+export function locationPhrase(
+  geo: Pick<WorldEntityGeo, "pos" | "footprint">,
+  frame: MapCrop,
+): string | null {
+  if (!frame.w || !frame.h) return null;
+  const fx = (geo.pos.x - frame.x) / frame.w;
+  const fy = (geo.pos.y - frame.y) / frame.h;
+  if (!Number.isFinite(fx) || !Number.isFinite(fy)) return null;
+  // Outside the frame (stale geo / sub-frame leak) -> no claim beats a wrong one.
+  if (fx < -0.05 || fx > 1.05 || fy < -0.05 || fy > 1.05) return null;
+  const row = fy < 1 / 3 ? "north" : fy > 2 / 3 ? "south" : "";
+  const col = fx < 1 / 3 ? "west" : fx > 2 / 3 ? "east" : "";
+  const spansEW = geo.footprint.w >= frame.w * 0.6;
+  const spansNS = geo.footprint.d >= frame.h * 0.6;
+  if (spansEW && spansNS) return "spanning the whole map";
+  if (spansEW)
+    return `spanning the map east–west across its ${row || "middle"}`;
+  if (spansNS)
+    return `spanning the map north–south through its ${col || "middle"}`;
+  if (!row && !col) return "the center of the map";
+  return `the ${row && col ? `${row}-${col}` : row || col} of the map`;
+}

--- a/apps/web/lib/waterfall-segments.test.ts
+++ b/apps/web/lib/waterfall-segments.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSegments,
+  marksForEndReportedStage,
+  type WaterfallMark,
+} from "./waterfall-segments";
+
+describe("buildSegments", () => {
+  it("start-marks run until the next mark; the active tail grows to now", () => {
+    const marks: WaterfallMark[] = [
+      { stage: "request", t: 1000 },
+      { stage: "planning", t: 1500 },
+      { stage: "generating_image", t: 2000 },
+    ];
+    const segs = buildSegments(marks, 1000, "generating_image", 5000);
+    expect(segs).toEqual([
+      { stage: "request", start: 0, end: 500 },
+      { stage: "planning", start: 500, end: 1000 },
+      { stage: "generating_image", start: 1000, end: 4000 },
+    ]);
+  });
+
+  it("explicit ends beat next-mark inference (the off-by-one fix)", () => {
+    const marks: WaterfallMark[] = [
+      { stage: "final", t: 2000 },
+      { stage: "decode", t: 2010, end: 2200 },
+      { stage: "morph", t: 2200, end: 2800 },
+    ];
+    const segs = buildSegments(marks, 1000, null, 9999);
+    expect(segs.find((s) => s.stage === "decode")).toEqual({
+      stage: "decode",
+      start: 1010,
+      end: 1200,
+    });
+    expect(segs.find((s) => s.stage === "morph")).toEqual({
+      stage: "morph",
+      start: 1200,
+      end: 1800,
+    });
+  });
+
+  it("dead time between an explicit end and the next mark reads as idle", () => {
+    const marks: WaterfallMark[] = [
+      { stage: "decode", t: 2000, end: 2100 },
+      { stage: "morph", t: 9000, end: 9600 },
+    ];
+    const segs = buildSegments(marks, 1000, null, 0);
+    expect(segs.map((s) => s.stage)).toEqual(["decode", "idle", "morph"]);
+    expect(segs[1]).toEqual({ stage: "idle", start: 1100, end: 8000 });
+  });
+});
+
+describe("marksForEndReportedStage", () => {
+  it("reconstructs the stage start from its measured duration", () => {
+    const prev: WaterfallMark[] = [{ stage: "final", t: 2000 }];
+    const out = marksForEndReportedStage(prev, "decode", 2005, 180);
+    expect(out[out.length - 1]).toEqual({
+      stage: "decode",
+      t: 2005,
+      end: 2185,
+    });
+    expect(out).toHaveLength(2); // 5ms gap -> no idle inserted
+  });
+
+  it("the 184813ms incident: a deferred decode surfaces as idle, not decode", () => {
+    // Tab hidden through a 3-minute pro render: the decode promise resolved
+    // 184s after the final frame, with the decode itself taking ~190ms.
+    const prev: WaterfallMark[] = [{ stage: "final", t: 2000 }];
+    const out = marksForEndReportedStage(prev, "decode", 186_813, 190);
+    expect(out.map((m) => m.stage)).toEqual(["final", "idle", "decode"]);
+    expect(out[1]).toEqual({ stage: "idle", t: 2000, end: 186_813 });
+    expect(out[2]).toEqual({ stage: "decode", t: 186_813, end: 187_003 });
+  });
+});

--- a/apps/web/lib/waterfall-segments.ts
+++ b/apps/web/lib/waterfall-segments.ts
@@ -1,0 +1,93 @@
+// Pure segment math for the generation-waterfall HUD. Extracted (and fixed)
+// because the inline version mislabeled the tail of every run: decode/morph
+// events report stage ENDS, but the painter treated every mark as a START —
+// so labels shifted one segment left, and a browser-deferred image decode
+// (backgrounded tab) painted as a 100s+ "decode" bar (the 184813ms incident).
+// Marks may now carry an explicit `end`; gaps before an explicitly-timed mark
+// surface honestly as `idle` instead of inflating their neighbour.
+
+export type WaterfallStage =
+  | "request"
+  | "click_resolving"
+  | "click_resolved"
+  | "planning"
+  | "generating_image"
+  | "draft"
+  | "verifying"
+  | "final"
+  | "decode"
+  | "idle"
+  | "morph";
+
+export interface WaterfallMark {
+  stage: WaterfallStage;
+  /** Stage start, on the shared trace clock. */
+  t: number;
+  /** Explicit stage end for self-terminating stages (decode/morph/idle).
+   * Absent -> the stage runs until the next mark (or `now` while active). */
+  end?: number;
+  hint?: string;
+}
+
+export interface WaterfallSegment {
+  stage: WaterfallStage;
+  start: number;
+  end: number;
+}
+
+/** A gap longer than this before an explicitly-timed mark is rendered as its
+ * own `idle` segment (tab hidden, deferred decode) instead of stretching the
+ * previous stage's bar. */
+export const IDLE_GAP_MS = 250;
+
+export function buildSegments(
+  marks: readonly WaterfallMark[],
+  startedAt: number,
+  activeStage: WaterfallStage | null,
+  now: number,
+): WaterfallSegment[] {
+  const segments: WaterfallSegment[] = [];
+  for (let i = 0; i < marks.length; i++) {
+    const m = marks[i]!;
+    const next = marks[i + 1];
+    const start = m.t - startedAt;
+    const end =
+      m.end != null
+        ? m.end - startedAt
+        : next != null
+          ? next.t - startedAt
+          : activeStage != null && activeStage === m.stage
+            ? Math.max(start + 1, now - startedAt)
+            : start + 1;
+    segments.push({ stage: m.stage, start, end: Math.max(end, start) });
+    // An explicitly-ended stage followed by a much-later mark: the in-between
+    // is dead time, not part of either stage.
+    if (m.end != null && next != null && next.t - m.end > IDLE_GAP_MS) {
+      segments.push({
+        stage: "idle",
+        start: m.end - startedAt,
+        end: next.t - startedAt,
+      });
+    }
+  }
+  return segments;
+}
+
+/** Insert-point helper for end-reported events (decode): the event arrives at
+ * its END carrying a measured duration; reconstruct the start, and surface a
+ * leading idle gap when the stage began long after the previous mark ended. */
+export function marksForEndReportedStage(
+  prev: readonly WaterfallMark[],
+  stage: WaterfallStage,
+  startT: number,
+  durationMs: number,
+): WaterfallMark[] {
+  const last = prev[prev.length - 1];
+  const lastEnd = last == null ? startT : (last.end ?? last.t);
+  const out = [...prev];
+  if (startT - lastEnd > IDLE_GAP_MS) {
+    out.push({ stage: "idle", t: lastEnd, end: startT });
+  }
+  out.push({ stage, t: startT, end: startT + Math.max(0, durationMs) });
+  return out;
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -325,6 +325,9 @@ export type GenerateStage =
   | "click_resolved"
   | "planning"
   | "generating_image"
+  // A fast-tier draft frame is about to land as `progress`; the main render
+  // is still running and will replace it (PROGRESSIVE_DRAFT).
+  | "draft"
   | "verifying";
 
 export interface GenerateStatusEvent {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -7,7 +7,7 @@ export type GenerateMode = "query" | "tap" | "edit" | "expand" | "ascend";
 // scale-level: component = -1, peer = 0, container = +1.
 export type ScaleKind = "component" | "peer" | "container";
 
-// ── Scale ladder (B2, SCALE_LADDER_NAV) ──────────────────────────────────────
+// ââ Scale ladder (B2, SCALE_LADDER_NAV) ââââââââââââââââââââââââââââââââââââââ
 // An explicit, ordered, metric-anchored zoom axis: a node's COARSE absolute
 // "where on the zoom axis am I". Distinct from ScaleKind (relative:
 // component/peer/container) and from WorldEntityGeo.scale (fine metric: the size
@@ -19,7 +19,7 @@ export const SCALE_LADDER = [
 ] as const;
 export type ScaleTier = (typeof SCALE_LADDER)[number];
 
-// Order-of-magnitude metric anchor (metres) per rung — the bridge that makes the
+// Order-of-magnitude metric anchor (metres) per rung â the bridge that makes the
 // ladder metric-conserving. ~27 orders of magnitude end to end, so callers
 // store/compare in LOG space. `world` and `planet` share an anchor by design (a
 // "world" is a planet-surface framing); tierStep still separates them by index.
@@ -42,7 +42,7 @@ export function tierStep(from: ScaleTier, to: ScaleTier): number {
 export function tierMetricMultiplier(from: ScaleTier, to: ScaleTier): number {
   return SCALE_TIER_METERS[to] / SCALE_TIER_METERS[from];
 }
-// INV-2: the metric span must move monotonically with the rung step — going
+// INV-2: the metric span must move monotonically with the rung step â going
 // DEEPER (step > 0) shrinks it (multiplier <= 1), OUTWARD (step < 0) grows it
 // (multiplier >= 1); ==1 is allowed only between the deliberately-equal
 // world/planet rungs. A transition that violates this is a mis-classified rung
@@ -54,8 +54,8 @@ export function tierTransitionValid(from: ScaleTier, to: ScaleTier): boolean {
   return step > 0 ? m <= 1 : m >= 1;
 }
 // One rung FINER (toward `object`, DEEPER); clamps at `object`. The inverse of the
-// Python `model_router.coarser_tier` used by OUTWARD — together they make a tap a
-// `tierStep` of +1 and an OUTWARD −1 on the SAME ladder.
+// Python `model_router.coarser_tier` used by OUTWARD â together they make a tap a
+// `tierStep` of +1 and an OUTWARD â1 on the SAME ladder.
 export function finerTier(t: ScaleTier): ScaleTier {
   const i = tierIndex(t);
   return SCALE_LADDER[Math.min(i + 1, SCALE_LADDER.length - 1)] ?? t;
@@ -64,7 +64,7 @@ export function finerTier(t: ScaleTier): ScaleTier {
 // How a node relates to its parent: "descend" = went IN (a tap child, the
 // default), "expand" = bloomed OUT (a neighbour from mode:"expand"), "ascend" =
 // zoomed OUT to a synthesized container (the OUTWARD reparent, SCALE_OUTWARD),
-// "edit" = a REVISION of the parent (mode:"edit") — the same page changed, not
+// "edit" = a REVISION of the parent (mode:"edit") â the same page changed, not
 // a place inside it, so the graph chrome must not read it as a tap-in.
 export type NodeRelation = "descend" | "expand" | "ascend" | "edit";
 
@@ -74,7 +74,7 @@ export type VideoTier = "fast" | "balanced" | "pro";
 
 // World Mode (opt-in). `autonomy` "auto" generates straight away; "semi" first
 // surfaces the resolver's clarifying questions. `RenderMode` is how a tapped
-// subject is drawn — an immersive place you've stepped into, a closer
+// subject is drawn â an immersive place you've stepped into, a closer
 // cartographic map of a sub-area, or today's labelled explainer diagram.
 export type Autonomy = "auto" | "semi";
 export type RenderMode = "place_scene" | "place_submap" | "explainer";
@@ -109,7 +109,7 @@ export interface GenerateRequestBody {
   // it's a no-op until enabled). `edit_mask` is an opaque PNG data URL at the
   // page's natural dims, WHITE = edit / black = keep (flux fill's native
   // convention); `edit_region` is the drag selection that produced it,
-  // normalized to natural-image space — the mask drives the model, the box
+  // normalized to natural-image space â the mask drives the model, the box
   // scopes the judge's inside crop. Absent -> the legacy whole-image edit.
   edit_mask?: string;
   edit_region?: { x: number; y: number; w: number; h: number };
@@ -144,16 +144,16 @@ export interface GenerateRequestBody {
   // so recurring characters / places preserve their look across pages without
   // the user having to re-describe them.
   world_context?: WorldContextEntity[];
-  // Image conditioning — an ordered stack of reference images (data URLs) the
+  // Image conditioning â an ordered stack of reference images (data URLs) the
   // generator blends so the page belongs to the same world: region crop (the
-  // spot you came from) → whole parent → global style anchor. `condition_roles`
+  // spot you came from) â whole parent â global style anchor. `condition_roles`
   // labels each url in order so the backend can phrase the conditioning prompt.
-  // Built client-side (lib/image-condition.ts). Omit → today's text-only gen.
+  // Built client-side (lib/image-condition.ts). Omit â today's text-only gen.
   condition_image_urls?: string[];
   condition_roles?: string[];
   // World Mode (opt-in; the backend also gates it behind the WORLD_MODE env so
   // it's a no-op in prod until enabled). When on, a tap ENTERS the tapped place
-  // — a scene you stand in or a closer sub-map — instead of explaining a topic,
+  // â a scene you stand in or a closer sub-map â instead of explaining a topic,
   // and the place persists + reopens. `render_mode` explicitly overrides the
   // per-place framing the resolver would otherwise pick from `enter_as`.
   world_mode?: boolean;
@@ -162,7 +162,7 @@ export interface GenerateRequestBody {
   // B2 logical AROUND (mode:"expand", SCALE_AROUND_LOGICAL). The same-scale
   // neighbours the client already knows from geometry (excluded) + the focus's
   // rung, so the bloom proposes NEW peers at that scale. Ignored unless the flag
-  // is on; absent → today's unconstrained bloom.
+  // is on; absent â today's unconstrained bloom.
   known_neighbors?: string[];
   around_tier?: ScaleTier;
   // Geometric world (GEOMETRIC_WORLD). The scene's observer pose + level, and the
@@ -189,10 +189,16 @@ export interface WorldContextEntity {
   // Optional geometric size (world units) carried from the entity's
   // WorldEntityGeo when the web proxy resolves the slice. Lets the planner
   // hint a consistent relative scale for recurring entities across pages so a
-  // building rendered large once doesn't come back tiny next time. Omitted →
+  // building rendered large once doesn't come back tiny next time. Omitted â
   // today's behaviour (appearance text only).
   footprint?: { w: number; d: number };
   height?: number;
+  // Compass phrase from the entity's top-level map geo ("the north-west of
+  // the map", "spanning the map east–west across its middle") — the spatial
+  // half of continuity. The clause builder renders it as a fixed-position
+  // instruction so landmarks stop relocating between pages. Omitted →
+  // appearance-only continuity, exactly today's behaviour.
+  location_hint?: string;
 }
 
 export interface ResolveClickRequestBody {
@@ -211,7 +217,7 @@ export interface ResolveClickRequestBody {
 }
 
 // VLM's best-estimate centroid of the resolved subject (0..1 in image
-// frame). Powers the "we think you tapped this — yes/try again" overlay.
+// frame). Powers the "we think you tapped this â yes/try again" overlay.
 export interface ResolveClickPoint {
   x: number;
   y: number;
@@ -299,11 +305,11 @@ export interface GenerateFinalEvent {
   // or the model returned none. Already domain-deduped, capped at ~3.
   sources?: Citation[];
   // Which non-fresh image operation rendered this page ("zoom_continue",
-  // "enter_scene"). Absent on the fresh path — additive, backwards-compat.
+  // "enter_scene"). Absent on the fresh path â additive, backwards-compat.
   image_op?: string;
-  // Geometric grounding summary — present only when VLM_GROUNDING was on.
+  // Geometric grounding summary â present only when VLM_GROUNDING was on.
   grounding?: GroundingSummary;
-  // Judged mask-scoped edit verdict — present only on the EDIT_REGION path.
+  // Judged mask-scoped edit verdict â present only on the EDIT_REGION path.
   edit_verdict?: EditVerdict;
   trace_id?: string;
 }
@@ -357,7 +363,7 @@ export interface GenerateNeighborEvent {
   trace_id?: string;
 }
 
-// Terminal event of an expand bloom — the tray stops showing pending slots.
+// Terminal event of an expand bloom â the tray stops showing pending slots.
 export interface GenerateExpandDoneEvent {
   type: "expand_done";
   count: number;
@@ -465,7 +471,7 @@ export const DEFAULTS = {
 export type EntityKind = "person" | "place" | "item" | "creature";
 
 // Free-form key/value bag for causality (door=open, lantern=lit, mira_present=true).
-// Kept loose on purpose — the extractor emits whatever verbs/state words fit
+// Kept loose on purpose â the extractor emits whatever verbs/state words fit
 // the scene; the codex surface renders them as plain key:value chips.
 export type EntityState = Record<string, string | number | boolean>;
 
@@ -500,7 +506,7 @@ export interface Entity {
   // Atlas tile ids (== node ids in the current world-layout) the entity has
   // appeared on. Used for the atlas-pin overlay.
   appears_on_node_ids: string[];
-  // Sparse map of `node_id` → bounding box for the entity's appearance on
+  // Sparse map of `node_id` â bounding box for the entity's appearance on
   // that node. Populated by the extractor when it can localize the entity
   // in the image; omitted otherwise. Hover chips read this when rendering
   // the current page; atlas pins can use it to place markers within a
@@ -516,13 +522,13 @@ export interface Entity {
   updated_at: string;
 }
 
-// ── Geometric world model ────────────────────────────────────────────────────
+// ââ Geometric world model ââââââââââââââââââââââââââââââââââââââââââââââââââââ
 // A persistent 2D coordinate world: entities sit at numeric map positions with a
 // height + footprint; an observer has a pose; a rendered scene is a VIEW of the
 // in-frame entities from that pose (there is no single correct view). All
 // additive + dormant until GEOMETRIC_WORLD is enabled. The geometry engine
-// (apps/web/lib/world-geometry.ts ↔ apps/modal-backend/providers/geometry.py)
-// projects (map + observer) → the per-frame layout below.
+// (apps/web/lib/world-geometry.ts â apps/modal-backend/providers/geometry.py)
+// projects (map + observer) â the per-frame layout below.
 
 // A point in world units (arbitrary scale; origin top-left, +x east, +y south).
 export interface WorldVec2 {
@@ -535,7 +541,7 @@ export interface WorldVec2 {
 // Nested frames (the sub-entity consistency model): a place you can ENTER (the
 // Unseen University) is its own little world. Its sub-entities (Tower of Art,
 // Library, Great Hall) carry `parent_id` = that place's geo id, and their `pos`
-// is LOCAL to the parent's frame — so the University's internal layout is fixed
+// is LOCAL to the parent's frame â so the University's internal layout is fixed
 // ONCE and stays consistent across every view of it, and editing one ripples to
 // its siblings. Top-level city entities have `parent_id: null` (pos == world).
 export interface WorldEntityGeo {
@@ -554,14 +560,14 @@ export interface WorldEntityGeo {
   // default) = sits on the ground; >0 lifts it (a bird aloft, a clifftop castle,
   // a wall-mounted lantern). The projector reads `elevation ?? 0`.
   elevation?: number;
-  footprint: { w: number; d: number }; // ground extent: width (x) × depth (y)
+  footprint: { w: number; d: number }; // ground extent: width (x) Ã depth (y)
   // Per-frame scale: the size of ONE unit of THIS place's INTERIOR frame, in its
   // parent's units (default 1). Set when the place is first entered (its
-  // footprint extent ÷ the interior's local extent) so a child's local `pos`
-  // resolves to a true absolute position INSIDE this place. Metric — distinct
+  // footprint extent Ã· the interior's local extent) so a child's local `pos`
+  // resolves to a true absolute position INSIDE this place. Metric â distinct
   // from the categorical Entity.scale LOD bucket.
   scale?: number;
-  // Coarse absolute rung on SCALE_LADDER (city / place / room …) — which order of
+  // Coarse absolute rung on SCALE_LADDER (city / place / room â¦) â which order of
   // magnitude this entity's frame sits at, independent of the fine metric `scale`.
   // Optional; seeded by the view estimator, used by B2 scale navigation.
   scale_tier?: ScaleTier;
@@ -570,12 +576,12 @@ export interface WorldEntityGeo {
   state: EntityState;
   confidence: number; // 0..1
   // How this geometry was set: "user" (hand-placed, authoritative), "extracted"
-  // (a confirmed detection), or "derived" (back-projected from a bbox — a guess).
+  // (a confirmed detection), or "derived" (back-projected from a bbox â a guess).
   source: "extracted" | "user" | "derived";
   updated_at: string;
 }
 
-// Where the camera stands for a scene. Null observer ⇒ a top-down map view.
+// Where the camera stands for a scene. Null observer â a top-down map view.
 export interface ObserverPose {
   pos: WorldVec2;
   eye_height: number;
@@ -595,20 +601,20 @@ export interface MapCrop {
   h: number;
 }
 
-// What level a scene renders at — there is no single correct view.
+// What level a scene renders at â there is no single correct view.
 export type ViewLevel = "map" | "building" | "street" | "eye";
 
 // Render-INTENT camera vocabulary (the view grammar). Distinct from
 // ViewProjection below, which is the estimator's PERCEPTION read-out of an
 // already-generated image (estimator "perspective" maps to "eye_level" here).
 // A deliberate projection per render: flat 2D plan, 2.5D oblique bird's-eye,
-// true isometric, or 3D eye-level — plus optional numeric camera params.
+// true isometric, or 3D eye-level â plus optional numeric camera params.
 export type ViewSpecProjection = "top_down" | "oblique" | "isometric" | "eye_level";
 export interface ViewSpec {
   projection: ViewSpecProjection;
-  pitch_deg?: number; // camera tilt: -90 straight down … 0 horizon
+  pitch_deg?: number; // camera tilt: -90 straight down â¦ 0 horizon
   azimuth_deg?: number; // compass bearing of the gaze, 0 = north
-  // Qualitative register ("eye" ≈ 1.7 world units) or a metric height.
+  // Qualitative register ("eye" â 1.7 world units) or a metric height.
   camera_height?: "ground" | "eye" | "rooftop" | "aerial" | number;
   fov_deg?: number;
   // Who decided this view: the per-place policy, an explicit user pick
@@ -628,10 +634,10 @@ export interface SceneView {
   // stays consistent across re-entries. Null for a top-level map view.
   focus_id?: string | null;
   // Coarse absolute rung on SCALE_LADDER for this view (DEEPER stamps childTier,
-  // OUTWARD stamps parentTier) — so both directions share one ladder. Optional.
+  // OUTWARD stamps parentTier) â so both directions share one ladder. Optional.
   scale_tier?: ScaleTier;
   // The deliberate camera for this render (the view grammar). Absent/null on
-  // legacy nodes ⇒ the pre-grammar hardcoded behavior, byte-identical.
+  // legacy nodes â the pre-grammar hardcoded behavior, byte-identical.
   view?: ViewSpec | null;
 }
 
@@ -645,8 +651,8 @@ export interface ProjectedEntity {
   w_pct: number; // apparent size
   h_pct: number;
   depth: number; // distance from observer; lower = nearer (drawn on top)
-  // Coarse bins — what prompts + the VLM judge actually consume (honest: bins,
-  // not pixels). h_pos ∈ far-left..far-right, v_pos ∈ top|mid|bottom, size bin.
+  // Coarse bins â what prompts + the VLM judge actually consume (honest: bins,
+  // not pixels). h_pos â far-left..far-right, v_pos â top|mid|bottom, size bin.
   h_pos: string;
   v_pos: string;
   size: string;
@@ -654,14 +660,14 @@ export interface ProjectedEntity {
 
 // What the camera estimator reads out of a generated image, so the geometry
 // layer doesn't assume top-down. `projection` decides how a detection
-// box back-projects: top_down → the box is a footprint; oblique/perspective →
+// box back-projects: top_down â the box is a footprint; oblique/perspective â
 // its vertical extent reads as apparent height.
 export type ViewProjection = "top_down" | "oblique" | "perspective";
 export interface ViewEstimate {
   level: ViewLevel;
   projection: ViewProjection;
   pitch_deg: number;
-  // Coarse SCALE_LADDER rung the estimator read (or the ViewLevel→tier fallback).
+  // Coarse SCALE_LADDER rung the estimator read (or the ViewLevelâtier fallback).
   // Optional; mirrored in the Python ViewEstimate TypedDict (view_estimator.py).
   scale_tier?: ScaleTier;
   // The estimator's own 0..1 confidence. Gates the C12 node PATCH backend-side
@@ -678,7 +684,7 @@ export interface WorldMapSnapshot {
   updated_at: string;
 }
 
-// Backend → web wire format for one extraction pass. The web layer takes
+// Backend â web wire format for one extraction pass. The web layer takes
 // this, allocates ids for `added`, merges into the WorldStateDoc, emits
 // SSE events to subscribed frontends. State changes ride inside
 // `updated[].changes.state` rather than a separate channel; kept simple
@@ -702,7 +708,7 @@ export interface EntityUpdate {
   changes: Partial<Pick<Entity, "name" | "appearance" | "facts" | "state" | "aliases">>;
   confidence: number;
   // Re-localized box on THIS node: a recurring entity is detected again so it
-  // keeps an appearance_bbox per node — without it, geometry/overlay drop the
+  // keeps an appearance_bbox per node â without it, geometry/overlay drop the
   // entity on every re-appearance. Omitted when localization fails.
   bbox?: { x_pct: number; y_pct: number; w_pct: number; h_pct: number } | null;
 }
@@ -719,7 +725,7 @@ export interface ExtractEntitiesRequestBody {
   caption: string;
   // Lightweight summary of the world's current entities so the VLM can
   // diff. Web side selects the most relevant slice (recent + name-overlap
-  // candidates) before sending — full registry on every call wastes tokens.
+  // candidates) before sending â full registry on every call wastes tokens.
   prior_entities: Array<Pick<Entity, "id" | "kind" | "name" | "aliases" | "appearance">>;
   trace_id?: string;
 }
@@ -729,7 +735,7 @@ export interface ExtractEntitiesResponse {
   trace_id?: string;
 }
 
-// Snapshot returned by GET /api/world/:sessionId — used to hydrate the
+// Snapshot returned by GET /api/world/:sessionId â used to hydrate the
 // codex panel and the atlas overlay on permalink load.
 export interface WorldStateSnapshot {
   session_id: string;
@@ -748,10 +754,10 @@ export type WorldEntityMutation =
   | { op: "pin"; id: string; pinned: boolean }
   | { op: "set_appearance"; id: string; appearance: string; reference_image_url?: string | null };
 
-// ── Geometry edits: NL-editable map ──────────────────────────────────────────
+// ââ Geometry edits: NL-editable map ââââââââââââââââââââââââââââââââââââââââââ
 // A structured edit to the geometric world map (WorldEntityGeo by id). These are
 // what `edit_entities_nl` turns a natural-language instruction into ("move the
-// lighthouse north" → {op:"move", target, dx, dy}). `target` is a WorldEntityGeo
+// lighthouse north" â {op:"move", target, dx, dy}). `target` is a WorldEntityGeo
 // id; deltas are op-specific and in world units. Applied by lib/world-map.ts.
 export type EntityGeoEdit =
   | { op: "move"; target: string; dx: number; dy: number }
@@ -766,9 +772,9 @@ export type EntityGeoEdit =
       footprint?: { w: number; d: number };
     };
 
-// The result of an NL edit: the structured ops plus the blast-radius — the node
+// The result of an NL edit: the structured ops plus the blast-radius â the node
 // ids whose saved render references an edited entity and so are now stale (the
-// codex can offer "editing this restages N scenes — restage now?").
+// codex can offer "editing this restages N scenes â restage now?").
 export interface EntityEditPlan {
   edits: EntityGeoEdit[];
   blast_radius: string[];
@@ -784,7 +790,7 @@ export interface EditEntitiesRequestBody {
       "id" | "entity_id" | "label" | "pos" | "height" | "footprint" | "visual"
     >
   >;
-  // geo-id → node ids that show it; lets the backend compute blast-radius
+  // geo-id â node ids that show it; lets the backend compute blast-radius
   // without the full codex registry (web side builds it from appears_on_node_ids).
   references?: Record<string, string[]>;
   scene_view?: SceneView | null;
@@ -796,9 +802,9 @@ export interface EditEntitiesResponse {
   trace_id?: string;
 }
 
-// ── Describe a place -> logical object world (WORLD_FROM_DESCRIPTION) ─────────
+// ââ Describe a place -> logical object world (WORLD_FROM_DESCRIPTION) âââââââââ
 // Turn a natural-language place description into all its objects on the shared 2D
-// plane. The planner emits STRUCTURE (entities + relations), NEVER coordinates —
+// plane. The planner emits STRUCTURE (entities + relations), NEVER coordinates â
 // the deterministic solver (providers/layout_solver.py) turns relations into
 // WorldEntityGeo positions. All additive + flag-gated; no existing type changes.
 


### PR DESCRIPTION
First wave of the live-testing fix program (3 commits, each independently revertable).

## The tap crash (every other tap 502'd)
gemini-3-flash intermittently returns `[{...}]` even under `response_format: json_object`; `_safe_json` blindly cast it and seven callers crashed on `.get()` — the `'list' object has no attribute 'get'` banner. Now unwrapped at the single choke point (`_coerce_json_dict`), with the same tolerance in `parse_scene_graph` (unwrap, don't discard) and the judge parser. Regression tests pin the prod payload shapes.

## The teleporting palace (spatial continuity)
`world_context` locks appearance but carried zero position — a world-off tap on the river freely re-composed the city and moved the Patrician's Palace to the bank. Two halves:
- **`location_hint`**: the generate-page proxy joins each top-level geo's compass phrase (`lib/location-phrase.ts` — 3×3 grid, +y=south, river-style spans called out) onto the continuity slice; the prompt renders it as a `fixed position` instruction. No hints → byte-identical prompt (tested).
- **`wideRegionCut`** (`lib/geo-tap.ts`): world OFF + a tap on a frame-spanning mapped region routes as `place_submap` — the same Kontext crop-zoom a world-mode submap tap rides — a faithful **cut** of the map instead of a reinvention. Narrow entities / nested frames / unmapped taps keep the classic topical tap. Backend pin: explicit `place_submap` zoom-continues with `world_mode: false`.

## Legible generation
- `status: draft` precedes the PROGRESSIVE_DRAFT frame; banner reads "Draft preview — the full render is refining…", waterfall gets a `draft preview` segment.
- Pro tier names itself: "Drawing … (pro model — usually 2–3 min)" — it has no draft to show (OpenRouter path) and routinely takes minutes.
- The waterfall's tail stopped lying: decode/morph events report stage ENDS but the painter treated marks as STARTS — labels shifted one left, and a backgrounded tab's deferred decode painted as `decode 184813ms`. Segment math now lives in `lib/waterfall-segments.ts` (pure, tested): explicit ends, reconstructed starts, dead time as `idle (tab hidden?)`.

## Tests
Backend 609 passed (+ list-unwrap pins, clause byte-identity, world-off submap routing); web 540 passed (+ location-phrase, wideRegionCut, waterfall-segments incl. the 184813ms incident as a named regression test); tsc + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)