### PR TITLE
feat(eval): matrix bench chassis — the evolvable eval skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ scripts/perfbudget/report.json
 
 # Superpowers brainstorm companion (ephemeral mockup files).
 .superpowers/
+
+# Matrix-bench disk cache (cell images + records + judge replies — re-runs
+# must be free, but the binaries never belong in git).
+apps/modal-backend/tests/**/cache/

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,17 @@ eval-baselines:
 	-cd apps/modal-backend && ENTER_BENCH_RUN=1 .venv/bin/python -m tests.continuity_bench.enter_runner
 	-cd apps/modal-backend && VIEW_BENCH_RUN=1 .venv/bin/python -m tests.continuity_bench.view_runner
 	-cd apps/modal-backend && EDIT_REGION_BENCH_RUN=1 .venv/bin/python -m tests.edit_bench.runner
+# Matrix bench (the evolvable eval): scenarios × arms × models × prompt-
+# variants, disk-cached so prompt evolution re-bills only changed cells.
+# DRY-RUN IS THE DEFAULT — eval-matrix-dry prints the per-cell cost table
+# (the mandatory preview, $0). eval-matrix runs uncached cells under the
+# hard budget cap (MATRIX_BUDGET_USD, default $3; MATRIX_ALLOW_PARTIAL=1
+# runs to the cap instead of refusing). Scenarios come from the map corpus
+# once the recon bench (tests/recon_bench) lands.
+eval-matrix-dry:
+	cd apps/modal-backend && .venv/bin/python -m tests.matrix_bench.runner
+eval-matrix:
+	cd apps/modal-backend && MATRIX_BENCH_RUN=1 .venv/bin/python -m tests.matrix_bench.runner
 # Free coverage report (backend lines + the web view-path files).
 coverage:
 	cd apps/modal-backend && .venv/bin/python -m pytest -q -m "not paid" --cov=providers --cov=generate --cov-report=term | tail -30

--- a/apps/modal-backend/tests/matrix_bench/__init__.py
+++ b/apps/modal-backend/tests/matrix_bench/__init__.py
@@ -1,0 +1,4 @@
+"""Matrix bench — the evolvable eval chassis (scenarios x arms x models x
+prompt-variants). Pure pieces (_cache, _budget, _record, _pareto) are free-CI
+golden-tested; runner.py drives them with injected gen/extract/judge functions
+so the whole loop is testable without spending a cent."""

--- a/apps/modal-backend/tests/matrix_bench/_budget.py
+++ b/apps/modal-backend/tests/matrix_bench/_budget.py
@@ -1,0 +1,39 @@
+"""Budget ledger — the matrix runner's hard spending gate.
+
+`charge()` is called BEFORE each paid call (estimate → charge → call), so a
+bug can overrun the cap by exactly zero calls. Estimates come from
+providers/spend.py (the same table docs/COSTS.md documents); this module is
+pure — no I/O, no env reads — so the refusal order is golden-testable.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+class BudgetExceeded(RuntimeError):
+    """Raised BEFORE a paid call that would cross the cap."""
+
+
+# One VLM judge / extraction call on gemini-flash — coarse, mirrors how
+# spend.py folds the whole VLM stack into a flat $0.02 per generation.
+JUDGE_CALL_FLAT = 0.005
+
+
+@dataclass
+class Ledger:
+    cap_usd: float
+    spent_usd: float = 0.0
+
+    def charge(self, estimate_usd: float) -> None:
+        """Reserve `estimate_usd` or raise — never partially mutates."""
+        est = max(0.0, estimate_usd)
+        if self.spent_usd + est > self.cap_usd + 1e-9:
+            raise BudgetExceeded(
+                f"${self.spent_usd + est:.2f} would cross the "
+                f"${self.cap_usd:.2f} cap (spent ${self.spent_usd:.2f})"
+            )
+        self.spent_usd += est
+
+    @property
+    def remaining_usd(self) -> float:
+        return max(0.0, self.cap_usd - self.spent_usd)

--- a/apps/modal-backend/tests/matrix_bench/_cache.py
+++ b/apps/modal-backend/tests/matrix_bench/_cache.py
@@ -1,0 +1,106 @@
+"""Disk cache for matrix cells and judge replies — evolution's free lunch.
+
+A cell's identity is the sha of everything that could change its output:
+(scenario, description sha, arm, model, prompt sha, params sha). Editing a
+prompt file or a corpus description changes its sha → only those cells
+re-bill; an identical re-run is 100% hits and $0.00 to-bill.
+
+Layout (gitignored):
+    tests/matrix_bench/cache/<cell_key>/record.json
+    tests/matrix_bench/cache/<cell_key>/image.jpg
+    tests/matrix_bench/cache/judges/<judge_key>.json
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+DEFAULT_ROOT = Path(__file__).resolve().parent / "cache"
+
+
+def _sha(blob: bytes) -> str:
+    return hashlib.sha256(blob).hexdigest()
+
+
+def params_sha(params: dict[str, Any]) -> str:
+    """Order-insensitive digest of the params dict."""
+    return _sha(
+        json.dumps(params, sort_keys=True, separators=(",", ":")).encode()
+    )[:12]
+
+
+def text_sha(text: str) -> str:
+    """Digest for prompt templates / descriptions (full content, not name)."""
+    return _sha(text.encode())[:12]
+
+
+def image_sha(jpeg: bytes) -> str:
+    return _sha(jpeg)[:12]
+
+
+def cell_key(
+    scenario_id: str,
+    desc_sha: str,
+    arm: str,
+    model: str,
+    prompt_sha: str,
+    params: dict[str, Any],
+) -> str:
+    blob = "|".join(
+        [scenario_id, desc_sha, arm, model, prompt_sha, params_sha(params)]
+    )
+    return _sha(blob.encode())[:20]
+
+
+def judge_key(judge_name: str, judge_model: str, img_sha: str, extra: str = "") -> str:
+    return _sha("|".join([judge_name, judge_model, img_sha, extra]).encode())[:20]
+
+
+class CellCache:
+    def __init__(self, root: Path | None = None) -> None:
+        self.root = root or DEFAULT_ROOT
+
+    def _dir(self, key: str) -> Path:
+        return self.root / key
+
+    def image_path(self, key: str) -> Path:
+        return self._dir(key) / "image.jpg"
+
+    def load(self, key: str) -> dict[str, Any] | None:
+        p = self._dir(key) / "record.json"
+        if not p.exists():
+            return None
+        try:
+            return json.loads(p.read_text())
+        except (json.JSONDecodeError, OSError):
+            return None  # corrupt entry = miss; the cell simply re-runs
+
+    def store(
+        self, key: str, record: dict[str, Any], jpeg: bytes | None = None
+    ) -> Path:
+        d = self._dir(key)
+        d.mkdir(parents=True, exist_ok=True)
+        if jpeg is not None:
+            (d / "image.jpg").write_bytes(jpeg)
+        (d / "record.json").write_text(json.dumps(record, indent=1))
+        return d
+
+
+class JudgeCache:
+    def __init__(self, root: Path | None = None) -> None:
+        self.root = (root or DEFAULT_ROOT) / "judges"
+
+    def load(self, key: str) -> dict[str, Any] | None:
+        p = self.root / f"{key}.json"
+        if not p.exists():
+            return None
+        try:
+            return json.loads(p.read_text())
+        except (json.JSONDecodeError, OSError):
+            return None
+
+    def store(self, key: str, reply: dict[str, Any]) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+        (self.root / f"{key}.json").write_text(json.dumps(reply, indent=1))

--- a/apps/modal-backend/tests/matrix_bench/_pareto.py
+++ b/apps/modal-backend/tests/matrix_bench/_pareto.py
@@ -1,0 +1,91 @@
+"""Pareto analysis over matrix cells — the "90% faster, style a bit off"
+tradeoff surface. Pure; golden-tested for free.
+
+Cells aggregate to CONFIGS (model x prompt-variant, means over scenarios);
+the front is non-dominated on (quality max, cost min, latency min); findings
+are the human sentences the report prints ("nano-banana @ recon_base.v1:
+94% of the best composite at 26% of its cost, 2.5x faster").
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def aggregate_configs(
+    records: list[dict[str, Any]], quality_key: str = "composite"
+) -> list[dict[str, Any]]:
+    """Mean quality/cost/latency per (model, variant) over all its cells."""
+    groups: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for r in records:
+        groups.setdefault((r["model"], r["prompt_variant"]), []).append(r)
+    configs: list[dict[str, Any]] = []
+    for (model, variant), cells in sorted(groups.items()):
+        quals = [c["scores"].get(quality_key) for c in cells]
+        quals = [q for q in quals if isinstance(q, (int, float))]
+        if not quals:
+            continue  # nothing scored — nothing to rank
+        costs = [float(c["cost_usd"].get("total", 0.0)) for c in cells]
+        lats = [sum(c.get("timing_s", {}).values()) for c in cells]
+        n = len(cells)
+        configs.append(
+            {
+                "model": model,
+                "variant": variant,
+                "n": n,
+                "quality": sum(quals) / len(quals),
+                "cost_usd": sum(costs) / n,
+                "latency_s": sum(lats) / n,
+            }
+        )
+    return configs
+
+
+def _dominates(a: dict[str, Any], b: dict[str, Any]) -> bool:
+    """a beats-or-ties b everywhere and beats it somewhere."""
+    ge = (
+        a["quality"] >= b["quality"]
+        and a["cost_usd"] <= b["cost_usd"]
+        and a["latency_s"] <= b["latency_s"]
+    )
+    gt = (
+        a["quality"] > b["quality"]
+        or a["cost_usd"] < b["cost_usd"]
+        or a["latency_s"] < b["latency_s"]
+    )
+    return ge and gt
+
+
+def pareto_front(configs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        c
+        for c in configs
+        if not any(_dominates(o, c) for o in configs if o is not c)
+    ]
+
+
+def near_best_findings(
+    configs: list[dict[str, Any]],
+    quality_slack: float = 0.10,
+    min_saving: float = 0.30,
+) -> list[str]:
+    """Configs within `quality_slack` of the best quality that save at least
+    `min_saving` (fraction) on cost or latency vs the best-quality config."""
+    if not configs:
+        return []
+    best = max(configs, key=lambda c: c["quality"])
+    floor = best["quality"] * (1.0 - quality_slack)
+    out: list[str] = []
+    for c in configs:
+        if c is best or c["quality"] < floor:
+            continue
+        cost_save = 1.0 - (c["cost_usd"] / best["cost_usd"]) if best["cost_usd"] > 0 else 0.0
+        speedup = best["latency_s"] / c["latency_s"] if c["latency_s"] > 0 else 1.0
+        if cost_save >= min_saving or speedup >= 1.0 / (1.0 - min_saving):
+            pct_q = 100.0 * c["quality"] / best["quality"] if best["quality"] > 0 else 0.0
+            pct_c = 100.0 * c["cost_usd"] / best["cost_usd"] if best["cost_usd"] > 0 else 0.0
+            out.append(
+                f"{c['model']} @ {c['variant']}: {pct_q:.0f}% of the best "
+                f"composite ({best['model']} @ {best['variant']}) at "
+                f"{pct_c:.0f}% of its cost, {speedup:.1f}x faster"
+            )
+    return out

--- a/apps/modal-backend/tests/matrix_bench/_record.py
+++ b/apps/modal-backend/tests/matrix_bench/_record.py
@@ -1,0 +1,130 @@
+"""Sweep configs, cell expansion, prompt-variant rendering, run records.
+
+Prompt variants are VERSIONED FILES (prompts/<name>.v<N>.txt) with named
+{placeholders}; evolution = copy v1 → v2, edit, point the sweep at it. The
+old version's cells stay cached, only the new one bills. The run record is
+the "inputs/outputs in great detail" requirement: everything needed to
+reproduce or audit a cell rides in one JSON object.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
+SWEEPS_DIR = Path(__file__).resolve().parent / "sweeps"
+
+_REQUIRED_SWEEP_KEYS = ("name", "scenarios", "arms", "models", "variants", "judges")
+
+
+@dataclass(frozen=True)
+class Cell:
+    scenario_id: str
+    arm: str
+    model: str
+    variant: str  # prompt file stem, e.g. "recon_base.v1"
+    params: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def label(self) -> str:
+        return f"{self.scenario_id}/{self.arm}/{self.model}/{self.variant}"
+
+
+def load_sweep(path: Path) -> dict[str, Any]:
+    sweep = json.loads(path.read_text())
+    missing = [k for k in _REQUIRED_SWEEP_KEYS if k not in sweep]
+    if missing:
+        raise ValueError(f"sweep {path.name} missing keys: {missing}")
+    for k in ("scenarios", "arms", "models", "variants", "judges"):
+        if not isinstance(sweep[k], list) or not all(
+            isinstance(v, str) for v in sweep[k]
+        ):
+            raise ValueError(f"sweep {path.name}: '{k}' must be a list of strings")
+    sweep.setdefault("params", {})
+    sweep.setdefault("budget_usd", 3.0)
+    sweep.setdefault("composite_weights", {})
+    return sweep
+
+
+def expand_cells(sweep: dict[str, Any], scenario_ids: list[str]) -> list[Cell]:
+    """The full product — scenario order outermost so a budget-partial run
+    still covers whole scenarios before starting the next."""
+    return [
+        Cell(sid, arm, model, variant, dict(sweep.get("params", {})))
+        for sid in scenario_ids
+        for arm in sweep["arms"]
+        for model in sweep["models"]
+        for variant in sweep["variants"]
+    ]
+
+
+def load_prompt(variant: str, prompts_dir: Path | None = None) -> str:
+    p = (prompts_dir or PROMPTS_DIR) / f"{variant}.txt"
+    if not p.exists():
+        raise FileNotFoundError(
+            f"prompt variant '{variant}' not found at {p} — variants are "
+            "versioned files; copy an existing one and bump the version"
+        )
+    return p.read_text()
+
+
+class _StrictSlots(dict):
+    def __missing__(self, key: str) -> str:
+        raise KeyError(
+            f"prompt template references {{{key}}} but no value was provided"
+        )
+
+
+def render_prompt(template: str, **slots: str) -> str:
+    """Fill named {placeholders}; a referenced-but-missing slot raises (a
+    silently empty slot would bill a garbage cell)."""
+    return template.format_map(_StrictSlots(slots)).strip()
+
+
+def new_record(
+    cell: Cell,
+    *,
+    cell_id: str,
+    run_at: str,
+    prompt_sha: str,
+    desc_sha: str,
+    inputs: dict[str, Any],
+    outputs: dict[str, Any],
+    timing_s: dict[str, float],
+    cost_usd: dict[str, float],
+    scores: dict[str, float],
+    cache: dict[str, str],
+) -> dict[str, Any]:
+    cost = dict(cost_usd)
+    cost["total"] = round(sum(cost.values()), 6)
+    return {
+        "cell_key": cell_id,
+        "run_at": run_at,
+        "scenario_id": cell.scenario_id,
+        "arm": cell.arm,
+        "model": cell.model,
+        "prompt_variant": cell.variant,
+        "prompt_sha": prompt_sha,
+        "description_sha": desc_sha,
+        "params": cell.params,
+        "inputs": inputs,
+        "outputs": outputs,
+        "timing_s": {k: round(v, 3) for k, v in timing_s.items()},
+        "cost_usd": cost,
+        "scores": scores,
+        "cache": cache,
+    }
+
+
+_REQUIRED_RECORD_KEYS = (
+    "cell_key", "run_at", "scenario_id", "arm", "model", "prompt_variant",
+    "prompt_sha", "description_sha", "params", "inputs", "outputs",
+    "timing_s", "cost_usd", "scores", "cache",
+)
+
+
+def validate_record(record: dict[str, Any]) -> list[str]:
+    """Schema lint for tests + report ingestion: missing keys, not errors."""
+    return [k for k in _REQUIRED_RECORD_KEYS if k not in record]

--- a/apps/modal-backend/tests/matrix_bench/prompts/recon_base.v1.txt
+++ b/apps/modal-backend/tests/matrix_bench/prompts/recon_base.v1.txt
@@ -1,0 +1,9 @@
+A complete top-down illustrated map, drawn as {style}.
+
+{description}
+
+{layout_clause}
+
+Draw the WHOLE mapped area edge to edge — one coherent map sheet, nothing
+cut off, no collage panels. Flat overhead cartographic view, no perspective.
+Keep any lettering sparse and legible — no garbled text.

--- a/apps/modal-backend/tests/matrix_bench/runner.py
+++ b/apps/modal-backend/tests/matrix_bench/runner.py
@@ -1,0 +1,281 @@
+"""Matrix bench chassis — scenarios x arms x models x prompt-variants.
+
+DRY-RUN IS THE DEFAULT. Without MATRIX_BENCH_RUN=1 the runner walks the
+sweep, resolves the cache, prints the per-cell table (cached? / est $) and
+the total to-bill figure, touches no network, and exits 0 — that table is
+the mandatory cost preview AND the free CI smoke. With MATRIX_BENCH_RUN=1
+it runs uncached cells through injected gen/extract/judge functions, hard-
+capped by the budget ledger (charge BEFORE every paid call).
+
+Run it (standalone, .env auto-loaded, judge pinned to Gemini):
+    cd apps/modal-backend && .venv/bin/python -m tests.matrix_bench.runner
+or:  make eval-matrix-dry   /   make eval-matrix
+
+Scenario types plug in via `run_matrix(scenarios=...)` — the recon bench
+(tests/recon_bench) registers the map-corpus scenarios; the chassis itself
+is scenario-agnostic and fully testable with mock functions.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from tests.matrix_bench._budget import JUDGE_CALL_FLAT, BudgetExceeded, Ledger
+from tests.matrix_bench._cache import CellCache, cell_key, text_sha
+from tests.matrix_bench._record import (
+    SWEEPS_DIR,
+    Cell,
+    expand_cells,
+    load_prompt,
+    load_sweep,
+    new_record,
+)
+
+_REPORTS = Path(__file__).resolve().parent / "reports"
+
+# Extraction (detector + segmenter + view estimate) — flat, mirrors spend.py's
+# honest-coarse style.
+EXTRACT_FLAT = 0.01
+
+# gen_fn(cell, scenario_payload, prompt_template) -> {"jpeg": bytes,
+#   "model": str, "inputs": {...}}  (inputs = the rendered prompt + refs etc.)
+GenFn = Callable[[Cell, Any, str], dict[str, Any]]
+# judge_fn(cell, scenario_payload, jpeg) -> (score, cost_usd)
+JudgeFn = Callable[[Cell, Any, bytes], tuple[float, float]]
+# extract_fn(cell, scenario_payload, jpeg) -> (outputs dict, cost_usd)
+ExtractFn = Callable[[Cell, Any, bytes], tuple[dict[str, Any], float]]
+# score_fn(cell, scenario_payload, outputs, judge_scores) -> scores (incl composite)
+ScoreFn = Callable[[Cell, Any, dict[str, Any], dict[str, float]], dict[str, float]]
+
+
+@dataclass(frozen=True)
+class Scenario:
+    id: str
+    desc_sha: str  # digest of the scenario's ground truth — part of cell identity
+    payload: Any = None  # opaque to the chassis; scenario types interpret
+
+
+def estimate_cell(
+    cell: Cell, n_judges: int, has_extract: bool
+) -> float:
+    from providers import spend
+
+    return (
+        spend.estimate_image(cell.model)
+        + n_judges * JUDGE_CALL_FLAT
+        + (EXTRACT_FLAT if has_extract else 0.0)
+    )
+
+
+def _table(rows: list[tuple[Cell, bool, float]]) -> str:
+    lines = [f"{'cell':60} {'cached':>6} {'est $':>7}"]
+    for cell, cached, est in rows:
+        lines.append(f"{cell.label[:60]:60} {'yes' if cached else 'no':>6} {est:>7.3f}")
+    return "\n".join(lines)
+
+
+def run_matrix(
+    scenarios: list[Scenario],
+    sweep: dict[str, Any],
+    *,
+    gen_fn: GenFn,
+    judge_fns: dict[str, JudgeFn] | None = None,
+    extract_fn: ExtractFn | None = None,
+    score_fn: ScoreFn | None = None,
+    live: bool = False,
+    allow_partial: bool = False,
+    cache: CellCache | None = None,
+    ledger: Ledger | None = None,
+    prompts_dir: Path | None = None,
+    report_path: Path | None = None,
+    run_at: str = "",
+    log: Callable[[str], None] = print,
+) -> dict[str, Any]:
+    judge_fns = judge_fns or {}
+    missing_judges = [j for j in sweep["judges"] if j not in judge_fns]
+    if live and missing_judges:
+        raise ValueError(f"sweep names judges with no implementation: {missing_judges}")
+    cache = cache or CellCache()
+    by_id = {s.id: s for s in scenarios}
+    cells = expand_cells(sweep, [s.id for s in scenarios])
+
+    # Resolve every cell against the cache BEFORE any spend — the preview.
+    resolved: list[tuple[Cell, str, str, dict[str, Any] | None, float]] = []
+    for cell in cells:
+        template = load_prompt(cell.variant, prompts_dir)
+        psha = text_sha(template)
+        key = cell_key(
+            cell.scenario_id, by_id[cell.scenario_id].desc_sha,
+            cell.arm, cell.model, psha, cell.params,
+        )
+        cached = cache.load(key)
+        est = (
+            0.0
+            if cached is not None
+            else estimate_cell(cell, len(sweep["judges"]), extract_fn is not None)
+        )
+        resolved.append((cell, key, psha, cached, est))
+
+    to_bill = round(sum(est for *_, est in resolved), 4)
+    log(_table([(c, cached is not None, est) for c, _, _, cached, est in resolved]))
+    log(f"total to-bill: ${to_bill:.2f} ({sum(1 for *_, c, _ in resolved if c is None)} uncached cells)")
+
+    report: dict[str, Any] = {
+        "sweep": sweep["name"],
+        "run_at": run_at,
+        "live": live,
+        "to_bill_usd": to_bill,
+        "cells": [],
+        "stopped_reason": None,
+    }
+
+    if not live:
+        report["cells"] = [
+            cached
+            if cached is not None
+            else {"cell_key": key, "status": "would_run", "label": cell.label,
+                  "est_usd": round(est, 4)}
+            for cell, key, _, cached, est in resolved
+        ]
+        _write_report(report, report_path)
+        return report
+
+    ledger = ledger or Ledger(cap_usd=float(sweep["budget_usd"]))
+    if to_bill > ledger.remaining_usd + 1e-9 and not allow_partial:
+        raise BudgetExceeded(
+            f"sweep needs ${to_bill:.2f} but only ${ledger.remaining_usd:.2f} "
+            "remains under the cap — trim the sweep, raise MATRIX_BUDGET_USD, "
+            "or set MATRIX_ALLOW_PARTIAL=1 to run until the cap"
+        )
+
+    for cell, key, psha, cached, est in resolved:
+        if cached is not None:
+            report["cells"].append(cached)
+            continue
+        try:
+            ledger.charge(est)
+        except BudgetExceeded:
+            report["stopped_reason"] = f"budget exhausted before {cell.label}"
+            log(f"STOP: {report['stopped_reason']}")
+            break
+
+        scenario = by_id[cell.scenario_id]
+        template = load_prompt(cell.variant, prompts_dir)
+        timing: dict[str, float] = {}
+        cost: dict[str, float] = {}
+
+        t0 = time.monotonic()
+        gen = gen_fn(cell, scenario.payload, template)
+        timing["gen"] = time.monotonic() - t0
+        jpeg: bytes = gen["jpeg"]
+        from providers import spend
+
+        cost["image"] = spend.estimate_image(gen.get("model") or cell.model)
+
+        outputs: dict[str, Any] = {"model": gen.get("model") or cell.model}
+        if extract_fn is not None:
+            t0 = time.monotonic()
+            extracted, ex_cost = extract_fn(cell, scenario.payload, jpeg)
+            timing["extract"] = time.monotonic() - t0
+            cost["extract"] = ex_cost
+            outputs.update(extracted)
+
+        judge_scores: dict[str, float] = {}
+        t0 = time.monotonic()
+        judge_cost = 0.0
+        for name in sweep["judges"]:
+            score, j_cost = judge_fns[name](cell, scenario.payload, jpeg)
+            judge_scores[name] = score
+            judge_cost += j_cost
+        timing["judges"] = time.monotonic() - t0
+        cost["judges"] = judge_cost
+
+        scores = (
+            score_fn(cell, scenario.payload, outputs, judge_scores)
+            if score_fn is not None
+            else dict(judge_scores)
+        )
+
+        record = new_record(
+            cell,
+            cell_id=key,
+            run_at=run_at,
+            prompt_sha=psha,
+            desc_sha=scenario.desc_sha,
+            inputs=dict(gen.get("inputs", {})),
+            outputs=outputs,
+            timing_s=timing,
+            cost_usd=cost,
+            scores=scores,
+            cache={"image": "miss", "judges": "miss"},
+        )
+        cache.store(key, record, jpeg)
+        report["cells"].append(record)
+        log(f"ran {cell.label}: scores={scores} (${record['cost_usd']['total']:.3f})")
+
+    report["spent_usd"] = round(ledger.spent_usd, 4)
+    _write_report(report, report_path)
+    return report
+
+
+def _write_report(report: dict[str, Any], path: Path | None) -> None:
+    out = path or (_REPORTS / "matrix_latest.json")
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=1))
+
+
+def _load_env() -> None:
+    """Best-effort .env load + pin the judge to Gemini (not the .env's qwen
+    VLM, which rate-limits — see memory project_qwen_ratelimit)."""
+    env_path = Path(__file__).resolve().parents[2] / ".env"
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+    os.environ.setdefault("WORLD_BENCH_JUDGE_MODEL", "google/gemini-3-flash-preview")
+
+
+def main() -> int:
+    _load_env()
+    sweep_path = Path(os.environ.get("MATRIX_SWEEP", "")) if os.environ.get(
+        "MATRIX_SWEEP"
+    ) else SWEEPS_DIR / "default.json"
+    sweep = load_sweep(sweep_path)
+    if os.environ.get("MATRIX_BUDGET_USD"):
+        sweep["budget_usd"] = float(os.environ["MATRIX_BUDGET_USD"])
+
+    # Scenario providers register here as they land. "corpus:*" → the
+    # map-corpus reconstruction scenarios (tests/recon_bench, PR B4).
+    try:
+        from tests.recon_bench.runner import corpus_scenarios, recon_fns
+    except ImportError:
+        print(
+            "matrix: no scenario providers available yet — the recon bench "
+            "(tests/recon_bench) registers the map-corpus scenarios. "
+            "Sweep + cache + budget validated; nothing to run."
+        )
+        return 0
+
+    scenarios = corpus_scenarios(sweep["scenarios"])
+    fns = recon_fns(sweep)
+    report = run_matrix(
+        scenarios,
+        sweep,
+        live=os.environ.get("MATRIX_BENCH_RUN") == "1",
+        allow_partial=os.environ.get("MATRIX_ALLOW_PARTIAL") == "1",
+        run_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        **fns,
+    )
+    return 0 if report.get("stopped_reason") is None else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/modal-backend/tests/matrix_bench/sweeps/default.json
+++ b/apps/modal-backend/tests/matrix_bench/sweeps/default.json
@@ -1,0 +1,22 @@
+{
+  "name": "default",
+  "scenarios": ["corpus:*"],
+  "arms": ["graph"],
+  "models": [
+    "fal-ai/nano-banana",
+    "fal-ai/nano-banana-2",
+    "fal-ai/nano-banana-pro"
+  ],
+  "variants": ["recon_base.v1"],
+  "params": { "aspect_ratio": "16:9" },
+  "judges": ["style_pair", "map_plausibility", "prompt_alignment"],
+  "composite_weights": {
+    "presence": 0.2,
+    "pos_aligned": 0.25,
+    "size": 0.1,
+    "height_order": 0.15,
+    "style_pair": 0.15,
+    "map_plausibility": 0.15
+  },
+  "budget_usd": 3.0
+}

--- a/apps/modal-backend/tests/test_matrix_bench.py
+++ b/apps/modal-backend/tests/test_matrix_bench.py
@@ -1,0 +1,296 @@
+"""Matrix-bench chassis gate (free): cell identity, cache hit/miss, the
+budget refusal order (charge BEFORE the call), dry-run cost math, Pareto
+goldens, prompt rendering, and a full mock-provider end-to-end — the whole
+loop without spending a cent."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.matrix_bench._budget import BudgetExceeded, Ledger
+from tests.matrix_bench._cache import (
+    CellCache,
+    JudgeCache,
+    cell_key,
+    params_sha,
+)
+from tests.matrix_bench._pareto import (
+    aggregate_configs,
+    near_best_findings,
+    pareto_front,
+)
+from tests.matrix_bench._record import (
+    Cell,
+    expand_cells,
+    load_sweep,
+    render_prompt,
+    validate_record,
+)
+from tests.matrix_bench.runner import Scenario, run_matrix
+
+# --- cell identity ---------------------------------------------------------
+
+
+def test_cell_key_stable_golden() -> None:
+    """The key must NEVER drift across refactors — a drift invalidates every
+    cached cell and silently re-bills the whole matrix."""
+    key = cell_key("s1", "d" * 12, "graph", "fal-ai/nano-banana", "p" * 12, {"a": 1})
+    assert key == cell_key("s1", "d" * 12, "graph", "fal-ai/nano-banana", "p" * 12, {"a": 1})
+    assert len(key) == 20
+    assert key == "59a039bb0a00651525a2"
+
+
+def test_cell_key_sensitive_to_every_component() -> None:
+    base = ("s1", "d" * 12, "graph", "m", "p" * 12, {"a": 1})
+    k0 = cell_key(*base)
+    variants = [
+        ("s2", "d" * 12, "graph", "m", "p" * 12, {"a": 1}),
+        ("s1", "e" * 12, "graph", "m", "p" * 12, {"a": 1}),
+        ("s1", "d" * 12, "direct", "m", "p" * 12, {"a": 1}),
+        ("s1", "d" * 12, "graph", "m2", "p" * 12, {"a": 1}),
+        ("s1", "d" * 12, "graph", "m", "q" * 12, {"a": 1}),
+        ("s1", "d" * 12, "graph", "m", "p" * 12, {"a": 2}),
+    ]
+    assert all(cell_key(*v) != k0 for v in variants)
+
+
+def test_params_sha_order_insensitive() -> None:
+    assert params_sha({"a": 1, "b": 2}) == params_sha({"b": 2, "a": 1})
+
+
+# --- budget ----------------------------------------------------------------
+
+
+def test_ledger_charges_before_the_call_and_never_partially() -> None:
+    ledger = Ledger(cap_usd=1.0)
+    ledger.charge(0.6)
+    with pytest.raises(BudgetExceeded):
+        ledger.charge(0.5)  # would cross — refused BEFORE any spend
+    assert ledger.spent_usd == 0.6  # the failed charge mutated nothing
+    ledger.charge(0.4)  # exactly to the cap is fine
+    assert ledger.remaining_usd == 0.0
+
+
+# --- sweep / prompts -------------------------------------------------------
+
+
+def _sweep(**over: Any) -> dict[str, Any]:
+    s: dict[str, Any] = {
+        "name": "t",
+        "scenarios": ["corpus:*"],
+        "arms": ["graph"],
+        "models": ["fal-ai/nano-banana"],
+        "variants": ["v1"],
+        "judges": ["j"],
+        "params": {},
+        "budget_usd": 1.0,
+        "composite_weights": {},
+    }
+    s.update(over)
+    return s
+
+
+def test_load_sweep_validates(tmp_path: Path) -> None:
+    p = tmp_path / "bad.json"
+    p.write_text('{"name": "x"}')
+    with pytest.raises(ValueError, match="missing keys"):
+        load_sweep(p)
+
+
+def test_expand_cells_scenario_outermost() -> None:
+    cells = expand_cells(
+        _sweep(models=["m1", "m2"], variants=["v1", "v2"]), ["s1", "s2"]
+    )
+    assert len(cells) == 8
+    # Whole scenarios complete before the next starts (budget-partial runs
+    # then cover full scenarios, not a ragged diagonal).
+    assert [c.scenario_id for c in cells[:4]] == ["s1"] * 4
+
+
+def test_render_prompt_fills_and_rejects_missing() -> None:
+    assert render_prompt("map of {style}!", style="ink") == "map of ink!"
+    with pytest.raises(KeyError, match="style"):
+        render_prompt("map of {style}", description="x")
+
+
+# --- cache -----------------------------------------------------------------
+
+
+def test_cell_cache_roundtrip_and_corrupt_is_miss(tmp_path: Path) -> None:
+    cache = CellCache(tmp_path)
+    assert cache.load("k1") is None
+    cache.store("k1", {"cell_key": "k1"}, jpeg=b"\xff\xd8jpeg")
+    assert cache.load("k1") == {"cell_key": "k1"}
+    assert cache.image_path("k1").read_bytes() == b"\xff\xd8jpeg"
+    (tmp_path / "k1" / "record.json").write_text("{not json")
+    assert cache.load("k1") is None  # corrupt = miss, the cell just re-runs
+
+
+def test_judge_cache_roundtrip(tmp_path: Path) -> None:
+    jc = JudgeCache(tmp_path)
+    assert jc.load("j1") is None
+    jc.store("j1", {"score": 7.0})
+    assert jc.load("j1") == {"score": 7.0}
+
+
+# --- pareto ----------------------------------------------------------------
+
+
+def _rec(model: str, variant: str, quality: float, cost: float, lat: float) -> dict[str, Any]:
+    return {
+        "model": model,
+        "prompt_variant": variant,
+        "scores": {"composite": quality},
+        "cost_usd": {"total": cost},
+        "timing_s": {"gen": lat},
+    }
+
+
+def test_pareto_front_drops_dominated() -> None:
+    configs = aggregate_configs(
+        [
+            _rec("pro", "v1", 0.9, 0.15, 12.0),
+            _rec("nano", "v1", 0.85, 0.04, 5.0),
+            _rec("mid", "v1", 0.80, 0.08, 10.0),  # dominated by nano everywhere
+        ]
+    )
+    front = pareto_front(configs)
+    names = {c["model"] for c in front}
+    assert names == {"pro", "nano"}
+
+
+def test_near_best_findings_surfaces_the_tradeoff() -> None:
+    configs = aggregate_configs(
+        [
+            _rec("pro", "v1", 0.9, 0.15, 12.0),
+            _rec("nano", "v1", 0.85, 0.04, 5.0),
+        ]
+    )
+    findings = near_best_findings(configs)
+    assert len(findings) == 1
+    assert "nano @ v1" in findings[0]
+    assert "94% of the best" in findings[0]
+    assert "27% of its cost" in findings[0]
+
+
+# --- the loop, end to end (mock providers, $0) ------------------------------
+
+
+def _scenario() -> Scenario:
+    return Scenario(id="s1", desc_sha="d" * 12, payload={"style": "ink"})
+
+
+def _prompts(tmp_path: Path) -> Path:
+    d = tmp_path / "prompts"
+    d.mkdir()
+    (d / "v1.txt").write_text("map in {style}")
+    return d
+
+
+def test_dry_run_estimates_without_calling_anything(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    def gen(cell: Cell, payload: Any, template: str) -> dict[str, Any]:
+        calls.append("gen")
+        return {"jpeg": b"x", "model": cell.model, "inputs": {}}
+
+    report = run_matrix(
+        [_scenario()],
+        _sweep(),
+        gen_fn=gen,
+        judge_fns={"j": lambda c, p, b: (0.5, 0.005)},
+        live=False,
+        cache=CellCache(tmp_path / "cache"),
+        prompts_dir=_prompts(tmp_path),
+        report_path=tmp_path / "report.json",
+        log=lambda s: None,
+    )
+    assert calls == []  # dry-run touches nothing paid
+    assert report["live"] is False
+    # nano-banana $0.039 + 1 judge x $0.005
+    assert report["to_bill_usd"] == pytest.approx(0.044)
+    assert report["cells"][0]["status"] == "would_run"
+    assert (tmp_path / "report.json").exists()
+
+
+def test_live_mock_end_to_end_then_full_cache_hit(tmp_path: Path) -> None:
+    gen_calls: list[str] = []
+
+    def gen(cell: Cell, payload: Any, template: str) -> dict[str, Any]:
+        gen_calls.append(cell.label)
+        return {
+            "jpeg": b"\xff\xd8fake",
+            "model": cell.model,
+            "inputs": {"prompt_text": render_prompt(template, **payload)},
+        }
+
+    def judge(cell: Cell, payload: Any, jpeg: bytes) -> tuple[float, float]:
+        return 7.5, 0.005
+
+    def score(
+        cell: Cell, payload: Any, outputs: dict[str, Any], judges: dict[str, float]
+    ) -> dict[str, float]:
+        return {**judges, "composite": judges["j"] / 10.0}
+
+    kwargs: dict[str, Any] = dict(
+        gen_fn=gen,
+        judge_fns={"j": judge},
+        score_fn=score,
+        cache=CellCache(tmp_path / "cache"),
+        prompts_dir=_prompts(tmp_path),
+        report_path=tmp_path / "report.json",
+        run_at="2026-06-12T00:00:00Z",
+        log=lambda s: None,
+    )
+    first = run_matrix([_scenario()], _sweep(), live=True, **kwargs)
+    assert gen_calls == ["s1/graph/fal-ai/nano-banana/v1"]
+    rec = first["cells"][0]
+    assert validate_record(rec) == []
+    assert rec["scores"]["composite"] == pytest.approx(0.75)
+    assert rec["inputs"]["prompt_text"] == "map in ink"
+    assert rec["cost_usd"]["total"] == pytest.approx(0.039 + 0.005)
+    assert first["stopped_reason"] is None
+
+    second = run_matrix([_scenario()], _sweep(), live=True, **kwargs)
+    assert gen_calls == ["s1/graph/fal-ai/nano-banana/v1"]  # no re-bill
+    assert second["to_bill_usd"] == 0.0
+    assert second["cells"][0]["cell_key"] == rec["cell_key"]
+
+
+def test_preflight_refuses_over_cap_unless_partial(tmp_path: Path) -> None:
+    def gen(cell: Cell, payload: Any, template: str) -> dict[str, Any]:
+        return {"jpeg": b"x", "model": cell.model, "inputs": {}}
+
+    sweep = _sweep(models=["fal-ai/nano-banana-pro"], budget_usd=0.01)
+    kwargs: dict[str, Any] = dict(
+        gen_fn=gen,
+        judge_fns={"j": lambda c, p, b: (1.0, 0.005)},
+        cache=CellCache(tmp_path / "cache"),
+        prompts_dir=_prompts(tmp_path),
+        report_path=tmp_path / "report.json",
+        log=lambda s: None,
+    )
+    with pytest.raises(BudgetExceeded, match="trim the sweep"):
+        run_matrix([_scenario()], sweep, live=True, **kwargs)
+    # allow_partial runs to the cap, then stops with a reason — no raise.
+    report = run_matrix(
+        [_scenario()], sweep, live=True, allow_partial=True, **kwargs
+    )
+    assert report["stopped_reason"] is not None
+    assert report["cells"] == []
+
+
+def test_live_refuses_unimplemented_judges(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="no implementation"):
+        run_matrix(
+            [_scenario()],
+            _sweep(judges=["ghost"]),
+            gen_fn=lambda c, p, t: {"jpeg": b"x", "inputs": {}},
+            judge_fns={},
+            live=True,
+            cache=CellCache(tmp_path / "cache"),
+            prompts_dir=_prompts(tmp_path),
+            log=lambda s: None,
+        )


### PR DESCRIPTION
Track B, PR 1 of 5 (plan: world-mode reliability + evolvable eval system). $0 to validate — everything here is free-CI tested with mock providers.

## What it is

A scenario-agnostic eval chassis: **scenarios × arms × models × prompt-variants**, with the frugality guarantees designed in from the start:

- **Cell identity & cache**: `sha(scenario | desc_sha | arm | model | prompt_sha | params)` → `tests/matrix_bench/cache/<key>/{record.json,image.jpg}` (gitignored). Prompt evolution = copy `recon_base.v1.txt` → `v2`, edit, point the sweep at it — only changed cells re-bill; identical re-runs are 100% hits, $0.00.
- **Dry-run is the default**: without `MATRIX_BENCH_RUN=1` the runner prints the per-cell table (cached? / est $) + total to-bill and exits — the mandatory cost preview, also the free CI smoke (`make eval-matrix-dry`).
- **Hard budget cap**: `Ledger.charge()` runs BEFORE every paid call; default `MATRIX_BUDGET_USD=3.0`; pre-flight refuses over-cap sweeps unless `MATRIX_ALLOW_PARTIAL=1` (runs to the cap, writes a partial report with `stopped_reason`).
- **Detailed records per cell**: full inputs (rendered prompt + shas), outputs, per-stage timing, itemized cost, scores, cache status — the "inputs/outputs in great detail" requirement.
- **Pareto reporting primitives**: configs aggregate per (model, variant); non-dominated front on (quality, −cost, −latency); near-best findings like "nano @ v1: 94% of the best composite at 27% of its cost, 2.4× faster".

Estimates reuse `providers/spend.py`'s cost table; the CLI pins the judge to Gemini via `WORLD_BENCH_JUDGE_MODEL` (same `_load_env` trick as `layout_runner`, dodges the .env qwen rate-limit gotcha).

## What plugs in next
B2 segmenter+heights → B3 map corpus → B4 recon bench (registers `corpus:*` scenarios + real gen/judge fns) → B5 sweep report. Until B4 lands, `make eval-matrix-dry` validates sweep/cache/budget and exits cleanly.

## Verification
15 new free tests: cell-key stability golden (pinned hash — a drift would silently re-bill the whole matrix), key sensitivity to every component, ledger refusal order (charge-before-call, no partial mutation), dry-run cost math, cache roundtrip + corrupt-entry-is-miss, Pareto goldens, strict prompt rendering, full mock end-to-end → second run = all hits / $0. Full `pytest -m "not paid"`, repo `ruff`, `mypy` on the new modules: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)