### PR TITLE
fix(world): un-routable taps degrade to a faithful zoom; lettering taps enter the named place

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -290,9 +290,13 @@ def _geometric_world_on() -> bool:
     return env_flag("GEOMETRIC_WORLD")
 
 
-def _world_geometry_gen_on() -> bool:
-    """Geometry steers generation (WORLD_GEOMETRY_GEN). Off → no layout clause."""
-    return env_flag("WORLD_GEOMETRY_GEN")
+def _world_geometry_gen_on(world_mode: bool = False) -> bool:
+    """Geometry steers generation (WORLD_GEOMETRY_GEN). Defaults ON under an
+    active world mode — the layout clause is the only thing pinning the map's
+    geography, and without it entered scenes relocate landmarks freely — and
+    OFF otherwise (non-world prompts stay byte-identical). An explicit
+    =false is a kill-switch everywhere."""
+    return env_flag("WORLD_GEOMETRY_GEN", "true" if world_mode else "false")
 
 
 def _condition_url_for_role(body: GenerateBody, role: str) -> str | None:
@@ -314,7 +318,7 @@ def _layout_clause_for(body: GenerateBody, *, view_grammar: bool = False) -> str
     already ride expected_layout) + relative heights from world_context
     entries with REAL heights (the extraction seed constant 4.0 is excluded —
     the A1 audit's information-loss fix, V1 must-fix 9)."""
-    if not _world_geometry_gen_on() or not body.expected_layout:
+    if not _world_geometry_gen_on(_world_mode_on(body.world_mode)) or not body.expected_layout:
         return ""
     from providers import geometry_prompt
 
@@ -353,6 +357,79 @@ def _view_grammar_on() -> bool:
     """The view grammar (a deliberate camera per render). Default ON; =false
     is a strict kill-switch — every render byte-identical to pre-grammar."""
     return env_flag("VIEW_GRAMMAR", "true")
+
+
+# Words that carry no identity — dropped before token comparison so "the
+# palace of the patrician" still meets "Patrician's Palace". Twin of the
+# client's entity-label-match.ts STOP_WORDS.
+_LABEL_STOP_WORDS = frozenset(
+    {"the", "a", "an", "of", "and", "its", "their", "in", "on", "at"}
+)
+
+
+def _normalize_label(s: str) -> str:
+    """lowercase → strip diacritics → strip punctuation → collapse spaces.
+    Apostrophes are REMOVED (not space-split) so "Patrician's" folds to
+    "patricians" rather than shedding a stray "s" token."""
+    import unicodedata
+
+    folded = unicodedata.normalize("NFKD", s.lower())
+    # U+2019 = the curly apostrophe.
+    folded = folded.replace("'", "").replace("\u2019", "")
+    stripped = "".join(c for c in folded if not unicodedata.combining(c))
+    alnum = "".join(c if c.isalnum() else " " for c in stripped)
+    return " ".join(alnum.split())
+
+
+def _label_tokens(s: str) -> list[str]:
+    return [t for t in _normalize_label(s).split() if t not in _LABEL_STOP_WORDS]
+
+
+def _match_world_entity(
+    entities: list[WorldContextEntity], subject: str | None
+) -> dict | None:
+    """W2 label-click routing, server half (covers autonomy="auto", where the
+    click resolve runs in-band). The resolved subject names a mapped PLACE —
+    the tap landed on the map's baked-in lettering rather than the footprint.
+    Exact or token-containment match over normalized name/aliases, places
+    only; the semi-autonomy client does its own (fuzzier) match in
+    entity-label-match.ts before the request."""
+    subj_norm = _normalize_label(subject or "")
+    subj_tokens = _label_tokens(subject or "")
+    if not subj_norm or not subj_tokens:
+        return None
+    subj_set = set(subj_tokens)
+    best: dict | None = None
+    best_score = 0
+    for e in entities:
+        d = e.model_dump()
+        if str(d.get("kind") or "") != "place":
+            continue
+        names = [str(d.get("name") or "")] + [
+            str(a) for a in (d.get("aliases") or [])
+        ]
+        for name in names:
+            name_norm = _normalize_label(name)
+            name_tokens = _label_tokens(name)
+            if not name_norm or not name_tokens:
+                continue
+            if name_norm == subj_norm:
+                score = 2
+            else:
+                # Either direction: a subject "patrician's palace and its
+                # gardens" contains the label; a clipped subject "the river"
+                # is contained by "The River Ankh".
+                name_set = set(name_tokens)
+                contained = all(t in subj_set for t in name_tokens) or all(
+                    t in name_set for t in subj_tokens
+                )
+                score = 1 if contained else 0
+            if score > best_score:
+                best_score = score
+                best = d
+        if best_score == 2:
+            break
+    return best
 
 
 def _focus_world_entry(body: GenerateBody, subject: str | None) -> dict | None:
@@ -1500,6 +1577,24 @@ async def _event_stream(
                     surroundings_for_plan = resolution.surroundings
                 if resolution.place_form:
                     place_form_resolved = resolution.place_form
+
+            # W2 (label-click routing): the resolved subject names a mapped
+            # PLACE — the tap landed on the map's baked-in lettering rather
+            # than the footprint — but the framing fell through to
+            # "explainer", which rides the FRESH path (ignores image refs →
+            # invents an unrelated scene). Upgrade to place_scene so the
+            # enter edit keeps the place; no geometry needed (observer
+            # absent → the view policy picks the camera).
+            if effective_world_mode and render_mode in ("", "explainer"):
+                label_hit = _match_world_entity(body.world_context, effective_query)
+                if label_hit is not None:
+                    render_mode = "place_scene"
+                    log(
+                        "info",
+                        "world.label_match",
+                        subject=effective_query,
+                        entity=label_hit.get("name") or "",
+                    )
 
             # The view policy matches names against the subject BEFORE the
             # hint fold (a hint suffix would break world_context name matches).

--- a/apps/modal-backend/tests/test_generate_geometry.py
+++ b/apps/modal-backend/tests/test_generate_geometry.py
@@ -54,6 +54,41 @@ def test_layout_clause_empty_without_expected(
     assert generate._layout_clause_for(_body([])) == ""
 
 
+def _world_body(expected: list[ProjectedEntity]) -> GenerateBody:
+    return GenerateBody(
+        query="q", session_id="s", expected_layout=expected, world_mode=True
+    )
+
+
+def test_layout_clause_defaults_on_under_world_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """W1: under an ACTIVE world mode the layout clause defaults ON — it is
+    the only thing pinning the map's geography on a steered render."""
+    monkeypatch.delenv("WORLD_GEOMETRY_GEN", raising=False)
+    monkeypatch.setenv("WORLD_MODE", "true")
+    clause = generate._layout_clause_for(_world_body([_proj("Tower")]))
+    assert "SCENE LAYOUT" in clause
+
+
+def test_layout_clause_world_mode_explicit_false_kills(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("WORLD_GEOMETRY_GEN", "false")
+    monkeypatch.setenv("WORLD_MODE", "true")
+    assert generate._layout_clause_for(_world_body([_proj("Tower")])) == ""
+
+
+def test_layout_clause_world_request_without_env_keeps_old_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A world_mode request against a WORLD_MODE-off deploy is NOT world mode
+    — the old default (off) stands, byte-identical prompts."""
+    monkeypatch.delenv("WORLD_GEOMETRY_GEN", raising=False)
+    monkeypatch.delenv("WORLD_MODE", raising=False)
+    assert generate._layout_clause_for(_world_body([_proj("Tower")])) == ""
+
+
 def test_topdown_clause_only_for_maps_when_flag_on(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/apps/modal-backend/tests/test_label_match.py
+++ b/apps/modal-backend/tests/test_label_match.py
@@ -1,0 +1,61 @@
+"""W2 label-click routing, server half (free): a resolved subject that names
+a mapped PLACE upgrades the framing instead of falling through to the fresh
+path. Twin of the client's entity-label-match.test.ts."""
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+# generate.py imports `modal` at module level (deploy-only, not a test dep).
+sys.modules.setdefault("modal", MagicMock())
+
+from generate import WorldContextEntity, _match_world_entity  # noqa: E402
+
+
+def _entity(name: str, kind: str = "place", aliases: list[str] | None = None) -> WorldContextEntity:
+    return WorldContextEntity(
+        id=name.lower().replace(" ", "-"),
+        kind=kind,
+        name=name,
+        aliases=aliases or [],
+        appearance="",
+    )
+
+
+CITY = [
+    _entity("Patrician's Palace"),
+    _entity("The River Ankh"),
+    _entity("Unseen University", aliases=["UU"]),
+]
+
+
+def test_exact_match_case_and_punctuation_insensitive() -> None:
+    hit = _match_world_entity(CITY, "patricians palace")
+    assert hit is not None and hit["name"] == "Patrician's Palace"
+
+
+def test_subject_containing_the_label_matches() -> None:
+    hit = _match_world_entity(CITY, "The Patrician's Palace and its gardens")
+    assert hit is not None and hit["name"] == "Patrician's Palace"
+
+
+def test_clipped_subject_contained_by_label_matches() -> None:
+    hit = _match_world_entity(CITY, "the river")
+    assert hit is not None and hit["name"] == "The River Ankh"
+
+
+def test_alias_matches() -> None:
+    hit = _match_world_entity(CITY, "UU")
+    assert hit is not None and hit["name"] == "Unseen University"
+
+
+def test_places_only() -> None:
+    people = [_entity("The Librarian", kind="person")]
+    assert _match_world_entity(people, "the librarian") is None
+
+
+def test_no_match_and_empty_subject_return_none() -> None:
+    assert _match_world_entity(CITY, "a mysterious stranger") is None
+    assert _match_world_entity(CITY, "") is None
+    assert _match_world_entity(CITY, None) is None
+    assert _match_world_entity(CITY, "the of and") is None  # stop-words only

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -97,11 +97,15 @@ import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useWorldState } from "@/hooks/useWorldState";
 import { useWorldMap } from "@/hooks/useWorldMap";
 import {
+  degradedSubmapTap,
+  geoTapForEntity,
   geoTapRequest,
   MAP_IMAGE_FRAME,
   wideRegionCut,
+  type GeoTap,
   type GeoTapOverride,
 } from "@/lib/geo-tap";
+import { matchEntityLabel } from "@/lib/entity-label-match";
 import { selectNeighbors } from "@/lib/scale-neighbors";
 import { childrenOf, projectTopDown } from "@/lib/world-geometry";
 import { viewNeutralAppearance } from "@/lib/appearance";
@@ -119,6 +123,15 @@ type Phase = "idle" | "generating" | "ready" | "error";
 // after the user drew a box is the worst surprise). Backend twin: EDIT_REGION.
 const EDIT_REGION_ENABLED = ["1", "true", "yes"].includes(
   (process.env.NEXT_PUBLIC_EDIT_REGION ?? "").toLowerCase()
+);
+
+// W1 kill-switch (default ON): a world-mode tap that the geometric router
+// can't anchor (lettering / unmapped parchment) degrades to a faithful
+// place_submap zoom-cut instead of falling to the fresh path, which ignores
+// image refs and invents an unrelated scene. =false restores the old fall-
+// through exactly (same semantics as ENTER_EDIT_REF's kill-switch).
+const WORLD_TAP_DEGRADE_ENABLED = !["0", "false", "no"].includes(
+  (process.env.NEXT_PUBLIC_WORLD_TAP_DEGRADE ?? "").toLowerCase()
 );
 
 interface Page {
@@ -2170,6 +2183,43 @@ export default function PlayPage() {
               page.sceneView,
             )
           : null;
+      // W1/W2 fallback chain: the geometric route fell through on a map frame
+      // (the tap landed on baked-in lettering or unmapped parchment). Without
+      // this, the request rides the classic FRESH path — which ignores image
+      // refs — and that is the "brand-new unrelated city near the river" bug.
+      //   ① label match: the VLM's subject names a mapped place (the tap hit
+      //     the map's LETTERING) → enter that entity, footprint-hit semantics.
+      //   ② degrade (kill-switch): zoom-continue the clicked region — a
+      //     faithful Kontext cut of the map, never a reinvention.
+      let fallbackTap: GeoTap | null = null;
+      if (
+        worldEnabled &&
+        !geoTap &&
+        geoEntities.length > 0 &&
+        (!page.sceneView || page.sceneView.level === "map")
+      ) {
+        const matched = worldResolved?.subject
+          ? matchEntityLabel(worldResolved.subject, geoEntities)
+          : null;
+        if (matched) {
+          fallbackTap = geoTapForEntity(
+            { entities: geoEntities, bounds: geoBounds },
+            page.nodeId ?? "",
+            matched,
+            16 / 9,
+            page.sceneView,
+          );
+        } else if (WORLD_TAP_DEGRADE_ENABLED) {
+          fallbackTap = degradedSubmapTap(
+            { entities: geoEntities, bounds: geoBounds },
+            page.nodeId ?? "",
+            { x_pct: click.x_pct, y_pct: click.y_pct },
+            16 / 9,
+            page.sceneView,
+          );
+        }
+      }
+      const worldTap = geoTap ?? fallbackTap;
       // World OFF + a wide mapped region (the river): a fresh re-composition
       // relocates landmarks, so zoom-cut the map instead (see wideRegionCut).
       const wideCut =
@@ -2236,41 +2286,41 @@ export default function PlayPage() {
                 : {}),
             }
           : {}),
-        ...(geoTap
+        ...(worldTap
           ? {
-              scene_view: geoTap.scene_view,
-              expected_layout: geoTap.expected_layout,
+              scene_view: worldTap.scene_view,
+              expected_layout: worldTap.expected_layout,
               // Enter the aligned-zoom path: a submap stays in map mode and
               // zoom-continues (Kontext) rather than a loose fresh gen, so the
               // sub-map is a true zoom of the tapped region. A scene first-enter
               // keeps the (reprojecting) fresh path until B2 wires the guarded
               // scene→scene continuation. Spread last so it wins.
               render_mode:
-                geoTap.kind === "submap" ? "place_submap" : "place_scene",
+                worldTap.kind === "submap" ? "place_submap" : "place_scene",
               // The geometric tap KNOWS which entity you hit (by coordinates) —
               // make it the subject so tapping the Tower of Art enters the Tower,
               // overriding the looser VLM read that picked its container. Spread
               // last so it wins over the cached / world-resolved subjects above.
-              ...(geoTap.focus_label
-                ? { prefetched_subject: geoTap.focus_label }
+              ...(worldTap.focus_label
+                ? { prefetched_subject: worldTap.focus_label }
                 : {}),
               // Anchor the entity's IDENTITY across zoom levels: feed its
               // appearance as the authoritative subject context, view-neutral so
               // it carries the materials/architecture (ancient stone, concentric
               // rings) without forcing the angle it was captured at.
-              ...(viewNeutralAppearance(geoTap.focus_visual)
+              ...(viewNeutralAppearance(worldTap.focus_visual)
                 ? {
                     prefetched_subject_context: viewNeutralAppearance(
-                      geoTap.focus_visual,
+                      worldTap.focus_visual,
                     ),
                   }
                 : {}),
               // FAITHFUL backdrop: the focus's frame-mates straight from the geo
               // (real bearings + appearances), so a stepped-into scene draws the
               // SAME landmarks the map shows in the right directions — overriding
-              // the VLM-invented surroundings above (geoTap is spread last → wins).
-              ...(geoTap.surroundings
-                ? { prefetched_surroundings: geoTap.surroundings }
+              // the VLM-invented surroundings above (worldTap is spread last → wins).
+              ...(worldTap.surroundings
+                ? { prefetched_surroundings: worldTap.surroundings }
                 : {}),
             }
           : {}),

--- a/apps/web/lib/click-route.test.ts
+++ b/apps/web/lib/click-route.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { MapCrop, ObserverPose, SceneView, WorldEntityGeo } from "@openflipbook/config";
 
-import { routeClick } from "./click-route";
+import { routeClick, routeToFocus } from "./click-route";
 
 function geo(
   id: string,
@@ -112,5 +112,47 @@ describe("routeClick (P6 coordinate-driven mode detection)", () => {
     expect(
       routeClick(map, sceneView(observer), { x_pct: 0.02, y_pct: 0.02 }, ASPECT).kind,
     ).toBe("explainer");
+  });
+
+  it("minSubmapEntities: 0 → empty map area routes submap, never explainer (W1 degrade)", () => {
+    // Same setup as the no-entities explainer case above; the override flips it.
+    const map = { entities: [geo("a", 90, 90)], bounds: CROP };
+    const r = routeClick(map, mapView(CROP), { x_pct: 0.1, y_pct: 0.1 }, ASPECT, {
+      minSubmapEntities: 0,
+    });
+    expect(r.kind).toBe("submap");
+    if (r.kind === "submap") {
+      // The window is centred on the tap, not the far-away entity.
+      expect(r.crop.x + r.crop.w / 2).toBeCloseTo(10, 5);
+      expect(r.crop.y + r.crop.h / 2).toBeCloseTo(10, 5);
+    }
+  });
+});
+
+describe("routeToFocus (enter a place resolved by NAME)", () => {
+  it("synthesizes the same scene route a footprint hit would", () => {
+    const focus = geo("tower", 60, 30, { height: 18 });
+    const byHit = routeClick(
+      { entities: [focus], bounds: CROP },
+      mapView(CROP),
+      { x_pct: 0.6, y_pct: 0.3 },
+      ASPECT,
+    );
+    const byName = routeToFocus(focus, { x: 50, y: 50 });
+    expect(byName.kind).toBe("scene");
+    expect(byName.focus_id).toBe("tower");
+    expect(byName.level).toBe("building"); // tall → building
+    expect(byHit.kind).toBe("scene");
+    if (byHit.kind === "scene") {
+      // Same standoff distance from the focus (direction differs with `from`).
+      const d = (o: ObserverPose) => Math.hypot(o.pos.x - 60, o.pos.y - 30);
+      expect(d(byName.observer)).toBeCloseTo(d(byHit.observer), 5);
+    }
+  });
+
+  it("short places enter at street level", () => {
+    expect(routeToFocus(geo("hut", 10, 10, { height: 4 }), { x: 0, y: 0 }).level).toBe(
+      "street",
+    );
   });
 });

--- a/apps/web/lib/click-route.ts
+++ b/apps/web/lib/click-route.ts
@@ -44,7 +44,7 @@ const MIN_SUBMAP_ENTITIES = 2;
 const EYE_HEIGHT = 1.7;
 const DEFAULT_FOV = Math.PI / 2;
 
-function focusOnMap(
+export function focusOnMap(
   entities: WorldEntityGeo[],
   crop: MapCrop,
   click: ClickPoint,
@@ -113,11 +113,27 @@ function cropCentre(crop: MapCrop): WorldVec2 {
   return { x: crop.x + crop.w / 2, y: crop.y + crop.h / 2 };
 }
 
+/** The scene route for a known focus entity, exactly as a geometric hit on
+ *  its footprint would synthesize it. Exported so a tap resolved by NAME (the
+ *  map's lettering names a mapped place) can enter that place too. */
+export function routeToFocus(
+  focus: WorldEntityGeo,
+  from: WorldVec2,
+): Extract<ClickRoute, { kind: "scene" }> {
+  return {
+    kind: "scene",
+    level: focus.height >= BUILDING_HEIGHT ? "building" : "street",
+    observer: observerFacing(focus, from),
+    focus_id: focus.id,
+  };
+}
+
 export function routeClick(
   map: Pick<WorldMapSnapshot, "entities" | "bounds">,
   view: SceneView,
   click: ClickPoint,
   aspect: number,
+  opts?: { minSubmapEntities?: number },
 ): ClickRoute {
   const { entities } = map;
   const focus = view.observer
@@ -129,12 +145,7 @@ export function routeClick(
   // A place under the finger → enter it.
   if (focus && focus.kind === "place") {
     const from = view.observer?.pos ?? cropCentre(view.map_crop ?? map.bounds);
-    return {
-      kind: "scene",
-      level: focus.height >= BUILDING_HEIGHT ? "building" : "street",
-      observer: observerFacing(focus, from),
-      focus_id: focus.id,
-    };
+    return routeToFocus(focus, from);
   }
 
   // Empty map area that still holds a cluster → crop a submap around it.
@@ -148,7 +159,8 @@ export function routeClick(
       w: crop.w * SUBMAP_FRACTION,
       h: crop.h * SUBMAP_FRACTION,
     };
-    if (cropEntities(entities, win).length >= MIN_SUBMAP_ENTITIES) {
+    const minEntities = opts?.minSubmapEntities ?? MIN_SUBMAP_ENTITIES;
+    if (cropEntities(entities, win).length >= minEntities) {
       return { kind: "submap", crop: win, focus_id: focus?.id ?? null };
     }
   }

--- a/apps/web/lib/entity-label-match.test.ts
+++ b/apps/web/lib/entity-label-match.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import type { WorldEntityGeo } from "@openflipbook/config";
+
+import { matchEntityLabel } from "./entity-label-match";
+
+function geo(
+  id: string,
+  label: string,
+  opts: Partial<WorldEntityGeo> = {},
+): WorldEntityGeo {
+  return {
+    id,
+    entity_id: id,
+    kind: "place",
+    label,
+    pos: { x: 50, y: 30 },
+    height: 4,
+    footprint: { w: 8, d: 8 },
+    visual: "",
+    state: {},
+    confidence: 1,
+    source: "user",
+    updated_at: "t",
+    ...opts,
+  };
+}
+
+describe("matchEntityLabel (lettering tap → the named place)", () => {
+  const city = [
+    geo("palace", "Patrician's Palace"),
+    geo("river", "The River Ankh"),
+    geo("uni", "Unseen University"),
+  ];
+
+  it("exact label (case/punctuation-insensitive)", () => {
+    expect(matchEntityLabel("patricians palace", city)?.id).toBe("palace");
+    expect(matchEntityLabel("THE RIVER ANKH", city)?.id).toBe("river");
+  });
+
+  it("subject contains the label — the VLM padded the lettering read", () => {
+    expect(
+      matchEntityLabel("The Patrician's Palace and its gardens", city)?.id,
+    ).toBe("palace");
+  });
+
+  it("subject contained by the label — a clipped lettering read", () => {
+    expect(matchEntityLabel("the river", city)?.id).toBe("river");
+  });
+
+  it("fuzzy bigram net for near-misses", () => {
+    expect(matchEntityLabel("patrician palace", city)?.id).toBe("palace");
+  });
+
+  it("no plausible match → null (the classic tap must stand)", () => {
+    expect(matchEntityLabel("a mysterious stranger", city)).toBeNull();
+    expect(matchEntityLabel("", city)).toBeNull();
+    expect(matchEntityLabel("   ", city)).toBeNull();
+  });
+
+  it("places outrank non-places at equal strength", () => {
+    const entities = [
+      geo("vetinari", "The Patrician", { kind: "person" }),
+      geo("palace2", "The Patrician", { kind: "place" }),
+    ];
+    expect(matchEntityLabel("the patrician", entities)?.id).toBe("palace2");
+  });
+
+  it("entities with blank labels never match", () => {
+    expect(matchEntityLabel("anything", [geo("x", "  ")])).toBeNull();
+  });
+});

--- a/apps/web/lib/entity-label-match.ts
+++ b/apps/web/lib/entity-label-match.ts
@@ -1,0 +1,104 @@
+import type { WorldEntityGeo } from "@openflipbook/config";
+
+/**
+ * Match the VLM's read of a tap ("The Patrician's Palace and its gardens")
+ * against the mapped entities, so a click on a map's baked-in LETTERING
+ * enters the named place instead of falling through to the fresh path
+ * (which ignores image refs and invents an unrelated scene).
+ *
+ * Pure. Mirrored (loosely) by generate.py's _match_world_entity for the
+ * auto-autonomy path where the VLM resolve happens in-band.
+ */
+
+// Words that carry no identity — dropped before token comparison so
+// "the palace of the patrician" still meets "Patrician's Palace".
+const STOP_WORDS = new Set([
+  "the", "a", "an", "of", "and", "its", "their", "in", "on", "at",
+]);
+
+/** lowercase → strip diacritics → strip punctuation → collapse spaces.
+ *  Apostrophes are REMOVED (not space-split) so "Patrician's" folds to
+ *  "patricians" rather than shedding a stray "s" token. */
+function normalize(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/['’]/g, "")
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function tokens(s: string): string[] {
+  return normalize(s)
+    .split(" ")
+    .filter((t) => t.length > 0 && !STOP_WORDS.has(t));
+}
+
+/** Character-bigram Dice similarity on the normalized strings (0..1) —
+ *  the fuzzy net for near-misses ("patricians palace" vs "patrician palace"). */
+function bigramSimilarity(a: string, b: string): number {
+  const grams = (s: string): Map<string, number> => {
+    const m = new Map<string, number>();
+    for (let i = 0; i < s.length - 1; i++) {
+      const g = s.slice(i, i + 2);
+      m.set(g, (m.get(g) ?? 0) + 1);
+    }
+    return m;
+  };
+  const ga = grams(a);
+  const gb = grams(b);
+  if (ga.size === 0 || gb.size === 0) return a === b ? 1 : 0;
+  let overlap = 0;
+  let total = 0;
+  for (const [g, n] of ga) {
+    overlap += Math.min(n, gb.get(g) ?? 0);
+    total += n;
+  }
+  for (const n of gb.values()) total += n;
+  return (2 * overlap) / total;
+}
+
+const FUZZY_THRESHOLD = 0.8;
+
+/** Match strength: exact (3) > token containment (2) > fuzzy bigram (1) > none (0). */
+function matchStrength(subject: string, label: string): number {
+  const ns = normalize(subject);
+  const nl = normalize(label);
+  if (!ns || !nl) return 0;
+  if (ns === nl) return 3;
+  const ts = tokens(subject);
+  const tl = tokens(label);
+  if (ts.length === 0 || tl.length === 0) return 0;
+  // Token-set containment, either direction: a subject "patrician's palace
+  // and its gardens" contains the label "Patrician's Palace"; a clipped
+  // subject "the river" is contained by the label "The River Ankh".
+  const setS = new Set(ts);
+  const setL = new Set(tl);
+  if (tl.every((t) => setS.has(t)) || ts.every((t) => setL.has(t))) return 2;
+  if (bigramSimilarity(ns, nl) >= FUZZY_THRESHOLD) return 1;
+  return 0;
+}
+
+export function matchEntityLabel(
+  subject: string,
+  entities: WorldEntityGeo[],
+): WorldEntityGeo | null {
+  if (!subject.trim()) return null;
+  let best: WorldEntityGeo | null = null;
+  let bestScore = 0;
+  for (const e of entities) {
+    if (!e.label.trim()) continue;
+    const strength = matchStrength(subject, e.label);
+    if (strength === 0) continue;
+    // Places outrank non-places at equal strength (a tap on lettering is a
+    // tap on a PLACE name); ties keep the first (closest-seeded) entity.
+    const score = strength * 2 + (e.kind === "place" ? 1 : 0);
+    if (score > bestScore) {
+      bestScore = score;
+      best = e;
+    }
+  }
+  return best;
+}

--- a/apps/web/lib/geo-tap.test.ts
+++ b/apps/web/lib/geo-tap.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import type { MapCrop, SceneView, WorldEntityGeo } from "@openflipbook/config";
 
-import { describeSurroundings, geoTapRequest, wideRegionCut } from "./geo-tap";
+import {
+  degradedSubmapTap,
+  describeSurroundings,
+  geoTapForEntity,
+  geoTapRequest,
+  wideRegionCut,
+} from "./geo-tap";
 
 function geo(
   id: string,
@@ -373,5 +379,94 @@ describe("wideRegionCut (world-off coherence net)", () => {
       16 / 9,
     );
     expect(cut).toBeNull();
+  });
+});
+
+describe("degradedSubmapTap (W1: anchor the un-routable tap)", () => {
+  // One far-away place: a tap elsewhere misses every footprint AND leaves the
+  // submap window under MIN_SUBMAP_ENTITIES — geoTapRequest returns null and
+  // (without the degrade) the request would ride the fresh path.
+  const map = {
+    entities: [geo("uni", "Unseen University", 90, 50)],
+    bounds: CROP,
+  };
+
+  it("the fell-through tap becomes a faithful submap of the clicked region", () => {
+    const click = { x_pct: 0.2, y_pct: 0.3 };
+    expect(geoTapRequest(map, "n1", click, 16 / 9)).toBeNull(); // the bug path
+    const t = degradedSubmapTap(map, "n1", click, 16 / 9);
+    expect(t).not.toBeNull();
+    expect(t!.kind).toBe("submap");
+    expect(t!.scene_view.level).toBe("map");
+    expect(t!.scene_view.observer).toBeNull();
+    // The crop is centred on the TAP (in the seeded 100×60 frame).
+    const crop = t!.scene_view.map_crop!;
+    expect(crop.x + crop.w / 2).toBeCloseTo(20, 5);
+    expect(crop.y + crop.h / 2).toBeCloseTo(18, 5);
+  });
+
+  it("inside an entered place → null (its frame isn't the map to cut)", () => {
+    const inside: SceneView = {
+      node_id: "n2",
+      level: "eye",
+      observer: {
+        pos: { x: 0, y: 0 },
+        eye_height: 1.7,
+        gaze: 0,
+        pitch: 0,
+        fov: 1.2,
+      },
+      map_crop: null,
+    };
+    expect(
+      degradedSubmapTap(map, "n2", { x_pct: 0.5, y_pct: 0.5 }, 16 / 9, inside),
+    ).toBeNull();
+  });
+
+  it("empty world → null (nothing to anchor against)", () => {
+    expect(
+      degradedSubmapTap(
+        { entities: [], bounds: CROP },
+        "n1",
+        { x_pct: 0.5, y_pct: 0.5 },
+        16 / 9,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("geoTapForEntity (W2: enter the place the lettering names)", () => {
+  it("matches the scene tap a footprint hit would produce", () => {
+    const tower = geo("tower", "Tower of Art", 60, 30, {
+      height: 18,
+      visual: "an 800-foot stone tower",
+    });
+    const map = { entities: [tower], bounds: CROP };
+    // Footprint hit at the tower's centre (frame is 100×60 → y_pct = 30/60).
+    const byHit = geoTapRequest(map, "n1", { x_pct: 0.6, y_pct: 0.5 }, 16 / 9);
+    const byName = geoTapForEntity(map, "n1", tower, 16 / 9);
+    expect(byName.kind).toBe("scene");
+    expect(byName.focus_id).toBe("tower");
+    expect(byName.focus_label).toBe("Tower of Art"); // drives the subject
+    expect(byName.focus_visual).toBe("an 800-foot stone tower");
+    expect(byName.scene_view.level).toBe(byHit!.scene_view.level);
+    expect(byName.scene_view.focus_id).toBe(byHit!.scene_view.focus_id);
+    expect(byName.scene_view.observer).not.toBeNull();
+    // First enter steers by nothing, same as the footprint hit.
+    expect(byName.expected_layout).toEqual([]);
+  });
+
+  it("carries the focus's frame-mates as surroundings", () => {
+    const tower = geo("tower", "Tower of Art", 60, 30, { height: 18 });
+    const bridge = geo("bridge", "Brass Bridge", 40, 40, {
+      visual: "an iron bridge with hippo statues",
+    });
+    const t = geoTapForEntity(
+      { entities: [tower, bridge], bounds: CROP },
+      "n1",
+      tower,
+      16 / 9,
+    );
+    expect(t.surroundings).toContain("Brass Bridge");
   });
 });

--- a/apps/web/lib/geo-tap.ts
+++ b/apps/web/lib/geo-tap.ts
@@ -2,6 +2,7 @@ import type {
   MapCrop,
   ObserverPose,
   ProjectedEntity,
+  ScaleTier,
   SceneView,
   ViewLevel,
   ViewSpec,
@@ -9,7 +10,7 @@ import type {
 } from "@openflipbook/config";
 import { finerTier } from "@openflipbook/config";
 
-import { routeClick, type ClickPoint } from "./click-route";
+import { routeClick, routeToFocus, type ClickPoint } from "./click-route";
 import {
   childrenOf,
   cropEntities,
@@ -157,47 +158,87 @@ export function geoTapRequest(
   // than the frame you tapped from (a tap = tierStep +1). Stamp it on the entered
   // scene_view so a node's rung is consistent however it was reached. Optional —
   // only when the source frame carries a rung (PR A seeds it).
-  const parentTier = currentView?.scale_tier ?? byId.get(route.focus_id ?? "")?.scale_tier ?? null;
-  const childTier = parentTier ? finerTier(parentTier) : undefined;
+  const childTier = childTierFor(currentView, byId, route.focus_id ?? null);
 
   // Tap on empty map area that still holds a cluster → stay in MAP mode + crop
   // the region (a sub-map), instead of entering a single place.
   if (route.kind === "submap") {
-    return {
-      kind: "submap",
-      scene_view: {
-        node_id: nodeId,
-        level: "map",
-        observer: null,
-        map_crop: route.crop,
-        focus_id: route.focus_id,
-        ...(childTier ? { scale_tier: childTier } : {}),
-        ...(override?.view ? { view: override.view } : {}),
-      },
-      expected_layout: [],
-      layout_entities: cropEntities(candidates.entities, route.crop),
-      focus_id: route.focus_id,
-      focus_label: route.focus_id ? byId.get(route.focus_id)?.label ?? null : null,
-      focus_visual: route.focus_id ? byId.get(route.focus_id)?.visual ?? null : null,
-      surroundings: route.focus_id ? describeSurroundings(route.focus_id, map.entities) : "",
-    };
+    return buildSubmapTap(
+      map.entities,
+      candidates.entities,
+      nodeId,
+      route.crop,
+      route.focus_id,
+      childTier,
+      override?.view,
+    );
   }
 
   // route.kind === "scene": enter the place.
   // The popover's adjusted pose/level (if any) win over the synthesized ones.
-  const observer = override?.observer ?? route.observer;
-  const level = override?.level ?? route.level;
+  return buildSceneTap(
+    map.entities,
+    nodeId,
+    route.focus_id,
+    override?.observer ?? route.observer,
+    override?.level ?? route.level,
+    aspect,
+    childTier,
+    override?.view,
+  );
+}
 
-  // An entered scene shows the place's INTERIOR, never the city around it.
-  //   - Re-enter: we have the saved interior — its sub-entities seeded into the
-  //     child frame on a prior visit — so steer by THOSE (resolved local →
-  //     absolute) and the inside stays consistent across visits.
-  //   - First enter: we know nothing inside yet, so steer by NOTHING and let the
-  //     model render the place freely. Projecting the city's *other* landmarks
-  //     here is what wrongly draws e.g. the Brass Bridge inside the University
-  //     ("parts outside my image shown in my image"). The child frame still
-  //     seeds from this scene's extraction (keyed on focus_id below).
-  const kids = childrenOf(map.entities, route.focus_id);
+function buildSubmapTap(
+  allEntities: WorldEntityGeo[],
+  candidates: WorldEntityGeo[],
+  nodeId: string,
+  crop: MapCrop,
+  focusId: string | null,
+  childTier: ScaleTier | undefined,
+  view?: ViewSpec,
+): GeoTap {
+  const byId = new Map(allEntities.map((e) => [e.id, e]));
+  return {
+    kind: "submap",
+    scene_view: {
+      node_id: nodeId,
+      level: "map",
+      observer: null,
+      map_crop: crop,
+      focus_id: focusId,
+      ...(childTier ? { scale_tier: childTier } : {}),
+      ...(view ? { view } : {}),
+    },
+    expected_layout: [],
+    layout_entities: cropEntities(candidates, crop),
+    focus_id: focusId,
+    focus_label: focusId ? byId.get(focusId)?.label ?? null : null,
+    focus_visual: focusId ? byId.get(focusId)?.visual ?? null : null,
+    surroundings: focusId ? describeSurroundings(focusId, allEntities) : "",
+  };
+}
+
+// An entered scene shows the place's INTERIOR, never the city around it.
+//   - Re-enter: we have the saved interior — its sub-entities seeded into the
+//     child frame on a prior visit — so steer by THOSE (resolved local →
+//     absolute) and the inside stays consistent across visits.
+//   - First enter: we know nothing inside yet, so steer by NOTHING and let the
+//     model render the place freely. Projecting the city's *other* landmarks
+//     here is what wrongly draws e.g. the Brass Bridge inside the University
+//     ("parts outside my image shown in my image"). The child frame still
+//     seeds from this scene's extraction (keyed on focus_id below).
+function buildSceneTap(
+  allEntities: WorldEntityGeo[],
+  nodeId: string,
+  focusId: string,
+  observer: ObserverPose,
+  level: ViewLevel,
+  aspect: number,
+  childTier: ScaleTier | undefined,
+  view?: ViewSpec,
+): GeoTap {
+  const byId = new Map(allEntities.map((e) => [e.id, e]));
+  const kids = childrenOf(allEntities, focusId);
   const layoutEntities =
     kids.length > 0
       ? kids.map((k) => ({ ...k, pos: resolveAbsolutePos(k.id, byId) ?? k.pos }))
@@ -211,18 +252,103 @@ export function geoTapRequest(
       map_crop: null,
       // The place you entered: its geo id anchors the child frame the entered
       // scene's sub-entities seed into.
-      focus_id: route.focus_id,
+      focus_id: focusId,
       ...(childTier ? { scale_tier: childTier } : {}),
       // The projection pill (user-pinned camera) — beats the backend policy.
-      ...(override?.view ? { view: override.view } : {}),
+      ...(view ? { view } : {}),
     },
     expected_layout: projectScene(layoutEntities, observer, aspect),
     layout_entities: layoutEntities,
-    focus_id: route.focus_id,
-    focus_label: byId.get(route.focus_id)?.label ?? null,
-    focus_visual: byId.get(route.focus_id)?.visual ?? null,
-    surroundings: describeSurroundings(route.focus_id, map.entities),
+    focus_id: focusId,
+    focus_label: byId.get(focusId)?.label ?? null,
+    focus_visual: byId.get(focusId)?.visual ?? null,
+    surroundings: describeSurroundings(focusId, allEntities),
   };
+}
+
+/** One rung FINER than the frame the tap happened in (see geoTapRequest). */
+function childTierFor(
+  currentView: SceneView | null | undefined,
+  byId: Map<string, WorldEntityGeo>,
+  focusId: string | null,
+): ScaleTier | undefined {
+  const parentTier =
+    currentView?.scale_tier ?? byId.get(focusId ?? "")?.scale_tier ?? null;
+  return parentTier ? finerTier(parentTier) : undefined;
+}
+
+/**
+ * W1 degrade net. The geometric route fell through on a map frame (the tap
+ * landed on baked-in lettering or unmapped parchment), and the classic
+ * fallback would re-compose the scene on the FRESH path — which ignores
+ * image refs and is exactly what produced brand-new unrelated pages
+ * ("a new city near the river"). Answer instead with the same place_submap
+ * zoom-cut a world-mode submap tap rides (Kontext continuation of the
+ * region crop): worst case a boring crop, never a reinvention.
+ */
+export function degradedSubmapTap(
+  map: { entities: WorldEntityGeo[]; bounds: MapCrop },
+  nodeId: string,
+  click: ClickPoint,
+  aspect: number,
+  currentView?: SceneView | null,
+): GeoTap | null {
+  if (map.entities.length === 0) return null;
+  // Map frames only — inside an entered place the classic tap stands (its
+  // frame isn't the map the cut would continue).
+  if (currentView && currentView.level !== "map") return null;
+  const mapView: SceneView = {
+    node_id: nodeId,
+    level: "map",
+    observer: null,
+    map_crop: MAP_IMAGE_FRAME,
+  };
+  const route = routeClick(map, mapView, click, aspect, {
+    minSubmapEntities: 0,
+  });
+  // A place hit would have routed via geoTapRequest already; anything else
+  // on a map frame is a submap window around the tap.
+  if (route.kind !== "submap") return null;
+  const byId = new Map(map.entities.map((e) => [e.id, e]));
+  return buildSubmapTap(
+    map.entities,
+    map.entities,
+    nodeId,
+    route.crop,
+    route.focus_id,
+    childTierFor(currentView, byId, route.focus_id),
+  );
+}
+
+/**
+ * W2 label-click routing. The tap was resolved by NAME — the VLM read the
+ * map's baked-in lettering and it matches a mapped place — so enter THAT
+ * entity exactly as a geometric hit on its footprint would, observer pose
+ * and all. The caller does the matching (entity-label-match.ts).
+ */
+export function geoTapForEntity(
+  map: { entities: WorldEntityGeo[]; bounds: MapCrop },
+  nodeId: string,
+  entity: WorldEntityGeo,
+  aspect: number,
+  currentView?: SceneView | null,
+): GeoTap {
+  const byId = new Map(map.entities.map((e) => [e.id, e]));
+  // Stand at the frame centre looking at the place — the same default a
+  // footprint hit synthesizes when the viewer has no prior pose.
+  const route = routeToFocus(entity, {
+    x: MAP_IMAGE_FRAME.x + MAP_IMAGE_FRAME.w / 2,
+    y: MAP_IMAGE_FRAME.y + MAP_IMAGE_FRAME.h / 2,
+  });
+  return buildSceneTap(
+    map.entities,
+    nodeId,
+    route.focus_id,
+    route.observer,
+    route.level,
+    aspect,
+    childTierFor(currentView, byId, entity.id),
+  );
 }
 
 export interface WideRegionCut {


### PR DESCRIPTION
## The bug (user repro)

In world mode, the second click on a map often produced a **brand-new unrelated image** ("near the river, disregarding style/location/geometry"), and clicking a map's baked-in lettering ("PATRICIAN'S PALACE") produced garbage.

Root cause: a tap the geometric router can't anchor (lettering or unmapped parchment) falls through to `explainer` → the **fresh text-to-image path, which accepts-but-ignores reference images** → an unrelated reinvented scene. No warning, no fallback.

## The fixes (all additive)

1. **W1 degrade** (`NEXT_PUBLIC_WORLD_TAP_DEGRADE`, kill-switch semantics, default ON): a fell-through world-mode tap on a map frame now rides the same `place_submap` Kontext zoom-continue a submap tap uses — a faithful cut of the clicked region. Worst case is a boring crop, never a reinvention. (`degradedSubmapTap` in `geo-tap.ts`, reusing `routeClick` with `minSubmapEntities: 0`.)
2. **W2 label-click routing** (always on): the VLM's subject is matched against mapped place labels — normalized exact / token-containment / bigram-fuzzy — so clicking lettering enters the named place with footprint-hit semantics. Client half: `entity-label-match.ts` + `geoTapForEntity` (semi autonomy). Server half: `_match_world_entity` in `generate.py` upgrades `explainer → place_scene` (auto autonomy), logged as `world.label_match`.
3. **`WORLD_GEOMETRY_GEN` defaults ON under an active world mode** — the layout clause is the only thing pinning the map's geography. Explicit `=false` still kills it everywhere; non-world requests stay byte-identical.

## Verification

- `pytest -m "not paid"` full suite green; `mypy generate.py` clean; `ruff` clean
- web: 565 vitest tests green (incl. new `entity-label-match.test.ts`, degrade + by-name routing cases), `tsc --noEmit` clean
- Manual repro to try: world ON → fantasy city map → click empty parchment → expect a styled zoom (`render_mode=place_submap`, op `zoom_continue`) instead of a fresh unrelated image; click palace lettering → enters the palace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)