### PR TITLE
Wave 4: provider registry capabilities, failover chain + circuit breaker, dev model picker

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -2582,6 +2582,15 @@ async def status() -> dict:
     return await status_payload(APP_NAME)
 
 
+@fastapi_app.get("/models")
+async def models() -> dict:
+    """The image-model registry (slug + capabilities) for pickers — the dev
+    model dropdown reads this through the web's /api/models proxy."""
+    from providers import model_router
+
+    return {"models": model_router.registry()}
+
+
 @fastapi_app.get("/trace/recent")
 async def trace_recent(limit: int = 50) -> dict:
     """Return the in-memory ring buffer of recent completed traces.

--- a/apps/modal-backend/providers/breaker.py
+++ b/apps/modal-backend/providers/breaker.py
@@ -1,0 +1,45 @@
+"""Per-slug circuit breaker — in-process, same posture as providers/spend.py.
+
+Three consecutive terminal failures open a slug's circuit for a cooldown;
+while open, the fallback chain starts from the next candidate instead of
+re-burning wall-clock (and retries) on a provider that's down. Success
+closes the circuit. In-process by design: per container, reset on restart —
+right-sized for a self-hosted stack.
+"""
+from __future__ import annotations
+
+import threading
+import time
+
+FAILURE_THRESHOLD = 3
+COOLDOWN_S = 120.0
+
+_lock = threading.Lock()
+_failures: dict[str, int] = {}
+_open_until: dict[str, float] = {}
+
+
+def available(slug: str) -> bool:
+    with _lock:
+        until = _open_until.get(slug, 0.0)
+        return not (until and time.monotonic() < until)
+
+
+def record_success(slug: str) -> None:
+    with _lock:
+        _failures.pop(slug, None)
+        _open_until.pop(slug, None)
+
+
+def record_failure(slug: str) -> None:
+    with _lock:
+        count = _failures.get(slug, 0) + 1
+        _failures[slug] = count
+        if count >= FAILURE_THRESHOLD:
+            _open_until[slug] = time.monotonic() + COOLDOWN_S
+
+
+def reset_for_tests() -> None:
+    with _lock:
+        _failures.clear()
+        _open_until.clear()

--- a/apps/modal-backend/providers/image.py
+++ b/apps/modal-backend/providers/image.py
@@ -265,34 +265,17 @@ def _openai_size(aspect_ratio: str, model: str) -> str:
     return table.get(aspect_ratio, "1024x1024")
 
 
-async def generate_image(
+async def _generate_with_slug(
+    model: str,
     prompt: str,
     aspect_ratio: str,
-    tier: str | None = None,
-    model_override: str | None = None,
-    reference_urls: list[str] | None = None,
+    reference_urls: list[str] | None,
 ) -> GeneratedImage:
+    """One slug, one attempt (plus its own transient retries). The dispatch
+    body of generate_image, extracted so the failover chain can call it per
+    candidate."""
     from obs import span
-    from providers import mock
 
-    if mock.on():
-        m = mock.mock_image(prompt, op="fresh", aspect_ratio=aspect_ratio)
-        return GeneratedImage(m.jpeg_bytes, m.mime_type, m.model, m.request_id)
-    if _image_provider() != "fal":
-        # Reference conditioning is fal/nano-banana only — other providers stay
-        # text-only (refs ignored).
-        prov, base_url, api_key = _resolve_image_provider()
-        model = model_override or _image_model()
-        async with span(
-            "image.generate", model=model, prompt_len=len(prompt), provider=prov
-        ) as ctx:
-            generated = await _openai_compatible_image(
-                base_url, api_key, model, prompt, aspect_ratio
-            )
-            ctx["bytes"] = len(generated.jpeg_bytes)
-        return generated
-
-    model = _resolve_model(tier, model_override)
     if model.startswith(OPENROUTER_IMAGE_PREFIX):
         # OpenRouter image-modality slug (riverflow / recraft / …): needs only
         # OPENROUTER_API_KEY (already required for the planner), not FAL_KEY.
@@ -336,6 +319,72 @@ async def generate_image(
         model=model,
         provider_request_id=str(result.get("requestId") or "") or None,
     )
+
+
+async def generate_image(
+    prompt: str,
+    aspect_ratio: str,
+    tier: str | None = None,
+    model_override: str | None = None,
+    reference_urls: list[str] | None = None,
+) -> GeneratedImage:
+    from _env import env_flag
+    from obs import log, span
+    from providers import breaker, mock, model_router
+
+    if mock.on():
+        m = mock.mock_image(prompt, op="fresh", aspect_ratio=aspect_ratio)
+        return GeneratedImage(m.jpeg_bytes, m.mime_type, m.model, m.request_id)
+    if _image_provider() != "fal":
+        # Reference conditioning is fal/nano-banana only — other providers stay
+        # text-only (refs ignored). Custom IMAGE_PROVIDER deployments sit
+        # outside the failover chain (their slugs aren't in the registry).
+        prov, base_url, api_key = _resolve_image_provider()
+        model = model_override or _image_model()
+        async with span(
+            "image.generate", model=model, prompt_len=len(prompt), provider=prov
+        ) as ctx:
+            generated = await _openai_compatible_image(
+                base_url, api_key, model, prompt, aspect_ratio
+            )
+            ctx["bytes"] = len(generated.jpeg_bytes)
+        return generated
+
+    model = _resolve_model(tier, model_override)
+    if not env_flag("PROVIDER_FALLBACK"):
+        return await _generate_with_slug(model, prompt, aspect_ratio, reference_urls)
+
+    # PROVIDER_FALLBACK: the resolved slug plus its registry chain, with
+    # circuit-open slugs skipped (three consecutive failures → cooldown).
+    # A degraded page beats an error frame; the final's image_model says
+    # honestly which model actually rendered. Fresh-gen only by design.
+    candidates = [model, *model_router.fallback_chain(model)]
+    open_skipped = [c for c in candidates if not breaker.available(c)]
+    usable = [c for c in candidates if breaker.available(c)] or [model]
+    if open_skipped:
+        log("warn", "image.breaker_skip", skipped=",".join(open_skipped))
+    last_exc: Exception | None = None
+    for i, slug in enumerate(usable):
+        try:
+            generated = await _generate_with_slug(
+                slug, prompt, aspect_ratio, reference_urls
+            )
+        except Exception as exc:
+            breaker.record_failure(slug)
+            last_exc = exc
+            log(
+                "warn",
+                "image.fallback_step",
+                failed=slug,
+                error=f"{type(exc).__name__}: {exc}",
+                remaining=len(usable) - i - 1,
+            )
+            continue
+        breaker.record_success(slug)
+        if i > 0:
+            log("warn", "image.fallback_used", requested=model, used=slug)
+        return generated
+    raise last_exc if last_exc is not None else RuntimeError("no image candidates")
 
 
 def encode_data_url(jpeg_bytes: bytes, mime_type: str = "image/jpeg") -> str:

--- a/apps/modal-backend/providers/model_router.py
+++ b/apps/modal-backend/providers/model_router.py
@@ -131,3 +131,83 @@ def select_enter_model(projection: str | None) -> str | None:
     if projection in STEEP_ENTER_PROJECTIONS:
         return os.environ.get("FAL_ENTER_MODEL_STEEP") or STEEP_ENTER_DEFAULT
     return resolve_model("enter_scene")
+
+
+# ── Capability registry + fallback chains (Wave 4) ───────────────────────────
+# Data, not behavior: what each slug can do, what it costs, how it fails over.
+# Longest-prefix matching (same posture as providers/spend.py's price table);
+# costs mirror docs/COSTS.md — spend.py owns the billing copy of these numbers.
+
+from dataclasses import dataclass  # noqa: E402
+
+
+@dataclass(frozen=True)
+class ModelCaps:
+    label: str  # short human name for pickers
+    supports_edit: bool  # honours an image input as an EDIT target
+    supports_refs: bool  # honours reference images on fresh generation
+    legible_text: bool  # renders crisp in-image labels (the map-text gotcha)
+    est_cost: float  # $/image, ≈ docs/COSTS.md
+    est_latency_s: float  # typical wall-clock per image
+
+
+CAPABILITIES: tuple[tuple[str, ModelCaps], ...] = (
+    ("fal-ai/nano-banana-pro", ModelCaps("nano-banana-pro", True, True, True, 0.15, 25)),
+    ("fal-ai/nano-banana-2", ModelCaps("nano-banana-2", True, True, True, 0.08, 18)),
+    ("fal-ai/nano-banana", ModelCaps("nano-banana", True, True, False, 0.039, 10)),
+    ("fal-ai/flux-pro/kontext", ModelCaps("flux kontext", True, False, True, 0.04, 20)),
+    ("fal-ai/flux-pro/v1/fill", ModelCaps("flux fill (inpaint)", True, False, True, 0.10, 25)),
+    ("fal-ai/bria", ModelCaps("bria expand", True, False, True, 0.04, 15)),
+    ("openrouter:sourceful/riverflow-v2.5-pro", ModelCaps("riverflow pro", False, False, True, 0.24, 150)),
+    ("openai/gpt-image-2", ModelCaps("gpt-image-2", True, False, True, 0.17, 90)),
+)
+
+
+def capabilities_for(slug: str) -> ModelCaps | None:
+    s = (slug or "").lower()
+    best: ModelCaps | None = None
+    best_len = -1
+    for prefix, caps in CAPABILITIES:
+        if s.startswith(prefix) and len(prefix) > best_len:
+            best, best_len = caps, len(prefix)
+    return best
+
+
+def registry() -> list[dict[str, object]]:
+    """The picker payload: every known slug with its caps. Served by
+    GET /models for the dev model dropdown."""
+    return [
+        {
+            "slug": prefix,
+            "label": caps.label,
+            "supports_edit": caps.supports_edit,
+            "supports_refs": caps.supports_refs,
+            "legible_text": caps.legible_text,
+            "est_cost": caps.est_cost,
+            "est_latency_s": caps.est_latency_s,
+        }
+        for prefix, caps in CAPABILITIES
+    ]
+
+
+# Fresh-generation failover order (PROVIDER_FALLBACK=1): when a slug's call
+# fails terminally, the next one takes the prompt. Chains step DOWN in cost —
+# a degraded page beats an error frame, and the final's image_model says
+# honestly which model actually rendered. Fresh-gen only by design: edit /
+# continue ops carry semantics (refs, masks) a substitute may not honour.
+FALLBACK_CHAINS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("openrouter:sourceful/riverflow-v2.5-pro", ("fal-ai/nano-banana-pro", "fal-ai/nano-banana")),
+    ("fal-ai/nano-banana-pro", ("fal-ai/nano-banana-2", "fal-ai/nano-banana")),
+    ("fal-ai/nano-banana-2", ("fal-ai/nano-banana",)),
+    ("fal-ai/nano-banana", ("fal-ai/nano-banana-2",)),
+)
+
+
+def fallback_chain(slug: str) -> tuple[str, ...]:
+    s = (slug or "").lower()
+    best: tuple[str, ...] = ()
+    best_len = -1
+    for prefix, chain in FALLBACK_CHAINS:
+        if s.startswith(prefix) and len(prefix) > best_len:
+            best, best_len = chain, len(prefix)
+    return tuple(c for c in best if c != slug)

--- a/apps/modal-backend/tests/test_provider_fallback.py
+++ b/apps/modal-backend/tests/test_provider_fallback.py
@@ -1,0 +1,124 @@
+"""Wave 4: capability registry, fallback chains, the circuit breaker, and
+the failover path in image.generate_image (slug dispatch monkeypatched)."""
+from __future__ import annotations
+
+import pytest
+
+from providers import breaker, image, model_router
+from providers.image import GeneratedImage
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch: pytest.MonkeyPatch):
+    breaker.reset_for_tests()
+    monkeypatch.delenv("PROVIDER_FALLBACK", raising=False)
+    monkeypatch.setenv("FAL_KEY", "test")  # dispatch is mocked; key gate is upstream
+    yield
+    breaker.reset_for_tests()
+
+
+def test_capabilities_longest_prefix() -> None:
+    pro = model_router.capabilities_for("fal-ai/nano-banana-pro/edit")
+    assert pro is not None and pro.label == "nano-banana-pro"
+    base = model_router.capabilities_for("fal-ai/nano-banana")
+    assert base is not None and base.est_cost == 0.039
+    assert model_router.capabilities_for("acme/unknown") is None
+
+
+def test_registry_shape() -> None:
+    rows = model_router.registry()
+    assert any(r["slug"] == "fal-ai/nano-banana-pro" for r in rows)
+    sample = rows[0]
+    for key in ("slug", "label", "supports_edit", "est_cost", "est_latency_s"):
+        assert key in sample
+
+
+def test_fallback_chain_steps_down_in_cost() -> None:
+    chain = model_router.fallback_chain("openrouter:sourceful/riverflow-v2.5-pro")
+    assert chain == ("fal-ai/nano-banana-pro", "fal-ai/nano-banana")
+    assert model_router.fallback_chain("fal-ai/flux-pro/kontext") == ()
+    # never include the slug itself
+    assert "fal-ai/nano-banana" not in model_router.fallback_chain("fal-ai/nano-banana")[:0]
+
+
+def test_breaker_opens_after_threshold_and_recovers() -> None:
+    slug = "fal-ai/nano-banana-pro"
+    assert breaker.available(slug)
+    for _ in range(breaker.FAILURE_THRESHOLD):
+        breaker.record_failure(slug)
+    assert not breaker.available(slug)
+    breaker.record_success(slug)  # success closes the circuit
+    assert breaker.available(slug)
+
+
+def _img(model: str) -> GeneratedImage:
+    return GeneratedImage(b"jpeg", "image/jpeg", model, None)
+
+
+async def test_fallback_off_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    async def boom(model, prompt, aspect, refs):
+        calls.append(model)
+        raise RuntimeError("provider down")
+
+    monkeypatch.setattr(image, "_generate_with_slug", boom)
+    with pytest.raises(RuntimeError):
+        await image.generate_image("p", "16:9", tier="balanced")
+    assert calls == ["fal-ai/nano-banana-pro"]  # one slug, no chain
+
+
+async def test_fallback_chain_degrades_to_next_slug(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PROVIDER_FALLBACK", "1")
+    calls: list[str] = []
+
+    async def flaky(model, prompt, aspect, refs):
+        calls.append(model)
+        if model == "fal-ai/nano-banana-pro":
+            raise RuntimeError("outage")
+        return _img(model)
+
+    monkeypatch.setattr(image, "_generate_with_slug", flaky)
+    out = await image.generate_image("p", "16:9", tier="balanced")
+    assert out.model == "fal-ai/nano-banana-2"  # the chain's next stop
+    assert calls == ["fal-ai/nano-banana-pro", "fal-ai/nano-banana-2"]
+
+
+async def test_open_circuit_skips_the_dead_slug(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PROVIDER_FALLBACK", "1")
+    for _ in range(breaker.FAILURE_THRESHOLD):
+        breaker.record_failure("fal-ai/nano-banana-pro")
+    calls: list[str] = []
+
+    async def ok(model, prompt, aspect, refs):
+        calls.append(model)
+        return _img(model)
+
+    monkeypatch.setattr(image, "_generate_with_slug", ok)
+    out = await image.generate_image("p", "16:9", tier="balanced")
+    assert calls == ["fal-ai/nano-banana-2"]  # pro never even attempted
+    assert out.model == "fal-ai/nano-banana-2"
+
+
+async def test_all_circuits_open_still_tries_the_requested_slug(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PROVIDER_FALLBACK", "1")
+    for slug in ("fal-ai/nano-banana-pro", "fal-ai/nano-banana-2", "fal-ai/nano-banana"):
+        for _ in range(breaker.FAILURE_THRESHOLD):
+            breaker.record_failure(slug)
+    calls: list[str] = []
+
+    async def ok(model, prompt, aspect, refs):
+        calls.append(model)
+        return _img(model)
+
+    monkeypatch.setattr(image, "_generate_with_slug", ok)
+    out = await image.generate_image("p", "16:9", tier="balanced")
+    # everything open -> last resort is the requested slug itself, not an error
+    assert calls == ["fal-ai/nano-banana-pro"]
+    assert out.model == "fal-ai/nano-banana-pro"

--- a/apps/web/app/api/models/route.ts
+++ b/apps/web/app/api/models/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { modalUrl as joinModalUrl } from "@/lib/modal";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/** Thin proxy to the backend's GET /models — the image-model registry
+ * (slug + capabilities) the dev model dropdown lists. */
+export async function GET() {
+  const modalUrl = process.env.MODAL_API_URL;
+  if (!modalUrl) {
+    return NextResponse.json({ error: "MODAL_API_URL not set." }, { status: 503 });
+  }
+  try {
+    const upstream = await fetch(joinModalUrl(modalUrl, "/models"), {
+      cache: "no-store",
+    });
+    return NextResponse.json(await upstream.json(), {
+      status: upstream.status,
+    });
+  } catch {
+    return NextResponse.json({ error: "backend unreachable" }, { status: 502 });
+  }
+}

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -497,6 +497,9 @@ export default function PlayPage() {
   // Running spend estimate for THIS session, read off final frames (the
   // backend meter, providers/spend.py). Null until the first final lands.
   const [sessionSpend, setSessionSpend] = useState<number | null>(null);
+  // Dev-only explicit model override (NEXT_PUBLIC_DEV_PROVIDERS): rides the
+  // wire's image_model on every generate body. null = the tier decides.
+  const [devModel, setDevModel] = useState<string | null>(null);
   // The speed preset's wire half — spread into every generate() body next to
   // image_tier. Balanced knobs produce {} (byte-identity with today).
   const loopWire = useMemo(() => wireFields(loopKnobs), [loopKnobs]);
@@ -916,6 +919,7 @@ export default function PlayPage() {
       parent_title: page.title,
       image_tier: imageTier,
       ...loopWire,
+      ...(devModel ? { image_model: devModel } : {}),
       output_locale: resolveOutputLocale(outputLocale),
       ...(condition.urls.length
         ? {
@@ -935,6 +939,7 @@ export default function PlayPage() {
     startBloom,
     imageTier,
     loopWire,
+    devModel,
     outputLocale,
     styleAnchor,
     history,
@@ -1065,11 +1070,12 @@ export default function PlayPage() {
         mode: "query",
         image_tier: imageTier,
         ...loopWire,
+        ...(devModel ? { image_model: devModel } : {}),
         output_locale: resolveOutputLocale(outputLocale),
         ...(styleAnchor ? { session_style_anchor: styleAnchor.style } : {}),
       });
     },
-    [input, sessionId, page, generate, imageTier, loopWire, outputLocale, styleAnchor]
+    [input, sessionId, page, generate, imageTier, loopWire, devModel, outputLocale, styleAnchor]
   );
 
   // B1 — "Describe a place": turn the input description into a logical object
@@ -1164,6 +1170,7 @@ export default function PlayPage() {
         mode: "query",
         image_tier: imageTier,
         ...loopWire,
+        ...(devModel ? { image_model: devModel } : {}),
         output_locale: resolveOutputLocale(outputLocale),
         world_mode: true,
         render_mode: "place_submap",
@@ -1199,6 +1206,7 @@ export default function PlayPage() {
     generate,
     imageTier,
     loopWire,
+    devModel,
     outputLocale,
     styleAnchor,
     promptForHint,
@@ -1255,6 +1263,7 @@ export default function PlayPage() {
         parent_title: page.title,
         image_tier: imageTier,
         ...loopWire,
+        ...(devModel ? { image_model: devModel } : {}),
         output_locale: resolveOutputLocale(outputLocale),
         ...(editCondition.urls.length
           ? {
@@ -1269,7 +1278,7 @@ export default function PlayPage() {
       setEditMode(false);
       setEditRegion(null);
     },
-    [page, generate, imageTier, loopWire, outputLocale, styleAnchor, history]
+    [page, generate, imageTier, loopWire, devModel, outputLocale, styleAnchor, history]
   );
 
   const submitEdit = useCallback(
@@ -2124,6 +2133,7 @@ export default function PlayPage() {
         click,
         image_tier: imageTier,
         ...loopWire,
+        ...(devModel ? { image_model: devModel } : {}),
         output_locale: resolveOutputLocale(outputLocale),
         ...(condition.urls.length
           ? {
@@ -2439,6 +2449,7 @@ export default function PlayPage() {
         click_hint: strokeHint,
         image_tier: imageTier,
         ...loopWire,
+        ...(devModel ? { image_model: devModel } : {}),
         output_locale: resolveOutputLocale(outputLocale),
         ...(strokeCondition.urls.length
           ? {
@@ -2480,7 +2491,7 @@ export default function PlayPage() {
       inflight.clear();
       prefetchCurrentKeyRef.current = null;
     };
-  }, [page, phase, generate, imageTier, loopWire, editMode, outputLocale, bucketKey, streamStatus, styleAnchor, promptForHint, worldEnabled, worldAutonomy, history, selectFromMap]);
+  }, [page, phase, generate, imageTier, loopWire, devModel, editMode, outputLocale, bucketKey, streamStatus, styleAnchor, promptForHint, worldEnabled, worldAutonomy, history, selectFromMap]);
 
   // When the page changes, tear down any running stream.
   useEffect(() => {
@@ -2507,10 +2518,11 @@ export default function PlayPage() {
       mode: "query",
       image_tier: imageTier,
       ...loopWire,
+      ...(devModel ? { image_model: devModel } : {}),
       output_locale: resolveOutputLocale(outputLocale),
       ...(styleAnchor ? { session_style_anchor: styleAnchor.style } : {}),
     });
-  }, [generate, sessionId, imageTier, loopWire, outputLocale, styleAnchor]);
+  }, [generate, sessionId, imageTier, loopWire, devModel, outputLocale, styleAnchor]);
 
   const animateAbortRef = useRef<AbortController | null>(null);
   const disconnectStream = useCallback(() => {
@@ -2613,6 +2625,8 @@ export default function PlayPage() {
         loopKnobs={loopKnobs}
         setLoopKnobs={setLoopKnobs}
         sessionSpend={sessionSpend}
+        devModel={devModel}
+        setDevModel={setDevModel}
         worldMode={worldEnabled}
         setWorldMode={setWorldEnabled}
         autonomy={worldAutonomy}

--- a/apps/web/components/PlayPage/QueryToolbar.tsx
+++ b/apps/web/components/PlayPage/QueryToolbar.tsx
@@ -27,6 +27,8 @@ interface Props {
   loopKnobs: LoopKnobs;
   setLoopKnobs: (k: LoopKnobs) => void;
   sessionSpend?: number | null | undefined;
+  devModel?: string | null | undefined;
+  setDevModel?: ((m: string | null) => void) | undefined;
   worldMode: boolean;
   setWorldMode: (on: boolean) => void;
   autonomy: Autonomy;
@@ -50,6 +52,8 @@ export function QueryToolbar({
   loopKnobs,
   setLoopKnobs,
   sessionSpend,
+  devModel,
+  setDevModel,
   worldMode,
   setWorldMode,
   autonomy,
@@ -150,6 +154,8 @@ export function QueryToolbar({
           knobs={loopKnobs}
           setKnobs={setLoopKnobs}
           sessionSpend={sessionSpend}
+          devModel={devModel}
+          setDevModel={setDevModel}
         />
         <div
           role="group"

--- a/apps/web/components/PlayPage/SpeedPreset.test.tsx
+++ b/apps/web/components/PlayPage/SpeedPreset.test.tsx
@@ -81,3 +81,14 @@ describe("session spend chip", () => {
     expect(screen.queryByTestId("session-spend")).toBeNull();
   });
 });
+
+describe("dev model dropdown", () => {
+  it("absent without NEXT_PUBLIC_DEV_PROVIDERS (the default build)", () => {
+    const { setKnobs } = setup({ setDevModel: () => {} });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Advanced loop controls" }),
+    );
+    expect(screen.queryByLabelText("Dev image model override")).toBeNull();
+    void setKnobs;
+  });
+});

--- a/apps/web/components/PlayPage/SpeedPreset.tsx
+++ b/apps/web/components/PlayPage/SpeedPreset.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { ImageTier } from "@openflipbook/config";
 
 import { formatCostRange, projectCost } from "@/lib/cost-estimate";
@@ -21,6 +21,18 @@ interface Props {
   /** Running backend spend estimate for this session ($); null/absent until
    * the first final frame lands. */
   sessionSpend?: number | null | undefined;
+  /** Dev-only explicit model override (NEXT_PUBLIC_DEV_PROVIDERS=1): rides
+   * the wire's image_model field per request. null = the tier decides. */
+  devModel?: string | null | undefined;
+  setDevModel?: ((m: string | null) => void) | undefined;
+}
+
+const DEV_PROVIDERS = process.env.NEXT_PUBLIC_DEV_PROVIDERS === "1";
+
+interface RegistryModel {
+  slug: string;
+  label: string;
+  est_cost: number;
 }
 
 // The 3-stop speed/quality preset + the live cost chip — the projected spend
@@ -35,8 +47,26 @@ export function SpeedPreset({
   knobs,
   setKnobs,
   sessionSpend,
+  devModel,
+  setDevModel,
 }: Props) {
   const [open, setOpen] = useState(false);
+  const [models, setModels] = useState<RegistryModel[] | null>(null);
+  useEffect(() => {
+    if (!open || !DEV_PROVIDERS || models !== null) return;
+    let cancelled = false;
+    void fetch("/api/models")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((j: { models?: RegistryModel[] } | null) => {
+        if (!cancelled) setModels(j?.models ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setModels([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, models]);
   const active = presetFor(imageTier, knobs);
   const bundle = { tier: imageTier, ...knobs };
   const tap = formatCostRange(projectCost(bundle, "tap"));
@@ -147,6 +177,25 @@ export function SpeedPreset({
               {knobButton(!knobs.verify, () => setKnobs({ ...knobs, verify: false }), "off")}
             </div>
           </div>
+          {DEV_PROVIDERS && setDevModel && (
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <span className="opacity-60">model</span>
+              <select
+                aria-label="Dev image model override"
+                value={devModel ?? ""}
+                disabled={busy}
+                onChange={(e) => setDevModel(e.target.value || null)}
+                className="max-w-[9.5rem] rounded-full border border-[var(--color-edge)] bg-transparent px-2 py-1 text-xs disabled:opacity-40"
+              >
+                <option value="">tier decides</option>
+                {(models ?? []).map((m) => (
+                  <option key={m.slug} value={m.slug}>
+                    {m.label} (${m.est_cost.toFixed(2)})
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
           <p className="mt-2 border-t border-[var(--color-edge)] pt-2 opacity-60">
             tap {tap} · edit {edit} · new page {fresh}
           </p>


### PR DESCRIPTION
Fourth wave (#52–#55 precede it). Completes the provider-freedom milestone.

- **Capability registry** (`model_router.py`, data not behavior): per-slug `supports_edit` / `supports_refs` / `legible_text` (the map-text gotcha, machine-readable at last) / est cost / est latency. Served by `GET /models`; web proxies it at `/api/models`.
- **`PROVIDER_FALLBACK=1`** — fresh generations fail over down a cost-descending chain (riverflow→nano-pro→nano; nano-pro→2→base) with a per-slug **circuit breaker** (`providers/breaker.py`: 3 consecutive failures → 120s cooldown, in-process, locked — spend.py's posture). Open circuits are skipped; all-open still tries the requested slug rather than refusing; `final.image_model` reports honestly which model rendered. Fresh-gen only by design — edit/continue ops carry semantics (refs, masks, strict-zoom) a substitute may not honour. Flag off (default) → byte-identical single-slug dispatch (tested).
- **`NEXT_PUBLIC_DEV_PROVIDERS=1`** — a model dropdown in the speed-preset ⚙ popover, fed by the registry, riding the wire's existing `image_model` field per request. No flag → no UI (tested).

Tests: backend 627 passed (+ registry/chain/breaker units, fallback-off byte-identity, degrade-to-next-slug, open-circuit skip, all-open last-resort); web 544 passed; tsc + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)