### PR TITLE
Wave 6: exports — ZIP, flipbook PDF, animated GIF of a session path

### DIFF
--- a/apps/web/app/api/export/[nodeId]/route.ts
+++ b/apps/web/app/api/export/[nodeId]/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from "next/server";
+
+import { getNodeChain } from "@/lib/db";
+import { readServerEnv } from "@/lib/env";
+import {
+  buildFlipbookPdf,
+  buildGif,
+  buildZip,
+  sampleEvenly,
+  type ExportPage,
+} from "@/lib/export-build";
+import { getStoredBytes } from "@/lib/r2";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface Params {
+  params: Promise<{ nodeId: string }>;
+}
+
+const GIF_FRAME_CAP = 16;
+const CHAIN_CAP = 40;
+
+/** GET /api/export/[nodeId]?fmt=zip|pdf|gif — the root→node path as a
+ * shareable artifact. ZIP = pages + graph.json; PDF = the flipbook; GIF =
+ * an animated flip (evenly sampled to GIF_FRAME_CAP frames). */
+export async function GET(req: Request, { params }: Params) {
+  const { nodeId } = await params;
+  const env = readServerEnv();
+  if (!env.MONGODB_URI || !env.MONGODB_DB) {
+    return NextResponse.json(
+      { error: "persistence not configured" },
+      { status: 503 },
+    );
+  }
+  const fmt = new URL(req.url).searchParams.get("fmt") ?? "zip";
+  if (!["zip", "pdf", "gif"].includes(fmt)) {
+    return NextResponse.json({ error: "fmt must be zip|pdf|gif" }, { status: 400 });
+  }
+
+  const chain = await getNodeChain(nodeId, CHAIN_CAP);
+  if (chain.length === 0) {
+    return NextResponse.json({ error: "node not found" }, { status: 404 });
+  }
+
+  const wanted =
+    fmt === "gif" ? new Set(sampleEvenly(chain.length, GIF_FRAME_CAP)) : null;
+  const pages: ExportPage[] = [];
+  for (let i = 0; i < chain.length; i++) {
+    if (wanted && !wanted.has(i)) continue;
+    const row = chain[i]!;
+    const stored = await getStoredBytes(row.image_key);
+    if (!stored) continue; // a missing blob drops the page, not the export
+    pages.push({
+      id: row.id,
+      parent_id: row.parent_id,
+      title: row.page_title || row.query,
+      query: row.query,
+      created_at: row.created_at,
+      bytes: stored.bytes,
+    });
+  }
+  if (pages.length === 0) {
+    return NextResponse.json({ error: "no stored pages" }, { status: 404 });
+  }
+
+  const stamp = nodeId.slice(0, 8);
+  if (fmt === "zip") {
+    const bytes = await buildZip(pages);
+    return new Response(Buffer.from(bytes), {
+      headers: {
+        "Content-Type": "application/zip",
+        "Content-Disposition": `attachment; filename="openflipbook-${stamp}.zip"`,
+      },
+    });
+  }
+  if (fmt === "pdf") {
+    const bytes = await buildFlipbookPdf(pages);
+    return new Response(Buffer.from(bytes), {
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `attachment; filename="openflipbook-${stamp}.pdf"`,
+      },
+    });
+  }
+  // gif: decode JPEGs to RGBA (pure-JS) then encode
+  const { decode } = await import("jpeg-js");
+  const frames = pages.map((p) => {
+    const d = decode(Buffer.from(p.bytes), { useTArray: true, maxMemoryUsageInMB: 1024 });
+    return { width: d.width, height: d.height, data: d.data };
+  });
+  const bytes = await buildGif(frames);
+  return new Response(Buffer.from(bytes), {
+    headers: {
+      "Content-Type": "image/gif",
+      "Content-Disposition": `attachment; filename="openflipbook-${stamp}.gif"`,
+    },
+  });
+}

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -1410,8 +1410,22 @@ export default function PlayPage() {
         },
       });
     }
+    // Export the root→here path as a shareable artifact (Wave 6). Server
+    // route walks the chain; these just open the download.
+    if (page?.nodeId) {
+      const exportId = page.nodeId;
+      for (const fmt of ["pdf", "zip", "gif"] as const) {
+        items.push({
+          label: `Export path (${fmt.toUpperCase()})`,
+          onClick: () => {
+            close();
+            window.open(`/api/export/${exportId}?fmt=${fmt}`, "_blank");
+          },
+        });
+      }
+    }
     return items;
-  }, [contextMenu, phase, dispatchTapAt, runEdit, geoMap.entities.length, mutateWorldEntity]);
+  }, [contextMenu, phase, page, dispatchTapAt, runEdit, geoMap.entities.length, mutateWorldEntity]);
 
   const canGoBack = history.trailIdx > 0;
   const canGoForward = history.trailIdx < history.trail.length - 1;

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -390,3 +390,25 @@ export async function updateNodeEstimatedView(
   );
   return res.matchedCount === 1;
 }
+
+/** The root→node path: walk parent_id up from `nodeId` (cycle-guarded,
+ * capped) and return it ROOT-FIRST — the page order a flipbook export
+ * reads in. Missing intermediate nodes truncate the walk (best-effort). */
+export async function getNodeChain(
+  nodeId: string,
+  cap = 40
+): Promise<NodeRow[]> {
+  const collection = await nodes();
+  const chain: NodeRow[] = [];
+  const seen = new Set<string>();
+  let cursor: string | null = nodeId;
+  while (cursor && !seen.has(cursor) && chain.length < cap) {
+    seen.add(cursor);
+    const doc = await collection.findOne({ _id: cursor });
+    if (!doc) break;
+    const row = toRow(doc);
+    chain.push(row);
+    cursor = row.parent_id;
+  }
+  return chain.reverse();
+}

--- a/apps/web/lib/export-build.test.ts
+++ b/apps/web/lib/export-build.test.ts
@@ -1,0 +1,82 @@
+import JSZip from "jszip";
+import { PDFDocument } from "pdf-lib";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildFlipbookPdf,
+  buildGif,
+  buildZip,
+  sampleEvenly,
+  type ExportPage,
+} from "./export-build";
+
+// A minimal valid JPEG (1x1, generated once with jpeg-js) — enough for the
+// zip entries; the PDF test needs real JPEG structure, which this is.
+async function tinyJpeg(): Promise<Uint8Array> {
+  const { encode } = await import("jpeg-js");
+  const data = new Uint8Array([200, 180, 150, 255]);
+  return new Uint8Array(
+    encode({ data, width: 1, height: 1 }, 90).data,
+  );
+}
+
+function page(id: string, bytes: Uint8Array, parent: string | null): ExportPage {
+  return {
+    id,
+    parent_id: parent,
+    title: `Page ${id}`,
+    query: `query ${id}`,
+    created_at: "2026-06-11T00:00:00Z",
+    bytes,
+  };
+}
+
+describe("sampleEvenly", () => {
+  it("identity under the cap; first+last kept over it", () => {
+    expect(sampleEvenly(3, 16)).toEqual([0, 1, 2]);
+    const sampled = sampleEvenly(40, 16);
+    expect(sampled.length).toBeLessThanOrEqual(16);
+    expect(sampled[0]).toBe(0);
+    expect(sampled[sampled.length - 1]).toBe(39);
+    expect(sampleEvenly(0, 16)).toEqual([]);
+  });
+});
+
+describe("buildZip", () => {
+  it("one entry per page + a graph.json that rebuilds the path", async () => {
+    const jpg = await tinyJpeg();
+    const bytes = await buildZip([page("a", jpg, null), page("b", jpg, "a")]);
+    const zip = await JSZip.loadAsync(bytes);
+    const names = Object.keys(zip.files);
+    expect(names.filter((n) => n.endsWith(".jpg"))).toHaveLength(2);
+    const graph = JSON.parse(await zip.file("graph.json")!.async("string"));
+    expect(graph.exported_path).toHaveLength(2);
+    expect(graph.exported_path[1].parent_id).toBe("a");
+  });
+});
+
+describe("buildFlipbookPdf", () => {
+  it("a real PDF with one page per image", async () => {
+    const jpg = await tinyJpeg();
+    const bytes = await buildFlipbookPdf([
+      page("a", jpg, null),
+      page("b", jpg, "a"),
+      page("c", jpg, "b"),
+    ]);
+    expect(new TextDecoder().decode(bytes.slice(0, 5))).toBe("%PDF-");
+    const doc = await PDFDocument.load(bytes);
+    expect(doc.getPageCount()).toBe(3);
+  });
+});
+
+describe("buildGif", () => {
+  it("an animated GIF89a from RGBA frames", async () => {
+    const frame = {
+      width: 4,
+      height: 4,
+      data: new Uint8Array(4 * 4 * 4).fill(180),
+    };
+    const bytes = await buildGif([frame, frame]);
+    expect(new TextDecoder().decode(bytes.slice(0, 6))).toBe("GIF89a");
+  });
+});

--- a/apps/web/lib/export-build.ts
+++ b/apps/web/lib/export-build.ts
@@ -1,0 +1,108 @@
+// Session-path exports — pure builders over already-fetched page bytes, so
+// every format is unit-testable without storage. The route walks the chain
+// (db.getNodeChain), fetches each page's stored JPEG (r2.getStoredBytes) and
+// hands the list here. Pure-JS deps only (jszip / pdf-lib / gifenc + jpeg-js)
+// — no native modules, Vercel-safe.
+
+import JSZip from "jszip";
+import { PDFDocument, StandardFonts, rgb } from "pdf-lib";
+
+export interface ExportPage {
+  id: string;
+  parent_id: string | null;
+  title: string;
+  query: string;
+  created_at: string;
+  bytes: Uint8Array;
+}
+
+/** Evenly sample at most `cap` indices from 0..n-1, always keeping the first
+ * and last (a GIF of a 40-page path should still open on the root and end on
+ * the exported page). */
+export function sampleEvenly(n: number, cap: number): number[] {
+  if (n <= 0) return [];
+  if (n <= cap) return Array.from({ length: n }, (_, i) => i);
+  const out: number[] = [];
+  for (let i = 0; i < cap; i++) {
+    out.push(Math.round((i * (n - 1)) / (cap - 1)));
+  }
+  return [...new Set(out)];
+}
+
+/** ZIP: NN-title.jpg per page + graph.json (ids/titles/parents — enough to
+ * rebuild the path structure elsewhere). */
+export async function buildZip(pages: ExportPage[]): Promise<Uint8Array> {
+  const zip = new JSZip();
+  pages.forEach((p, i) => {
+    const slug = p.title.replace(/[^\w\- ]+/g, "").trim().slice(0, 60) || p.id;
+    zip.file(`pages/${String(i + 1).padStart(2, "0")}-${slug}.jpg`, p.bytes);
+  });
+  zip.file(
+    "graph.json",
+    JSON.stringify(
+      {
+        exported_path: pages.map((p) => ({
+          id: p.id,
+          parent_id: p.parent_id,
+          title: p.title,
+          query: p.query,
+          created_at: p.created_at,
+        })),
+      },
+      null,
+      2,
+    ),
+  );
+  return zip.generateAsync({ type: "uint8array" });
+}
+
+/** Flipbook PDF: one full-bleed page per image with a slim title strip under
+ * it — the artifact the project is named after. */
+export async function buildFlipbookPdf(pages: ExportPage[]): Promise<Uint8Array> {
+  const doc = await PDFDocument.create();
+  doc.setTitle("openflipbook export");
+  const font = await doc.embedFont(StandardFonts.Helvetica);
+  const STRIP = 26;
+  for (const p of pages) {
+    const img = await doc.embedJpg(p.bytes);
+    const page = doc.addPage([img.width, img.height + STRIP]);
+    page.drawImage(img, { x: 0, y: STRIP, width: img.width, height: img.height });
+    page.drawRectangle({
+      x: 0,
+      y: 0,
+      width: img.width,
+      height: STRIP,
+      color: rgb(0.94, 0.92, 0.87),
+    });
+    const label = p.title.slice(0, 140);
+    page.drawText(label, {
+      x: 12,
+      y: 8,
+      size: 12,
+      font,
+      color: rgb(0.24, 0.2, 0.16),
+    });
+  }
+  return doc.save();
+}
+
+interface RgbaFrame {
+  width: number;
+  height: number;
+  data: Uint8ClampedArray | Uint8Array;
+}
+
+/** Animated GIF from decoded RGBA frames (the route decodes JPEGs with
+ * jpeg-js and pre-samples via sampleEvenly). ~900ms per page. */
+export async function buildGif(frames: RgbaFrame[]): Promise<Uint8Array> {
+  const { GIFEncoder, quantize, applyPalette } = await import("gifenc");
+  const gif = GIFEncoder();
+  for (const f of frames) {
+    const rgba = new Uint8Array(f.data.buffer, f.data.byteOffset, f.data.byteLength);
+    const palette = quantize(rgba, 256);
+    const indexed = applyPalette(rgba, palette);
+    gif.writeFrame(indexed, f.width, f.height, { palette, delay: 900 });
+  }
+  gif.finish();
+  return gif.bytes();
+}

--- a/apps/web/lib/r2.ts
+++ b/apps/web/lib/r2.ts
@@ -121,3 +121,20 @@ export async function inlineStoredImage(url: string): Promise<string | null> {
     return null;
   }
 }
+
+/** Raw stored bytes by key (the nodes collection stores image_key directly).
+ * Best-effort: null on any failure. */
+export async function getStoredBytes(
+  key: string
+): Promise<{ bytes: Buffer; contentType: string } | null> {
+  try {
+    const { s3, bucket } = r2Client();
+    const got = await s3.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+    if (!got.Body) return null;
+    const bytes = Buffer.from(await got.Body.transformToByteArray());
+    if (bytes.length === 0) return null;
+    return { bytes, contentType: got.ContentType || "image/jpeg" };
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,8 +30,12 @@
     "@aws-sdk/client-s3": "^3.700.0",
     "@openflipbook/config": "workspace:*",
     "@sentry/nextjs": "^8.42.0",
+    "gifenc": "^1.0.3",
+    "jpeg-js": "^0.4.4",
+    "jszip": "^3.10.1",
     "mongodb": "^6.10.0",
     "next": "^15.1.0",
+    "pdf-lib": "^1.17.1",
     "qrcode": "^1.5.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/apps/web/types/gifenc.d.ts
+++ b/apps/web/types/gifenc.d.ts
@@ -1,0 +1,14 @@
+declare module "gifenc" {
+  export function GIFEncoder(): {
+    writeFrame(
+      index: Uint8Array,
+      width: number,
+      height: number,
+      opts: { palette: number[][]; delay?: number },
+    ): void;
+    finish(): void;
+    bytes(): Uint8Array;
+  };
+  export function quantize(rgba: Uint8Array, maxColors: number): number[][];
+  export function applyPalette(rgba: Uint8Array, palette: number[][]): Uint8Array;
+}


### PR DESCRIPTION
Sixth wave (#52–#57 precede it). The session graph finally produces shareable artifacts.

`GET /api/export/[nodeId]?fmt=zip|pdf|gif` walks the root→node chain (`db.getNodeChain`, cycle-guarded, capped 40) and serves:
- **ZIP** — `pages/NN-title.jpg` + `graph.json` (ids/titles/parents: the structure travels with the images),
- **PDF** — the literal flipbook: one full-bleed page per image with a slim parchment title strip (pdf-lib),
- **GIF** — an animated flip, evenly sampled to 16 frames with root + exported page always kept (jpeg-js decode + gifenc).

Pure-JS deps only (jszip / pdf-lib / gifenc / jpeg-js) — no native modules, Vercel-safe. Builders are pure over fetched bytes (`lib/export-build.ts`) and unit-tested: zip round-trip + graph parse, PDF reload + page count, GIF89a magic, sampling caps. Missing blobs drop a page, never the export. Three "Export path" entries join the right-click menu through its existing `extraItems` seam.

Tests: web 548 passed, tsc + build clean; backend untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)