### PR TITLE
Wave 7: opt-in public gallery

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -2652,6 +2652,21 @@ async def models() -> dict:
     return {"models": model_router.registry()}
 
 
+class ModerateTextBody(BaseModel):
+    text: str
+
+
+@fastapi_app.post("/moderate-text")
+async def moderate_text(body: ModerateTextBody) -> dict:
+    """Thin wrapper over providers/moderation.flagged for web-side flows
+    (gallery publish). MODERATE_PROMPTS off -> instantly allowed; fail-open
+    inside the module, same as the generate-path check."""
+    from providers import moderation
+
+    blocked, reason = await moderation.flagged(body.text)
+    return {"allowed": not blocked, "reason": reason}
+
+
 @fastapi_app.get("/trace/recent")
 async def trace_recent(limit: int = 50) -> dict:
     """Return the in-memory ring buffer of recent completed traces.

--- a/apps/modal-backend/tests/test_deploy_safety.py
+++ b/apps/modal-backend/tests/test_deploy_safety.py
@@ -172,3 +172,20 @@ async def test_blocked_prompt_yields_clean_error_frame(
         for e in events
     )
     gen.assert_not_awaited()
+
+
+def test_moderate_text_endpoint_allows_when_off() -> None:
+    client = TestClient(fastapi_app)
+    res = client.post("/moderate-text", json={"text": "a quiet harbor"})
+    assert res.status_code == 200
+    assert res.json() == {"allowed": True, "reason": ""}
+
+
+def test_moderate_text_endpoint_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MODERATE_PROMPTS", "1")
+    monkeypatch.setattr(
+        llm_mod, "_client", lambda: _fake_client({"allowed": False, "reason": "nope"})
+    )
+    client = TestClient(fastapi_app)
+    res = client.post("/moderate-text", json={"text": "bad"})
+    assert res.json() == {"allowed": False, "reason": "nope"}

--- a/apps/web/app/api/gallery/publish/route.ts
+++ b/apps/web/app/api/gallery/publish/route.ts
@@ -1,0 +1,94 @@
+import { NextResponse } from "next/server";
+
+import { getNode, publishSession, unpublishSession } from "@/lib/db";
+import { readServerEnv } from "@/lib/env";
+import { modalAuthHeaders, modalUrl as joinModalUrl } from "@/lib/modal";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/** Publish a session to the public gallery, fronted by one of its pages.
+ * Gated on the backend's moderation hook (instant allow when MODERATE_PROMPTS
+ * is off; fail-open on moderation-infra hiccups — same posture as generate).
+ * The node must belong to the session, so a guessed node id can't front a
+ * stranger's session. */
+export async function POST(req: Request) {
+  const env = readServerEnv();
+  if (!env.MONGODB_URI || !env.MONGODB_DB) {
+    return NextResponse.json(
+      { error: "persistence not configured" },
+      { status: 503 },
+    );
+  }
+  let body: { session_id?: string; node_id?: string };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
+  }
+  if (!body.session_id || !body.node_id) {
+    return NextResponse.json(
+      { error: "missing session_id / node_id" },
+      { status: 400 },
+    );
+  }
+  const node = await getNode(body.node_id);
+  if (!node || node.session_id !== body.session_id) {
+    return NextResponse.json(
+      { error: "node not found in this session" },
+      { status: 404 },
+    );
+  }
+
+  if (env.MODAL_API_URL) {
+    try {
+      const upstream = await fetch(
+        joinModalUrl(env.MODAL_API_URL, "/moderate-text"),
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json", ...modalAuthHeaders() },
+          body: JSON.stringify({
+            text: `${node.page_title}\n${node.query}\n${node.final_prompt ?? ""}`,
+          }),
+        },
+      );
+      const verdict = (await upstream.json()) as {
+        allowed?: boolean;
+        reason?: string;
+      };
+      if (verdict.allowed === false) {
+        return NextResponse.json(
+          { error: `blocked by moderation: ${verdict.reason ?? ""}` },
+          { status: 403 },
+        );
+      }
+    } catch {
+      // fail-open: moderation infra never blocks a self-hoster's publish
+    }
+  }
+
+  await publishSession({
+    session_id: body.session_id,
+    node_id: node.id,
+    title: node.page_title || node.query,
+    query: node.query,
+    poster_key: node.image_key,
+  });
+  return NextResponse.json({ ok: true });
+}
+
+export async function DELETE(req: Request) {
+  const env = readServerEnv();
+  if (!env.MONGODB_URI || !env.MONGODB_DB) {
+    return NextResponse.json(
+      { error: "persistence not configured" },
+      { status: 503 },
+    );
+  }
+  const sessionId = new URL(req.url).searchParams.get("session_id");
+  if (!sessionId) {
+    return NextResponse.json({ error: "missing session_id" }, { status: 400 });
+  }
+  const removed = await unpublishSession(sessionId);
+  return NextResponse.json({ ok: true, removed });
+}

--- a/apps/web/app/gallery/page.tsx
+++ b/apps/web/app/gallery/page.tsx
@@ -1,0 +1,64 @@
+import Link from "next/link";
+
+import { listPublishedSessions } from "@/lib/db";
+import { readServerEnv } from "@/lib/env";
+
+export const dynamic = "force-dynamic";
+
+/** The opt-in public gallery: sessions their owners chose to publish
+ * (right-click → "Publish session to gallery"), newest first. Each card
+ * fronts the published page and links into its permalink. */
+export default async function GalleryPage() {
+  const env = readServerEnv();
+  if (!env.MONGODB_URI || !env.MONGODB_DB) {
+    return (
+      <main className="mx-auto max-w-3xl px-6 py-16">
+        <h1 className="text-2xl font-semibold">Gallery</h1>
+        <p className="mt-4 opacity-70">Persistence is not configured.</p>
+      </main>
+    );
+  }
+  const rows = await listPublishedSessions(60);
+  const base = (env.R2_PUBLIC_BASE_URL ?? "").replace(/\/$/, "");
+  return (
+    <main className="mx-auto max-w-6xl px-6 py-10">
+      <div className="mb-8 flex items-baseline justify-between">
+        <h1 className="text-2xl font-semibold">Gallery</h1>
+        <Link href="/play" className="text-sm underline opacity-70">
+          ← back to the canvas
+        </Link>
+      </div>
+      {rows.length === 0 ? (
+        <p className="opacity-70">
+          Nothing published yet. In a session, right-click a page and choose
+          “Publish session to gallery”.
+        </p>
+      ) : (
+        <ul className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {rows.map((row) => (
+            <li key={row.session_id}>
+              <Link
+                href={`/n/${row.node_id}`}
+                className="block overflow-hidden rounded-xl border border-[var(--color-edge)] bg-[var(--color-canvas)] shadow-sm transition-shadow hover:shadow-md"
+              >
+                {base && (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={`${base}/${row.poster_key}`}
+                    alt={row.title}
+                    className="aspect-video w-full object-cover"
+                    loading="lazy"
+                  />
+                )}
+                <div className="px-4 py-3">
+                  <h2 className="truncate text-sm font-medium">{row.title}</h2>
+                  <p className="mt-1 truncate text-xs opacity-60">{row.query}</p>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -1423,6 +1423,41 @@ export default function PlayPage() {
           },
         });
       }
+      // Opt-in gallery (Wave 7): this page fronts the published session.
+      const publishSessionId = page.sessionId;
+      items.push({
+        label: "Publish session to gallery",
+        onClick: () => {
+          close();
+          void fetch("/api/gallery/publish", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              session_id: publishSessionId,
+              node_id: exportId,
+            }),
+          }).then(async (r) => {
+            if (r.ok) {
+              window.open("/gallery", "_blank");
+            } else {
+              const j = (await r.json().catch(() => null)) as {
+                error?: string;
+              } | null;
+              window.alert(j?.error ?? "publish failed");
+            }
+          });
+        },
+      });
+      items.push({
+        label: "Unpublish session",
+        onClick: () => {
+          close();
+          void fetch(
+            `/api/gallery/publish?session_id=${encodeURIComponent(publishSessionId)}`,
+            { method: "DELETE" },
+          );
+        },
+      });
     }
     return items;
   }, [contextMenu, phase, page, dispatchTapAt, runEdit, geoMap.entities.length, mutateWorldEntity]);

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -412,3 +412,77 @@ export async function getNodeChain(
   }
   return chain.reverse();
 }
+
+// ── Public gallery (Wave 7) ──────────────────────────────────────────────────
+
+export interface PublishedSessionDoc extends Document {
+  _id: string; // session id
+  node_id: string; // the page that fronts the gallery card
+  title: string;
+  query: string;
+  poster_key: string; // store key of the poster image
+  published_at: Date;
+}
+
+export interface PublishedSessionRow {
+  session_id: string;
+  node_id: string;
+  title: string;
+  query: string;
+  poster_key: string;
+  published_at: string;
+}
+
+async function publishedSessions(): Promise<Collection<PublishedSessionDoc>> {
+  return (await getDb()).collection<PublishedSessionDoc>("published_sessions");
+}
+
+/** Idempotent publish: a session appears in the gallery at most once; a
+ * re-publish just refreshes its poster/title/timestamp. */
+export async function publishSession(entry: {
+  session_id: string;
+  node_id: string;
+  title: string;
+  query: string;
+  poster_key: string;
+}): Promise<void> {
+  const col = await publishedSessions();
+  await col.updateOne(
+    { _id: entry.session_id },
+    {
+      $set: {
+        node_id: entry.node_id,
+        title: entry.title,
+        query: entry.query,
+        poster_key: entry.poster_key,
+        published_at: new Date(),
+      },
+    },
+    { upsert: true }
+  );
+}
+
+export async function unpublishSession(sessionId: string): Promise<boolean> {
+  const col = await publishedSessions();
+  const res = await col.deleteOne({ _id: sessionId });
+  return res.deletedCount > 0;
+}
+
+export async function listPublishedSessions(
+  limit = 60
+): Promise<PublishedSessionRow[]> {
+  const col = await publishedSessions();
+  const docs = await col
+    .find({})
+    .sort({ published_at: -1 })
+    .limit(Math.max(1, Math.min(200, limit)))
+    .toArray();
+  return docs.map((d) => ({
+    session_id: d._id,
+    node_id: d.node_id,
+    title: d.title,
+    query: d.query,
+    poster_key: d.poster_key,
+    published_at: d.published_at.toISOString(),
+  }));
+}


### PR DESCRIPTION
Seventh wave (#52–#58 precede it).

- **`/gallery`** — a grid of sessions their owners chose to publish, newest first; each card fronts the published page and links to its permalink.
- **Publish/unpublish** from the right-click menu (the existing `extraItems` seam): idempotent upsert into a new `published_sessions` collection. The fronting node must belong to the session (a guessed node id can't front a stranger's session).
- **Moderation-gated**: publishing runs title/query/prompt through the backend's new `POST /moderate-text` (a thin wrapper over Wave 5's hook) — instant allow when `MODERATE_PROMPTS` is off, fail-open on infra hiccups, blocked = a clear 403 with the reason shown to the user.
- No accounts by design: unpublish is offered wherever the owner has the session open.

Tests: backend 638 passed (+ /moderate-text allow-when-off, blocked-with-reason); web 548; tsc + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)