### PR TITLE
Retest follow-ups: inline stored images for VLM calls, docker world flags, review nits

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -19,6 +19,7 @@ import contextlib
 import hashlib
 import json
 import os
+import threading as _threading
 import time as _time_mod
 from collections import OrderedDict
 from collections.abc import AsyncIterator, Awaitable, Callable
@@ -584,6 +585,9 @@ def _gate_json(message: str, trace_id: str) -> JSONResponse:
 
 _RECENT_GENERATE_TTL_S = 30.0
 _RECENT_GENERATES: OrderedDict[str, float] = OrderedDict()
+# Same posture as providers/spend.py: module state stays correct if anyone
+# ever runs this app with threaded workers.
+_RECENT_GENERATES_LOCK = _threading.Lock()
 
 
 def _note_duplicate_generate(body: GenerateBody) -> bool:
@@ -604,15 +608,20 @@ def _note_duplicate_generate(body: GenerateBody) -> bool:
             bucket,
             (body.query or "")[:200],
             (body.edit_instruction or "")[:200],
+            # A re-run at a different tier/model is a deliberate choice, not
+            # a stutter — keep it out of the duplicate bucket.
+            body.image_tier or "",
+            body.image_model or "",
         ]
     )
     key = hashlib.sha1(raw.encode()).hexdigest()
     now = _time_mod.monotonic()
-    seen = _RECENT_GENERATES.get(key)
-    _RECENT_GENERATES[key] = now
-    _RECENT_GENERATES.move_to_end(key)
-    while len(_RECENT_GENERATES) > 256:
-        _RECENT_GENERATES.popitem(last=False)
+    with _RECENT_GENERATES_LOCK:
+        seen = _RECENT_GENERATES.get(key)
+        _RECENT_GENERATES[key] = now
+        _RECENT_GENERATES.move_to_end(key)
+        while len(_RECENT_GENERATES) > 256:
+            _RECENT_GENERATES.popitem(last=False)
     return seen is not None and (now - seen) < _RECENT_GENERATE_TTL_S
 
 

--- a/apps/modal-backend/tests/test_llm_provider.py
+++ b/apps/modal-backend/tests/test_llm_provider.py
@@ -1227,9 +1227,10 @@ def test_world_context_clause_renders_fixed_position() -> None:
     assert "fixed position" not in drum_line
 
 
-def test_world_context_clause_without_hints_is_byte_identical() -> None:
+def test_world_context_clause_without_hints_adds_no_position_text() -> None:
     # The spatial half is strictly additive: no location_hint anywhere ->
-    # the clause must not change at all (header included).
+    # nothing position-related enters the clause (per-entity lines or the
+    # header rule). The rest of the header predates this change.
     entities = [
         {
             "name": "Mira",

--- a/apps/web/app/api/generate-page/route.ts
+++ b/apps/web/app/api/generate-page/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import type { GenerateRequestBody } from "@openflipbook/config";
 import { locationPhrase } from "@/lib/location-phrase";
+import { inlineStoredImage } from "@/lib/r2";
 import { resolveEntitiesForPrompt } from "@/lib/world";
 import { getWorldMap } from "@/lib/world-map";
 import { modalUrl as joinModalUrl } from "@/lib/modal";
@@ -37,6 +38,18 @@ export async function POST(req: Request) {
   let upstreamBody = rawText;
   try {
     const parsed = JSON.parse(rawText) as GenerateRequestBody;
+    let mutated = false;
+    // A reopened node's page image arrives as its STORE URL; on the docker
+    // stack that's a localhost minio URL the VLM providers refuse to fetch.
+    // Inline our own stored bytes to a data URL (best-effort; see
+    // inlineStoredImage).
+    if (parsed?.image && !parsed.image.startsWith("data:")) {
+      const inlined = await inlineStoredImage(parsed.image);
+      if (inlined) {
+        parsed.image = inlined;
+        mutated = true;
+      }
+    }
     if (parsed && parsed.session_id && parsed.query && !parsed.world_context) {
       const world_context = await resolveEntitiesForPrompt({
         sessionId: parsed.session_id,
@@ -84,8 +97,10 @@ export async function POST(req: Request) {
           // size enrichment is best-effort; never block generation
         }
         upstreamBody = JSON.stringify({ ...parsed, world_context });
+        mutated = false; // serialized above, inlined image included
       }
     }
+    if (mutated) upstreamBody = JSON.stringify(parsed);
   } catch {
     // Body is presumably already the right shape (or malformed enough
     // that the backend will surface the error). Forward verbatim.

--- a/apps/web/app/api/resolve-click/route.ts
+++ b/apps/web/app/api/resolve-click/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { modalUrl as joinModalUrl } from "@/lib/modal";
+import { inlineStoredImage } from "@/lib/r2";
 import { TRACE_HEADER, newTraceId } from "@/lib/trace";
 
 export const runtime = "nodejs";
@@ -14,7 +15,22 @@ export async function POST(req: Request) {
     );
   }
   const traceId = req.headers.get(TRACE_HEADER) || newTraceId();
-  const body = await req.text();
+  let body = await req.text();
+  // Reopened nodes resolve clicks against their STORE URL — on the docker
+  // stack a localhost minio URL the VLM providers refuse to fetch. Inline
+  // our own stored bytes (best-effort; see lib/r2.inlineStoredImage).
+  try {
+    const parsed = JSON.parse(body) as { image_data_url?: string };
+    if (parsed?.image_data_url && !parsed.image_data_url.startsWith("data:")) {
+      const inlined = await inlineStoredImage(parsed.image_data_url);
+      if (inlined) {
+        parsed.image_data_url = inlined;
+        body = JSON.stringify(parsed);
+      }
+    }
+  } catch {
+    // malformed body -> forward verbatim, the backend surfaces the error
+  }
   let upstream: Response;
   try {
     upstream = await fetch(joinModalUrl(modalUrl, "/resolve-click"), {

--- a/apps/web/lib/r2.test.ts
+++ b/apps/web/lib/r2.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { r2ClientConfig } from "./r2";
+import { r2ClientConfig, storedKeyFromUrl } from "./r2";
 
 /**
  * M4 — the blob endpoint seam. With no override the client derives the
@@ -29,5 +29,18 @@ describe("r2ClientConfig", () => {
     });
     expect(cfg.endpoint).toBe("http://minio:9000");
     expect(cfg.forcePathStyle).toBe(true);
+  });
+});
+
+describe("storedKeyFromUrl", () => {
+  it("extracts keys under our public base (and only ours)", () => {
+    const base = "http://localhost:9000/openflipbook";
+    expect(
+      storedKeyFromUrl(`${base}/session_a/page-1.jpg`, base),
+    ).toBe("session_a/page-1.jpg");
+    expect(storedKeyFromUrl(`${base}/a/b.jpg?x=1#y`, `${base}/`)).toBe("a/b.jpg");
+    expect(storedKeyFromUrl("https://elsewhere.com/a.jpg", base)).toBeNull();
+    expect(storedKeyFromUrl(`${base}/`, base)).toBeNull();
+    expect(storedKeyFromUrl("data:image/jpeg;base64,xxx", base)).toBeNull();
   });
 });

--- a/apps/web/lib/r2.ts
+++ b/apps/web/lib/r2.ts
@@ -1,4 +1,4 @@
-import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { GetObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { readServerEnv, requireR2 } from "./env";
 
 let cachedClient: S3Client | null = null;
@@ -80,4 +80,44 @@ export function decodeDataUrl(dataUrl: string): {
   const contentType = match[1]!;
   const b64 = match[2]!;
   return { contentType, bytes: Buffer.from(b64, "base64") };
+}
+
+/** The storage key when `url` lives under our public base, else null.
+ * Pure — the testable half of inlineStoredImage. */
+export function storedKeyFromUrl(
+  url: string,
+  publicBaseUrl: string
+): string | null {
+  const base = publicBaseUrl.replace(/\/$/, "");
+  if (!base || !url.startsWith(`${base}/`)) return null;
+  const key = url.slice(base.length + 1).split(/[?#]/, 1)[0] ?? "";
+  return key.length > 0 ? decodeURIComponent(key) : null;
+}
+
+/**
+ * Inline one of OUR stored images into a data URL. Self-host reality check:
+ * the docker stack's public base is a localhost minio URL — the browser can
+ * load it, but OpenRouter/Google refuse to fetch private/localhost URLs, so
+ * an unprefetched tap on a reopened node 400s at the VLM ("Cannot fetch
+ * from private/localhost URLs"). The web server CAN reach the store (its S3
+ * client speaks to the container endpoint), so the proxies inline the bytes
+ * before forwarding. Best-effort: foreign URLs / fetch failures -> null and
+ * the caller forwards the original URL (today's behaviour).
+ */
+export async function inlineStoredImage(url: string): Promise<string | null> {
+  try {
+    const { s3, bucket, publicBaseUrl } = r2Client();
+    const key = storedKeyFromUrl(url, publicBaseUrl);
+    if (!key) return null;
+    const got = await s3.send(
+      new GetObjectCommand({ Bucket: bucket, Key: key })
+    );
+    if (!got.Body) return null;
+    const bytes = Buffer.from(await got.Body.transformToByteArray());
+    if (bytes.length === 0) return null;
+    const contentType = got.ContentType || "image/jpeg";
+    return `data:${contentType};base64,${bytes.toString("base64")}`;
+  } catch {
+    return null;
+  }
 }

--- a/docs/COSTS.md
+++ b/docs/COSTS.md
@@ -126,3 +126,7 @@ Honest limitations: totals are **in-process** (per container, reset on
 restart, not shared across replicas) and **estimates** (the slug price table
 above, not provider invoices). Right-sized for a self-hosted cap; don't bill
 anyone off it.
+
+One more cap honesty note: the gate is checked at stream start, so requests
+already in flight when the cap trips still complete — worst case overshoot is
+one generation per concurrent stream. Right-sized for a personal cap.


### PR DESCRIPTION
Live-retest round on the docker stack after #52/#53 merged. Three finds, all fixed and re-verified live:

- **Self-host blocker (latent, pre-existing):** a tap on a *reopened* node sends the page image as its store URL — on the docker stack that's a localhost minio URL, and OpenRouter/Google refuse private/localhost fetches, so every unprefetched tap on a continued session 400'd at the VLM. The web proxies (generate-page, resolve-click, world/extract) now inline our own stored bytes into data URLs before forwarding (`lib/r2.inlineStoredImage`; pure key-matching half vitest'd). Foreign URLs/failures fall through unchanged.
- **Docker stack never seeded geometry:** the compose web service didn't load the root `.env`, so `GEOMETRIC_WORLD` (gating geo seeding in the web's extract route) was silently off in docker while local dev had it on — which is why the geo store was empty and the wide-region zoom-cut had nothing to hit-test. The web service now loads root `.env` like the backend; the client also fetches geos when empty regardless of world mode (wideRegionCut needs them with world off).
- **Review follow-ups** from the adversarial pass on #52/#53: duplicate-generate key includes image_tier/image_model (a re-run at a different tier is a choice, not a stutter); the dup map takes a lock (same posture as spend.py); a test renamed to claim only what it asserts; docs note the spend cap's worst-case in-flight overshoot.

**Live verification on the rebuilt stack** (the Ankh-Morpork session): extraction on the reopened map node succeeded through the inline path and seeded 12 geos; a river tap then routed `image.continue` → `fal-ai/flux-pro/kontext` (22s) — a pixel-faithful cut of the map, no landmark relocation; waterfall read warm-up 37ms / planner 4.7s / image gen 22.3s / decode 8ms; the toolbar showed `session ≈ $0.27`, matching the two generations.

Tests: backend 616 passed, web 543 passed, tsc + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)