### PR TITLE
Wave 8: read-along shared sessions — change-stream feed, presence, replica-set migration

### DIFF
--- a/apps/web/app/api/session/[sessionId]/events/route.ts
+++ b/apps/web/app/api/session/[sessionId]/events/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from "next/server";
+
+import { countPresence, watchSessionNodes } from "@/lib/db";
+import { readServerEnv } from "@/lib/env";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface Params {
+  params: Promise<{ sessionId: string }>;
+}
+
+/** The shared-session read-along feed (Wave 8): an SSE stream of this
+ * session's node inserts (via a Mongo change stream — needs the compose
+ * stack's single-node replica set) plus a periodic live viewer count.
+ * On a standalone Mongo the stream says `unsupported` once and ends —
+ * the feature soft-degrades, nothing else breaks. */
+export async function GET(req: Request, { params }: Params) {
+  const { sessionId } = await params;
+  const env = readServerEnv();
+  if (!env.MONGODB_URI || !env.MONGODB_DB) {
+    return NextResponse.json(
+      { error: "persistence not configured" },
+      { status: 503 },
+    );
+  }
+
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    async start(controller) {
+      let closed = false;
+      const send = (obj: unknown) => {
+        if (closed) return;
+        try {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(obj)}\n\n`));
+        } catch {
+          closed = true;
+        }
+      };
+      const finish = () => {
+        if (closed) return;
+        closed = true;
+        try {
+          controller.close();
+        } catch {
+          // already closed by the runtime
+        }
+      };
+
+      let watcher: Awaited<ReturnType<typeof watchSessionNodes>> | null = null;
+      try {
+        watcher = await watchSessionNodes(sessionId);
+      } catch {
+        send({ type: "unsupported" });
+        finish();
+        return;
+      }
+
+      send({ type: "hello", viewers: await countPresence(sessionId).catch(() => 0) });
+      const ping = setInterval(() => {
+        void countPresence(sessionId)
+          .then((viewers) => send({ type: "presence", viewers }))
+          .catch(() => {});
+      }, 20_000);
+
+      const teardown = () => {
+        clearInterval(ping);
+        void watcher?.close().catch(() => {});
+        finish();
+      };
+      req.signal.addEventListener("abort", teardown);
+
+      try {
+        for await (const ev of watcher) {
+          const doc = (ev as { fullDocument?: Record<string, unknown> })
+            .fullDocument;
+          if (!doc) continue;
+          send({
+            type: "node_added",
+            node: {
+              id: String(doc._id),
+              parent_id: (doc.parent_id as string | null) ?? null,
+              title: String(doc.page_title || doc.query || ""),
+              created_at: doc.created_at instanceof Date
+                ? doc.created_at.toISOString()
+                : String(doc.created_at ?? ""),
+            },
+          });
+        }
+      } catch {
+        // A standalone Mongo throws here on the first pull; an aborted
+        // stream lands here too. Either way: degrade quietly.
+        send({ type: "unsupported" });
+      } finally {
+        teardown();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/apps/web/app/api/session/[sessionId]/presence/route.ts
+++ b/apps/web/app/api/session/[sessionId]/presence/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+
+import { touchPresence } from "@/lib/db";
+import { readServerEnv } from "@/lib/env";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface Params {
+  params: Promise<{ sessionId: string }>;
+}
+
+/** Viewer heartbeat: upserts {session, viewer} presence (TTL-expired) and
+ * returns the live count. The client beats every ~20s while the tab is on
+ * the session. */
+export async function POST(req: Request, { params }: Params) {
+  const { sessionId } = await params;
+  const env = readServerEnv();
+  if (!env.MONGODB_URI || !env.MONGODB_DB) {
+    return NextResponse.json(
+      { error: "persistence not configured" },
+      { status: 503 },
+    );
+  }
+  let viewerId = "";
+  try {
+    const body = (await req.json()) as { viewer_id?: string };
+    viewerId = (body.viewer_id ?? "").slice(0, 64);
+  } catch {
+    // fall through to the validation below
+  }
+  if (!viewerId) {
+    return NextResponse.json({ error: "missing viewer_id" }, { status: 400 });
+  }
+  const viewers = await touchPresence(sessionId, viewerId);
+  return NextResponse.json({ viewers });
+}

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -46,6 +46,7 @@ import {
 import { getStrings, resolveOutputLocale } from "@/lib/i18n";
 import { useImageTier, useVideoTier } from "@/hooks/usePersistedTier";
 import { useLoopKnobs, wireFields } from "@/hooks/useSpeedPreset";
+import { useSharedSession } from "@/hooks/useSharedSession";
 import { useExpandBloom } from "@/hooks/useExpandBloom";
 import { type Ascended, useAscend } from "@/hooks/useAscend";
 import { buildConditionRefs, cropBox, orderedRefs } from "@/lib/image-condition";
@@ -500,6 +501,18 @@ export default function PlayPage() {
   // Dev-only explicit model override (NEXT_PUBLIC_DEV_PROVIDERS): rides the
   // wire's image_model on every generate body. null = the tier decides.
   const [devModel, setDevModel] = useState<string | null>(null);
+  // Read-along shared sessions (Wave 8): live viewer count + a click-to-open
+  // chip when a co-viewer adds a page this tab hasn't seen.
+  const knownNodeIds = useMemo(
+    () =>
+      new Set(
+        history.items
+          .map((p) => p.nodeId)
+          .filter((id): id is string => Boolean(id)),
+      ),
+    [history.items],
+  );
+  const shared = useSharedSession(sessionId, knownNodeIds);
   // The speed preset's wire half — spread into every generate() body next to
   // image_tier. Balanced knobs produce {} (byte-identity with today).
   const loopWire = useMemo(() => wireFields(loopKnobs), [loopKnobs]);
@@ -2771,7 +2784,27 @@ export default function PlayPage() {
             {history.items.length > history.trail.length
               ? ` · ${history.items.length} pages explored`
               : ""}
+            {shared.viewers !== null && shared.viewers > 1 && (
+              <span title="people viewing this session right now">
+                {" "}
+                · 👁 {shared.viewers}
+              </span>
+            )}
           </span>
+          {shared.incoming && (
+            <button
+              type="button"
+              onClick={() => {
+                const id = shared.incoming?.id;
+                shared.clearIncoming();
+                if (id) selectFromMap(id);
+              }}
+              className="rounded-full border border-emerald-600/40 bg-emerald-50 px-3 py-1 text-xs text-emerald-900 hover:bg-emerald-100"
+              title="A co-viewer added this page — click to open it"
+            >
+              ✦ new: {shared.incoming.title.slice(0, 32)} →
+            </button>
+          )}
           </div>
         </div>
       )}

--- a/apps/web/hooks/useSharedSession.ts
+++ b/apps/web/hooks/useSharedSession.ts
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+export interface IncomingNode {
+  id: string;
+  parent_id: string | null;
+  title: string;
+}
+
+export interface SharedSessionState {
+  /** Live viewer count (this tab included); null until the feed says hello. */
+  viewers: number | null;
+  /** The latest node another viewer added that THIS tab hasn't visited —
+   * surfaced as a click-to-open chip; null when caught up. */
+  incoming: IncomingNode | null;
+  clearIncoming: () => void;
+}
+
+/** Read-along shared sessions (Wave 8): subscribes to the session's
+ * change-stream feed + heartbeats presence while the tab is open. Degrades
+ * to {viewers: null} silently on a standalone Mongo (the feed says
+ * `unsupported` once and ends). `knownNodeIds` keeps this tab's own pages
+ * from echoing back as "incoming". */
+export function useSharedSession(
+  sessionId: string | null,
+  knownNodeIds: ReadonlySet<string>,
+): SharedSessionState {
+  const [viewers, setViewers] = useState<number | null>(null);
+  const [incoming, setIncoming] = useState<IncomingNode | null>(null);
+  const viewerIdRef = useRef<string>("");
+  const knownRef = useRef(knownNodeIds);
+  knownRef.current = knownNodeIds;
+
+  useEffect(() => {
+    if (!sessionId || typeof window === "undefined") return;
+    if (!viewerIdRef.current) {
+      viewerIdRef.current =
+        window.crypto?.randomUUID?.() ?? `v_${Math.random().toString(36).slice(2)}`;
+    }
+    const viewerId = viewerIdRef.current;
+    let stopped = false;
+
+    const beat = () => {
+      void fetch(`/api/session/${encodeURIComponent(sessionId)}/presence`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ viewer_id: viewerId }),
+      })
+        .then((r) => (r.ok ? r.json() : null))
+        .then((j: { viewers?: number } | null) => {
+          if (!stopped && j && typeof j.viewers === "number") {
+            setViewers(j.viewers);
+          }
+        })
+        .catch(() => {});
+    };
+    beat();
+    const beatTimer = window.setInterval(beat, 20_000);
+
+    const es = new EventSource(
+      `/api/session/${encodeURIComponent(sessionId)}/events`,
+    );
+    es.onmessage = (msg) => {
+      try {
+        const evt = JSON.parse(msg.data) as
+          | { type: "hello" | "presence"; viewers?: number }
+          | { type: "unsupported" }
+          | { type: "node_added"; node: IncomingNode };
+        if (evt.type === "unsupported") {
+          es.close();
+          return;
+        }
+        if (evt.type === "node_added") {
+          if (!knownRef.current.has(evt.node.id)) setIncoming(evt.node);
+          return;
+        }
+        if (typeof evt.viewers === "number") setViewers(evt.viewers);
+      } catch {
+        // malformed frame: skip
+      }
+    };
+    es.onerror = () => {
+      // EventSource auto-reconnects; nothing to do
+    };
+
+    return () => {
+      stopped = true;
+      window.clearInterval(beatTimer);
+      es.close();
+    };
+  }, [sessionId]);
+
+  return {
+    viewers,
+    incoming,
+    clearIncoming: () => setIncoming(null),
+  };
+}

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -59,7 +59,14 @@ async function ensureIndexes(db: Db): Promise<void> {
   // lookups that link a map entity back to its Codex Entity. Created up front so
   // we don't migrate a populated collection later.
   const worldMap = db.collection("world_map");
+  // Shared-session presence heartbeats expire on their own (TTL); the live
+  // viewer count uses a tighter window on top.
+  const presenceCol = db.collection("session_presence");
   await Promise.all([
+    presenceCol.createIndex(
+      { last_seen: 1 },
+      { name: "presence_ttl_idx", expireAfterSeconds: 120 }
+    ),
     nodes.createIndex(
       { session_id: 1, created_at: -1 },
       { name: "session_created_idx" }
@@ -485,4 +492,66 @@ export async function listPublishedSessions(
     poster_key: d.poster_key,
     published_at: d.published_at.toISOString(),
   }));
+}
+
+// ── Shared sessions (Wave 8): presence + change-stream watch ────────────────
+
+export interface PresenceDoc extends Document {
+  _id: string; // `${session_id}:${viewer_id}`
+  session_id: string;
+  last_seen: Date;
+}
+
+async function presence(): Promise<Collection<PresenceDoc>> {
+  return (await getDb()).collection<PresenceDoc>("session_presence");
+}
+
+const PRESENCE_WINDOW_MS = 45_000;
+
+/** Heartbeat: upsert this viewer's last_seen and return the live count.
+ * Docs expire via the TTL index; the count uses a tighter live window. */
+export async function touchPresence(
+  sessionId: string,
+  viewerId: string
+): Promise<number> {
+  const col = await presence();
+  await col.updateOne(
+    { _id: `${sessionId}:${viewerId}` },
+    { $set: { session_id: sessionId, last_seen: new Date() } },
+    { upsert: true }
+  );
+  return countPresence(sessionId);
+}
+
+export async function countPresence(sessionId: string): Promise<number> {
+  const col = await presence();
+  return col.countDocuments({
+    session_id: sessionId,
+    last_seen: { $gt: new Date(Date.now() - PRESENCE_WINDOW_MS) },
+  });
+}
+
+export interface SessionNodeEvent {
+  id: string;
+  parent_id: string | null;
+  title: string;
+  created_at: string;
+}
+
+/** A change-stream over this session's node inserts — the read-along feed.
+ * Requires a replica set (the compose stack runs single-node rs0); callers
+ * catch the unsupported error and degrade. */
+export async function watchSessionNodes(sessionId: string) {
+  const db = await getDb();
+  return db.collection<NodeDoc>("nodes").watch(
+    [
+      {
+        $match: {
+          operationType: "insert",
+          "fullDocument.session_id": sessionId,
+        },
+      },
+    ],
+    { fullDocument: "updateLookup" }
+  );
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,14 @@ services:
     image: mongo:7
     container_name: openflipbook-mongo
     restart: unless-stopped
-    command: ["--bind_ip_all", "--quiet"]
+    # Single-node replica set (Wave 8): change streams power the shared-
+    # session read-along, and Mongo only serves them from a replica set.
+    # Existing standalone data volumes convert in place — mongo-init runs a
+    # one-time rs.initiate() pinned to the compose hostname. Clients OUTSIDE
+    # the compose network (local `pnpm dev` against localhost:27017) need
+    # `?directConnection=true` on their MONGODB_URI, since the set advertises
+    # `mongo:27017`.
+    command: ["--replSet", "rs0", "--bind_ip_all", "--quiet"]
     ports:
       - "27017:27017"
     volumes:
@@ -25,6 +32,18 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+
+  mongo-init:
+    image: mongo:7
+    container_name: openflipbook-mongo-init
+    restart: "no"
+    depends_on:
+      mongo:
+        condition: service_healthy
+    # Idempotent: initiates the set on first boot, no-ops once initiated.
+    command: >
+      mongosh --host mongo --quiet --eval
+      "try { rs.status() } catch (e) { rs.initiate({_id: 'rs0', members: [{_id: 0, host: 'mongo:27017'}]}) }"
 
   # S3-compatible blob store — the local stand-in for Cloudflare R2. The web
   # app writes here (R2_ENDPOINT=http://minio:9000) and the browser reads image
@@ -138,7 +157,7 @@ services:
       # Backend URL is fixed inside the compose network.
       MODAL_API_URL: http://backend:8787
       # Metadata → local Mongo by default.
-      MONGODB_URI: ${MONGODB_URI:-mongodb://mongo:27017}
+      MONGODB_URI: ${MONGODB_URI:-mongodb://mongo:27017/?directConnection=true}
       MONGODB_DB: ${MONGODB_DB:-openflipbook}
       # Blobs → local Minio by default. R2_ENDPOINT makes the S3 client target
       # Minio (path-style); the public base URL is what the browser fetches.
@@ -154,6 +173,8 @@ services:
         condition: service_healthy
       mongo:
         condition: service_healthy
+      mongo-init:
+        condition: service_completed_successfully
       minio-setup:
         condition: service_completed_successfully
 


### PR DESCRIPTION
Eighth wave (#52–#59 precede it). A second person on the same session now sees it move.

- **Compose mongo → single-node replica set** (change streams need one). Existing volumes convert **in place** — a one-shot `mongo-init` service runs an idempotent `rs.initiate` pinned to the compose hostname. Verified on a live stack: 37 nodes / 8 world docs / 1 map intact through the migration, member PRIMARY. Clients outside the compose network need `?directConnection=true` (the set advertises `mongo:27017`); the compose default URI carries it and the caveat is documented in the compose file.
- **`GET /api/session/[id]/events`** — an SSE feed of the session's node inserts (Mongo change stream) plus a periodic live viewer count. On a standalone Mongo it emits `unsupported` once and ends: the feature soft-degrades, nothing else breaks.
- **`POST /api/session/[id]/presence`** — viewer heartbeats into a TTL collection (120s expiry, 45s live window for the count).
- **`useSharedSession`** — heartbeats while the tab is open, subscribes the feed, renders a 👁 viewer-count chip and a click-to-open chip when a co-viewer adds a page this tab hasn't seen. Co-editing explicitly deferred — v1 is read-along.

**Live proof on the migrated stack**: presence 1→2 across two simulated viewers; a synthetic node insert arrived as `node_added` over the feed within seconds (then cleaned up).

Tests: web 548 passed, tsc + build clean; backend untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)