### PR TITLE
Wave 2: live spend meter + MAX_DAILY_SPEND gate + duplicate observability

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -16,8 +16,11 @@ from __future__ import annotations
 import asyncio as _asyncio
 import base64
 import contextlib
+import hashlib
 import json
 import os
+import time as _time_mod
+from collections import OrderedDict
 from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import TYPE_CHECKING, Any, cast
 
@@ -579,6 +582,40 @@ def _gate_json(message: str, trace_id: str) -> JSONResponse:
     )
 
 
+_RECENT_GENERATE_TTL_S = 30.0
+_RECENT_GENERATES: OrderedDict[str, float] = OrderedDict()
+
+
+def _note_duplicate_generate(body: GenerateBody) -> bool:
+    """True when an identical generate (same session/node/mode/query and
+    click bucket) arrived within the TTL. The web's in-flight guard should
+    make this impossible — so it's worth a loud log line when it isn't —
+    but a deliberate user retry is legitimate, hence log-only, never a
+    block."""
+    click = body.click
+    bucket = (
+        f"{round(click.x_pct * 20)}:{round(click.y_pct * 20)}" if click else "-"
+    )
+    raw = "|".join(
+        [
+            body.session_id,
+            body.current_node_id,
+            body.mode,
+            bucket,
+            (body.query or "")[:200],
+            (body.edit_instruction or "")[:200],
+        ]
+    )
+    key = hashlib.sha1(raw.encode()).hexdigest()
+    now = _time_mod.monotonic()
+    seen = _RECENT_GENERATES.get(key)
+    _RECENT_GENERATES[key] = now
+    _RECENT_GENERATES.move_to_end(key)
+    while len(_RECENT_GENERATES) > 256:
+        _RECENT_GENERATES.popitem(last=False)
+    return seen is not None and (now - seen) < _RECENT_GENERATE_TTL_S
+
+
 async def _event_stream(
     body: GenerateBody,
     trace_id: str,
@@ -589,11 +626,41 @@ async def _event_stream(
     from obs import bind_trace, log, record_error
     from providers import image as image_provider
     from providers import image_edit as image_edit_provider
-    from providers import llm, model_router
+    from providers import llm, model_router, spend
 
     bind_trace(trace_id)
     started = _time.perf_counter()
     log("info", "sse.generate.start", mode=body.mode, locale=body.output_locale)
+
+    # Observability for client-guard regressions: the web's in-flight ref
+    # should make identical back-to-back generates impossible — if one shows
+    # up anyway, say so loudly (log-only; never blocks a legitimate retry).
+    if _note_duplicate_generate(body):
+        log("warn", "sse.generate.duplicate", mode=body.mode)
+
+    # The daily spend gate (MAX_DAILY_SPEND, providers/spend.py): refuse with
+    # a clean error frame BEFORE any model call once today's estimate crosses
+    # the cap. Absent/0 -> uncapped, byte-identical to before.
+    if spend.cap_exceeded():
+        log(
+            "warn",
+            "sse.generate.spend_capped",
+            daily=round(spend.daily_total(), 2),
+            cap=spend.daily_cap(),
+        )
+        yield _sse(
+            {
+                "type": "error",
+                "message": (
+                    "Daily spend cap reached (≈$"
+                    f"{spend.daily_total():.2f} of MAX_DAILY_SPEND=$"
+                    f"{spend.daily_cap():.2f}). Raise or unset MAX_DAILY_SPEND "
+                    "to continue."
+                ),
+            },
+            trace_id,
+        )
+        return
 
     async def _abort_if_disconnected(stage: str) -> None:
         """Raise CancelledError when the client has dropped the SSE socket.
@@ -785,6 +852,12 @@ async def _event_stream(
                     "session_id": body.session_id,
                     "final_prompt": described,
                     "image_op": "inpaint",
+                    "session_spend_estimate": spend.record_generation(
+                        body.session_id,
+                        inp_result.model,
+                        # every loop attempt billed an inpaint; unjudged = one
+                        images=len(edit_attempts) if verdict is not None else 1,
+                    ),
                 }
                 if verdict is not None:
                     final_frame["edit_verdict"] = verdict
@@ -877,6 +950,11 @@ async def _event_stream(
                             "prompt_author_model": llm._text_model(online=False),
                             "session_id": body.session_id,
                             "final_prompt": polished,
+                            "session_spend_estimate": spend.record_generation(
+                                body.session_id,
+                                judged_image.model,
+                                images=len(judged_attempts),
+                            ),
                             "edit_verdict": {
                                 "alignment": (
                                     judged_best.alignment.score
@@ -915,6 +993,9 @@ async def _event_stream(
                     "prompt_author_model": llm._text_model(online=False),
                     "session_id": body.session_id,
                     "final_prompt": polished,
+                    "session_spend_estimate": spend.record_generation(
+                        body.session_id, edit_result.model
+                    ),
                 },
                 trace_id,
             )
@@ -1452,6 +1533,10 @@ async def _event_stream(
         # edit endpoint; everything else is a fresh gen.
         image_op = model_router.select_operation(render_mode, region_ref is not None)
         use_continuation = image_op == "zoom_continue"
+        # Spend accounting (providers/spend.py): how many images this
+        # generation billed — judged loops overwrite with their attempt count,
+        # the draft records itself at emission.
+        billed_images = 1
 
         # The deliberate camera (view grammar): user/persisted pin > policy >
         # None (legacy bytes). Resolved once; consumed by the layout clause,
@@ -1739,6 +1824,7 @@ async def _event_stream(
                             trace_id,
                         )
                 result = render_loop.conclude(loop_attempts).image
+                billed_images = max(1, len(loop_attempts))
             else:
                 main_task = _asyncio.create_task(
                     image_edit_provider.edit_image(
@@ -1781,6 +1867,10 @@ async def _event_stream(
                 except Exception:
                     draft_result = None
                 if draft_result is not None:
+                    # The draft is a real fal call — bill it as it lands.
+                    spend.record(
+                        body.session_id, spend.estimate_image(draft_result.model)
+                    )
                     # Name the phase honestly: what lands next is a fast-tier
                     # DRAFT the main render will replace — the banner and the
                     # waterfall both label it so the swap isn't a mystery.
@@ -1870,6 +1960,9 @@ async def _event_stream(
                 else composed_prompt
             ),
             "sources": sources_payload,
+            "session_spend_estimate": spend.record_generation(
+                body.session_id, result.model, images=billed_images
+            ),
         }
         # Which non-fresh op actually rendered the image — additive, absent on
         # the fresh path (unchanged wire shape). Lets the demo trace / A-B

--- a/apps/modal-backend/providers/spend.py
+++ b/apps/modal-backend/providers/spend.py
@@ -1,0 +1,112 @@
+"""In-process spend accounting — the bill, visible before it arrives.
+
+Honest-coarse estimates mirroring docs/COSTS.md: the fal/OpenRouter image
+call is ~99% of the dollars, so each generation records its image calls by
+model slug plus one flat increment for the whole VLM stack (planner +
+judges + extraction ≈ $0.02 on gemini-flash). Totals live in-process —
+per-container, reset on restart — which is the right cheapness for a
+self-hosted cap; the limitation is documented in docs/COSTS.md.
+
+`MAX_DAILY_SPEND` (dollars, env) turns the daily total into a hard gate:
+generate streams refuse with a clean error frame once today's estimate
+crosses it. Absent/0 → no cap (today's behaviour).
+"""
+from __future__ import annotations
+
+import os
+import threading
+import time
+from collections import OrderedDict
+
+# Slug-prefix → $ per image. Mirrors docs/COSTS.md "The models we call";
+# longest prefix wins so "fal-ai/nano-banana-pro/edit" beats "fal-ai/nano-banana".
+_IMAGE_PRICES: tuple[tuple[str, float], ...] = (
+    ("fal-ai/nano-banana-pro", 0.15),
+    ("fal-ai/nano-banana-2", 0.08),
+    ("fal-ai/nano-banana", 0.039),
+    ("fal-ai/flux-pro/v1/fill", 0.10),
+    ("fal-ai/flux-pro/kontext", 0.04),
+    ("fal-ai/bria", 0.04),
+    ("openrouter:sourceful/riverflow", 0.24),
+    ("openai/gpt-image", 0.17),
+)
+_DEFAULT_IMAGE_PRICE = 0.15  # unknown slug: assume the balanced default
+VLM_STACK_FLAT = 0.02  # planner + judges + extraction, per generation
+
+_MAX_SESSIONS = 512  # bounded LRU of per-session totals
+
+_lock = threading.Lock()
+_session_totals: OrderedDict[str, float] = OrderedDict()
+_daily_total = 0.0
+_daily_key = ""  # YYYY-MM-DD the daily total belongs to
+
+
+def estimate_image(model: str | None) -> float:
+    slug = (model or "").strip().lower()
+    best: float | None = None
+    best_len = -1
+    for prefix, price in _IMAGE_PRICES:
+        if slug.startswith(prefix) and len(prefix) > best_len:
+            best, best_len = price, len(prefix)
+    return best if best is not None else _DEFAULT_IMAGE_PRICE
+
+
+def _today() -> str:
+    return time.strftime("%Y-%m-%d", time.gmtime())
+
+
+def record(session_id: str, amount: float) -> float:
+    """Add `amount` to the session + daily totals; returns the session total."""
+    global _daily_total, _daily_key
+    if amount <= 0:
+        amount = 0.0
+    with _lock:
+        day = _today()
+        if day != _daily_key:
+            _daily_key = day
+            _daily_total = 0.0
+        _daily_total += amount
+        total = _session_totals.get(session_id, 0.0) + amount
+        _session_totals[session_id] = total
+        _session_totals.move_to_end(session_id)
+        while len(_session_totals) > _MAX_SESSIONS:
+            _session_totals.popitem(last=False)
+        return total
+
+
+def record_generation(session_id: str, model: str | None, images: int = 1) -> float:
+    """One generation: `images` calls on `model` + the flat VLM stack."""
+    return record(
+        session_id, estimate_image(model) * max(1, images) + VLM_STACK_FLAT
+    )
+
+
+def session_total(session_id: str) -> float:
+    with _lock:
+        return _session_totals.get(session_id, 0.0)
+
+
+def daily_total() -> float:
+    with _lock:
+        return _daily_total if _daily_key == _today() else 0.0
+
+
+def daily_cap() -> float:
+    """The configured cap in dollars; 0 = uncapped."""
+    try:
+        return max(0.0, float(os.environ.get("MAX_DAILY_SPEND", "") or 0.0))
+    except ValueError:
+        return 0.0
+
+
+def cap_exceeded() -> bool:
+    cap = daily_cap()
+    return cap > 0 and daily_total() >= cap
+
+
+def reset_for_tests() -> None:
+    global _daily_total, _daily_key
+    with _lock:
+        _session_totals.clear()
+        _daily_total = 0.0
+        _daily_key = ""

--- a/apps/modal-backend/tests/test_generate_spend.py
+++ b/apps/modal-backend/tests/test_generate_spend.py
@@ -1,0 +1,99 @@
+"""The spend gate + estimate on the generate stream (uses the stubbed-modal
+harness from test_generate_enter.py)."""
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.modules.setdefault("modal", MagicMock())
+
+import providers.image as image_mod  # noqa: E402
+import providers.llm as llm_mod  # noqa: E402
+from generate import GenerateBody, _event_stream  # noqa: E402
+from providers import spend  # noqa: E402
+from providers.image import GeneratedImage  # noqa: E402
+from providers.llm import PagePlan  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _fresh_meter(monkeypatch: pytest.MonkeyPatch):
+    spend.reset_for_tests()
+    monkeypatch.delenv("MAX_DAILY_SPEND", raising=False)
+    monkeypatch.setenv("PROGRESSIVE_DRAFT", "false")
+    yield
+    spend.reset_for_tests()
+
+
+async def _collect(agen: Any) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    async for chunk in agen:
+        text = chunk.decode() if isinstance(chunk, bytes) else chunk
+        for block in text.strip().split("\n\n"):
+            block = block.strip()
+            if block.startswith("data:"):
+                events.append(json.loads(block[len("data:") :].strip()))
+    return events
+
+
+def _query_body() -> GenerateBody:
+    return GenerateBody(
+        query="how do boilers work", session_id="s1", web_search=False
+    )
+
+
+def _mock_providers(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    monkeypatch.setattr(
+        llm_mod,
+        "plan_page",
+        AsyncMock(return_value=PagePlan("Boilers", "a cutaway", ["Drum"], [])),
+    )
+    gen = AsyncMock(
+        return_value=GeneratedImage(b"jpeg", "image/jpeg", "fal-ai/nano-banana-pro", "r1")
+    )
+    monkeypatch.setattr(image_mod, "generate_image", gen)
+    return gen
+
+
+async def test_final_carries_session_spend_estimate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_providers(monkeypatch)
+    events = await _collect(_event_stream(_query_body(), "t1"))
+    final = next(e for e in events if e["type"] == "final")
+    assert final["session_spend_estimate"] == pytest.approx(
+        0.15 + spend.VLM_STACK_FLAT
+    )
+    # a second page in the same session accumulates
+    events2 = await _collect(_event_stream(_query_body(), "t2"))
+    final2 = next(e for e in events2 if e["type"] == "final")
+    assert final2["session_spend_estimate"] == pytest.approx(2 * (0.15 + 0.02))
+
+
+async def test_daily_cap_refuses_before_any_model_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gen = _mock_providers(monkeypatch)
+    monkeypatch.setenv("MAX_DAILY_SPEND", "0.05")
+    spend.record("warmup", 0.06)  # someone already burned today's budget
+
+    events = await _collect(_event_stream(_query_body(), "t1"))
+
+    assert len(events) == 1 and events[0]["type"] == "error"
+    assert "MAX_DAILY_SPEND" in events[0]["message"]
+    gen.assert_not_awaited()
+
+
+async def test_duplicate_generate_logged_not_blocked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The client guard should make identical back-to-back generates
+    # impossible; when one arrives anyway it's a LOG, never a refusal.
+    gen = _mock_providers(monkeypatch)
+    await _collect(_event_stream(_query_body(), "t1"))
+    events = await _collect(_event_stream(_query_body(), "t2"))
+    assert any(e["type"] == "final" for e in events)  # second run still works
+    assert gen.await_count == 2

--- a/apps/modal-backend/tests/test_spend.py
+++ b/apps/modal-backend/tests/test_spend.py
@@ -1,0 +1,52 @@
+"""providers/spend.py — the in-process meter behind MAX_DAILY_SPEND."""
+from __future__ import annotations
+
+import pytest
+
+from providers import spend
+
+
+@pytest.fixture(autouse=True)
+def _fresh_meter(monkeypatch: pytest.MonkeyPatch):
+    spend.reset_for_tests()
+    monkeypatch.delenv("MAX_DAILY_SPEND", raising=False)
+    yield
+    spend.reset_for_tests()
+
+
+def test_estimate_image_longest_prefix_wins() -> None:
+    assert spend.estimate_image("fal-ai/nano-banana") == 0.039
+    assert spend.estimate_image("fal-ai/nano-banana-pro") == 0.15
+    assert spend.estimate_image("fal-ai/nano-banana-pro/edit") == 0.15
+    assert spend.estimate_image("fal-ai/flux-pro/kontext") == 0.04
+    assert spend.estimate_image("openrouter:sourceful/riverflow-v2.5-pro") == 0.24
+    # unknown slug -> the balanced default, never zero
+    assert spend.estimate_image("acme/mystery-model") == 0.15
+    assert spend.estimate_image(None) == 0.15
+
+
+def test_record_generation_accumulates_per_session_and_day() -> None:
+    total = spend.record_generation("s1", "fal-ai/nano-banana-pro", images=2)
+    assert total == pytest.approx(0.15 * 2 + spend.VLM_STACK_FLAT)
+    spend.record_generation("s2", "fal-ai/nano-banana")
+    assert spend.session_total("s1") == pytest.approx(0.32)
+    assert spend.session_total("s2") == pytest.approx(0.059)
+    assert spend.daily_total() == pytest.approx(0.32 + 0.059)
+
+
+def test_cap_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert spend.cap_exceeded() is False  # uncapped by default
+    monkeypatch.setenv("MAX_DAILY_SPEND", "0.10")
+    assert spend.cap_exceeded() is False
+    spend.record("s1", 0.11)
+    assert spend.cap_exceeded() is True
+    monkeypatch.setenv("MAX_DAILY_SPEND", "junk")
+    assert spend.cap_exceeded() is False  # bad value -> uncapped, never bricked
+
+
+def test_session_totals_are_bounded() -> None:
+    for i in range(600):
+        spend.record(f"s{i}", 0.01)
+    # the LRU keeps the most recent 512; the earliest sessions are evicted
+    assert spend.session_total("s0") == 0.0
+    assert spend.session_total("s599") == pytest.approx(0.01)

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -494,6 +494,9 @@ export default function PlayPage() {
   // overwriting that initial paint with the default values on mount.
   const [imageTier, setImageTier] = useImageTier();
   const [loopKnobs, setLoopKnobs] = useLoopKnobs();
+  // Running spend estimate for THIS session, read off final frames (the
+  // backend meter, providers/spend.py). Null until the first final lands.
+  const [sessionSpend, setSessionSpend] = useState<number | null>(null);
   // The speed preset's wire half — spread into every generate() body next to
   // image_tier. Balanced knobs produce {} (byte-identity with today).
   const loopWire = useMemo(() => wireFields(loopKnobs), [loopKnobs]);
@@ -709,6 +712,9 @@ export default function PlayPage() {
                 trace_id: traceId,
                 t: nowMs(),
               });
+              if (typeof evt.session_spend_estimate === "number") {
+                setSessionSpend(evt.session_spend_estimate);
+              }
               setProgressiveDraft(false);
               setPage({
                 nodeId: null,
@@ -2604,6 +2610,7 @@ export default function PlayPage() {
         setImageTier={setImageTier}
         loopKnobs={loopKnobs}
         setLoopKnobs={setLoopKnobs}
+        sessionSpend={sessionSpend}
         worldMode={worldEnabled}
         setWorldMode={setWorldEnabled}
         autonomy={worldAutonomy}

--- a/apps/web/components/PlayPage/QueryToolbar.tsx
+++ b/apps/web/components/PlayPage/QueryToolbar.tsx
@@ -26,6 +26,7 @@ interface Props {
   setImageTier: (t: ImageTier) => void;
   loopKnobs: LoopKnobs;
   setLoopKnobs: (k: LoopKnobs) => void;
+  sessionSpend?: number | null | undefined;
   worldMode: boolean;
   setWorldMode: (on: boolean) => void;
   autonomy: Autonomy;
@@ -48,6 +49,7 @@ export function QueryToolbar({
   setImageTier,
   loopKnobs,
   setLoopKnobs,
+  sessionSpend,
   worldMode,
   setWorldMode,
   autonomy,
@@ -147,6 +149,7 @@ export function QueryToolbar({
           setImageTier={setImageTier}
           knobs={loopKnobs}
           setKnobs={setLoopKnobs}
+          sessionSpend={sessionSpend}
         />
         <div
           role="group"

--- a/apps/web/components/PlayPage/SpeedPreset.test.tsx
+++ b/apps/web/components/PlayPage/SpeedPreset.test.tsx
@@ -67,3 +67,17 @@ describe("SpeedPreset", () => {
     expect(setKnobs).toHaveBeenCalledWith({ maxAttempts: 3, verify: true });
   });
 });
+
+describe("session spend chip", () => {
+  it("shows the backend's running estimate when present", () => {
+    setup({ sessionSpend: 0.48 });
+    expect(screen.getByTestId("session-spend").textContent).toContain(
+      "session ≈ $0.48",
+    );
+  });
+
+  it("absent until the first final frame lands", () => {
+    setup();
+    expect(screen.queryByTestId("session-spend")).toBeNull();
+  });
+});

--- a/apps/web/components/PlayPage/SpeedPreset.tsx
+++ b/apps/web/components/PlayPage/SpeedPreset.tsx
@@ -18,6 +18,9 @@ interface Props {
   setImageTier: (t: ImageTier) => void;
   knobs: LoopKnobs;
   setKnobs: (k: LoopKnobs) => void;
+  /** Running backend spend estimate for this session ($); null/absent until
+   * the first final frame lands. */
+  sessionSpend?: number | null | undefined;
 }
 
 // The 3-stop speed/quality preset + the live cost chip — the projected spend
@@ -31,6 +34,7 @@ export function SpeedPreset({
   setImageTier,
   knobs,
   setKnobs,
+  sessionSpend,
 }: Props) {
   const [open, setOpen] = useState(false);
   const active = presetFor(imageTier, knobs);
@@ -108,9 +112,19 @@ export function SpeedPreset({
       <span
         data-testid="cost-chip"
         className="whitespace-nowrap opacity-60"
-        title={`Projected spend per action — tap ${tap} · edit ${edit} · new page ${fresh}. Ranges span retries; see docs/COSTS.md.`}
+        title={`Projected spend per action — tap ${tap} · edit ${edit} · new page ${fresh}. Ranges span retries; see docs/COSTS.md.${
+          typeof sessionSpend === "number"
+            ? ` Session so far ≈ $${sessionSpend.toFixed(2)} (backend estimate).`
+            : ""
+        }`}
       >
         ≈ {tap}/tap
+        {typeof sessionSpend === "number" && (
+          <span data-testid="session-spend">
+            {" "}
+            · session ≈ ${sessionSpend.toFixed(2)}
+          </span>
+        )}
       </span>
       {open && (
         <div className="absolute left-0 top-full z-20 mt-2 w-60 rounded-xl border border-[var(--color-edge)] bg-[var(--color-canvas)] p-3 shadow-md">

--- a/docs/COSTS.md
+++ b/docs/COSTS.md
@@ -112,3 +112,17 @@ flux-pro/v1/fill $0.05/MP, flux-pro/kontext $0.04, nano-banana $0.039),
 OpenRouter (gemini-3-flash-preview $0.50/$3, gemini-3.1-flash-lite $0.25/$1.50),
 repo `prompt_tokens` logs + Makefile eval cost anchors (eval-view ~$2.5,
 eval-edit-region ~$1, mask-smoke ~$0.5).
+
+## The live meter (`providers/spend.py`)
+
+The backend now keeps a running **estimate** of spend using the prices above:
+each generation records its image calls by model slug + a flat ~$0.02 for the
+VLM stack. The session total rides every `final` frame
+(`session_spend_estimate`) and shows next to the toolbar's cost chip;
+`MAX_DAILY_SPEND` (dollars) turns the daily total into a hard gate — streams
+refuse with a clear error once today's estimate crosses it.
+
+Honest limitations: totals are **in-process** (per container, reset on
+restart, not shared across replicas) and **estimates** (the slug price table
+above, not provider invoices). Right-sized for a self-hosted cap; don't bill
+anyone off it.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -311,6 +311,10 @@ export interface GenerateFinalEvent {
   grounding?: GroundingSummary;
   // Judged mask-scoped edit verdict â present only on the EDIT_REGION path.
   edit_verdict?: EditVerdict;
+  // Running estimated spend ($) for this session — coarse, mirrors
+  // docs/COSTS.md prices (providers/spend.py). Additive; absent on older
+  // backends.
+  session_spend_estimate?: number;
   trace_id?: string;
 }
 


### PR DESCRIPTION
Second wave of the post-live-testing program (plan: Wave 1 = #52).

- **`providers/spend.py`** — in-process spend accounting, honest-coarse per docs/COSTS.md: image calls billed by slug price (longest-prefix table) + a flat ~$0.02 VLM-stack increment per generation. Judged loops bill every attempt; the progressive draft bills itself at emission. Bounded per-session LRU + a daily total.
- **`session_spend_estimate` on every final frame** (all four emission sites) → the toolbar cost chip now reads `≈ $0.16–0.32/tap · session ≈ $0.48`.
- **`MAX_DAILY_SPEND`** (dollars, env): once today's estimate crosses it, generate streams refuse with a clean error frame *before any model call*. Absent/0 → uncapped, byte-identical.
- **Duplicate-generate observability**: identical back-to-back generates (session/node/mode/click-bucket hash, 30s TTL) get a loud `sse.generate.duplicate` log — log-only, a deliberate retry is never blocked. The client side already covers double-taps via `clickInFlightRef`; no redundant second guard added.
- Limitations documented in docs/COSTS.md: in-process (per container, reset on restart), estimates not invoices.

Tests: backend 616 passed (+ spend table/cap/LRU, cap-refuses-before-model-call, estimate-on-final accumulation, duplicate-not-blocked); web 542 passed (+ session chip); tsc + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)