### PR TITLE
Wave 5: public-deploy safety — shared-token auth, per-IP rate limit, moderation hook

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -61,6 +61,43 @@ secrets = [
 app = modal.App(APP_NAME, image=image)
 fastapi_app = FastAPI(title="Endless Canvas — generate")
 
+# ── Public-deploy safety (Wave 5; all default OFF) ───────────────────────────
+SHARED_TOKEN_HEADER = "x-openflipbook-token"
+
+
+@fastapi_app.middleware("http")
+async def _shared_token_gate(request: Request, call_next: Any) -> Any:
+    """SHARED_TOKEN (env, unset = open): when set, every endpoint except
+    /health requires the matching header. The web's server-side proxies
+    inject it (lib/modal.modalAuthHeaders); browsers never hold the token."""
+    token = os.environ.get("SHARED_TOKEN")
+    if (
+        token
+        and request.url.path != "/health"
+        and request.headers.get(SHARED_TOKEN_HEADER) != token
+    ):
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+    return await call_next(request)
+
+
+def _client_ip(req: Request) -> str:
+    forwarded = req.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return req.client.host if req.client else "unknown"
+
+
+def _rate_limited(req: Request) -> JSONResponse | None:
+    """RATE_LIMIT_RPM (env, 0/unset = off): per-IP token bucket on the
+    spendy endpoints. Returns the 429 to send, or None to proceed."""
+    from providers import ratelimit
+
+    if ratelimit.allow(_client_ip(req)):
+        return None
+    return JSONResponse(
+        {"error": "rate limited — slow down (RATE_LIMIT_RPM)"}, status_code=429
+    )
+
 
 class Click(BaseModel):
     x_pct: float = Field(ge=0.0, le=1.0)
@@ -1523,6 +1560,19 @@ async def _event_stream(
         # keep their labels.
         if plan.facts and render_mode != "place_scene":
             composed_prompt += "\n\nLabels to include:\n- " + "\n- ".join(plan.facts)
+        # MODERATE_PROMPTS (default off): one cheap LLM check on the composed
+        # prompt before any image dollars are spent — a public deployment's
+        # opt-in. Fail-open inside (providers/moderation.py); a block is a
+        # clean error frame, not a 500.
+        from providers import moderation
+
+        blocked, block_reason = await moderation.flagged(composed_prompt)
+        if blocked:
+            yield _sse(
+                {"type": "error", "message": f"Blocked by moderation: {block_reason}"},
+                trace_id,
+            )
+            return
         # World Mode sub-map: pixel-continue the click region with a continuation
         # model (Kontext) so the closer map keeps the parent's streets/buildings
         # in place instead of re-planning a fresh image. Needs the region crop.
@@ -2021,6 +2071,9 @@ async def _event_stream(
 async def sse_generate(req: Request):
     from obs import TRACE_HEADER, bind_trace
 
+    limited = _rate_limited(req)
+    if limited is not None:
+        return limited
     raw = await req.json()
     try:
         body = GenerateBody.model_validate(raw)
@@ -2059,6 +2112,10 @@ async def animate(req: Request, body: AnimateBody):
     from obs import TRACE_HEADER, bind_trace, log, record_error
     from providers import llm as llm_provider
     from providers import video as video_provider
+
+    limited = _rate_limited(req)
+    if limited is not None:
+        return limited
 
     trace_id = bind_trace(req.headers.get(TRACE_HEADER) or body.trace_id)
     img_size_kb = len(body.image_data_url) // 1024
@@ -2138,6 +2195,10 @@ async def resolve_click(req: Request, body: ResolveClickBody):
     """
     from obs import TRACE_HEADER, bind_trace, record_error
     from providers import llm as llm_provider
+
+    limited = _rate_limited(req)
+    if limited is not None:
+        return limited
 
     trace_id = bind_trace(req.headers.get(TRACE_HEADER) or body.trace_id)
     try:

--- a/apps/modal-backend/providers/mock.py
+++ b/apps/modal-backend/providers/mock.py
@@ -119,6 +119,8 @@ def _route(system: str, user: str) -> str:
     s = system.lower()
     seed = _h(system[:120], user[:200])
     subject = _SUBJECTS[seed % len(_SUBJECTS)]
+    if "content reviewer" in s:
+        return json.dumps({"allowed": True, "reason": ""})
     if "score" in s and ("judge" in s or "rate" in s or "0-10" in s or "10" in s):
         return json.dumps({"score": 8.5, "rationale": "mock judge: accepted"})
     if "tapped" in s or "crosshair" in s or "click" in s:

--- a/apps/modal-backend/providers/moderation.py
+++ b/apps/modal-backend/providers/moderation.py
@@ -1,0 +1,52 @@
+"""MODERATE_PROMPTS=1 — one cheap LLM check on the composed image prompt
+before any image dollars are spent. Off (the default) -> no call, no change.
+
+Fail-open by design: a moderation-infra hiccup must never brick generation
+for a self-hoster — a parse failure or client error logs and allows. The
+check rides the existing llm client (so MOCK_PROVIDERS covers it too).
+"""
+from __future__ import annotations
+
+import contextlib
+from typing import Any
+
+from _env import env_flag
+
+_SYSTEM = (
+    "You are a content reviewer for an image-generation prompt. Reply as "
+    'JSON: {"allowed": true|false, "reason": "<short>"}. Disallow only '
+    "clearly prohibited visual content (sexual content involving minors, "
+    "gratuitous real-person sexual imagery, instructions for serious harm); "
+    "fantasy violence, maps, machinery and ordinary scenes are all allowed."
+)
+
+
+async def flagged(text: str) -> tuple[bool, str]:
+    """(blocked, reason). Always (False, "") when the flag is off."""
+    if not env_flag("MODERATE_PROMPTS"):
+        return (False, "")
+    from obs import log
+    from providers import llm
+
+    try:
+        client = llm._client()
+        resp: Any = await client.chat.completions.create(
+            model=llm._vlm_model(),
+            messages=[
+                {"role": "system", "content": _SYSTEM},
+                {"role": "user", "content": text[:4000]},
+            ],
+            response_format={"type": "json_object"},
+        )
+        raw = resp.choices[0].message.content or "{}"
+        parsed = llm._safe_json(raw)
+        allowed = parsed.get("allowed")
+        if allowed is False:
+            reason = str(parsed.get("reason", ""))[:200] or "blocked by moderation"
+            log("warn", "moderation.blocked", reason=reason)
+            return (True, reason)
+        return (False, "")
+    except Exception as exc:  # fail-open: never brick generation
+        with contextlib.suppress(Exception):
+            log("warn", "moderation.degraded", error=f"{type(exc).__name__}: {exc}")
+        return (False, "")

--- a/apps/modal-backend/providers/ratelimit.py
+++ b/apps/modal-backend/providers/ratelimit.py
@@ -1,0 +1,48 @@
+"""Per-IP token bucket — in-process, locked (the spend.py posture).
+
+RATE_LIMIT_RPM (requests/minute, env) arms it; absent/0 = off, byte-identical.
+Burst capacity is rpm/4 (floor 2) so a human's quick double-action passes
+while a flood drains immediately. Per container, reset on restart — a public
+deployment that needs real limits should still front this with a proxy; this
+is the in-app seatbelt.
+"""
+from __future__ import annotations
+
+import os
+import threading
+import time
+
+_lock = threading.Lock()
+_buckets: dict[str, tuple[float, float]] = {}  # ip -> (tokens, last_ts)
+_MAX_BUCKETS = 4096
+
+
+def rpm() -> float:
+    try:
+        return max(0.0, float(os.environ.get("RATE_LIMIT_RPM", "") or 0.0))
+    except ValueError:
+        return 0.0
+
+
+def allow(ip: str) -> bool:
+    rate = rpm()
+    if rate <= 0:
+        return True
+    capacity = max(2.0, rate / 4.0)
+    refill_per_s = rate / 60.0
+    now = time.monotonic()
+    with _lock:
+        tokens, last = _buckets.get(ip, (capacity, now))
+        tokens = min(capacity, tokens + (now - last) * refill_per_s)
+        if tokens < 1.0:
+            _buckets[ip] = (tokens, now)
+            return False
+        _buckets[ip] = (tokens - 1.0, now)
+        if len(_buckets) > _MAX_BUCKETS:
+            _buckets.pop(next(iter(_buckets)))
+        return True
+
+
+def reset_for_tests() -> None:
+    with _lock:
+        _buckets.clear()

--- a/apps/modal-backend/tests/test_deploy_safety.py
+++ b/apps/modal-backend/tests/test_deploy_safety.py
@@ -1,0 +1,174 @@
+"""Wave 5: SHARED_TOKEN gate, per-IP rate limit, MODERATE_PROMPTS hook —
+all default OFF (the self-host posture), each proven both ways."""
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.modules.setdefault("modal", MagicMock())
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+import providers.image as image_mod  # noqa: E402
+import providers.llm as llm_mod  # noqa: E402
+from generate import GenerateBody, _event_stream, fastapi_app  # noqa: E402
+from providers import moderation, ratelimit  # noqa: E402
+from providers.image import GeneratedImage  # noqa: E402
+from providers.llm import PagePlan  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch: pytest.MonkeyPatch):
+    ratelimit.reset_for_tests()
+    for var in ("SHARED_TOKEN", "RATE_LIMIT_RPM", "MODERATE_PROMPTS"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("PROGRESSIVE_DRAFT", "false")
+    yield
+    ratelimit.reset_for_tests()
+
+
+# ── SHARED_TOKEN ────────────────────────────────────────────────────────────
+
+
+def test_token_unset_everything_open() -> None:
+    client = TestClient(fastapi_app)
+    assert client.get("/models").status_code == 200
+
+
+def test_token_set_gates_everything_but_health(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SHARED_TOKEN", "s3cret")
+    client = TestClient(fastapi_app)
+    assert client.get("/health").status_code == 200  # probes stay open
+    assert client.get("/models").status_code == 401
+    ok = client.get("/models", headers={"x-openflipbook-token": "s3cret"})
+    assert ok.status_code == 200
+    wrong = client.get("/models", headers={"x-openflipbook-token": "nope"})
+    assert wrong.status_code == 401
+
+
+# ── Rate limit ──────────────────────────────────────────────────────────────
+
+
+def test_ratelimit_off_by_default() -> None:
+    for _ in range(50):
+        assert ratelimit.allow("1.2.3.4")
+
+
+def test_ratelimit_bucket_drains_and_isolates_ips(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RATE_LIMIT_RPM", "4")  # capacity = max(2, 1) = 2
+    assert ratelimit.allow("a")
+    assert ratelimit.allow("a")
+    assert not ratelimit.allow("a")  # bucket drained
+    assert ratelimit.allow("b")  # other IPs unaffected
+
+
+def test_sse_generate_429s_when_drained(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RATE_LIMIT_RPM", "4")
+    client = TestClient(fastapi_app)
+    # empty body: the gate sits BEFORE validation, so the first two get 400
+    # (pydantic), the third gets 429 (drained bucket).
+    codes = [
+        client.post("/sse/generate", json={}).status_code for _ in range(3)
+    ]
+    assert codes == [400, 400, 429]
+
+
+# ── Moderation ──────────────────────────────────────────────────────────────
+
+
+class _FakeChat:
+    def __init__(self, payload: dict[str, Any]):
+        self._payload = payload
+
+    async def create(self, **kwargs: Any) -> Any:
+        msg = MagicMock()
+        msg.content = json.dumps(self._payload)
+        choice = MagicMock()
+        choice.message = msg
+        resp = MagicMock()
+        resp.choices = [choice]
+        return resp
+
+
+def _fake_client(payload: dict[str, Any]) -> Any:
+    client = MagicMock()
+    client.chat.completions = _FakeChat(payload)
+    return client
+
+
+async def test_moderation_off_means_no_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = MagicMock()
+    monkeypatch.setattr(llm_mod, "_client", called)
+    assert await moderation.flagged("anything") == (False, "")
+    called.assert_not_called()
+
+
+async def test_moderation_blocks_and_allows(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MODERATE_PROMPTS", "1")
+    monkeypatch.setattr(
+        llm_mod, "_client", lambda: _fake_client({"allowed": False, "reason": "nope"})
+    )
+    assert await moderation.flagged("bad thing") == (True, "nope")
+    monkeypatch.setattr(
+        llm_mod, "_client", lambda: _fake_client({"allowed": True, "reason": ""})
+    )
+    assert await moderation.flagged("fine thing") == (False, "")
+
+
+async def test_moderation_fails_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MODERATE_PROMPTS", "1")
+
+    def boom() -> Any:
+        raise RuntimeError("moderation infra down")
+
+    monkeypatch.setattr(llm_mod, "_client", boom)
+    assert await moderation.flagged("anything") == (False, "")
+
+
+async def _collect(agen: Any) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    async for chunk in agen:
+        text = chunk.decode() if isinstance(chunk, bytes) else chunk
+        for block in text.strip().split("\n\n"):
+            block = block.strip()
+            if block.startswith("data:"):
+                events.append(json.loads(block[len("data:") :].strip()))
+    return events
+
+
+async def test_blocked_prompt_yields_clean_error_frame(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        llm_mod,
+        "plan_page",
+        AsyncMock(return_value=PagePlan("T", "a scene", [], [])),
+    )
+    gen = AsyncMock(
+        return_value=GeneratedImage(b"jpeg", "image/jpeg", "fal-ai/nano-banana-pro", "r")
+    )
+    monkeypatch.setattr(image_mod, "generate_image", gen)
+    from providers import moderation as moderation_mod
+
+    monkeypatch.setattr(
+        moderation_mod, "flagged", AsyncMock(return_value=(True, "test block"))
+    )
+
+    events = await _collect(
+        _event_stream(
+            GenerateBody(query="x", session_id="s1", web_search=False), "t1"
+        )
+    )
+    assert any(
+        e["type"] == "error" and "Blocked by moderation" in e["message"]
+        for e in events
+    )
+    gen.assert_not_awaited()

--- a/apps/web/app/api/animate/route.ts
+++ b/apps/web/app/api/animate/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { modalUrl as joinModalUrl } from "@/lib/modal";
+import { modalAuthHeaders, modalUrl as joinModalUrl } from "@/lib/modal";
 import { TRACE_HEADER, newTraceId } from "@/lib/trace";
 
 export const runtime = "nodejs";
@@ -19,7 +19,7 @@ export async function POST(req: Request) {
   try {
     upstream = await fetch(joinModalUrl(modalUrl, "/animate"), {
       method: "POST",
-      headers: { "Content-Type": "application/json", [TRACE_HEADER]: traceId },
+      headers: { "Content-Type": "application/json", [TRACE_HEADER]: traceId, ...modalAuthHeaders() },
       body,
       signal: req.signal,
     });

--- a/apps/web/app/api/generate-page/route.ts
+++ b/apps/web/app/api/generate-page/route.ts
@@ -4,7 +4,7 @@ import { locationPhrase } from "@/lib/location-phrase";
 import { inlineStoredImage } from "@/lib/r2";
 import { resolveEntitiesForPrompt } from "@/lib/world";
 import { getWorldMap } from "@/lib/world-map";
-import { modalUrl as joinModalUrl } from "@/lib/modal";
+import { modalAuthHeaders, modalUrl as joinModalUrl } from "@/lib/modal";
 import { TRACE_HEADER, newTraceId } from "@/lib/trace";
 
 export const runtime = "nodejs";
@@ -112,6 +112,7 @@ export async function POST(req: Request) {
     headers: {
       "Content-Type": "application/json",
       [TRACE_HEADER]: traceId,
+      ...modalAuthHeaders(),
     },
     body: upstreamBody,
   });

--- a/apps/web/app/api/models/route.ts
+++ b/apps/web/app/api/models/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { modalUrl as joinModalUrl } from "@/lib/modal";
+import { modalAuthHeaders, modalUrl as joinModalUrl } from "@/lib/modal";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -14,6 +14,7 @@ export async function GET() {
   try {
     const upstream = await fetch(joinModalUrl(modalUrl, "/models"), {
       cache: "no-store",
+      headers: modalAuthHeaders(),
     });
     return NextResponse.json(await upstream.json(), {
       status: upstream.status,

--- a/apps/web/app/api/precompute-candidates/route.ts
+++ b/apps/web/app/api/precompute-candidates/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { modalUrl as joinModalUrl } from "@/lib/modal";
+import { modalAuthHeaders, modalUrl as joinModalUrl } from "@/lib/modal";
 import { TRACE_HEADER, newTraceId } from "@/lib/trace";
 
 export const runtime = "nodejs";
@@ -30,6 +30,7 @@ export async function POST(req: Request) {
         headers: {
           "Content-Type": "application/json",
           [TRACE_HEADER]: traceId,
+          ...modalAuthHeaders(),
         },
         body,
         signal: req.signal,

--- a/apps/web/app/api/resolve-click/route.ts
+++ b/apps/web/app/api/resolve-click/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { modalUrl as joinModalUrl } from "@/lib/modal";
+import { modalAuthHeaders, modalUrl as joinModalUrl } from "@/lib/modal";
 import { inlineStoredImage } from "@/lib/r2";
 import { TRACE_HEADER, newTraceId } from "@/lib/trace";
 
@@ -35,7 +35,7 @@ export async function POST(req: Request) {
   try {
     upstream = await fetch(joinModalUrl(modalUrl, "/resolve-click"), {
       method: "POST",
-      headers: { "Content-Type": "application/json", [TRACE_HEADER]: traceId },
+      headers: { "Content-Type": "application/json", [TRACE_HEADER]: traceId, ...modalAuthHeaders() },
       body,
       signal: req.signal,
     });

--- a/apps/web/app/api/status/route.ts
+++ b/apps/web/app/api/status/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { modalUrl as joinModalUrl } from "@/lib/modal";
+import { modalAuthHeaders, modalUrl as joinModalUrl } from "@/lib/modal";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -16,6 +16,7 @@ export async function GET() {
     const upstream = await fetch(joinModalUrl(modalUrl, "/status"), {
       method: "GET",
       cache: "no-store",
+      headers: modalAuthHeaders(),
       signal: AbortSignal.timeout(4000),
     });
     const text = await upstream.text();

--- a/apps/web/app/api/trace/abort-stats/route.ts
+++ b/apps/web/app/api/trace/abort-stats/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server";
-import { modalUrl as joinModalUrl } from "@/lib/modal";
+import { modalAuthHeaders, modalUrl as joinModalUrl } from "@/lib/modal";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -22,6 +22,7 @@ export async function GET(req: NextRequest) {
       {
         method: "GET",
         cache: "no-store",
+        headers: modalAuthHeaders(),
         signal: AbortSignal.timeout(6000),
       }
     );

--- a/apps/web/app/api/trace/recent/route.ts
+++ b/apps/web/app/api/trace/recent/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server";
-import { modalUrl as joinModalUrl } from "@/lib/modal";
+import { modalAuthHeaders, modalUrl as joinModalUrl } from "@/lib/modal";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -22,6 +22,7 @@ export async function GET(req: NextRequest) {
       {
         method: "GET",
         cache: "no-store",
+        headers: modalAuthHeaders(),
         signal: AbortSignal.timeout(6000),
       }
     );

--- a/apps/web/app/api/world/[sessionId]/edit-entities/route.ts
+++ b/apps/web/app/api/world/[sessionId]/edit-entities/route.ts
@@ -8,7 +8,7 @@ import {
 } from "@/lib/world-map";
 import { readServerEnv } from "@/lib/env";
 import { envFlag } from "@/lib/env-flag";
-import { modalUrl as joinModalUrl } from "@/lib/modal";
+import { modalAuthHeaders, modalUrl as joinModalUrl } from "@/lib/modal";
 import { TRACE_HEADER, newTraceId } from "@/lib/trace";
 import type { EntityEditPlan, EntityGeoEdit, SceneView } from "@openflipbook/config";
 
@@ -101,7 +101,7 @@ export async function POST(req: Request, { params }: Params) {
       joinModalUrl(env.MODAL_API_URL, "/edit-entities"),
       {
         method: "POST",
-        headers: { "Content-Type": "application/json", [TRACE_HEADER]: traceId },
+        headers: { "Content-Type": "application/json", [TRACE_HEADER]: traceId, ...modalAuthHeaders() },
         body: JSON.stringify({
           session_id: sessionId,
           instruction,

--- a/apps/web/app/api/world/[sessionId]/extract/route.ts
+++ b/apps/web/app/api/world/[sessionId]/extract/route.ts
@@ -6,7 +6,7 @@ import { MAP_IMAGE_FRAME } from "@/lib/geo-tap";
 import { readServerEnv } from "@/lib/env";
 import { envFlag } from "@/lib/env-flag";
 import { inlineStoredImage } from "@/lib/r2";
-import { modalUrl as joinModalUrl } from "@/lib/modal";
+import { modalAuthHeaders, modalUrl as joinModalUrl } from "@/lib/modal";
 import { TRACE_HEADER, newTraceId } from "@/lib/trace";
 import type {
   Entity,
@@ -113,6 +113,7 @@ export async function POST(req: Request, { params }: Params) {
         headers: {
           "Content-Type": "application/json",
           [TRACE_HEADER]: traceId,
+          ...modalAuthHeaders(),
         },
         body: JSON.stringify({
           session_id: sessionId,

--- a/apps/web/app/api/world/[sessionId]/plan-world/route.ts
+++ b/apps/web/app/api/world/[sessionId]/plan-world/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { readServerEnv } from "@/lib/env";
-import { modalUrl as joinModalUrl } from "@/lib/modal";
+import { modalAuthHeaders, modalUrl as joinModalUrl } from "@/lib/modal";
 import { TRACE_HEADER, newTraceId } from "@/lib/trace";
 import type { PlanWorldResponse } from "@openflipbook/config";
 
@@ -39,7 +39,7 @@ export async function POST(req: Request, { params }: Params) {
   try {
     const upstream = await fetch(joinModalUrl(env.MODAL_API_URL, "/plan-world"), {
       method: "POST",
-      headers: { "Content-Type": "application/json", [TRACE_HEADER]: traceId },
+      headers: { "Content-Type": "application/json", [TRACE_HEADER]: traceId, ...modalAuthHeaders() },
       body: JSON.stringify({
         session_id: sessionId,
         description,

--- a/apps/web/lib/modal.ts
+++ b/apps/web/lib/modal.ts
@@ -4,3 +4,15 @@
 // double slash, or a missing one). `path` must start with "/".
 export const modalUrl = (base: string, path: string): string =>
   `${base.replace(/\/$/, "")}${path}`;
+
+// Optional shared-token auth (Wave 5): when SHARED_TOKEN is set on BOTH the
+// web server and the backend, every server-side proxy hop carries it and the
+// backend's middleware refuses requests without it. The browser never holds
+// the token — only these Node-side fetches do. Unset (the default) -> {}
+// and the backend stays open: byte-identical self-host behaviour.
+export const SHARED_TOKEN_HEADER = "x-openflipbook-token";
+
+export function modalAuthHeaders(): Record<string, string> {
+  const token = process.env.SHARED_TOKEN;
+  return token ? { [SHARED_TOKEN_HEADER]: token } : {};
+}

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -106,3 +106,23 @@ docker compose build web && docker compose up -d --no-deps web
 | `/play` 503 from generate | backend can't reach fal/OpenRouter (or Ollama) — `docker compose logs backend`. |
 | `make demo-local` slow / times out first request | models still downloading — `docker compose logs ollama-pull`. |
 | `/api/nodes` 500 | blob upload failed — check `R2_*` in the web service + `docker compose logs minio`. |
+
+## Exposing a deployment beyond localhost
+
+Three opt-in seatbelts (all default off — local stacks are unchanged):
+
+```sh
+SHARED_TOKEN=<random>     # backend refuses requests without the matching
+                          # x-openflipbook-token header; set the SAME value on
+                          # the web service — its server-side proxies inject it.
+                          # The browser never holds the token. /health stays open.
+RATE_LIMIT_RPM=30         # per-IP token bucket on the spendy endpoints
+                          # (/sse/generate, /resolve-click, /animate) -> 429s.
+MODERATE_PROMPTS=1        # one cheap LLM check on the composed image prompt
+                          # before image dollars are spent; blocks land as a
+                          # clean error frame. Fail-open on infra hiccups.
+```
+
+These are in-app seatbelts, not a perimeter: a genuinely public deployment
+should still sit behind a reverse proxy with TLS + real auth, and the web UI
+itself has no login — protect port 3000 at that layer.


### PR DESCRIPTION
Fifth wave (#52–#56 precede it). Three opt-in seatbelts for deployments that face strangers — all default OFF, a local stack is byte-identical.

- **`SHARED_TOKEN`**: backend middleware refuses everything but `/health` without the matching `x-openflipbook-token` header. Every web server-side proxy (all 11) injects it via `lib/modal.modalAuthHeaders()` — the browser never holds the token.
- **`RATE_LIMIT_RPM`**: per-IP token bucket (`providers/ratelimit.py` — burst rpm/4 floor 2, in-process + locked) on the spendy endpoints (`/sse/generate`, `/resolve-click`, `/animate`), refusing 429 before any body parsing.
- **`MODERATE_PROMPTS`**: one cheap LLM check on the composed image prompt before image dollars are spent; blocks land as a clean SSE error frame. **Fail-open** on infra hiccups — moderation must never brick a self-hoster. Rides the shared llm client, so MOCK_PROVIDERS covers it.

docs/DOCKER.md states the honest posture: in-app seatbelts, not a perimeter — a genuinely public deployment still belongs behind a reverse proxy with TLS and real auth (the web UI has no login by design).

Tests: backend 636 passed (+ token open/gated/wrong-token/health-exempt, bucket drain + IP isolation + endpoint 429 sequencing, moderation off-no-call / block / allow / fail-open, blocked-prompt-yields-clean-error-frame with zero image calls); web 544; tsc + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)