### PR TITLE
feat(world): idle enter affordances — pulsing rings + enter cursor

### DIFF
--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -78,6 +78,7 @@ import Breadcrumb from "@/components/PlayPage/Breadcrumb";
 import SpatialPath from "@/components/PlayPage/SpatialPath";
 import { buildBreadcrumb } from "@/lib/breadcrumb";
 import { EntityHoverOverlay } from "@/components/PlayPage/EntityHoverOverlay";
+import { EnterableMarkers } from "@/components/PlayPage/EnterableMarkers";
 import { ContextMenu, type ContextMenuItem } from "@/components/PlayPage/ContextMenu";
 import { HoverCrosshair } from "@/components/PlayPage/HoverCrosshair";
 import { HintPrompt } from "@/components/PlayPage/HintPrompt";
@@ -106,6 +107,7 @@ import {
   type GeoTapOverride,
 } from "@/lib/geo-tap";
 import { matchEntityLabel } from "@/lib/entity-label-match";
+import { focusOnMap } from "@/lib/click-route";
 import { selectNeighbors } from "@/lib/scale-neighbors";
 import { childrenOf, projectTopDown } from "@/lib/world-geometry";
 import { viewNeutralAppearance } from "@/lib/appearance";
@@ -462,7 +464,11 @@ export default function PlayPage() {
   // double-click can pass the `phase === "generating"` check twice and start
   // two overlapping generates.
   const clickInFlightRef = useRef(false);
-  const [hoverPos, setHoverPos] = useState<{ xPx: number; yPx: number } | null>(
+  const [hoverPos, setHoverPos] = useState<{
+    xPx: number;
+    yPx: number;
+    enterable?: boolean;
+  } | null>(
     null
   );
   // Annotate-and-regenerate: when the user holds Shift and drags on the
@@ -2349,9 +2355,33 @@ export default function PlayPage() {
     const move = (evt: PointerEvent) => {
       if (evt.pointerType === "touch") return;
       const rect = img.getBoundingClientRect();
+      // Enter affordance (W3): the crosshair grows an "enter" ring over an
+      // enterable place — world mode, map frames only. Pure footprint
+      // hit-test against the in-closure geo map; a lagging closure just
+      // delays the ring one render, same trade the tap handler accepts.
+      let hoverEnterable = false;
+      if (
+        worldEnabled &&
+        geoMap.entities.length > 0 &&
+        (!page?.sceneView || page.sceneView.level === "map")
+      ) {
+        const pointer = normalizeClickOnImage(evt, img);
+        if (pointer) {
+          const frame = page?.sceneView?.map_crop ?? MAP_IMAGE_FRAME;
+          hoverEnterable =
+            focusOnMap(
+              geoMap.entities.filter(
+                (e) => e.kind === "place" && (e.parent_id ?? null) === null,
+              ),
+              frame,
+              pointer,
+            ) != null;
+        }
+      }
       setHoverPos({
         xPx: evt.clientX - rect.left,
         yPx: evt.clientY - rect.top,
+        enterable: hoverEnterable,
       });
       if (editDragStartRef.current) {
         const s = editDragStartRef.current;
@@ -3054,7 +3084,11 @@ export default function PlayPage() {
                 phase !== "generating" &&
                 !editMode &&
                 streamStatus === "off" && (
-                  <HoverCrosshair xPx={hoverPos.xPx} yPx={hoverPos.yPx} />
+                  <HoverCrosshair
+                    xPx={hoverPos.xPx}
+                    yPx={hoverPos.yPx}
+                    enterable={hoverPos.enterable ?? false}
+                  />
                 )}
 
               {clickRipple && phase === "generating" && (
@@ -3108,6 +3142,16 @@ export default function PlayPage() {
                 onSelect={() => setCodexOpen(true)}
                 imgRef={imgRef}
               />
+              {worldEnabled &&
+                phase === "ready" &&
+                streamStatus === "off" &&
+                (!page?.sceneView || page.sceneView.level === "map") && (
+                  <EnterableMarkers
+                    entities={geoMap.entities}
+                    currentView={page?.sceneView ?? null}
+                    imgRef={imgRef}
+                  />
+                )}
               {geoOverlayOn && page?.nodeId && (
                 <GeometryOverlay
                   nodeId={page.nodeId}
@@ -3400,7 +3444,10 @@ export default function PlayPage() {
           bottom-centre, so they'd overlap; mid-bloom the hint is noise anyway.
           It returns when the tray is closed. */}
       {phase === "ready" && !helpOpen && !bloom && (
-        <FirstRunCoach onShowHelp={() => setHelpOpen(true)} />
+        <FirstRunCoach
+          onShowHelp={() => setHelpOpen(true)}
+          worldHint={worldEnabled}
+        />
       )}
 
       {scrubberOpen && page?.imageDataUrl && history.trail.length > 1 && (

--- a/apps/web/components/PlayPage/EnterableMarkers.test.tsx
+++ b/apps/web/components/PlayPage/EnterableMarkers.test.tsx
@@ -1,0 +1,94 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { SceneView, WorldEntityGeo } from "@openflipbook/config";
+
+import { EnterableMarkers } from "./EnterableMarkers";
+
+function geo(
+  id: string,
+  x: number,
+  y: number,
+  opts: Partial<WorldEntityGeo> = {},
+): WorldEntityGeo {
+  return {
+    id,
+    entity_id: id,
+    kind: "place",
+    label: id,
+    pos: { x, y },
+    height: 4,
+    footprint: { w: 8, d: 8 },
+    visual: "",
+    state: {},
+    confidence: 1,
+    source: "user",
+    updated_at: "t",
+    ...opts,
+  };
+}
+
+function markerIds(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll("[data-entity-id]")).map(
+    (el) => el.getAttribute("data-entity-id") ?? "",
+  );
+}
+
+describe("EnterableMarkers (W3 idle enter affordance)", () => {
+  it("rings top-level places on the map; items and nested children stay quiet", () => {
+    const { container } = render(
+      <EnterableMarkers
+        entities={[
+          geo("palace", 50, 30),
+          geo("sword", 40, 20, { kind: "item" }),
+          geo("hall", 60, 30, { parent_id: "palace" }),
+        ]}
+        currentView={null}
+      />,
+    );
+    expect(markerIds(container)).toEqual(["palace"]);
+  });
+
+  it("inside an entered place (scene frame) → renders nothing", () => {
+    const inside: SceneView = {
+      node_id: "n1",
+      level: "eye",
+      observer: {
+        pos: { x: 0, y: 0 },
+        eye_height: 1.7,
+        gaze: 0,
+        pitch: 0,
+        fov: 1.2,
+      },
+      map_crop: null,
+    };
+    const { container } = render(
+      <EnterableMarkers entities={[geo("palace", 50, 30)]} currentView={inside} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("a submap frame scopes rings to its crop window", () => {
+    const submap: SceneView = {
+      node_id: "n1",
+      level: "map",
+      observer: null,
+      map_crop: { x: 40, y: 20, w: 30, h: 20 },
+    };
+    const { container } = render(
+      <EnterableMarkers
+        entities={[geo("inside-crop", 50, 30), geo("outside-crop", 5, 5)]}
+        currentView={submap}
+      />,
+    );
+    expect(markerIds(container)).toEqual(["inside-crop"]);
+  });
+
+  it("markers never intercept pointer events (the tap must reach the image)", () => {
+    const { container } = render(
+      <EnterableMarkers entities={[geo("palace", 50, 30)]} currentView={null} />,
+    );
+    expect(
+      (container.firstChild as HTMLElement).className.includes("pointer-events-none"),
+    ).toBe(true);
+  });
+});

--- a/apps/web/components/PlayPage/EnterableMarkers.tsx
+++ b/apps/web/components/PlayPage/EnterableMarkers.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useMemo, type RefObject } from "react";
+import type { MapCrop, SceneView, WorldEntityGeo } from "@openflipbook/config";
+
+import { useContainRect } from "@/hooks/useContainRect";
+import { MAP_IMAGE_FRAME } from "@/lib/geo-tap";
+import { cropEntities } from "@/lib/world-geometry";
+
+interface Props {
+  /** The geo world map's entities (all of them; this component scopes). */
+  entities: WorldEntityGeo[];
+  /** The frame the page shows. Markers render only on map frames
+   *  (null = the top-level map; a submap carries its crop). */
+  currentView: SceneView | null;
+  /** The rendered <img>; markers track the object-contain content rect. */
+  imgRef?: RefObject<HTMLImageElement | null>;
+}
+
+/**
+ * Idle-state enter affordance (W3). A soft pulsing ring on every ENTERABLE
+ * place of the current map frame, so "tap = enter a place" is discoverable
+ * before the first click — previously only revealed by ⌘-tap. Pure
+ * decoration: pointer events pass through to the image's own tap handler,
+ * and world OFF never mounts it (the parent gates), so classic exploration
+ * is pixel-identical.
+ */
+export function EnterableMarkers({ entities, currentView, imgRef }: Props) {
+  const content = useContainRect(imgRef);
+  const markers = useMemo(() => {
+    // Inside an entered place the frame is a scene, not the map — no rings.
+    if (currentView && currentView.level !== "map") return [];
+    const frame: MapCrop = currentView?.map_crop ?? MAP_IMAGE_FRAME;
+    // Top-level places only: nested children live in their parent's frame
+    // and would project to the wrong spot on the city map.
+    const places = entities.filter(
+      (e) => e.kind === "place" && (e.parent_id ?? null) === null,
+    );
+    return cropEntities(places, frame).map((e) => ({
+      id: e.id,
+      label: e.label,
+      xPct: (e.pos.x - frame.x) / frame.w,
+      yPct: (e.pos.y - frame.y) / frame.h,
+    }));
+  }, [entities, currentView]);
+
+  if (markers.length === 0) return null;
+
+  return (
+    <div aria-hidden className="pointer-events-none absolute inset-0 z-10">
+      {markers.map((m) => {
+        const left = content
+          ? `${content.offsetX + m.xPct * content.width}px`
+          : `${m.xPct * 100}%`;
+        const top = content
+          ? `${content.offsetY + m.yPct * content.height}px`
+          : `${m.yPct * 100}%`;
+        return (
+          <span
+            key={m.id}
+            data-entity-id={m.id}
+            title={m.label}
+            className="absolute -translate-x-1/2 -translate-y-1/2"
+            style={{ left, top }}
+          >
+            <span className="block h-5 w-5 animate-pulse rounded-full border-2 border-emerald-600/60 shadow-[0_0_8px_rgba(16,185,129,0.45)]" />
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/components/PlayPage/FirstRunCoach.test.tsx
+++ b/apps/web/components/PlayPage/FirstRunCoach.test.tsx
@@ -23,4 +23,14 @@ describe("FirstRunCoach", () => {
     fireEvent.click(screen.getByRole("button", { name: /shortcut/i }));
     expect(onShowHelp).toHaveBeenCalledTimes(1);
   });
+
+  it("world mode adds the enter-rings hint; classic mode never shows it", () => {
+    const world = render(<FirstRunCoach onShowHelp={() => {}} worldHint />);
+    expect(/rings = enterable places/i.test(document.body.textContent ?? "")).toBe(
+      true,
+    );
+    world.unmount();
+    render(<FirstRunCoach onShowHelp={() => {}} />);
+    expect(/rings/i.test(document.body.textContent ?? "")).toBe(false);
+  });
 });

--- a/apps/web/components/PlayPage/FirstRunCoach.tsx
+++ b/apps/web/components/PlayPage/FirstRunCoach.tsx
@@ -4,6 +4,8 @@ import { BloomGlyph } from "./BloomGlyph";
 
 interface Props {
   onShowHelp: () => void;
+  /** World mode is on → also teach the enter affordance (the pulsing rings). */
+  worldHint?: boolean;
 }
 
 /**
@@ -13,7 +15,7 @@ interface Props {
  * Expand do" was a mystery. Stays out of the visual centre — the rendered
  * illustration is what matters.
  */
-export function FirstRunCoach({ onShowHelp }: Props) {
+export function FirstRunCoach({ onShowHelp, worldHint = false }: Props) {
   return (
     <div
       role="status"
@@ -24,6 +26,15 @@ export function FirstRunCoach({ onShowHelp }: Props) {
         {/* The two moves, side by side, so the in/around duality is obvious. */}
         <span className="whitespace-nowrap opacity-80">Tap to go in</span>
         <span className="opacity-40">·</span>
+        {worldHint && (
+          <>
+            <span className="flex items-center gap-1.5 whitespace-nowrap opacity-80">
+              <span className="inline-block h-2.5 w-2.5 rounded-full border-2 border-emerald-600/70" />
+              rings = enterable places
+            </span>
+            <span className="opacity-40">·</span>
+          </>
+        )}
         <span className="flex items-center gap-1.5 whitespace-nowrap opacity-80">
           <BloomGlyph className="h-3.5 w-3.5 text-teal-600" />
           around

--- a/apps/web/components/PlayPage/HoverCrosshair.tsx
+++ b/apps/web/components/PlayPage/HoverCrosshair.tsx
@@ -3,6 +3,9 @@
 interface Props {
   xPx: number;
   yPx: number;
+  /** The pointer rests on an enterable place (world mode, map frame) —
+   *  swap the crosshair for the enter ring + microlabel. */
+  enterable?: boolean;
 }
 
 /**
@@ -10,8 +13,28 @@ interface Props {
  * rendered illustration. Replaces the default cursor (which is hidden via
  * cursor-none on the image) so the click target is unambiguous on busy
  * backgrounds. The parent gates rendering on hoverPos != null + idle phase.
+ * Over an enterable place it becomes an emerald ring with a tiny "enter"
+ * label, matching the EnterableMarkers idle rings.
  */
-export function HoverCrosshair({ xPx, yPx }: Props) {
+export function HoverCrosshair({ xPx, yPx, enterable = false }: Props) {
+  if (enterable) {
+    return (
+      <span
+        aria-hidden
+        className="pointer-events-none absolute z-10 -translate-x-1/2 -translate-y-1/2"
+        style={{ left: `${xPx}px`, top: `${yPx}px`, width: "34px", height: "34px" }}
+      >
+        <svg viewBox="0 0 34 34" width="34" height="34" className="block">
+          <circle cx="17" cy="17" r="13" fill="none" stroke="rgba(255,255,255,0.95)" strokeWidth="3" />
+          <circle cx="17" cy="17" r="13" fill="none" stroke="#10b981" strokeWidth="1.5" />
+          <circle cx="17" cy="17" r="1.5" fill="#10b981" />
+        </svg>
+        <span className="absolute left-1/2 top-full mt-0.5 -translate-x-1/2 rounded bg-emerald-700/90 px-1 font-mono text-[9px] lowercase tracking-wide text-white">
+          enter
+        </span>
+      </span>
+    );
+  }
   return (
     <span
       aria-hidden


### PR DESCRIPTION
Stacked on #63 (needs its `focusOnMap` export).

Enterability was previously only discoverable via ⌘-tap — nothing on the idle image showed which places can be entered. Three default-on, world-mode-only affordances; **world OFF screens stay pixel-identical** (nothing mounts):

1. **`EnterableMarkers`** — a soft pulsing emerald ring at each top-level place's footprint centre on map frames; submap frames scope rings to their crop window. Entirely `pointer-events-none` so taps reach the image handler untouched.
2. **`HoverCrosshair` enterable variant** — when the pointer rests on an enterable footprint (`focusOnMap` hit-test in the move handler), the red crosshair becomes an emerald ring with a tiny "enter" microlabel.
3. **`FirstRunCoach`** — gains a "rings = enterable places" segment when world mode is on.

Deviation from plan: the coach hint is gated on `worldEnabled` rather than a localStorage dismissal — PR A4 gates the whole coach to first-run anyway, so per-segment dismissal machinery wasn't worth it.

## Verification
- 570 vitest green (new `EnterableMarkers.test.tsx`: scoping to places/top-level/crop, scene frames render nothing, pointer-events pass through), `tsc --noEmit` clean.
- Manual: world ON on a city map → rings pulse on places, crosshair flips to "enter" over them; enter a place → no rings inside; world OFF → unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)