### PR TITLE
feat(eval): ground-truth map corpus — 6 PD maps, 6 genres, authored descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ scripts/perfbudget/report.json
 
 # Superpowers brainstorm companion (ephemeral mockup files).
 .superpowers/
+
+# Ground-truth corpus images (fetched by scripts/fetch_corpus.py; text-only
+# descriptions + the sha-pinned manifest are what git tracks).
+apps/modal-backend/tests/map_corpus/images/

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,15 @@ eval-grounding:
 # zero fal). Override images: SEGMENT_SMOKE_IMAGES=/path/a.jpg,...
 eval-segment-smoke:
 	cd apps/modal-backend && SEGMENT_BENCH_RUN=1 .venv/bin/python -m tests.world_bench.segment_smoke
+# Ground-truth map corpus: fetch the public-domain scans (free, a few MB;
+# --pin on first run records sha256s into the manifest) and VLM-draft a
+# description for human verification (PAID ~$0.015/map, Gemini only):
+#   make corpus-fetch
+#   make corpus-draft id=fantasy-treasure-island   (or id=all)
+corpus-fetch:
+	cd apps/modal-backend && .venv/bin/python scripts/fetch_corpus.py --pin
+corpus-draft:
+	cd apps/modal-backend && CORPUS_DRAFT_RUN=1 .venv/bin/python -m tests.map_corpus.draft $(or $(id),all)
 eval-repair:
 	cd apps/modal-backend && REPAIR_BENCH_RUN=1 .venv/bin/python -m pytest -m repair -q
 eval-edit:

--- a/apps/modal-backend/scripts/fetch_corpus.py
+++ b/apps/modal-backend/scripts/fetch_corpus.py
@@ -1,0 +1,74 @@
+"""Fetch the ground-truth map corpus to tests/map_corpus/images/ (gitignored).
+
+    .venv/bin/python scripts/fetch_corpus.py          # verify pinned sha256s
+    .venv/bin/python scripts/fetch_corpus.py --pin    # first fetch: record shas
+or: make corpus-fetch
+
+Free (a few MB of public-domain scans). A sha mismatch on a pinned entry means
+the upstream rendition changed — re-pin deliberately, never silently.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1] / "tests" / "map_corpus"
+_MANIFEST = _ROOT / "manifest.json"
+_IMAGES = _ROOT / "images"
+
+
+def _fetch(url: str) -> bytes:
+    """Polite fetch: Commons 429s burst traffic — back off and retry."""
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "openflipbook-corpus/1.0 (personal eval corpus)"}
+    )
+    for attempt in range(4):
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                return resp.read()
+        except urllib.error.HTTPError as exc:
+            if exc.code != 429 or attempt == 3:
+                raise
+            wait = 20 * (attempt + 1)
+            print(f"  429 — backing off {wait}s")
+            time.sleep(wait)
+    raise RuntimeError("unreachable")
+
+
+def main() -> int:
+    pin = "--pin" in sys.argv
+    data = json.loads(_MANIFEST.read_text())
+    _IMAGES.mkdir(parents=True, exist_ok=True)
+    changed = False
+    for m in data["maps"]:
+        dest = _IMAGES / m["filename"]
+        if not dest.exists():
+            print(f"fetching {m['id']} ...")
+            dest.write_bytes(_fetch(m["source_url"]))
+            time.sleep(3)  # be polite between files
+        sha = hashlib.sha256(dest.read_bytes()).hexdigest()
+        if m["sha256"] is None:
+            if pin:
+                m["sha256"] = sha
+                changed = True
+                print(f"  pinned {m['id']}: {sha[:16]}…")
+            else:
+                print(f"  UNPINNED {m['id']}: {sha[:16]}… (run with --pin to record)")
+        elif m["sha256"] != sha:
+            print(f"  MISMATCH {m['id']}: expected {m['sha256'][:16]}…, got {sha[:16]}…")
+            return 1
+        else:
+            print(f"  ok {m['id']}")
+    if changed:
+        _MANIFEST.write_text(json.dumps(data, indent=2) + "\n")
+        print("manifest updated — commit it.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/modal-backend/tests/map_corpus/__init__.py
+++ b/apps/modal-backend/tests/map_corpus/__init__.py
@@ -1,0 +1,51 @@
+"""Ground-truth map corpus: real public-domain maps across genres + detailed,
+human-checkable descriptions (entities with positions, footprints, heights in
+meters, borders, relations). The reconstruction bench (tests/recon_bench)
+regenerates each map from its description and scores the result against this
+ground truth. Images are fetched (never committed); descriptions are text and
+live in git."""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent
+MANIFEST = ROOT / "manifest.json"
+IMAGES = ROOT / "images"
+DESCRIPTIONS = ROOT / "descriptions"
+
+FRAME_W = 100.0
+FRAME_H = 60.0
+
+
+def load_manifest() -> list[dict[str, Any]]:
+    return json.loads(MANIFEST.read_text())["maps"]
+
+
+def image_path(map_id: str) -> Path:
+    for m in load_manifest():
+        if m["id"] == map_id:
+            return IMAGES / m["filename"]
+    raise KeyError(f"unknown corpus map id: {map_id}")
+
+
+def load_descriptions(status: str | None = "verified") -> list[dict[str, Any]]:
+    """All committed descriptions, optionally filtered by review status.
+    The recon bench consumes only verified ones (status='verified');
+    status=None returns drafts too (the authoring workflow)."""
+    out = []
+    for p in sorted(DESCRIPTIONS.glob("*.json")):
+        d = json.loads(p.read_text())
+        if status is None or d.get("review", {}).get("status") == status:
+            out.append(d)
+    return out
+
+
+def description_sha(desc: dict[str, Any]) -> str:
+    """Digest of a description's CONTENT (review block excluded — verifying a
+    draft shouldn't re-bill its cells unless the ground truth itself changed)."""
+    body = {k: v for k, v in desc.items() if k != "review"}
+    blob = json.dumps(body, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(blob).hexdigest()[:12]

--- a/apps/modal-backend/tests/map_corpus/descriptions/fantasy-treasure-island.json
+++ b/apps/modal-backend/tests/map_corpus/descriptions/fantasy-treasure-island.json
@@ -1,0 +1,382 @@
+{
+ "map_id": "fantasy-treasure-island",
+ "rev": 2,
+ "genre": "fantasy",
+ "style": "Vintage lithograph illustration with a muted watercolor palette of sage green, slate blue, and earthy ochre.",
+ "scale_tier": "region",
+ "frame": {
+  "w": 100.0,
+  "h": 60.0
+ },
+ "description": "A pictorial map of Treasure Island, oriented with North at the top. The island is shaped like a fat, upright dragon or seahorse, surrounded by a pale blue sea. In the north, Spyglass Hill rises as a prominent white-capped peak. To the west, Mizzenmast Hill and Haulbowline Head form a rugged peninsula. A smaller, separate landmass named Skeleton Island sits off the southwest coast. The interior is dotted with narrative vignettes: pirates digging in the center, the Stockade fortified with logs in the south-central region, and Ben Gunn's cave nestled near the eastern Twin Peaks. A large title cartouche featuring Long John Silver and Jim Hawkins occupies the top right corner. The bottom of the map features a wide horizontal frieze showing scenes from the Admiral Benbow Inn and the Hispaniola at Bristol Harbor. A small inset map in the lower right shows the Atlantic Ocean route from England to the West Indies. The coastline is outlined in a thick white border, contrasting with the dark grey-green landmass.",
+ "entities": [
+  {
+   "ref": "spyglass-hill",
+   "kind": "place",
+   "label": "Spyglass Hill",
+   "visual": "A tall, snow-capped mountain peak in the northern part of the island.",
+   "pos": {
+    "x": 48.0,
+    "y": 13.1
+   },
+   "footprint": {
+    "w": 5.4,
+    "d": 1.1
+   },
+   "height_rel": 1.0,
+   "height_m": 60.0,
+   "border": [
+    [
+     44.8,
+     16.1
+    ],
+    [
+     48.5,
+     12.6
+    ],
+    [
+     53.0,
+     12.6
+    ],
+    [
+     57.0,
+     14.4
+    ],
+    [
+     58.0,
+     16.8
+    ],
+    [
+     54.0,
+     18.6
+    ],
+    [
+     48.0,
+     18.6
+    ],
+    [
+     45.0,
+     17.4
+    ]
+   ]
+  },
+  {
+   "ref": "skeleton-island",
+   "kind": "place",
+   "label": "Skeleton Island",
+   "visual": "A small, rocky island located off the southwest coast of the main island.",
+   "pos": {
+    "x": 27.0,
+    "y": 34.0
+   },
+   "footprint": {
+    "w": 8.0,
+    "d": 1.1
+   },
+   "height_rel": 0.4,
+   "height_m": 24.0,
+   "border": [
+    [
+     24.0,
+     30.0
+    ],
+    [
+     30.0,
+     29.4
+    ],
+    [
+     36.0,
+     30.0
+    ],
+    [
+     36.0,
+     38.4
+    ],
+    [
+     33.0,
+     39.6
+    ],
+    [
+     26.0,
+     39.0
+    ],
+    [
+     24.0,
+     34.8
+    ]
+   ]
+  },
+  {
+   "ref": "the-stockade",
+   "kind": "place",
+   "label": "The Stockade",
+   "visual": "A log-walled fortification located in the southern central plains.",
+   "pos": {
+    "x": 48.0,
+    "y": 35.2
+   },
+   "footprint": {
+    "w": 6.0,
+    "d": 1.0
+   },
+   "height_rel": 0.05,
+   "height_m": 3.0,
+   "border": [
+    [
+     41.0,
+     36.6
+    ],
+    [
+     45.0,
+     36.6
+    ],
+    [
+     48.0,
+     37.8
+    ],
+    [
+     48.0,
+     40.2
+    ],
+    [
+     44.0,
+     40.8
+    ],
+    [
+     41.0,
+     39.6
+    ]
+   ]
+  },
+  {
+   "ref": "mizzenmast-hill",
+   "kind": "place",
+   "label": "Mizzenmast Hill",
+   "visual": "A rounded, rocky hill on the western side of the island.",
+   "pos": {
+    "x": 31.0,
+    "y": 20.3
+   },
+   "footprint": {
+    "w": 6.0,
+    "d": 1.0
+   },
+   "height_rel": 0.7,
+   "height_m": 42.0,
+   "border": [
+    [
+     26.0,
+     19.2
+    ],
+    [
+     31.0,
+     16.8
+    ],
+    [
+     36.0,
+     16.8
+    ],
+    [
+     41.0,
+     19.2
+    ],
+    [
+     41.0,
+     22.8
+    ],
+    [
+     35.0,
+     25.2
+    ],
+    [
+     28.0,
+     25.2
+    ],
+    [
+     25.0,
+     22.8
+    ]
+   ]
+  },
+  {
+   "ref": "rum-cove",
+   "kind": "place",
+   "label": "Rum Cove",
+   "visual": "A small inlet on the southeastern shore near the treasure loading site.",
+   "pos": {
+    "x": 66.6,
+    "y": 41.0
+   },
+   "footprint": {
+    "w": 4.0,
+    "d": 1.7
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": [
+    [
+     64.0,
+     38.4
+    ],
+    [
+     68.0,
+     38.4
+    ],
+    [
+     69.0,
+     40.8
+    ],
+    [
+     67.0,
+     42.6
+    ],
+    [
+     64.0,
+     42.0
+    ],
+    [
+     63.0,
+     40.2
+    ]
+   ]
+  },
+  {
+   "ref": "hispaniola-ship",
+   "kind": "item",
+   "label": "The Hispaniola",
+   "visual": "three-masted ship in the bottom-right Bristol Harbour frieze",
+   "pos": {
+    "x": 79.1,
+    "y": 48.1
+   },
+   "footprint": {
+    "w": 8.8,
+    "d": 9.2
+   },
+   "height_rel": 0.1,
+   "height_m": 6.0,
+   "border": null
+  },
+  {
+   "ref": "ben-gunns-cave",
+   "kind": "place",
+   "label": "Ben Gunn's cave",
+   "visual": "A rocky cavern entrance located near the eastern Twin Peaks.",
+   "pos": {
+    "x": 67.4,
+    "y": 32.2
+   },
+   "footprint": {
+    "w": 5.0,
+    "d": 1.2
+   },
+   "height_rel": 0.15,
+   "height_m": 9.0,
+   "border": [
+    [
+     60.0,
+     30.6
+    ],
+    [
+     64.0,
+     30.6
+    ],
+    [
+     68.0,
+     31.8
+    ],
+    [
+     68.0,
+     34.8
+    ],
+    [
+     64.0,
+     36.0
+    ],
+    [
+     60.0,
+     34.8
+    ]
+   ]
+  },
+  {
+   "ref": "north-inlet",
+   "kind": "place",
+   "label": "North Inlet",
+   "visual": "A deep bay on the northeastern side of the island.",
+   "pos": {
+    "x": 71.0,
+    "y": 28.2
+   },
+   "footprint": {
+    "w": 6.0,
+    "d": 1.0
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": [
+    [
+     65.0,
+     25.8
+    ],
+    [
+     71.0,
+     25.8
+    ],
+    [
+     74.0,
+     27.6
+    ],
+    [
+     74.0,
+     30.0
+    ],
+    [
+     70.0,
+     31.2
+    ],
+    [
+     65.0,
+     30.0
+    ]
+   ]
+  }
+ ],
+ "relations": [
+  {
+   "subject": "spyglass-hill",
+   "relation": "near",
+   "object": "north-inlet"
+  },
+  {
+   "subject": "skeleton-island",
+   "relation": "near",
+   "object": "mizzenmast-hill"
+  },
+  {
+   "subject": "the-stockade",
+   "relation": "in_front_of",
+   "object": "spyglass-hill"
+  },
+  {
+   "subject": "hispaniola-ship",
+   "relation": "near",
+   "object": "rum-cove"
+  },
+  {
+   "subject": "ben-gunns-cave",
+   "relation": "right_of",
+   "object": "the-stockade"
+  },
+  {
+   "subject": "rum-cove",
+   "relation": "facing",
+   "object": "ben-gunns-cave"
+  }
+ ],
+ "review": {
+  "status": "verified",
+  "by": "claude (image-inspected); eren spot-check welcome",
+  "date": "2026-06-11"
+ }
+}

--- a/apps/modal-backend/tests/map_corpus/descriptions/forest-yellowstone-1904.json
+++ b/apps/modal-backend/tests/map_corpus/descriptions/forest-yellowstone-1904.json
@@ -1,0 +1,419 @@
+{
+ "map_id": "forest-yellowstone-1904",
+ "rev": 1,
+ "genre": "forest",
+ "style": "Vintage lithographic bird's-eye view with a naturalistic palette of earthy ochres, forest greens, and pale blue water.",
+ "scale_tier": "region",
+ "frame": {
+  "w": 100.0,
+  "h": 60.0
+ },
+ "description": "A panoramic bird's-eye view of Yellowstone National Park looking south from an elevated northern perspective. In the foreground, the Yellowstone River winds through deep, rocky canyons and past the Mammoth Hot Springs, which appear as a white, terraced formation on the right. To the far right foreground, the Gardiner entrance with its stone arch is visible. The midground is dominated by a vast, undulating landscape of green forests, rolling hills, and jagged mountain peaks like Mount Washburn. To the left, the Grand Canyon of the Yellowstone shows distinct yellow and orange cliffs. In the far distance, the massive, pale blue expanse of Yellowstone Lake stretches toward the horizon, flanked by the snow-capped peaks of the Teton Range and other distant mountains under a soft, cloudy sky. The composition uses atmospheric perspective to create immense depth, with fine details of geyser basins and river tributaries scattered throughout the central plateau.",
+ "entities": [
+  {
+   "ref": "yellowstone-lake",
+   "kind": "place",
+   "label": "Yellowstone Lake",
+   "visual": "Large, pale blue body of water in the far upper background.",
+   "pos": {
+    "x": 31.0,
+    "y": 60.0
+   },
+   "footprint": {
+    "w": 25.0,
+    "d": 6.0
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": [
+    [
+     18.0,
+     15.0
+    ],
+    [
+     25.0,
+     12.6
+    ],
+    [
+     35.0,
+     12.0
+    ],
+    [
+     45.0,
+     10.8
+    ],
+    [
+     48.0,
+     13.2
+    ],
+    [
+     40.0,
+     15.6
+    ],
+    [
+     30.0,
+     16.8
+    ],
+    [
+     20.0,
+     16.2
+    ]
+   ]
+  },
+  {
+   "ref": "mammoth-hot-springs",
+   "kind": "place",
+   "label": "Mammoth Hot Springs",
+   "visual": "White, terraced geological formation in the lower right midground.",
+   "pos": {
+    "x": 58.0,
+    "y": 36.0
+   },
+   "footprint": {
+    "w": 10.0,
+    "d": 4.8
+   },
+   "height_rel": 0.1,
+   "height_m": 150.0,
+   "border": [
+    [
+     53.0,
+     34.8
+    ],
+    [
+     58.0,
+     33.6
+    ],
+    [
+     63.0,
+     34.2
+    ],
+    [
+     65.0,
+     36.0
+    ],
+    [
+     62.0,
+     38.4
+    ],
+    [
+     55.0,
+     39.0
+    ],
+    [
+     52.0,
+     37.2
+    ]
+   ]
+  },
+  {
+   "ref": "grand-canyon-yellowstone",
+   "kind": "place",
+   "label": "Grand Canyon of the Yellowstone",
+   "visual": "Deep gorge with yellow-orange cliffs on the left side.",
+   "pos": {
+    "x": 20.0,
+    "y": 22.8
+   },
+   "footprint": {
+    "w": 15.0,
+    "d": 4.8
+   },
+   "height_rel": 0.2,
+   "height_m": 300.0,
+   "border": [
+    [
+     4.0,
+     25.2
+    ],
+    [
+     10.0,
+     24.0
+    ],
+    [
+     20.0,
+     22.8
+    ],
+    [
+     28.0,
+     21.0
+    ],
+    [
+     32.0,
+     22.8
+    ],
+    [
+     25.0,
+     25.2
+    ],
+    [
+     15.0,
+     27.0
+    ],
+    [
+     5.0,
+     28.8
+    ]
+   ]
+  },
+  {
+   "ref": "yellowstone-river",
+   "kind": "place",
+   "label": "Yellowstone River",
+   "visual": "Winding blue river flowing from the lake toward the foreground.",
+   "pos": {
+    "x": 40.0,
+    "y": 48.0
+   },
+   "footprint": {
+    "w": 60.0,
+    "d": 12.0
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": [
+    [
+     16.0,
+     46.8
+    ],
+    [
+     25.0,
+     49.2
+    ],
+    [
+     40.0,
+     49.8
+    ],
+    [
+     55.0,
+     51.6
+    ],
+    [
+     65.0,
+     52.8
+    ],
+    [
+     80.0,
+     52.8
+    ],
+    [
+     90.0,
+     51.0
+    ],
+    [
+     70.0,
+     50.4
+    ],
+    [
+     50.0,
+     48.0
+    ],
+    [
+     50.0,
+     39.0
+    ],
+    [
+     40.0,
+     33.0
+    ],
+    [
+     30.0,
+     27.0
+    ]
+   ]
+  },
+  {
+   "ref": "gardiner-entrance",
+   "kind": "place",
+   "label": "Gardiner Entrance",
+   "visual": "Small settlement with a red stone arch in the bottom right.",
+   "pos": {
+    "x": 75.0,
+    "y": 48.0
+   },
+   "footprint": {
+    "w": 10.0,
+    "d": 3.0
+   },
+   "height_rel": 0.05,
+   "height_m": 75.0,
+   "border": [
+    [
+     74.0,
+     45.6
+    ],
+    [
+     76.0,
+     45.6
+    ],
+    [
+     76.0,
+     47.4
+    ],
+    [
+     74.0,
+     47.4
+    ]
+   ]
+  },
+  {
+   "ref": "mount-washburn",
+   "kind": "place",
+   "label": "Mount Washburn",
+   "visual": "Prominent green and brown mountain peak in the central midground.",
+   "pos": {
+    "x": 35.0,
+    "y": 27.0
+   },
+   "footprint": {
+    "w": 10.0,
+    "d": 3.6
+   },
+   "height_rel": 0.8,
+   "height_m": 1200.0,
+   "border": [
+    [
+     30.0,
+     28.8
+    ],
+    [
+     38.0,
+     27.0
+    ],
+    [
+     45.0,
+     28.8
+    ],
+    [
+     48.0,
+     33.0
+    ],
+    [
+     40.0,
+     34.8
+    ],
+    [
+     32.0,
+     33.0
+    ]
+   ]
+  },
+  {
+   "ref": "upper-geyser-basin",
+   "kind": "place",
+   "label": "Upper Geyser Basin",
+   "visual": "Pale, smoky area in the distance near the lake.",
+   "pos": {
+    "x": 65.0,
+    "y": 12.0
+   },
+   "footprint": {
+    "w": 10.0,
+    "d": 3.0
+   },
+   "height_rel": 0.02,
+   "height_m": 30.0,
+   "border": [
+    [
+     62.0,
+     10.8
+    ],
+    [
+     70.0,
+     10.8
+    ],
+    [
+     75.0,
+     12.0
+    ],
+    [
+     72.0,
+     13.8
+    ],
+    [
+     65.0,
+     13.2
+    ]
+   ]
+  },
+  {
+   "ref": "teton-range",
+   "kind": "place",
+   "label": "Teton Range",
+   "visual": "Faint, jagged mountain peaks on the far southern horizon.",
+   "pos": {
+    "x": 10.0,
+    "y": 9.0
+   },
+   "footprint": {
+    "w": 15.0,
+    "d": 6.0
+   },
+   "height_rel": 1.0,
+   "height_m": 1500.0,
+   "border": [
+    [
+     5.0,
+     9.0
+    ],
+    [
+     15.0,
+     7.2
+    ],
+    [
+     25.0,
+     8.4
+    ],
+    [
+     30.0,
+     10.8
+    ],
+    [
+     20.0,
+     13.2
+    ],
+    [
+     10.0,
+     12.0
+    ]
+   ]
+  }
+ ],
+ "relations": [
+  {
+   "subject": "yellowstone-lake",
+   "relation": "behind",
+   "object": "mount-washburn"
+  },
+  {
+   "subject": "mammoth-hot-springs",
+   "relation": "on_top_of",
+   "object": "yellowstone-river"
+  },
+  {
+   "subject": "grand-canyon-yellowstone",
+   "relation": "left_of",
+   "object": "mount-washburn"
+  },
+  {
+   "subject": "gardiner-entrance",
+   "relation": "in_front_of",
+   "object": "mammoth-hot-springs"
+  },
+  {
+   "subject": "teton-range",
+   "relation": "behind",
+   "object": "yellowstone-lake"
+  },
+  {
+   "subject": "upper-geyser-basin",
+   "relation": "near",
+   "object": "yellowstone-lake"
+  }
+ ],
+ "review": {
+  "status": "vlm_draft",
+  "by": "",
+  "date": ""
+ }
+}

--- a/apps/modal-backend/tests/map_corpus/descriptions/scifi-mars-schiaparelli-1888.json
+++ b/apps/modal-backend/tests/map_corpus/descriptions/scifi-mars-schiaparelli-1888.json
@@ -1,0 +1,387 @@
+{
+ "map_id": "scifi-mars-schiaparelli-1888",
+ "rev": 2,
+ "genre": "sci-fi",
+ "style": "19th-century scientific stippled ink drawing, monochrome black and white, astronomical sketch style.",
+ "scale_tier": "region",
+ "frame": {
+  "w": 100.0,
+  "h": 60.0
+ },
+ "description": "A circular astronomical map of Mars as observed in 1888, presented in a monochrome stippled style. The map is dominated by a large, dark, textured region in the upper-left (northwest) quadrant, labeled Libya. From this dark mass, a complex network of thin, straight, and intersecting lines\u2014the famous 'canals'\u2014radiates across the lighter surface. In the center-left, the Nilosyrtis and Astusapes lines form a distinct curved loop. To the east (right), several prominent parallel and intersecting lines are labeled Euphrates, Hiddekel, and Gehon, converging at dark circular nodes. The southern (bottom) portion features the Callirhoe line running horizontally, with several smaller dark patches and stippled regions near the edge. The entire globe is framed by a thin circular border, with lowercase 'b' markers placed at various points around the perimeter. The background is a neutral, slightly textured paper tone, and the labels are written in a classic serif italicized script.",
+ "entities": [
+  {
+   "ref": "libya-region",
+   "kind": "place",
+   "label": "Libya",
+   "visual": "Large, dark stippled area in the upper-left quadrant.",
+   "pos": {
+    "x": 18.8,
+    "y": 24.6
+   },
+   "footprint": {
+    "w": 5.0,
+    "d": 3.0
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": [
+    [
+     16.0,
+     27.0
+    ],
+    [
+     20.0,
+     22.8
+    ],
+    [
+     24.0,
+     22.2
+    ],
+    [
+     26.0,
+     24.6
+    ],
+    [
+     22.0,
+     28.8
+    ],
+    [
+     18.0,
+     29.4
+    ]
+   ]
+  },
+  {
+   "ref": "nilosyrtis",
+   "kind": "place",
+   "label": "Nilosyrtis",
+   "visual": "A thick, curved dark line in the center-left.",
+   "pos": {
+    "x": 39.8,
+    "y": 31.8
+   },
+   "footprint": {
+    "w": 8.0,
+    "d": 4.8
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": [
+    [
+     35.0,
+     31.2
+    ],
+    [
+     38.0,
+     27.0
+    ],
+    [
+     42.0,
+     28.8
+    ],
+    [
+     45.0,
+     33.0
+    ],
+    [
+     42.0,
+     35.4
+    ],
+    [
+     37.0,
+     34.8
+    ]
+   ]
+  },
+  {
+   "ref": "euphrates",
+   "kind": "place",
+   "label": "Euphrates",
+   "visual": "A long, straight vertical line in the right-center.",
+   "pos": {
+    "x": 69.5,
+    "y": 25.2
+   },
+   "footprint": {
+    "w": 6.0,
+    "d": 4.8
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": [
+    [
+     68.0,
+     22.8
+    ],
+    [
+     70.0,
+     21.0
+    ],
+    [
+     73.0,
+     25.2
+    ],
+    [
+     72.0,
+     28.8
+    ],
+    [
+     69.0,
+     28.2
+    ],
+    [
+     68.0,
+     25.2
+    ]
+   ]
+  },
+  {
+   "ref": "hiddekel",
+   "kind": "place",
+   "label": "Hiddekel",
+   "visual": "A straight line running parallel to the Euphrates.",
+   "pos": {
+    "x": 74.5,
+    "y": 21.9
+   },
+   "footprint": {
+    "w": 5.0,
+    "d": 4.8
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": [
+    [
+     72.0,
+     20.4
+    ],
+    [
+     76.0,
+     18.0
+    ],
+    [
+     78.0,
+     19.8
+    ],
+    [
+     76.0,
+     24.6
+    ],
+    [
+     73.0,
+     25.2
+    ],
+    [
+     72.0,
+     22.8
+    ]
+   ]
+  },
+  {
+   "ref": "callirhoe",
+   "kind": "place",
+   "label": "Callirhoe",
+   "visual": "A horizontal line located in the lower-center region.",
+   "pos": {
+    "x": 58.5,
+    "y": 41.7
+   },
+   "footprint": {
+    "w": 8.0,
+    "d": 2.4
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": [
+    [
+     52.0,
+     40.8
+    ],
+    [
+     58.0,
+     40.8
+    ],
+    [
+     65.0,
+     41.4
+    ],
+    [
+     65.0,
+     43.2
+    ],
+    [
+     58.0,
+     42.6
+    ],
+    [
+     52.0,
+     42.0
+    ]
+   ]
+  },
+  {
+   "ref": "protonilus",
+   "kind": "place",
+   "label": "Protonilus",
+   "visual": "A horizontal line connecting the center to the right.",
+   "pos": {
+    "x": 59.5,
+    "y": 33.3
+   },
+   "footprint": {
+    "w": 8.0,
+    "d": 2.4
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": [
+    [
+     53.0,
+     31.8
+    ],
+    [
+     58.0,
+     30.6
+    ],
+    [
+     65.0,
+     31.2
+    ],
+    [
+     65.0,
+     33.6
+    ],
+    [
+     58.0,
+     34.2
+    ],
+    [
+     53.0,
+     34.8
+    ]
+   ]
+  },
+  {
+   "ref": "thoth",
+   "kind": "place",
+   "label": "Thoth",
+   "visual": "A diagonal line in the lower-left quadrant.",
+   "pos": {
+    "x": 26.0,
+    "y": 35.1
+   },
+   "footprint": {
+    "w": 5.0,
+    "d": 3.0
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": [
+    [
+     23.0,
+     33.0
+    ],
+    [
+     26.0,
+     31.8
+    ],
+    [
+     29.0,
+     35.4
+    ],
+    [
+     28.0,
+     37.8
+    ],
+    [
+     25.0,
+     37.2
+    ],
+    [
+     23.0,
+     34.8
+    ]
+   ]
+  },
+  {
+   "ref": "gehon",
+   "kind": "place",
+   "label": "Gehon",
+   "visual": "A vertical line on the far right edge.",
+   "pos": {
+    "x": 80.5,
+    "y": 22.2
+   },
+   "footprint": {
+    "w": 4.0,
+    "d": 3.6
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": [
+    [
+     78.0,
+     20.4
+    ],
+    [
+     81.0,
+     19.8
+    ],
+    [
+     82.0,
+     22.8
+    ],
+    [
+     81.0,
+     25.2
+    ],
+    [
+     79.0,
+     25.2
+    ],
+    [
+     78.0,
+     22.8
+    ]
+   ]
+  }
+ ],
+ "relations": [
+  {
+   "subject": "nilosyrtis",
+   "relation": "near",
+   "object": "libya-region"
+  },
+  {
+   "subject": "hiddekel",
+   "relation": "right_of",
+   "object": "euphrates"
+  },
+  {
+   "subject": "callirhoe",
+   "relation": "near",
+   "object": "protonilus"
+  },
+  {
+   "subject": "thoth",
+   "relation": "left_of",
+   "object": "nilosyrtis"
+  },
+  {
+   "subject": "gehon",
+   "relation": "right_of",
+   "object": "hiddekel"
+  },
+  {
+   "subject": "protonilus",
+   "relation": "left_of",
+   "object": "euphrates"
+  }
+ ],
+ "review": {
+  "status": "verified",
+  "by": "claude (image-inspected); eren spot-check welcome",
+  "date": "2026-06-11"
+ }
+}

--- a/apps/modal-backend/tests/map_corpus/descriptions/sea-boston-harbor-1877.json
+++ b/apps/modal-backend/tests/map_corpus/descriptions/sea-boston-harbor-1877.json
@@ -1,0 +1,383 @@
+{
+ "map_id": "sea-boston-harbor-1877",
+ "rev": 1,
+ "genre": "sea",
+ "style": "19th-century lithographic nautical chart with hand-colored green and red landmasses, fine black ink soundings, and cream paper.",
+ "scale_tier": "region",
+ "frame": {
+  "w": 100.0,
+  "h": 60.0
+ },
+ "description": "A detailed 1867 nautical chart of Massachusetts Bay, extending from Cape Ann in the north to the beginning of Cape Cod in the south. The landmasses are rendered with hachures for elevation and tinted in green and red. Cape Ann forms a prominent, jagged peninsula in the northeast corner, while the city of Boston is situated in the central-west, characterized by a dense cluster of red-tinted urban areas and a complex harbor of small islands. The coastline runs roughly north-to-south, curving inward to form the bay. The vast oceanic area to the east is filled with thousands of tiny numerical soundings and several large, elegant compass roses with radiating rhumb lines. Extensive text blocks containing light house data, sailing directions, and tidal tables occupy the left margin and top center. Small panoramic coastal profiles are featured at the top and bottom edges, providing mariners with a horizontal view of the shoreline from the sea.",
+ "entities": [
+  {
+   "ref": "cape-ann",
+   "kind": "place",
+   "label": "Cape Ann",
+   "visual": "Large green-tinted peninsula in the top right corner of the map.",
+   "pos": {
+    "x": 71.2,
+    "y": 7.5
+   },
+   "footprint": {
+    "w": 11.0,
+    "d": 3.0
+   },
+   "height_rel": 0.4,
+   "height_m": 50.0,
+   "border": [
+    [
+     64.0,
+     6.6
+    ],
+    [
+     71.0,
+     2.4
+    ],
+    [
+     77.0,
+     3.0
+    ],
+    [
+     78.0,
+     7.8
+    ],
+    [
+     75.0,
+     10.8
+    ],
+    [
+     68.0,
+     11.4
+    ],
+    [
+     64.0,
+     9.0
+    ]
+   ]
+  },
+  {
+   "ref": "boston-harbor",
+   "kind": "place",
+   "label": "Boston Bay",
+   "visual": "Central western inlet filled with numerous small islands and red-tinted land.",
+   "pos": {
+    "x": 25.0,
+    "y": 39.0
+   },
+   "footprint": {
+    "w": 15.0,
+    "d": 4.8
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": [
+    [
+     20.0,
+     27.0
+    ],
+    [
+     28.0,
+     27.0
+    ],
+    [
+     30.0,
+     33.0
+    ],
+    [
+     28.0,
+     39.0
+    ],
+    [
+     20.0,
+     39.0
+    ],
+    [
+     15.0,
+     33.0
+    ]
+   ]
+  },
+  {
+   "ref": "salem",
+   "kind": "place",
+   "label": "Salem",
+   "visual": "Red-tinted coastal town located north of Boston and south of Cape Ann.",
+   "pos": {
+    "x": 41.0,
+    "y": 7.5
+   },
+   "footprint": {
+    "w": 4.0,
+    "d": 1.2
+   },
+   "height_rel": 0.2,
+   "height_m": 25.0,
+   "border": [
+    [
+     38.0,
+     7.2
+    ],
+    [
+     42.0,
+     7.2
+    ],
+    [
+     44.0,
+     9.0
+    ],
+    [
+     42.0,
+     10.8
+    ],
+    [
+     38.0,
+     10.8
+    ],
+    [
+     36.0,
+     9.0
+    ]
+   ]
+  },
+  {
+   "ref": "massachusetts-bay",
+   "kind": "place",
+   "label": "Massachusetts Bay",
+   "visual": "The large central body of water filled with soundings and rhumb lines.",
+   "pos": {
+    "x": 15.8,
+    "y": 43.5
+   },
+   "footprint": {
+    "w": 12.0,
+    "d": 1.2
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": [
+    [
+     35.0,
+     21.0
+    ],
+    [
+     65.0,
+     21.0
+    ],
+    [
+     85.0,
+     33.0
+    ],
+    [
+     85.0,
+     51.0
+    ],
+    [
+     55.0,
+     57.0
+    ],
+    [
+     35.0,
+     45.0
+    ]
+   ]
+  },
+  {
+   "ref": "compass-rose-central",
+   "kind": "item",
+   "label": "Central Compass Rose",
+   "visual": "Large circular navigational aid with radiating lines in the middle sea area.",
+   "pos": {
+    "x": 53.5,
+    "y": 25.5
+   },
+   "footprint": {
+    "w": 10.0,
+    "d": 6.0
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": [
+    [
+     48.0,
+     21.6
+    ],
+    [
+     53.0,
+     21.6
+    ],
+    [
+     58.0,
+     25.2
+    ],
+    [
+     58.0,
+     28.8
+    ],
+    [
+     53.0,
+     32.4
+    ],
+    [
+     48.0,
+     32.4
+    ],
+    [
+     43.0,
+     28.8
+    ],
+    [
+     43.0,
+     25.2
+    ]
+   ]
+  },
+  {
+   "ref": "title-block",
+   "kind": "item",
+   "label": "Coast Chart No. 109",
+   "visual": "Large decorative text block in the upper left quadrant.",
+   "pos": {
+    "x": 25.0,
+    "y": 27.0
+   },
+   "footprint": {
+    "w": 8.0,
+    "d": 1.2
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": [
+    [
+     20.0,
+     24.0
+    ],
+    [
+     28.0,
+     24.0
+    ],
+    [
+     28.0,
+     26.4
+    ],
+    [
+     20.0,
+     26.4
+    ]
+   ]
+  },
+  {
+   "ref": "coastal-profile-top",
+   "kind": "item",
+   "label": "Cape Ann Profile",
+   "visual": "Thin horizontal landscape illustration at the very top center edge.",
+   "pos": {
+    "x": 55.0,
+    "y": 3.6
+   },
+   "footprint": {
+    "w": 28.0,
+    "d": 1.8
+   },
+   "height_rel": 1.0,
+   "height_m": 125.0,
+   "border": [
+    [
+     42.0,
+     3.0
+    ],
+    [
+     68.0,
+     3.0
+    ],
+    [
+     68.0,
+     4.2
+    ],
+    [
+     42.0,
+     4.2
+    ]
+   ]
+  },
+  {
+   "ref": "plymouth-coast",
+   "kind": "place",
+   "label": "Plymouth Coast",
+   "visual": "The long green coastal strip running down the bottom left side.",
+   "pos": {
+    "x": 31.0,
+    "y": 51.0
+   },
+   "footprint": {
+    "w": 8.0,
+    "d": 9.0
+   },
+   "height_rel": 0.3,
+   "height_m": 37.5,
+   "border": [
+    [
+     28.0,
+     45.0
+    ],
+    [
+     34.0,
+     45.0
+    ],
+    [
+     35.0,
+     51.0
+    ],
+    [
+     33.0,
+     58.2
+    ],
+    [
+     28.0,
+     58.2
+    ],
+    [
+     27.0,
+     51.0
+    ]
+   ]
+  }
+ ],
+ "relations": [
+  {
+   "subject": "cape-ann",
+   "relation": "facing",
+   "object": "massachusetts-bay"
+  },
+  {
+   "subject": "boston-harbor",
+   "relation": "left_of",
+   "object": "compass-rose-central"
+  },
+  {
+   "subject": "salem",
+   "relation": "near",
+   "object": "cape-ann"
+  },
+  {
+   "subject": "title-block",
+   "relation": "on_top_of",
+   "object": "boston-harbor"
+  },
+  {
+   "subject": "plymouth-coast",
+   "relation": "inside",
+   "object": "massachusetts-bay"
+  },
+  {
+   "subject": "coastal-profile-top",
+   "relation": "on_top_of",
+   "object": "cape-ann"
+  }
+ ],
+ "review": {
+  "status": "vlm_draft",
+  "by": "",
+  "date": ""
+ }
+}

--- a/apps/modal-backend/tests/map_corpus/descriptions/urban-seattle-1904.json
+++ b/apps/modal-backend/tests/map_corpus/descriptions/urban-seattle-1904.json
@@ -1,0 +1,387 @@
+{
+ "map_id": "urban-seattle-1904",
+ "rev": 1,
+ "genre": "urban",
+ "style": "Monochromatic lithographic engraving in sepia and cream, featuring high-detail architectural hatching and stippling for a 1904 bird's-eye perspective.",
+ "scale_tier": "city",
+ "frame": {
+  "w": 100.0,
+  "h": 60.0
+ },
+ "description": "This 1904 bird's-eye view of Seattle is oriented looking northeast from Elliott Bay. The foreground is dominated by the bustling waterfront of Elliott Bay, filled with numerous sailing vessels and steamships. A dense grid of multi-story commercial buildings forms the city's core, concentrated in the lower center and right. To the north (left), the land narrows between Elliott Bay and Lake Union, which sits centrally in the mid-ground. Further north, Green Lake appears as a smaller oval body of water. To the east (right and background), the massive expanse of Lake Washington stretches across the horizon, separated from the city by rolling, forested hills. In the far distance, a jagged range of snow-capped mountains lines the top edge of the frame. The topography is rendered with fine lines showing the steep hills characteristic of the region. A legend of numbered landmarks is located in the bottom left corner, while the ornate title 'BIRD'S EYE VIEW CITY OF SEATTLE' anchors the bottom center.",
+ "entities": [
+  {
+   "ref": "elliott-bay",
+   "kind": "place",
+   "label": "Elliott Bay",
+   "visual": "Large body of water in foreground with many ships.",
+   "pos": {
+    "x": 31.2,
+    "y": 42.9
+   },
+   "footprint": {
+    "w": 62.4,
+    "d": 34.2
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": [
+    [
+     1.0,
+     60.0
+    ],
+    [
+     25.0,
+     60.0
+    ],
+    [
+     45.0,
+     60.0
+    ],
+    [
+     65.0,
+     60.0
+    ],
+    [
+     75.0,
+     60.0
+    ]
+   ]
+  },
+  {
+   "ref": "lake-union",
+   "kind": "place",
+   "label": "Lake Union",
+   "visual": "Irregularly shaped lake in the center-left mid-ground.",
+   "pos": {
+    "x": 31.5,
+    "y": 18.6
+   },
+   "footprint": {
+    "w": 16.0,
+    "d": 10.2
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": [
+    [
+     23.0,
+     60.0
+    ],
+    [
+     31.0,
+     60.0
+    ],
+    [
+     35.0,
+     60.0
+    ],
+    [
+     39.0,
+     60.0
+    ],
+    [
+     35.0,
+     60.0
+    ],
+    [
+     28.0,
+     60.0
+    ]
+   ]
+  },
+  {
+   "ref": "lake-washington",
+   "kind": "place",
+   "label": "Lake Washington",
+   "visual": "Expansive body of water stretching across the background.",
+   "pos": {
+    "x": 75.0,
+    "y": 12.0
+   },
+   "footprint": {
+    "w": 45.0,
+    "d": 15.0
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": [
+    [
+     55.0,
+     60.0
+    ],
+    [
+     75.0,
+     60.0
+    ],
+    [
+     98.0,
+     60.0
+    ],
+    [
+     85.0,
+     60.0
+    ],
+    [
+     70.0,
+     60.0
+    ],
+    [
+     58.0,
+     60.0
+    ]
+   ]
+  },
+  {
+   "ref": "green-lake",
+   "kind": "place",
+   "label": "Green Lake",
+   "visual": "Small oval lake located in the upper left quadrant.",
+   "pos": {
+    "x": 18.5,
+    "y": 8.7
+   },
+   "footprint": {
+    "w": 5.0,
+    "d": 3.0
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": [
+    [
+     16.0,
+     60.0
+    ],
+    [
+     18.0,
+     60.0
+    ],
+    [
+     21.0,
+     60.0
+    ],
+    [
+     20.0,
+     60.0
+    ],
+    [
+     17.0,
+     60.0
+    ],
+    [
+     15.0,
+     60.0
+    ]
+   ]
+  },
+  {
+   "ref": "downtown-core",
+   "kind": "place",
+   "label": "Downtown Seattle",
+   "visual": "Dense cluster of tall rectangular buildings near the waterfront.",
+   "pos": {
+    "x": 58.0,
+    "y": 33.0
+   },
+   "footprint": {
+    "w": 30.0,
+    "d": 21.0
+   },
+   "height_rel": 1.0,
+   "height_m": 60.0,
+   "border": [
+    [
+     45.0,
+     60.0
+    ],
+    [
+     55.0,
+     60.0
+    ],
+    [
+     65.0,
+     60.0
+    ],
+    [
+     75.0,
+     60.0
+    ],
+    [
+     70.0,
+     60.0
+    ],
+    [
+     60.0,
+     60.0
+    ],
+    [
+     50.0,
+     60.0
+    ]
+   ]
+  },
+  {
+   "ref": "cascade-mountains",
+   "kind": "place",
+   "label": "Cascade Mountains",
+   "visual": "Jagged mountain range along the top horizon line.",
+   "pos": {
+    "x": 50.0,
+    "y": 4.8
+   },
+   "footprint": {
+    "w": 95.0,
+    "d": 6.0
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": [
+    [
+     5.0,
+     60.0
+    ],
+    [
+     30.0,
+     60.0
+    ],
+    [
+     60.0,
+     60.0
+    ],
+    [
+     95.0,
+     60.0
+    ],
+    [
+     50.0,
+     60.0
+    ]
+   ]
+  },
+  {
+   "ref": "waterfront-piers",
+   "kind": "place",
+   "label": "Waterfront Piers",
+   "visual": "Series of rectangular docks protruding into Elliott Bay.",
+   "pos": {
+    "x": 52.0,
+    "y": 39.0
+   },
+   "footprint": {
+    "w": 45.0,
+    "d": 12.0
+   },
+   "height_rel": 0.15,
+   "height_m": 9.0,
+   "border": [
+    [
+     26.0,
+     60.0
+    ],
+    [
+     35.0,
+     60.0
+    ],
+    [
+     45.0,
+     60.0
+    ],
+    [
+     55.0,
+     60.0
+    ],
+    [
+     65.0,
+     60.0
+    ],
+    [
+     75.0,
+     60.0
+    ],
+    [
+     70.0,
+     60.0
+    ],
+    [
+     50.0,
+     60.0
+    ],
+    [
+     30.0,
+     60.0
+    ]
+   ]
+  },
+  {
+   "ref": "smith-cove",
+   "kind": "place",
+   "label": "Smith Cove",
+   "visual": "Inlet and docks on the far left edge.",
+   "pos": {
+    "x": 8.0,
+    "y": 25.2
+   },
+   "footprint": {
+    "w": 10.0,
+    "d": 6.0
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": [
+    [
+     2.0,
+     60.0
+    ],
+    [
+     8.0,
+     60.0
+    ],
+    [
+     12.0,
+     60.0
+    ],
+    [
+     8.0,
+     60.0
+    ]
+   ]
+  }
+ ],
+ "relations": [
+  {
+   "subject": "downtown-core",
+   "relation": "in_front_of",
+   "object": "lake-washington"
+  },
+  {
+   "subject": "lake-union",
+   "relation": "left_of",
+   "object": "lake-washington"
+  },
+  {
+   "subject": "waterfront-piers",
+   "relation": "facing",
+   "object": "elliott-bay"
+  },
+  {
+   "subject": "green-lake",
+   "relation": "behind",
+   "object": "lake-union"
+  },
+  {
+   "subject": "cascade-mountains",
+   "relation": "behind",
+   "object": "lake-washington"
+  },
+  {
+   "subject": "downtown-core",
+   "relation": "right_of",
+   "object": "lake-union"
+  }
+ ],
+ "review": {
+  "status": "vlm_draft",
+  "by": "",
+  "date": ""
+ }
+}

--- a/apps/modal-backend/tests/map_corpus/descriptions/village-medieval-manor.json
+++ b/apps/modal-backend/tests/map_corpus/descriptions/village-medieval-manor.json
@@ -1,0 +1,415 @@
+{
+ "map_id": "village-medieval-manor",
+ "rev": 2,
+ "genre": "village",
+ "style": "Vintage educational lithograph with a muted palette of ochre, sage green, and tan, featuring clean black ink outlines and hatched textures.",
+ "scale_tier": "district",
+ "frame": {
+  "w": 100.0,
+  "h": 60.0
+ },
+ "description": "A vertical-oriented plan of a medieval manor, depicted as an irregular landmass surrounded by a white border. The central and northern regions are dominated by 'Fallow', 'Autumn Planting', and 'Spring Planting' fields, rendered as interlocking rectangular strips in alternating tan and white. A large 'Woodland' area in the northeast is filled with small tree icons on a yellow background, while a smaller woodland sits on the western edge. A green 'Common Pasture' occupies the eastern-central portion. In the lower-central area, a cluster of red-roofed buildings forms the 'Manor House', 'Parsonage', and 'Church'. Directly south of these, a small 'Village' of green-roofed houses is nestled within a green 'Meadow'. A blue 'Pond' sits east of the village, fed by a 'Stream' that flows horizontally across the southern third of the map. A main road bisects the manor from northwest to south, with a branch heading east. Small patches of stippled 'Waste' land are located in the far northwest and southeast corners.",
+ "entities": [
+  {
+   "ref": "manor-house",
+   "kind": "place",
+   "label": "Manor House",
+   "visual": "U-shaped red-roofed building in the lower-central region.",
+   "pos": {
+    "x": 43.1,
+    "y": 36.8
+   },
+   "footprint": {
+    "w": 5.8,
+    "d": 2.2
+   },
+   "height_rel": 0.8,
+   "height_m": 8.0,
+   "border": [
+    [
+     39.8,
+     36.1
+    ],
+    [
+     45.9,
+     36.1
+    ],
+    [
+     45.9,
+     37.9
+    ],
+    [
+     44.1,
+     37.9
+    ],
+    [
+     44.1,
+     36.9
+    ],
+    [
+     41.6,
+     36.9
+    ],
+    [
+     41.6,
+     37.9
+    ],
+    [
+     39.8,
+     37.9
+    ]
+   ]
+  },
+  {
+   "ref": "village",
+   "kind": "place",
+   "label": "Village",
+   "visual": "Cluster of small green-roofed houses south of the manor house.",
+   "pos": {
+    "x": 51.8,
+    "y": 41.6
+   },
+   "footprint": {
+    "w": 6.4,
+    "d": 6.2
+   },
+   "height_rel": 0.4,
+   "height_m": 4.0,
+   "border": [
+    [
+     45.5,
+     38.1
+    ],
+    [
+     56.5,
+     38.1
+    ],
+    [
+     58.5,
+     42.3
+    ],
+    [
+     54.5,
+     45.3
+    ],
+    [
+     48.5,
+     45.3
+    ],
+    [
+     45.5,
+     42.3
+    ]
+   ]
+  },
+  {
+   "ref": "church",
+   "kind": "place",
+   "label": "Church",
+   "visual": "Small building with a cross symbol, east of the parsonage.",
+   "pos": {
+    "x": 52.1,
+    "y": 35.5
+   },
+   "footprint": {
+    "w": 4.8,
+    "d": 2.5
+   },
+   "height_rel": 1.0,
+   "height_m": 10.0,
+   "border": [
+    [
+     50.1,
+     34.3
+    ],
+    [
+     53.8,
+     34.3
+    ],
+    [
+     53.8,
+     36.3
+    ],
+    [
+     50.1,
+     36.3
+    ]
+   ]
+  },
+  {
+   "ref": "pond",
+   "kind": "place",
+   "label": "Pond",
+   "visual": "Irregular light blue water body east of the village.",
+   "pos": {
+    "x": 64.0,
+    "y": 38.4
+   },
+   "footprint": {
+    "w": 9.4,
+    "d": 4.1
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": [
+    [
+     57.5,
+     36.3
+    ],
+    [
+     63.5,
+     36.3
+    ],
+    [
+     69.5,
+     38.1
+    ],
+    [
+     67.5,
+     40.5
+    ],
+    [
+     61.5,
+     40.5
+    ],
+    [
+     57.5,
+     38.7
+    ]
+   ]
+  },
+  {
+   "ref": "common-pasture",
+   "kind": "place",
+   "label": "Common Pasture",
+   "visual": "Large green area in the eastern half with internal divisions.",
+   "pos": {
+    "x": 72.8,
+    "y": 18.4
+   },
+   "footprint": {
+    "w": 38.4,
+    "d": 16.6
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": [
+    [
+     54.5,
+     15.3
+    ],
+    [
+     74.5,
+     9.9
+    ],
+    [
+     91.5,
+     12.3
+    ],
+    [
+     93.5,
+     26.1
+    ],
+    [
+     71.5,
+     26.7
+    ],
+    [
+     53.5,
+     26.1
+    ]
+   ]
+  },
+  {
+   "ref": "woodland-ne",
+   "kind": "place",
+   "label": "Woodland",
+   "visual": "Large yellow area with tree symbols in the northeast corner.",
+   "pos": {
+    "x": 71.6,
+    "y": 9.8
+   },
+   "footprint": {
+    "w": 41.2,
+    "d": 11.3
+   },
+   "height_rel": 0.6,
+   "height_m": 6.0,
+   "border": [
+    [
+     50.5,
+     9.3
+    ],
+    [
+     74.5,
+     4.5
+    ],
+    [
+     91.5,
+     4.5
+    ],
+    [
+     91.5,
+     11.7
+    ],
+    [
+     74.5,
+     9.3
+    ],
+    [
+     54.5,
+     14.7
+    ],
+    [
+     50.5,
+     14.7
+    ]
+   ]
+  },
+  {
+   "ref": "mill",
+   "kind": "place",
+   "label": "Mill",
+   "visual": "Small building located on the stream near the pond.",
+   "pos": {
+    "x": 57.4,
+    "y": 40.3
+   },
+   "footprint": {
+    "w": 2.4,
+    "d": 1.4
+   },
+   "height_rel": 0.5,
+   "height_m": 5.0,
+   "border": [
+    [
+     55.5,
+     39.3
+    ],
+    [
+     58.5,
+     39.3
+    ],
+    [
+     58.5,
+     41.1
+    ],
+    [
+     55.5,
+     41.1
+    ]
+   ]
+  },
+  {
+   "ref": "stream",
+   "kind": "item",
+   "label": "Stream",
+   "visual": "Thin blue line flowing west to east across the lower map.",
+   "pos": {
+    "x": 24.4,
+    "y": 41.5
+   },
+   "footprint": {
+    "w": 15.2,
+    "d": 2.4
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": [
+    [
+     17.5,
+     48.9
+    ],
+    [
+     25.5,
+     45.3
+    ],
+    [
+     35.5,
+     39.3
+    ],
+    [
+     42.5,
+     38.7
+    ],
+    [
+     57.5,
+     38.7
+    ],
+    [
+     75.5,
+     39.3
+    ],
+    [
+     88.5,
+     39.3
+    ],
+    [
+     88.5,
+     40.5
+    ],
+    [
+     75.5,
+     40.5
+    ],
+    [
+     57.5,
+     39.9
+    ],
+    [
+     42.5,
+     39.9
+    ],
+    [
+     35.5,
+     40.5
+    ],
+    [
+     25.5,
+     46.5
+    ],
+    [
+     18.5,
+     50.7
+    ]
+   ]
+  }
+ ],
+ "relations": [
+  {
+   "subject": "village",
+   "relation": "near",
+   "object": "stream"
+  },
+  {
+   "subject": "manor-house",
+   "relation": "left_of",
+   "object": "village"
+  },
+  {
+   "subject": "church",
+   "relation": "right_of",
+   "object": "manor-house"
+  },
+  {
+   "subject": "pond",
+   "relation": "right_of",
+   "object": "village"
+  },
+  {
+   "subject": "woodland-ne",
+   "relation": "behind",
+   "object": "common-pasture"
+  },
+  {
+   "subject": "mill",
+   "relation": "near",
+   "object": "pond"
+  }
+ ],
+ "review": {
+  "status": "verified",
+  "by": "claude (image-inspected); eren spot-check welcome",
+  "date": "2026-06-11"
+ }
+}

--- a/apps/modal-backend/tests/map_corpus/draft.py
+++ b/apps/modal-backend/tests/map_corpus/draft.py
@@ -1,0 +1,203 @@
+"""VLM-draft a corpus description — the authoring workflow's first half.
+
+    CORPUS_DRAFT_RUN=1 .venv/bin/python -m tests.map_corpus.draft <map-id|all>
+or: make corpus-draft id=<map-id>
+
+Per map (PAID, ~3 Gemini calls ≈ $0.015): one describe call (style, prose,
+entities, relations), one detector pass (positions/footprints in the 100x60
+frame), one segmenter pass (borders + the anchored height ladder). The output
+lands in descriptions/<id>.json with review.status="vlm_draft" — a HUMAN (or
+an agent with eyes on the image) then corrects labels/positions/heights and
+prose, flips status to "verified", bumps rev. The recon bench consumes only
+verified entries; the description sha is part of the cell key, so an edit
+re-bills exactly that map's cells.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+from tests.map_corpus import DESCRIPTIONS, FRAME_H, FRAME_W, image_path, load_manifest
+
+_DESCRIBE_SYSTEM = (
+    "You are a careful cartographic annotator. Given a map image, return ONE "
+    "JSON object: {style: <art medium + palette, <=25 words>, scale_tier: one "
+    'of ["region","city","district","place"], description: <a precise 120-200 '
+    "word prose description of the WHOLE map a painter could redraw it from — "
+    "name the major features, their relative positions (north/south/etc), "
+    "relative sizes and heights>, entities: [6-10 of the most prominent named "
+    "features: {ref: <kebab-slug>, kind: one of "
+    '["place","item","creature","person"], label: <name as lettered or a '
+    "plain name>, visual: <=12 words}], relations: [4-8 spatial relations "
+    "between entity refs: {subject: <ref>, relation: one of "
+    '["near","behind","in_front_of","left_of","right_of","inside","on_top_of",'
+    '"facing"], object: <ref>}]}. Use only refs you declared.'
+)
+
+
+def _load_env() -> None:
+    env_path = Path(__file__).resolve().parents[2] / ".env"
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+    os.environ.setdefault("WORLD_BENCH_JUDGE_MODEL", "google/gemini-3-flash-preview")
+
+
+async def _describe(image_bytes: bytes) -> dict[str, Any]:
+    from providers import llm
+
+    b64 = base64.b64encode(image_bytes).decode("ascii")
+    model = os.environ.get("WORLD_BENCH_JUDGE_MODEL", "google/gemini-3-flash-preview")
+    client = llm._client()
+    resp = await client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": _DESCRIBE_SYSTEM},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this map."},
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": f"data:image/jpeg;base64,{b64}",
+                            "detail": "high",
+                        },
+                    },
+                ],
+            },
+        ],
+        temperature=0.0,
+        max_tokens=1600,
+        **llm._maybe_response_format(model),
+    )
+    raw = resp.choices[0].message.content or "{}"
+    return json.loads(raw[raw.find("{") : raw.rfind("}") + 1])
+
+
+def _slug(s: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", s.lower()).strip("-") or "x"
+
+
+async def draft_one(map_id: str) -> Path:
+    from providers import heights
+    from providers.detector import detect
+    from providers.segmenter import segment
+
+    genre = next(m["genre"] for m in load_manifest() if m["id"] == map_id)
+    img = image_path(map_id)
+    if not img.exists():
+        raise SystemExit(f"{img} missing — run `make corpus-fetch` first")
+    image_bytes = img.read_bytes()
+
+    described = await _describe(image_bytes)
+    raw_entities = [
+        e for e in described.get("entities", [])
+        if isinstance(e, dict) and str(e.get("label", "")).strip()
+    ]
+    labels = [str(e["label"]).strip() for e in raw_entities]
+
+    detections = {d["label"].lower(): d for d in await detect(image_bytes, labels)}
+    segments = await segment(image_bytes, labels)
+    seg_by_label = {s["label"].lower(): s for s in segments}
+    heights_m = heights.infer_heights_m(list(segments))
+
+    entities = []
+    for e in raw_entities:
+        label = str(e["label"]).strip()
+        det = detections.get(label.lower())
+        if det is None:
+            print(f"  drop {label!r}: detector found no box (prose keeps it)")
+            continue
+        seg = seg_by_label.get(label.lower())
+        entities.append(
+            {
+                "ref": _slug(str(e.get("ref") or label)),
+                "kind": str(e.get("kind") or "place"),
+                "label": label,
+                "visual": str(e.get("visual") or ""),
+                "pos": {
+                    "x": round(det["x_pct"] * FRAME_W, 1),
+                    "y": round(det["y_pct"] * FRAME_H, 1),
+                },
+                "footprint": {
+                    "w": round(max(det["w_pct"] * FRAME_W, 0.5), 1),
+                    "d": round(max(det["h_pct"] * FRAME_H, 0.5), 1),
+                },
+                "height_rel": seg["rel_height"] if seg else 0.0,
+                "height_m": round(heights_m.get(label, 0.0), 1) or None,
+                "border": (
+                    [
+                        [round(x * FRAME_W, 1), round(y * FRAME_H, 1)]
+                        for x, y in seg["polygon"]
+                    ]
+                    if seg
+                    else None
+                ),
+            }
+        )
+
+    refs = {e["ref"] for e in entities}
+    relations = [
+        r for r in described.get("relations", [])
+        if isinstance(r, dict)
+        and _slug(str(r.get("subject", ""))) in refs
+        and _slug(str(r.get("object", ""))) in refs
+    ]
+    relations = [
+        {
+            "subject": _slug(str(r["subject"])),
+            "relation": str(r.get("relation", "near")),
+            "object": _slug(str(r["object"])),
+        }
+        for r in relations
+    ]
+
+    desc = {
+        "map_id": map_id,
+        "rev": 1,
+        "genre": genre,
+        "style": str(described.get("style") or ""),
+        "scale_tier": str(described.get("scale_tier") or "region"),
+        "frame": {"w": FRAME_W, "h": FRAME_H},
+        "description": str(described.get("description") or ""),
+        "entities": entities,
+        "relations": relations,
+        "review": {"status": "vlm_draft", "by": "", "date": ""},
+    }
+    DESCRIPTIONS.mkdir(parents=True, exist_ok=True)
+    out = DESCRIPTIONS / f"{map_id}.json"
+    out.write_text(json.dumps(desc, indent=1) + "\n")
+    print(f"  wrote {out.name}: {len(entities)} entities, {len(relations)} relations")
+    return out
+
+
+async def _run(target: str) -> int:
+    ids = [m["id"] for m in load_manifest()] if target == "all" else [target]
+    for map_id in ids:
+        print(f"drafting {map_id} ...")
+        await draft_one(map_id)
+    return 0
+
+
+def main() -> int:
+    if os.environ.get("CORPUS_DRAFT_RUN") != "1":
+        print("corpus-draft: PAID (~$0.015/map, Gemini). Set CORPUS_DRAFT_RUN=1 to run.")
+        return 0
+    _load_env()
+    target = sys.argv[1] if len(sys.argv) > 1 else "all"
+    return asyncio.run(_run(target))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/modal-backend/tests/map_corpus/manifest.json
+++ b/apps/modal-backend/tests/map_corpus/manifest.json
@@ -1,0 +1,53 @@
+{
+  "_comment": "Ground-truth corpus sources. All public-domain scans served via Wikimedia Commons Special:FilePath (width-1600 renditions). Binaries are fetched to images/ (gitignored) by scripts/fetch_corpus.py; sha256 is pinned on first fetch (--pin) and verified after.",
+  "maps": [
+    {
+      "id": "fantasy-treasure-island",
+      "genre": "fantasy",
+      "source_url": "https://commons.wikimedia.org/wiki/Special:FilePath/Treasure%20Island%20from%20the%20book%20by%20Robert%20Louis%20Stevenson%20LOC%2096682593.jpg?width=1600",
+      "license_note": "Public domain (R.L. Stevenson, 1883; Library of Congress scan via Wikimedia Commons)",
+      "sha256": "464a07bbab3db6088f171e04001e7c965ce179af880f10f8ad67c5e8cd2e9c92",
+      "filename": "fantasy-treasure-island.jpg"
+    },
+    {
+      "id": "urban-seattle-1904",
+      "genre": "urban",
+      "source_url": "https://commons.wikimedia.org/wiki/Special:FilePath/Bird's%20Eye%20View%2C%20City%20of%20Seattle%20and%20vicinity%2C%201904%20(MAPS%2063).jpg?width=1600",
+      "license_note": "Public domain (1904 pictorial city map via Wikimedia Commons)",
+      "sha256": "d82e1b8308f2b9311011488355584aedcf56610b000ce0cc415255ad13fb4b20",
+      "filename": "urban-seattle-1904.jpg"
+    },
+    {
+      "id": "sea-boston-harbor-1877",
+      "genre": "sea",
+      "source_url": "https://commons.wikimedia.org/wiki/Special:FilePath/1877%20U.S.%20Coast%20Survey%20Map%20or%20Chart%20of%20Boston%20Bay%20and%20Harbor%20-%20Geographicus%20-%20BostonBay-uscs-1877.jpg?width=1600",
+      "license_note": "Public domain (1877 U.S. Coast Survey chart via Wikimedia Commons)",
+      "sha256": "c007c88388076a05f42a62ffd77953756b610c198e78f6e78d0976873fcc3060",
+      "filename": "sea-boston-harbor-1877.jpg"
+    },
+    {
+      "id": "forest-yellowstone-1904",
+      "genre": "forest",
+      "source_url": "https://commons.wikimedia.org/wiki/Special:FilePath/Yellowstone%20National%20Park%20by%20Wellge%2C%201904.jpg?width=1600",
+      "license_note": "Public domain (Wellge 1904 panoramic park map via Wikimedia Commons)",
+      "sha256": "427f2fdf0c3734f174c94cff60b1cf6d2beb23f3882d58c9230c47d9d4ea528b",
+      "filename": "forest-yellowstone-1904.jpg"
+    },
+    {
+      "id": "scifi-mars-schiaparelli-1888",
+      "genre": "sci-fi",
+      "source_url": "https://commons.wikimedia.org/wiki/Special:FilePath/Map%20of%20Mars%20by%20Schiaparelli%201888.jpg?width=1600",
+      "license_note": "Public domain (Schiaparelli 1888 Mars map via Wikimedia Commons)",
+      "sha256": "4fba502c340e1632f2ec2975b31590a1867f8ee35897827127eb2c5d9320ba39",
+      "filename": "scifi-mars-schiaparelli-1888.jpg"
+    },
+    {
+      "id": "village-medieval-manor",
+      "genre": "village",
+      "source_url": "https://commons.wikimedia.org/wiki/Special:FilePath/Plan%20mediaeval%20manor.jpg?width=1600",
+      "license_note": "Public domain (medieval manor plan via Wikimedia Commons)",
+      "sha256": "7d7fcdf1d38ca5a55d592986f370681aa4111021f7574690f71791bb5888c00e",
+      "filename": "village-medieval-manor.jpg"
+    }
+  ]
+}

--- a/apps/modal-backend/tests/test_map_corpus.py
+++ b/apps/modal-backend/tests/test_map_corpus.py
@@ -1,0 +1,64 @@
+"""Corpus integrity gate (free): every committed description references a
+manifest map, refs are unique, positions sit inside the frame, heights pass
+the tier sanity band, relations use the solver vocabulary, and borders stay
+inside the frame. Runs on drafts AND verified entries — a draft that fails
+here isn't worth a human's review time."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from providers.heights import tier_sanity_band
+from providers.llm import _PLAN_RELATIONS
+from tests.map_corpus import DESCRIPTIONS, load_manifest
+
+_DESCRIPTIONS = sorted(DESCRIPTIONS.glob("*.json")) if DESCRIPTIONS.exists() else []
+
+
+def test_manifest_ids_unique_and_filenames_match() -> None:
+    maps = load_manifest()
+    ids = [m["id"] for m in maps]
+    assert len(ids) == len(set(ids))
+    for m in maps:
+        assert m["filename"].startswith(m["id"]), m["id"]
+        assert m["source_url"].startswith("https://"), m["id"]
+        assert m["license_note"], m["id"]
+
+
+def test_corpus_covers_five_genres() -> None:
+    genres = {m["genre"] for m in load_manifest()}
+    assert len(genres) >= 5, f"corpus spans only {sorted(genres)}"
+
+
+@pytest.mark.parametrize(
+    "path", _DESCRIPTIONS, ids=[p.stem for p in _DESCRIPTIONS]
+)
+def test_description_integrity(path) -> None:
+    desc = json.loads(path.read_text())
+    manifest_ids = {m["id"] for m in load_manifest()}
+    assert desc["map_id"] in manifest_ids
+    assert desc["map_id"] == path.stem
+    assert desc["review"]["status"] in {"vlm_draft", "verified"}
+    assert desc["description"].strip()
+    assert desc["style"].strip()
+
+    frame = desc["frame"]
+    refs = [e["ref"] for e in desc["entities"]]
+    assert refs and len(refs) == len(set(refs)), "entity refs must be unique"
+    lo, hi = tier_sanity_band(desc.get("scale_tier"))
+    for e in desc["entities"]:
+        assert 0 <= e["pos"]["x"] <= frame["w"], f"{e['ref']} x out of frame"
+        assert 0 <= e["pos"]["y"] <= frame["h"], f"{e['ref']} y out of frame"
+        assert e["footprint"]["w"] > 0 and e["footprint"]["d"] > 0
+        if e.get("height_m"):
+            assert lo <= e["height_m"] <= hi, (
+                f"{e['ref']}: {e['height_m']} m outside the "
+                f"{desc.get('scale_tier')} band {lo}-{hi}"
+            )
+        for vx, vy in e.get("border") or []:
+            assert -1 <= vx <= frame["w"] + 1 and -1 <= vy <= frame["h"] + 1
+
+    for r in desc["relations"]:
+        assert r["relation"] in _PLAN_RELATIONS, r
+        assert r["subject"] in refs and r["object"] in refs, r


### PR DESCRIPTION
Track B, PR 3 of 5. Stacked on #66 (draft.py uses the segmenter + heights ladder). Cost to author: ~$0.09 of Gemini calls.

## What it adds

- **`tests/map_corpus/manifest.json`** — 6 public-domain maps across 6 genres, served as sha256-pinned Wikimedia Commons width-1600 renditions: Treasure Island (1883, fantasy), Seattle birds-eye (1904, urban), Boston Harbor coast chart (1877, sea), Yellowstone panoramic (1904, forest), Schiaparelli's Mars (1888, sci-fi), and a medieval manor plan (village). `scripts/fetch_corpus.py --pin` fetches to a gitignored `images/` dir with 429 backoff and pins/verifies the shas — binaries never enter git.
- **Authoring workflow** (`make corpus-draft id=…`): one VLM describe call (style, 120-200 word redrawable prose, entities, relations in the layout-solver vocabulary) + the detector (positions/footprints in the shared 100×60 frame) + the B2 segmenter (borders + anchored heights) → `descriptions/<id>.json` at `review.status="vlm_draft"`. A reviewer with eyes on the image corrects and flips to `"verified"`; the recon bench consumes only verified entries.
- **3 of 6 verified by actual image inspection** (treasure-island, mars, manor). The review caught real draft errors — exactly why the human step exists: the segmenter traced a *different ship* than the detector boxed for the Hispaniola; two positions sat at label edges rather than feature centres; 7 relations were geometrically wrong (e.g. "hill on_top_of inlet", "village on_top_of stream"). The other 3 (urban/sea/forest) remain `vlm_draft` — **@eren they're ready for your pass** (open image + JSON side by side, fix, set status verified, bump rev).
- **Free integrity gate** `tests/test_map_corpus.py`: unique ids/refs, ≥5 genres, positions in frame, heights inside the `scale_tier` sanity band, relations ⊆ solver vocabulary, borders in frame — drafts must pass before they're worth review time.
- `description_sha` excludes the review block, so flipping a draft to verified re-bills **zero** matrix cells; editing actual ground truth re-bills exactly that map's cells.

## Verification
Full `pytest -m "not paid"` (incl. 8 corpus integrity cases over the committed descriptions), `ruff`, `mypy` green. Fetch + pin ran clean; all 6 images render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)