### PR TITLE
feat(world): VLM polygon segmenter + anchored absolute heights

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,11 @@ eval-layout:
 # entities, diff vs intent → the grounded confirmation signal. PAID (fal + VLM).
 eval-grounding:
 	cd apps/modal-backend && .venv/bin/python -m tests.world_bench.grounding_runner
+# B2 segmenter smoke: VLM polygon borders + anchored absolute heights over a
+# few existing report JPGs — eyeball the output. PAID (~$0.05, Gemini only,
+# zero fal). Override images: SEGMENT_SMOKE_IMAGES=/path/a.jpg,...
+eval-segment-smoke:
+	cd apps/modal-backend && SEGMENT_BENCH_RUN=1 .venv/bin/python -m tests.world_bench.segment_smoke
 eval-repair:
 	cd apps/modal-backend && REPAIR_BENCH_RUN=1 .venv/bin/python -m pytest -m repair -q
 eval-edit:

--- a/apps/modal-backend/providers/heights.py
+++ b/apps/modal-backend/providers/heights.py
@@ -1,0 +1,196 @@
+"""Pure height inference + scoring — the segmenter's brain. No I/O.
+
+ABSOLUTE meters come from an ANCHORED RELATIVE LADDER, never from map
+pixels: map symbology draws buildings oversized (a house spans a district's
+worth of world units), so world-unit sizes are not metric. The segmenter
+gives each entity rel_height (0..1 of the tallest visible); ONE anchor with
+a known absolute height scales the whole ladder. Anchor resolution order:
+
+  1. an AUTHORED height (corpus ground truth / user-set) — most trusted;
+  2. a CATEGORY PRIOR (a person is ~1.7 m, a tower ~25 m);
+  3. the VLM's own est_height_m guesses (median entity) — last resort.
+
+scale_tier provides a sanity BAND only: flags, never silent clamps.
+"""
+from __future__ import annotations
+
+from math import log2
+from typing import TypedDict
+
+
+class HeightInput(TypedDict, total=False):
+    label: str
+    rel_height: float  # 0..1 of the tallest visible (segmenter output)
+    est_height_m: float | None  # the VLM's raw absolute guess
+    visual: str
+
+
+# Mirrors SCALE_TIER_METERS in packages/config (kept in sync by hand, like
+# model_router._SCALE_LADDER): the characteristic EXTENT of a frame at each
+# rung — the ceiling for how tall anything inside it can plausibly be.
+_TIER_METERS: dict[str, float] = {
+    "universe": 8.8e26,
+    "galaxy": 9.5e20,
+    "star_system": 1.5e13,
+    "planet": 1.3e7,
+    "world": 1.3e7,
+    "region": 3e5,
+    "city": 1.5e4,
+    "district": 1.5e3,
+    "place": 1.2e2,
+    "room": 1.0e1,
+    "object": 1.0e0,
+}
+
+# Keyword → meters, FIRST match wins (ordered specific → generic). Coarse on
+# purpose: the prior anchors a ladder, it doesn't measure a building.
+CATEGORY_PRIORS: tuple[tuple[str, float], ...] = (
+    ("person", 1.7),
+    ("figure", 1.7),
+    ("door", 2.1),
+    ("lighthouse", 30.0),
+    ("skyscraper", 150.0),
+    ("cathedral", 40.0),
+    ("church", 20.0),
+    ("temple", 18.0),
+    ("tower", 25.0),
+    ("castle", 20.0),
+    ("palace", 18.0),
+    ("fortress", 15.0),
+    ("hall", 12.0),
+    ("warehouse", 10.0),
+    ("tavern", 8.0),
+    ("house", 8.0),
+    ("shop", 8.0),
+    ("hut", 4.0),
+    ("cottage", 5.0),
+    ("tent", 3.0),
+    ("gate", 8.0),
+    ("wall", 6.0),
+    ("bridge", 10.0),
+    ("fountain", 5.0),
+    ("statue", 6.0),
+    ("ship", 15.0),
+    ("boat", 4.0),
+    ("tree", 12.0),
+    ("forest", 15.0),
+    ("hill", 60.0),
+    ("mountain", 800.0),
+)
+
+
+def prior_height_m(label: str, visual: str = "") -> float | None:
+    """Category prior for an entity, by keyword over label + appearance."""
+    text = f"{label} {visual}".lower()
+    for keyword, meters in CATEGORY_PRIORS:
+        if keyword in text:
+            return meters
+    return None
+
+
+def resolve_anchor(
+    entities: list[HeightInput],
+    authored: dict[str, float] | None = None,
+) -> tuple[str, float, float] | None:
+    """(anchor_label, anchor_height_m, anchor_rel) or None when nothing in
+    the frame carries a usable absolute. Order: authored > prior > VLM est."""
+    usable = [e for e in entities if float(e.get("rel_height", 0.0)) > 0.0]
+    if authored:
+        for e in usable:
+            label = str(e.get("label", ""))
+            if label in authored and authored[label] > 0:
+                return label, authored[label], float(e["rel_height"])
+    for e in usable:
+        prior = prior_height_m(str(e.get("label", "")), str(e.get("visual", "")))
+        if prior is not None:
+            return str(e["label"]), prior, float(e["rel_height"])
+    with_est = [
+        e for e in usable
+        if isinstance(e.get("est_height_m"), (int, float)) and float(e["est_height_m"] or 0) > 0
+    ]
+    if with_est:
+        with_est.sort(key=lambda e: float(e["est_height_m"] or 0))
+        mid = with_est[len(with_est) // 2]
+        return str(mid["label"]), float(mid["est_height_m"] or 0), float(mid["rel_height"])
+    return None
+
+
+def infer_heights_m(
+    entities: list[HeightInput],
+    authored: dict[str, float] | None = None,
+) -> dict[str, float]:
+    """Absolute meters per label: the relative ladder scaled off one anchor.
+    Entities with rel_height 0 (the segmenter saw no height) are skipped.
+    No anchor at all → fall back to each entity's own raw est_height_m."""
+    anchor = resolve_anchor(entities, authored)
+    out: dict[str, float] = {}
+    if anchor is None:
+        for e in entities:
+            est = e.get("est_height_m")
+            if isinstance(est, (int, float)) and est > 0:
+                out[str(e["label"])] = float(est)
+        return out
+    _, anchor_m, anchor_rel = anchor
+    for e in entities:
+        rel = float(e.get("rel_height", 0.0))
+        if rel <= 0.0:
+            continue
+        out[str(e["label"])] = anchor_m * (rel / anchor_rel)
+    return out
+
+
+def tier_sanity_band(scale_tier: str | None) -> tuple[float, float]:
+    """Plausible absolute heights for entities INSIDE a frame at this rung —
+    the ceiling is the rung's characteristic extent (a `place`-tier courtyard
+    can't contain a 5 km spire). Unknown tier → effectively unbounded."""
+    ceiling = _TIER_METERS.get(scale_tier or "")
+    return (0.1, ceiling) if ceiling else (0.1, float("inf"))
+
+
+def flag_implausible(
+    heights_m: dict[str, float], scale_tier: str | None
+) -> list[str]:
+    """Human-readable flags for heights outside the tier band. Flags only —
+    the caller decides; nothing is clamped silently."""
+    lo, hi = tier_sanity_band(scale_tier)
+    return [
+        f"{label}: {h:.1f} m outside [{lo:.1f}, {hi:.1f}] for tier "
+        f"{scale_tier or '?'}"
+        for label, h in sorted(heights_m.items())
+        if not (lo <= h <= hi)
+    ]
+
+
+def height_order_score(
+    expected_m: dict[str, float], observed_m: dict[str, float]
+) -> float:
+    """Pairwise order agreement over labels present in BOTH (is the tower
+    still taller than the house?). Expected ties are skipped. Fewer than 2
+    comparable labels → 0.0: nothing demonstrably right earns no credit."""
+    common = sorted(set(expected_m) & set(observed_m))
+    agree = total = 0
+    for i, a in enumerate(common):
+        for b in common[i + 1:]:
+            if expected_m[a] == expected_m[b]:
+                continue
+            total += 1
+            if (expected_m[a] > expected_m[b]) == (observed_m[a] > observed_m[b]):
+                agree += 1
+    return agree / total if total else 0.0
+
+
+def height_abs_score(
+    expected_m: dict[str, float], observed_m: dict[str, float]
+) -> float:
+    """Fraction of common labels whose absolute height lands within x2 of
+    ground truth (|log2(obs/exp)| <= 1) — generous on purpose; absolute
+    height from one image is an estimate, not a measurement. No common
+    labels → 0.0."""
+    common = [
+        k for k in expected_m
+        if k in observed_m and expected_m[k] > 0 and observed_m[k] > 0
+    ]
+    if not common:
+        return 0.0
+    hits = sum(1 for k in common if abs(log2(observed_m[k] / expected_m[k])) <= 1.0)
+    return hits / len(common)

--- a/apps/modal-backend/providers/segmenter.py
+++ b/apps/modal-backend/providers/segmenter.py
@@ -1,0 +1,153 @@
+"""VLM polygon segmentation + relative heights (B2 segmenter).
+
+Same shape as detector.py, one level richer: instead of a box per label, the
+VLM traces each visible target's BORDER as a closed polygon and ranks its
+apparent built height. Polygons are normalized 0..1 image coords, 3..24
+vertices; rel_height is 0..1 of the tallest visible target; est_height_m is
+the VLM's own absolute guess (anchoring happens in providers/heights.py, not
+here). Tolerant parse: a malformed entry is dropped, never raises.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+from typing import Any, TypedDict
+
+
+class SegmentEntity(TypedDict):
+    label: str
+    polygon: list[list[float]]  # [[x, y], ...] normalized 0..1, 3..24 vertices
+    rel_height: float  # 0..1 vs the tallest visible target
+    est_height_m: float | None  # the VLM's raw absolute guess, meters
+    score: float
+
+
+MAX_VERTICES = 24
+MIN_VERTICES = 3
+
+
+def _segmenter_model() -> str:
+    return os.environ.get(
+        "WORLD_BENCH_JUDGE_MODEL",
+        os.environ.get("OPENROUTER_VLM_MODEL", "google/gemini-3-flash-preview"),
+    )
+
+
+def _clamp01(v: Any) -> float:
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, min(1.0, f))
+
+
+def _parse_vertices(raw: Any) -> list[list[float]]:
+    """Coerce a polygon reply into clamped [[x, y], ...]: accepts [x,y] pairs
+    or {x,y} dicts, drops malformed vertices and consecutive duplicates
+    (including a closing vertex equal to the first)."""
+    if not isinstance(raw, list):
+        return []
+    verts: list[list[float]] = []
+    for v in raw:
+        if isinstance(v, (list, tuple)) and len(v) >= 2:
+            vert = [_clamp01(v[0]), _clamp01(v[1])]
+        elif isinstance(v, dict) and "x" in v and "y" in v:
+            vert = [_clamp01(v["x"]), _clamp01(v["y"])]
+        else:
+            continue
+        if verts and vert == verts[-1]:
+            continue
+        verts.append(vert)
+    if len(verts) > 1 and verts[0] == verts[-1]:
+        verts.pop()
+    return verts[:MAX_VERTICES]
+
+
+def parse_segments(payload: Any) -> list[SegmentEntity]:
+    """Coerce a VLM segmentation reply. Tolerant: entries with a blank label
+    or a degenerate polygon (<3 usable vertices) are dropped (never raises)."""
+    if isinstance(payload, dict):
+        payload = payload.get("segments") or payload.get("entities") or []
+    if not isinstance(payload, list):
+        return []
+    out: list[SegmentEntity] = []
+    for s in payload:
+        if not isinstance(s, dict):
+            continue
+        label = str(s.get("label", "")).strip()
+        if not label:
+            continue
+        polygon = _parse_vertices(s.get("polygon") or s.get("border"))
+        if len(polygon) < MIN_VERTICES:
+            continue
+        est_raw = s.get("est_height_m")
+        try:
+            est = float(est_raw) if est_raw is not None else None
+        except (TypeError, ValueError):
+            est = None
+        if est is not None and est <= 0:
+            est = None
+        out.append(
+            {
+                "label": label,
+                "polygon": polygon,
+                "rel_height": _clamp01(s.get("rel_height", 0.0)),
+                "est_height_m": est,
+                "score": _clamp01(s.get("score", 1.0)),
+            }
+        )
+    return out
+
+
+async def segment(image_bytes: bytes, labels: list[str]) -> list[SegmentEntity]:
+    """Segment the given labels in the image: one closed border polygon +
+    height ranking per label actually present (the VLM is told NOT to invent
+    absent labels). One call covers all labels."""
+    from providers import llm
+
+    b64 = base64.b64encode(image_bytes).decode("ascii")
+    system = (
+        "You segment buildings and landmarks in illustrated maps and scenes. "
+        "For EACH target label actually visible, trace its outer border as ONE "
+        "closed polygon of 6-16 vertices (normalized 0..1 image coordinates, "
+        "clockwise), judge rel_height = its apparent BUILT height relative to "
+        "the tallest visible target (the tallest gets 1.0), and est_height_m = "
+        "your best absolute height guess in meters from the entity's category "
+        "and the image's scale cues. OMIT labels that are absent; do NOT "
+        "invent them. Return JSON exactly: "
+        '{"segments":[{"label":..,"polygon":[[x,y],..],"rel_height":..,'
+        '"est_height_m":..,"score":..}]}.'
+    )
+    user = "Target labels: " + ", ".join(labels) + ". Segment them in the image."
+    model = _segmenter_model()
+    client = llm._client()
+    messages: list[Any] = [
+        {"role": "system", "content": system},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": user},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/jpeg;base64,{b64}",
+                        "detail": "low",
+                    },
+                },
+            ],
+        },
+    ]
+    resp = await client.chat.completions.create(
+        model=model,
+        messages=messages,
+        temperature=0.0,
+        max_tokens=1400,
+        **llm._maybe_response_format(model),
+    )
+    raw = resp.choices[0].message.content or "{}"
+    try:
+        payload = json.loads(raw[raw.find("{") : raw.rfind("}") + 1])
+    except Exception:
+        return []
+    return parse_segments(payload)

--- a/apps/modal-backend/tests/test_heights.py
+++ b/apps/modal-backend/tests/test_heights.py
@@ -1,0 +1,104 @@
+"""Heights gate (free): anchor resolution order (authored > prior > VLM
+median), the anchored relative ladder, tier sanity bands (flags, never
+clamps), and the two scoring metrics the recon bench consumes."""
+from __future__ import annotations
+
+from providers.heights import (
+    flag_implausible,
+    height_abs_score,
+    height_order_score,
+    infer_heights_m,
+    prior_height_m,
+    resolve_anchor,
+    tier_sanity_band,
+)
+
+
+def _e(label: str, rel: float, est: float | None = None, visual: str = "") -> dict:
+    return {"label": label, "rel_height": rel, "est_height_m": est, "visual": visual}
+
+
+# --- anchor resolution -------------------------------------------------------
+
+
+def test_authored_beats_prior_beats_est() -> None:
+    entities = [
+        _e("watchtower", 1.0, est=99.0),  # has a category prior (tower)
+        _e("mystery blob", 0.5, est=10.0),
+    ]
+    # authored wins
+    assert resolve_anchor(entities, {"watchtower": 30.0}) == ("watchtower", 30.0, 1.0)
+    # no authored → category prior
+    assert resolve_anchor(entities) == ("watchtower", 25.0, 1.0)
+    # no prior anywhere → the VLM's own estimate (median entity)
+    blobs = [_e("blob a", 1.0, est=20.0), _e("blob b", 0.5, est=8.0)]
+    label, meters, _rel = resolve_anchor(blobs) or ("", 0.0, 0.0)
+    assert (label, meters) in {("blob a", 20.0), ("blob b", 8.0)}
+    # nothing usable → None
+    assert resolve_anchor([_e("blob", 0.0)]) is None
+
+
+def test_prior_matches_label_or_visual() -> None:
+    assert prior_height_m("The Old Mill") is None
+    assert prior_height_m("The Old Mill", "a squat stone tower with sails") == 25.0
+    assert prior_height_m("a person") == 1.7
+
+
+# --- the ladder --------------------------------------------------------------
+
+
+def test_infer_heights_scales_the_ladder_off_the_anchor() -> None:
+    entities = [
+        _e("tower", 1.0),  # prior anchor: 25 m
+        _e("house", 0.32),
+        _e("flat plaza", 0.0),  # no height read → skipped
+    ]
+    heights = infer_heights_m(entities)
+    assert heights["tower"] == 25.0
+    assert heights["house"] == 25.0 * 0.32
+    assert "flat plaza" not in heights
+
+
+def test_infer_heights_authored_anchor_rescales_everything() -> None:
+    entities = [_e("keep", 1.0), _e("gatehouse", 0.5)]
+    heights = infer_heights_m(entities, {"keep": 40.0})
+    assert heights == {"keep": 40.0, "gatehouse": 20.0}
+
+
+def test_infer_heights_no_anchor_falls_back_to_raw_estimates() -> None:
+    entities = [_e("blob", 0.0, est=7.0), _e("smudge", 0.0)]
+    assert infer_heights_m(entities) == {"blob": 7.0}
+
+
+# --- sanity bands ------------------------------------------------------------
+
+
+def test_tier_band_flags_but_never_clamps() -> None:
+    lo, hi = tier_sanity_band("place")
+    assert (lo, hi) == (0.1, 120.0)
+    assert tier_sanity_band(None)[1] == float("inf")
+    flags = flag_implausible({"spire": 5000.0, "hut": 4.0}, "place")
+    assert len(flags) == 1 and "spire" in flags[0] and "place" in flags[0]
+    # the value itself is untouched — the caller decides
+    assert flag_implausible({"hut": 4.0}, "place") == []
+
+
+# --- scoring -----------------------------------------------------------------
+
+
+def test_height_order_score_pairwise_agreement() -> None:
+    expected = {"tower": 25.0, "house": 8.0, "hut": 4.0}
+    assert height_order_score(expected, {"tower": 30.0, "house": 10.0, "hut": 2.0}) == 1.0
+    # the tower↔house pair inverts; the other two pairs still agree
+    swapped = {"tower": 5.0, "house": 10.0, "hut": 2.0}
+    assert height_order_score(expected, swapped) == 2 / 3
+    # fewer than 2 comparable labels → no credit
+    assert height_order_score(expected, {"tower": 30.0}) == 0.0
+    assert height_order_score({}, {}) == 0.0
+
+
+def test_height_abs_score_within_2x_in_log_space() -> None:
+    expected = {"tower": 25.0, "house": 8.0}
+    assert height_abs_score(expected, {"tower": 49.0, "house": 4.1}) == 1.0  # both within x2
+    assert height_abs_score(expected, {"tower": 51.0, "house": 8.0}) == 0.5  # tower busts x2
+    assert height_abs_score(expected, {}) == 0.0

--- a/apps/modal-backend/tests/test_segmenter.py
+++ b/apps/modal-backend/tests/test_segmenter.py
@@ -1,0 +1,79 @@
+"""Segmenter parse gate (free): garbage polygons dropped, vertices clamped
+and deduped, height fields coerced — the tolerant-parse contract that lets
+the VLM reply be sloppy without ever raising."""
+from __future__ import annotations
+
+from providers.segmenter import MAX_VERTICES, parse_segments
+
+
+def _seg(**over: object) -> dict[str, object]:
+    s: dict[str, object] = {
+        "label": "tower",
+        "polygon": [[0.1, 0.1], [0.3, 0.1], [0.3, 0.4], [0.1, 0.4]],
+        "rel_height": 1.0,
+        "est_height_m": 25,
+        "score": 0.9,
+    }
+    s.update(over)
+    return s
+
+
+def test_parses_a_clean_reply() -> None:
+    out = parse_segments({"segments": [_seg()]})
+    assert len(out) == 1
+    s = out[0]
+    assert s["label"] == "tower"
+    assert s["polygon"] == [[0.1, 0.1], [0.3, 0.1], [0.3, 0.4], [0.1, 0.4]]
+    assert s["rel_height"] == 1.0
+    assert s["est_height_m"] == 25.0
+    assert s["score"] == 0.9
+
+
+def test_accepts_xy_dict_vertices_and_border_alias() -> None:
+    out = parse_segments(
+        {"segments": [_seg(polygon=None, border=[{"x": 0, "y": 0}, {"x": 1, "y": 0}, {"x": 1, "y": 1}])]}
+    )
+    assert out[0]["polygon"] == [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]]
+
+
+def test_drops_degenerate_and_blank_entries_never_raises() -> None:
+    out = parse_segments(
+        {
+            "segments": [
+                _seg(label="  "),  # blank label
+                _seg(polygon=[[0.1, 0.1], [0.2, 0.2]]),  # <3 vertices
+                _seg(polygon="not a list"),
+                "not a dict",
+                _seg(label="keeper"),
+            ]
+        }
+    )
+    assert [s["label"] for s in out] == ["keeper"]
+    assert parse_segments(None) == []
+    assert parse_segments({"weird": True}) == []
+
+
+def test_clamps_dedupes_and_caps_vertices() -> None:
+    ring = [[0.0, 0.0], [0.0, 0.0], [2.0, -1.0], [0.5, 0.5], [0.0, 0.0]]
+    out = parse_segments({"segments": [_seg(polygon=ring)]})
+    # consecutive dupe dropped, coords clamped to 0..1, closing vertex == first dropped
+    assert out[0]["polygon"] == [[0.0, 0.0], [1.0, 0.0], [0.5, 0.5]]
+    big = [[i / 100, i / 100] for i in range(40)]
+    out = parse_segments({"segments": [_seg(polygon=big)]})
+    assert len(out[0]["polygon"]) == MAX_VERTICES
+
+
+def test_height_fields_coerced() -> None:
+    out = parse_segments(
+        {
+            "segments": [
+                _seg(label="a", rel_height=3.0, est_height_m="not a number"),
+                _seg(label="b", rel_height=-1, est_height_m=-5),
+                _seg(label="c", rel_height="0.5", est_height_m="12.5"),
+            ]
+        }
+    )
+    by = {s["label"]: s for s in out}
+    assert by["a"]["rel_height"] == 1.0 and by["a"]["est_height_m"] is None
+    assert by["b"]["rel_height"] == 0.0 and by["b"]["est_height_m"] is None
+    assert by["c"]["rel_height"] == 0.5 and by["c"]["est_height_m"] == 12.5

--- a/apps/modal-backend/tests/world_bench/segment_smoke.py
+++ b/apps/modal-backend/tests/world_bench/segment_smoke.py
@@ -1,0 +1,106 @@
+"""Segmenter smoke — eyeball the polygons + anchored heights on real images.
+
+VLM-only (zero fal): runs `segment()` over up to 3 existing report JPGs
+(any prior paid bench leaves some in tests/*/reports/), infers absolute
+heights off the anchored ladder, flags tier-implausible values, and writes
+everything to reports/segment_smoke_latest.json for a human look.
+
+Run (PAID, ~$0.02-0.05 — a few Gemini calls):
+    SEGMENT_BENCH_RUN=1 .venv/bin/python -m tests.world_bench.segment_smoke
+or:  make eval-segment-smoke
+Override the image set: SEGMENT_SMOKE_IMAGES=/path/a.jpg,/path/b.jpg
+Labels default to a generic landmark set; override: SEGMENT_SMOKE_LABELS=a,b
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+
+_TESTS = Path(__file__).resolve().parents[1]
+_REPORT = Path(__file__).resolve().parent / "reports" / "segment_smoke_latest.json"
+
+_DEFAULT_LABELS = [
+    "tower", "castle", "palace", "bridge", "house", "church",
+    "river", "wall", "gate", "ship",
+]
+
+
+def _load_env() -> None:
+    env_path = Path(__file__).resolve().parents[2] / ".env"
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+    os.environ.setdefault("WORLD_BENCH_JUDGE_MODEL", "google/gemini-3-flash-preview")
+
+
+def _images() -> list[Path]:
+    override = os.environ.get("SEGMENT_SMOKE_IMAGES", "")
+    if override:
+        return [Path(p) for p in override.split(",") if Path(p).exists()]
+    found = sorted(_TESTS.glob("*/reports/*.jpg"))
+    return found[:3]
+
+
+async def _run() -> int:
+    from providers import heights
+    from providers.segmenter import segment
+
+    labels = [
+        s.strip()
+        for s in os.environ.get("SEGMENT_SMOKE_LABELS", "").split(",")
+        if s.strip()
+    ] or _DEFAULT_LABELS
+    images = _images()
+    if not images:
+        print(
+            "segment-smoke: no report JPGs found — run any paid bench first "
+            "(e.g. make eval-enter-drift) or set SEGMENT_SMOKE_IMAGES=/path.jpg"
+        )
+        return 1
+
+    results = []
+    for img in images:
+        segs = await segment(img.read_bytes(), labels)
+        inferred = heights.infer_heights_m(list(segs))
+        flags = heights.flag_implausible(inferred, "city")
+        results.append(
+            {
+                "image": str(img),
+                "segments": segs,
+                "heights_m": inferred,
+                "tier_flags": flags,
+            }
+        )
+        print(f"{img.name}: {len(segs)} segments")
+        for s in segs:
+            h = inferred.get(s["label"])
+            print(
+                f"  {s['label']}: {len(s['polygon'])} verts, "
+                f"rel={s['rel_height']:.2f}, est={s['est_height_m']}, "
+                f"inferred={f'{h:.1f} m' if h else '-'}"
+            )
+        for f in flags:
+            print(f"  FLAG: {f}")
+
+    _REPORT.parent.mkdir(parents=True, exist_ok=True)
+    _REPORT.write_text(json.dumps(results, indent=1))
+    print(f"wrote {_REPORT}")
+    return 0
+
+
+def main() -> int:
+    if os.environ.get("SEGMENT_BENCH_RUN") != "1":
+        print("segment-smoke: PAID (a few Gemini calls). Set SEGMENT_BENCH_RUN=1 to run.")
+        return 0
+    _load_env()
+    return asyncio.run(_run())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/web/lib/world-geo-schema.test.ts
+++ b/apps/web/lib/world-geo-schema.test.ts
@@ -83,6 +83,13 @@ const worldEntityGeo: WorldEntityGeo = {
   confidence: 0.9,
   source: "user",
   updated_at: "2026-06-06T00:00:00Z",
+  border: [
+    { x: 8, y: 18 },
+    { x: 12, y: 18 },
+    { x: 12, y: 22 },
+    { x: 8, y: 22 },
+  ],
+  height_m: 30,
 };
 const worldMapSnapshot: WorldMapSnapshot = {
   session_id: "s1",

--- a/apps/web/lib/world-geometry-seed.test.ts
+++ b/apps/web/lib/world-geometry-seed.test.ts
@@ -4,6 +4,7 @@ import type { EntityBBox, ObserverPose, SceneView } from "@openflipbook/config";
 
 import {
   estimateGeoFromBBox,
+  mapPolygonToCrop,
   project,
   type ProjectInput,
 } from "./world-geometry";
@@ -117,5 +118,27 @@ describe("estimateGeoFromBBox (seeding bridge)", () => {
     const g = estimateGeoFromBBox(bbox, view, ASPECT);
     expect(g.pos.x).toBeCloseTo(60, 4);
     expect(g.pos.y).toBeCloseTo(20, 4);
+  });
+});
+
+describe("mapPolygonToCrop (B2 segmenter border -> frame coords)", () => {
+  it("maps 0..1 image vertices through the same linear map a bbox centre takes", () => {
+    const crop = { x: 0, y: 0, w: 100, h: 60 };
+    const out = mapPolygonToCrop(
+      [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+        { x: 0.5, y: 0.5 },
+      ],
+      crop,
+    );
+    expect(out).toEqual([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 50, y: 30 },
+    ]);
+    // and through an offset submap crop
+    const sub = mapPolygonToCrop([{ x: 0.5, y: 0.5 }], { x: 40, y: 20, w: 30, h: 20 });
+    expect(sub).toEqual([{ x: 55, y: 30 }]);
   });
 });

--- a/apps/web/lib/world-geometry.ts
+++ b/apps/web/lib/world-geometry.ts
@@ -159,6 +159,19 @@ export function projectTopDown(
   return out;
 }
 
+/** Map a normalized image-space polygon (0..1, as the segmenter traces it)
+ *  into the frame the entities are seeded in — the same linear map a bbox
+ *  centre takes on a top-down map frame (estimateGeoFromBBox). Pure. */
+export function mapPolygonToCrop(
+  polygon: WorldVec2[],
+  crop: MapCrop,
+): WorldVec2[] {
+  return polygon.map((v) => ({
+    x: crop.x + v.x * crop.w,
+    y: crop.y + v.y * crop.h,
+  }));
+}
+
 export function cropEntities<T extends ProjectInput>(
   entities: T[],
   crop: MapCrop,

--- a/apps/web/lib/world-map.ts
+++ b/apps/web/lib/world-map.ts
@@ -11,14 +11,17 @@ import type {
   ViewProjection,
   WorldEntityGeo,
   WorldMapSnapshot,
+  WorldVec2,
 } from "@openflipbook/config";
 import { tierStep } from "@openflipbook/config";
 
 import { getDb } from "./db";
+import { envFlag } from "./env-flag";
 import { optimisticReplace } from "./optimistic-update";
 import {
   estimateGeoFromBBox,
   localExtent,
+  mapPolygonToCrop,
   resolveAbsolutePos,
   siblingsOf,
   type FrameNode,
@@ -356,6 +359,12 @@ export interface ExtractedGeoItem {
   visual?: string;
   state?: EntityState;
   confidence?: number;
+  // B2 segmenter (optional): the entity's border polygon in normalized IMAGE
+  // space (0..1, as the segmenter returns it) + the inferred ABSOLUTE height
+  // in meters. Persisted only when WORLD_SEGMENT_BORDERS is on; borders only
+  // on top-down map frames, where the image→frame mapping is linear.
+  border?: WorldVec2[];
+  height_m?: number;
 }
 
 /** Map an extraction pass (entities that have a bbox on this scene) into derived
@@ -376,6 +385,8 @@ export async function deriveGeoFromExtraction(
   scaleTier?: ScaleTier,
 ): Promise<WorldMapSnapshot> {
   const nowIso = new Date().toISOString();
+  // B2 segmenter persistence — storage only, nothing renders these yet.
+  const bordersOn = envFlag("WORLD_SEGMENT_BORDERS");
   const geos: WorldEntityGeo[] = items.map((item) => {
     const est = estimateGeoFromBBox(item.bbox, view, aspect, projection, pitchDeg);
     return {
@@ -388,6 +399,17 @@ export async function deriveGeoFromExtraction(
       height: est.height,
       footprint: est.footprint,
       ...(scaleTier ? { scale_tier: scaleTier } : {}),
+      ...(bordersOn &&
+      item.border &&
+      item.border.length >= 3 &&
+      projection === "top_down" &&
+      view.level === "map" &&
+      view.map_crop
+        ? { border: mapPolygonToCrop(item.border, view.map_crop) }
+        : {}),
+      ...(bordersOn && item.height_m && item.height_m > 0
+        ? { height_m: item.height_m }
+        : {}),
       visual: item.visual ?? "",
       state: item.state ?? {},
       // Derived placements are discounted so a later user/extracted write wins.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -586,6 +586,14 @@ export interface WorldEntityGeo {
   // (a confirmed detection), or "derived" (back-projected from a bbox â a guess).
   source: "extracted" | "user" | "derived";
   updated_at: string;
+  // VLM-segmented border polygon (B2 segmenter), in the SAME frame as `pos`
+  // (the parent's local frame). 3..24 vertices; absent = only the rectangular
+  // footprint is known. Persisted behind WORLD_SEGMENT_BORDERS.
+  border?: WorldVec2[];
+  // Inferred ABSOLUTE height in meters - from the segmenter's anchored
+  // relative ladder, NOT from map pixels (map symbology is not metric).
+  // Distinct from `height` (relative world units). Absent = not inferred.
+  height_m?: number;
 }
 
 // Where the camera stands for a scene. Null observer â a top-down map view.

--- a/packages/config/src/world-geo-fixture.json
+++ b/packages/config/src/world-geo-fixture.json
@@ -2,7 +2,7 @@
   "_comment": "Single source of truth for the geometric-world wire shapes. The P0 schema-parity gate (apps/web/lib/world-geo-schema.test.ts + apps/modal-backend/tests/test_geo_schema.py) asserts both the TS interfaces and the Pydantic mirrors match these key sets. Edit here when a shape changes; both gates will fail until both sides follow.",
   "keys": {
     "WorldVec2": ["x", "y"],
-    "WorldEntityGeo": ["id", "entity_id", "kind", "label", "pos", "height", "elevation", "footprint", "scale", "scale_tier", "heading", "visual", "state", "confidence", "source", "updated_at"],
+    "WorldEntityGeo": ["id", "entity_id", "kind", "label", "pos", "height", "elevation", "footprint", "scale", "scale_tier", "heading", "visual", "state", "confidence", "source", "updated_at", "border", "height_m"],
     "ObserverPose": ["pos", "eye_height", "gaze", "pitch", "fov"],
     "MapCrop": ["x", "y", "w", "h"],
     "ViewSpec": ["projection", "pitch_deg", "azimuth_deg", "camera_height", "fov_deg", "source"],
@@ -29,7 +29,14 @@
       "state": { "lit": true },
       "confidence": 0.9,
       "source": "user",
-      "updated_at": "2026-06-06T00:00:00Z"
+      "updated_at": "2026-06-06T00:00:00Z",
+      "border": [
+        { "x": 8, "y": 18 },
+        { "x": 12, "y": 18 },
+        { "x": 12, "y": 22 },
+        { "x": 8, "y": 22 }
+      ],
+      "height_m": 30
     },
     "ObserverPose": { "pos": { "x": 0, "y": 0 }, "eye_height": 1.7, "gaze": 0, "pitch": 0, "fov": 1.2 },
     "MapCrop": { "x": 0, "y": 0, "w": 100, "h": 60 },


### PR DESCRIPTION
Track B, PR 2 of 5. Validated for ~$0.02 (3 Gemini calls, zero fal).

## What it adds

The per-entity **border + height** substrate the user asked for ("segment all the buildings around our target by their borders and sustain that information with an inferred relative and absolute height for each entity in all the worlds"):

- **`providers/segmenter.py`** — clones `detector.py` conventions. One VLM call per image traces each visible target's border as a closed polygon (3–24 vertices, normalized 0..1, clamped + deduped), ranks `rel_height` (0..1 vs the tallest visible), and offers `est_height_m`. Tolerant parse: malformed entries drop, never raises.
- **`providers/heights.py`** — pure. Absolute meters come from an **anchored relative ladder**, never map pixels (map symbology draws buildings oversized — not metric). Anchor order: authored ground truth > category prior (person 1.7m … tower 25m) > VLM median. `tier_sanity_band` gives a plausibility ceiling from the `SCALE_TIER_METERS` mirror — **flags, never silent clamps**. Plus the two metrics the recon bench (B4) consumes: `height_order_score` (pairwise order agreement) and `height_abs_score` (within ×2 in log space).
- **Schema, additive + parity-gated**: `WorldEntityGeo += border?: WorldVec2[]`, `height_m?: number` — TS interface, shared fixture, and witness test updated together (both parity gates green).
- **Persistence** behind `WORLD_SEGMENT_BORDERS` (default OFF, storage only): `deriveGeoFromExtraction` stamps `border` (image→frame via new pure `mapPolygonToCrop`, top-down map frames only) and `height_m`. Nothing renders these yet.

## Validation

- Free: 13 new pytest cases (parse goldens, anchor-order, ladder math, band flags, score metrics) + vitest (`mapPolygonToCrop`, parity witnesses). Full `pytest -m "not paid"` + full vitest + `tsc` + `mypy` + `ruff`: green.
- Paid smoke (`make eval-segment-smoke`, ~$0.02 spent): segmented 3 existing report JPGs — 5–8 clean polygons each, castle-prior-anchored ladder (castle 20m → gate 3.2m), zero tier flags. Output: `tests/world_bench/reports/segment_smoke_latest.json`.

Next: B3 ground-truth corpus uses `segment()` + `infer_heights_m` in its VLM-draft authoring step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)