### PR TITLE
feat(eval): reconstruction bench — description → regenerated map → compare

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ scripts/perfbudget/report.json
 
 # Superpowers brainstorm companion (ephemeral mockup files).
 .superpowers/
+
+# Matrix-bench disk cache (cell images + records + judge replies — re-runs
+# must be free, but the binaries never belong in git).
+apps/modal-backend/tests/**/cache/

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,15 @@ corpus-fetch:
 	cd apps/modal-backend && .venv/bin/python scripts/fetch_corpus.py --pin
 corpus-draft:
 	cd apps/modal-backend && CORPUS_DRAFT_RUN=1 .venv/bin/python -m tests.map_corpus.draft $(or $(id),all)
+# Reconstruction bench: regenerate each VERIFIED corpus map from its authored
+# description (graph = product planning path, direct = ground-truth layout),
+# extract + score vs ground truth + VLM judges. Rides the matrix chassis:
+# cached, budget-capped, dry-run without the flag. PAID (~$0.40 first run,
+# cached after):  make eval-recon   (preview: make eval-recon-dry)
+eval-recon-dry:
+	cd apps/modal-backend && .venv/bin/python -m tests.recon_bench.runner
+eval-recon:
+	cd apps/modal-backend && RECON_BENCH_RUN=1 .venv/bin/python -m tests.recon_bench.runner
 eval-repair:
 	cd apps/modal-backend && REPAIR_BENCH_RUN=1 .venv/bin/python -m pytest -m repair -q
 eval-edit:

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,17 @@ eval-baselines:
 	-cd apps/modal-backend && ENTER_BENCH_RUN=1 .venv/bin/python -m tests.continuity_bench.enter_runner
 	-cd apps/modal-backend && VIEW_BENCH_RUN=1 .venv/bin/python -m tests.continuity_bench.view_runner
 	-cd apps/modal-backend && EDIT_REGION_BENCH_RUN=1 .venv/bin/python -m tests.edit_bench.runner
+# Matrix bench (the evolvable eval): scenarios × arms × models × prompt-
+# variants, disk-cached so prompt evolution re-bills only changed cells.
+# DRY-RUN IS THE DEFAULT — eval-matrix-dry prints the per-cell cost table
+# (the mandatory preview, $0). eval-matrix runs uncached cells under the
+# hard budget cap (MATRIX_BUDGET_USD, default $3; MATRIX_ALLOW_PARTIAL=1
+# runs to the cap instead of refusing). Scenarios come from the map corpus
+# once the recon bench (tests/recon_bench) lands.
+eval-matrix-dry:
+	cd apps/modal-backend && .venv/bin/python -m tests.matrix_bench.runner
+eval-matrix:
+	cd apps/modal-backend && MATRIX_BENCH_RUN=1 .venv/bin/python -m tests.matrix_bench.runner
 # Free coverage report (backend lines + the web view-path files).
 coverage:
 	cd apps/modal-backend && .venv/bin/python -m pytest -q -m "not paid" --cov=providers --cov=generate --cov-report=term | tail -30

--- a/apps/modal-backend/providers/judge.py
+++ b/apps/modal-backend/providers/judge.py
@@ -163,6 +163,30 @@ async def score_prompt_alignment(prompt: str, image: bytes) -> JudgeResult:
     return await _ask_judge(system, user_text, [_image_block(image)])
 
 
+async def score_map_plausibility(
+    image: bytes, genre: str, description: str
+) -> JudgeResult:
+    """Is this a COHERENT, physically plausible map of its genre? The recon
+    bench's sanity judge — geometry scores can be high on a map that is
+    locally right but globally nonsense (collaged panels, rivers that stop
+    dead, three projections at once)."""
+    system = (
+        "You are a strict cartographic plausibility judge. Score on a 0-10 "
+        "scale how much the image reads as ONE coherent, physically "
+        "plausible map of the stated genre: a single consistent scale and "
+        "projection, connected features (roads, rivers and coasts continue "
+        "rather than stopping dead), no impossible geometry, no collaged "
+        "panels, lettering (if any) sparse and legible. Ignore artistic "
+        "quality — judge coherence only."
+        ' Return JSON exactly: {"score": <0-10 number>, "rationale": "<one short sentence>"}.'
+    )
+    user_text = (
+        f"Genre: {genre}. The map is meant to depict: {description[:400]}\n\n"
+        "Score the map's plausibility on a 0-10 scale."
+    )
+    return await _ask_judge(system, user_text, [_image_block(image)])
+
+
 async def score_view_conformance(image: bytes, projection: str) -> JudgeResult:
     """Does the render actually use the INTENDED projection? (the view grammar's
     conformance judge). Per-projection criteria spelled out so the judge can

--- a/apps/modal-backend/tests/eval_baselines.json
+++ b/apps/modal-backend/tests/eval_baselines.json
@@ -35,6 +35,13 @@
       "regression_band": 2.0,
       "n_min": 2,
       "source": "make eval-edit-region first run 2026-06-10 (flux fill, single-shot, production fill register): alignment 10.0 + medium 10.0 on both cases, outside-change 0.0000 per case (the compositor's promise, gated per-case not by mean). Tracks the production arm only; extra A/B arms via EDIT_REGION_BENCH_MODELS report but never gate. Band 2.0 absorbs single judge-noise samples."
+    },
+    "recon_fidelity": {
+      "metric": "composite_mean",
+      "baseline": 0.69,
+      "regression_band": 0.12,
+      "n_min": 4,
+      "source": "make eval-recon 2026-06-12 (3 verified corpus maps x graph/direct, nano-banana, recon_base.v1; judge ~0.6 Spearman so the band is wide)"
     }
   }
 }

--- a/apps/modal-backend/tests/matrix_bench/__init__.py
+++ b/apps/modal-backend/tests/matrix_bench/__init__.py
@@ -1,0 +1,4 @@
+"""Matrix bench — the evolvable eval chassis (scenarios x arms x models x
+prompt-variants). Pure pieces (_cache, _budget, _record, _pareto) are free-CI
+golden-tested; runner.py drives them with injected gen/extract/judge functions
+so the whole loop is testable without spending a cent."""

--- a/apps/modal-backend/tests/matrix_bench/_budget.py
+++ b/apps/modal-backend/tests/matrix_bench/_budget.py
@@ -1,0 +1,39 @@
+"""Budget ledger — the matrix runner's hard spending gate.
+
+`charge()` is called BEFORE each paid call (estimate → charge → call), so a
+bug can overrun the cap by exactly zero calls. Estimates come from
+providers/spend.py (the same table docs/COSTS.md documents); this module is
+pure — no I/O, no env reads — so the refusal order is golden-testable.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+class BudgetExceeded(RuntimeError):
+    """Raised BEFORE a paid call that would cross the cap."""
+
+
+# One VLM judge / extraction call on gemini-flash — coarse, mirrors how
+# spend.py folds the whole VLM stack into a flat $0.02 per generation.
+JUDGE_CALL_FLAT = 0.005
+
+
+@dataclass
+class Ledger:
+    cap_usd: float
+    spent_usd: float = 0.0
+
+    def charge(self, estimate_usd: float) -> None:
+        """Reserve `estimate_usd` or raise — never partially mutates."""
+        est = max(0.0, estimate_usd)
+        if self.spent_usd + est > self.cap_usd + 1e-9:
+            raise BudgetExceeded(
+                f"${self.spent_usd + est:.2f} would cross the "
+                f"${self.cap_usd:.2f} cap (spent ${self.spent_usd:.2f})"
+            )
+        self.spent_usd += est
+
+    @property
+    def remaining_usd(self) -> float:
+        return max(0.0, self.cap_usd - self.spent_usd)

--- a/apps/modal-backend/tests/matrix_bench/_cache.py
+++ b/apps/modal-backend/tests/matrix_bench/_cache.py
@@ -1,0 +1,106 @@
+"""Disk cache for matrix cells and judge replies — evolution's free lunch.
+
+A cell's identity is the sha of everything that could change its output:
+(scenario, description sha, arm, model, prompt sha, params sha). Editing a
+prompt file or a corpus description changes its sha → only those cells
+re-bill; an identical re-run is 100% hits and $0.00 to-bill.
+
+Layout (gitignored):
+    tests/matrix_bench/cache/<cell_key>/record.json
+    tests/matrix_bench/cache/<cell_key>/image.jpg
+    tests/matrix_bench/cache/judges/<judge_key>.json
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+DEFAULT_ROOT = Path(__file__).resolve().parent / "cache"
+
+
+def _sha(blob: bytes) -> str:
+    return hashlib.sha256(blob).hexdigest()
+
+
+def params_sha(params: dict[str, Any]) -> str:
+    """Order-insensitive digest of the params dict."""
+    return _sha(
+        json.dumps(params, sort_keys=True, separators=(",", ":")).encode()
+    )[:12]
+
+
+def text_sha(text: str) -> str:
+    """Digest for prompt templates / descriptions (full content, not name)."""
+    return _sha(text.encode())[:12]
+
+
+def image_sha(jpeg: bytes) -> str:
+    return _sha(jpeg)[:12]
+
+
+def cell_key(
+    scenario_id: str,
+    desc_sha: str,
+    arm: str,
+    model: str,
+    prompt_sha: str,
+    params: dict[str, Any],
+) -> str:
+    blob = "|".join(
+        [scenario_id, desc_sha, arm, model, prompt_sha, params_sha(params)]
+    )
+    return _sha(blob.encode())[:20]
+
+
+def judge_key(judge_name: str, judge_model: str, img_sha: str, extra: str = "") -> str:
+    return _sha("|".join([judge_name, judge_model, img_sha, extra]).encode())[:20]
+
+
+class CellCache:
+    def __init__(self, root: Path | None = None) -> None:
+        self.root = root or DEFAULT_ROOT
+
+    def _dir(self, key: str) -> Path:
+        return self.root / key
+
+    def image_path(self, key: str) -> Path:
+        return self._dir(key) / "image.jpg"
+
+    def load(self, key: str) -> dict[str, Any] | None:
+        p = self._dir(key) / "record.json"
+        if not p.exists():
+            return None
+        try:
+            return json.loads(p.read_text())
+        except (json.JSONDecodeError, OSError):
+            return None  # corrupt entry = miss; the cell simply re-runs
+
+    def store(
+        self, key: str, record: dict[str, Any], jpeg: bytes | None = None
+    ) -> Path:
+        d = self._dir(key)
+        d.mkdir(parents=True, exist_ok=True)
+        if jpeg is not None:
+            (d / "image.jpg").write_bytes(jpeg)
+        (d / "record.json").write_text(json.dumps(record, indent=1))
+        return d
+
+
+class JudgeCache:
+    def __init__(self, root: Path | None = None) -> None:
+        self.root = (root or DEFAULT_ROOT) / "judges"
+
+    def load(self, key: str) -> dict[str, Any] | None:
+        p = self.root / f"{key}.json"
+        if not p.exists():
+            return None
+        try:
+            return json.loads(p.read_text())
+        except (json.JSONDecodeError, OSError):
+            return None
+
+    def store(self, key: str, reply: dict[str, Any]) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+        (self.root / f"{key}.json").write_text(json.dumps(reply, indent=1))

--- a/apps/modal-backend/tests/matrix_bench/_pareto.py
+++ b/apps/modal-backend/tests/matrix_bench/_pareto.py
@@ -1,0 +1,91 @@
+"""Pareto analysis over matrix cells — the "90% faster, style a bit off"
+tradeoff surface. Pure; golden-tested for free.
+
+Cells aggregate to CONFIGS (model x prompt-variant, means over scenarios);
+the front is non-dominated on (quality max, cost min, latency min); findings
+are the human sentences the report prints ("nano-banana @ recon_base.v1:
+94% of the best composite at 26% of its cost, 2.5x faster").
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def aggregate_configs(
+    records: list[dict[str, Any]], quality_key: str = "composite"
+) -> list[dict[str, Any]]:
+    """Mean quality/cost/latency per (model, variant) over all its cells."""
+    groups: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for r in records:
+        groups.setdefault((r["model"], r["prompt_variant"]), []).append(r)
+    configs: list[dict[str, Any]] = []
+    for (model, variant), cells in sorted(groups.items()):
+        quals = [c["scores"].get(quality_key) for c in cells]
+        quals = [q for q in quals if isinstance(q, (int, float))]
+        if not quals:
+            continue  # nothing scored — nothing to rank
+        costs = [float(c["cost_usd"].get("total", 0.0)) for c in cells]
+        lats = [sum(c.get("timing_s", {}).values()) for c in cells]
+        n = len(cells)
+        configs.append(
+            {
+                "model": model,
+                "variant": variant,
+                "n": n,
+                "quality": sum(quals) / len(quals),
+                "cost_usd": sum(costs) / n,
+                "latency_s": sum(lats) / n,
+            }
+        )
+    return configs
+
+
+def _dominates(a: dict[str, Any], b: dict[str, Any]) -> bool:
+    """a beats-or-ties b everywhere and beats it somewhere."""
+    ge = (
+        a["quality"] >= b["quality"]
+        and a["cost_usd"] <= b["cost_usd"]
+        and a["latency_s"] <= b["latency_s"]
+    )
+    gt = (
+        a["quality"] > b["quality"]
+        or a["cost_usd"] < b["cost_usd"]
+        or a["latency_s"] < b["latency_s"]
+    )
+    return ge and gt
+
+
+def pareto_front(configs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        c
+        for c in configs
+        if not any(_dominates(o, c) for o in configs if o is not c)
+    ]
+
+
+def near_best_findings(
+    configs: list[dict[str, Any]],
+    quality_slack: float = 0.10,
+    min_saving: float = 0.30,
+) -> list[str]:
+    """Configs within `quality_slack` of the best quality that save at least
+    `min_saving` (fraction) on cost or latency vs the best-quality config."""
+    if not configs:
+        return []
+    best = max(configs, key=lambda c: c["quality"])
+    floor = best["quality"] * (1.0 - quality_slack)
+    out: list[str] = []
+    for c in configs:
+        if c is best or c["quality"] < floor:
+            continue
+        cost_save = 1.0 - (c["cost_usd"] / best["cost_usd"]) if best["cost_usd"] > 0 else 0.0
+        speedup = best["latency_s"] / c["latency_s"] if c["latency_s"] > 0 else 1.0
+        if cost_save >= min_saving or speedup >= 1.0 / (1.0 - min_saving):
+            pct_q = 100.0 * c["quality"] / best["quality"] if best["quality"] > 0 else 0.0
+            pct_c = 100.0 * c["cost_usd"] / best["cost_usd"] if best["cost_usd"] > 0 else 0.0
+            out.append(
+                f"{c['model']} @ {c['variant']}: {pct_q:.0f}% of the best "
+                f"composite ({best['model']} @ {best['variant']}) at "
+                f"{pct_c:.0f}% of its cost, {speedup:.1f}x faster"
+            )
+    return out

--- a/apps/modal-backend/tests/matrix_bench/_record.py
+++ b/apps/modal-backend/tests/matrix_bench/_record.py
@@ -1,0 +1,130 @@
+"""Sweep configs, cell expansion, prompt-variant rendering, run records.
+
+Prompt variants are VERSIONED FILES (prompts/<name>.v<N>.txt) with named
+{placeholders}; evolution = copy v1 → v2, edit, point the sweep at it. The
+old version's cells stay cached, only the new one bills. The run record is
+the "inputs/outputs in great detail" requirement: everything needed to
+reproduce or audit a cell rides in one JSON object.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
+SWEEPS_DIR = Path(__file__).resolve().parent / "sweeps"
+
+_REQUIRED_SWEEP_KEYS = ("name", "scenarios", "arms", "models", "variants", "judges")
+
+
+@dataclass(frozen=True)
+class Cell:
+    scenario_id: str
+    arm: str
+    model: str
+    variant: str  # prompt file stem, e.g. "recon_base.v1"
+    params: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def label(self) -> str:
+        return f"{self.scenario_id}/{self.arm}/{self.model}/{self.variant}"
+
+
+def load_sweep(path: Path) -> dict[str, Any]:
+    sweep = json.loads(path.read_text())
+    missing = [k for k in _REQUIRED_SWEEP_KEYS if k not in sweep]
+    if missing:
+        raise ValueError(f"sweep {path.name} missing keys: {missing}")
+    for k in ("scenarios", "arms", "models", "variants", "judges"):
+        if not isinstance(sweep[k], list) or not all(
+            isinstance(v, str) for v in sweep[k]
+        ):
+            raise ValueError(f"sweep {path.name}: '{k}' must be a list of strings")
+    sweep.setdefault("params", {})
+    sweep.setdefault("budget_usd", 3.0)
+    sweep.setdefault("composite_weights", {})
+    return sweep
+
+
+def expand_cells(sweep: dict[str, Any], scenario_ids: list[str]) -> list[Cell]:
+    """The full product — scenario order outermost so a budget-partial run
+    still covers whole scenarios before starting the next."""
+    return [
+        Cell(sid, arm, model, variant, dict(sweep.get("params", {})))
+        for sid in scenario_ids
+        for arm in sweep["arms"]
+        for model in sweep["models"]
+        for variant in sweep["variants"]
+    ]
+
+
+def load_prompt(variant: str, prompts_dir: Path | None = None) -> str:
+    p = (prompts_dir or PROMPTS_DIR) / f"{variant}.txt"
+    if not p.exists():
+        raise FileNotFoundError(
+            f"prompt variant '{variant}' not found at {p} — variants are "
+            "versioned files; copy an existing one and bump the version"
+        )
+    return p.read_text()
+
+
+class _StrictSlots(dict):
+    def __missing__(self, key: str) -> str:
+        raise KeyError(
+            f"prompt template references {{{key}}} but no value was provided"
+        )
+
+
+def render_prompt(template: str, **slots: str) -> str:
+    """Fill named {placeholders}; a referenced-but-missing slot raises (a
+    silently empty slot would bill a garbage cell)."""
+    return template.format_map(_StrictSlots(slots)).strip()
+
+
+def new_record(
+    cell: Cell,
+    *,
+    cell_id: str,
+    run_at: str,
+    prompt_sha: str,
+    desc_sha: str,
+    inputs: dict[str, Any],
+    outputs: dict[str, Any],
+    timing_s: dict[str, float],
+    cost_usd: dict[str, float],
+    scores: dict[str, float],
+    cache: dict[str, str],
+) -> dict[str, Any]:
+    cost = dict(cost_usd)
+    cost["total"] = round(sum(cost.values()), 6)
+    return {
+        "cell_key": cell_id,
+        "run_at": run_at,
+        "scenario_id": cell.scenario_id,
+        "arm": cell.arm,
+        "model": cell.model,
+        "prompt_variant": cell.variant,
+        "prompt_sha": prompt_sha,
+        "description_sha": desc_sha,
+        "params": cell.params,
+        "inputs": inputs,
+        "outputs": outputs,
+        "timing_s": {k: round(v, 3) for k, v in timing_s.items()},
+        "cost_usd": cost,
+        "scores": scores,
+        "cache": cache,
+    }
+
+
+_REQUIRED_RECORD_KEYS = (
+    "cell_key", "run_at", "scenario_id", "arm", "model", "prompt_variant",
+    "prompt_sha", "description_sha", "params", "inputs", "outputs",
+    "timing_s", "cost_usd", "scores", "cache",
+)
+
+
+def validate_record(record: dict[str, Any]) -> list[str]:
+    """Schema lint for tests + report ingestion: missing keys, not errors."""
+    return [k for k in _REQUIRED_RECORD_KEYS if k not in record]

--- a/apps/modal-backend/tests/matrix_bench/prompts/recon_base.v1.txt
+++ b/apps/modal-backend/tests/matrix_bench/prompts/recon_base.v1.txt
@@ -1,0 +1,9 @@
+A complete top-down illustrated map, drawn as {style}.
+
+{description}
+
+{layout_clause}
+
+Draw the WHOLE mapped area edge to edge — one coherent map sheet, nothing
+cut off, no collage panels. Flat overhead cartographic view, no perspective.
+Keep any lettering sparse and legible — no garbled text.

--- a/apps/modal-backend/tests/matrix_bench/runner.py
+++ b/apps/modal-backend/tests/matrix_bench/runner.py
@@ -164,56 +164,67 @@ def run_matrix(
             log(f"STOP: {report['stopped_reason']}")
             break
 
-        scenario = by_id[cell.scenario_id]
-        template = load_prompt(cell.variant, prompts_dir)
-        timing: dict[str, float] = {}
-        cost: dict[str, float] = {}
+        # One flaky provider call must not torch the rest of the sweep (paid
+        # cells already cached stay cached; this cell records its failure and
+        # re-runs next time — its charge stays spent, honestly).
+        try:
+            scenario = by_id[cell.scenario_id]
+            template = load_prompt(cell.variant, prompts_dir)
+            timing: dict[str, float] = {}
+            cost: dict[str, float] = {}
 
-        t0 = time.monotonic()
-        gen = gen_fn(cell, scenario.payload, template)
-        timing["gen"] = time.monotonic() - t0
-        jpeg: bytes = gen["jpeg"]
-        from providers import spend
-
-        cost["image"] = spend.estimate_image(gen.get("model") or cell.model)
-
-        outputs: dict[str, Any] = {"model": gen.get("model") or cell.model}
-        if extract_fn is not None:
             t0 = time.monotonic()
-            extracted, ex_cost = extract_fn(cell, scenario.payload, jpeg)
-            timing["extract"] = time.monotonic() - t0
-            cost["extract"] = ex_cost
-            outputs.update(extracted)
+            gen = gen_fn(cell, scenario.payload, template)
+            timing["gen"] = time.monotonic() - t0
+            jpeg: bytes = gen["jpeg"]
+            from providers import spend
 
-        judge_scores: dict[str, float] = {}
-        t0 = time.monotonic()
-        judge_cost = 0.0
-        for name in sweep["judges"]:
-            score, j_cost = judge_fns[name](cell, scenario.payload, jpeg)
-            judge_scores[name] = score
-            judge_cost += j_cost
-        timing["judges"] = time.monotonic() - t0
-        cost["judges"] = judge_cost
+            cost["image"] = spend.estimate_image(gen.get("model") or cell.model)
 
-        scores = (
-            score_fn(cell, scenario.payload, outputs, judge_scores)
-            if score_fn is not None
-            else dict(judge_scores)
-        )
+            outputs: dict[str, Any] = {"model": gen.get("model") or cell.model}
+            if extract_fn is not None:
+                t0 = time.monotonic()
+                extracted, ex_cost = extract_fn(cell, scenario.payload, jpeg)
+                timing["extract"] = time.monotonic() - t0
+                cost["extract"] = ex_cost
+                outputs.update(extracted)
 
-        record = new_record(
-            cell,
-            cell_id=key,
-            run_at=run_at,
-            prompt_sha=psha,
-            desc_sha=scenario.desc_sha,
-            inputs=dict(gen.get("inputs", {})),
-            outputs=outputs,
-            timing_s=timing,
-            cost_usd=cost,
-            scores=scores,
-            cache={"image": "miss", "judges": "miss"},
-        )
+            judge_scores: dict[str, float] = {}
+            t0 = time.monotonic()
+            judge_cost = 0.0
+            for name in sweep["judges"]:
+                score, j_cost = judge_fns[name](cell, scenario.payload, jpeg)
+                judge_scores[name] = score
+                judge_cost += j_cost
+            timing["judges"] = time.monotonic() - t0
+            cost["judges"] = judge_cost
+
+            scores = (
+                score_fn(cell, scenario.payload, outputs, judge_scores)
+                if score_fn is not None
+                else dict(judge_scores)
+            )
+
+            record = new_record(
+                cell,
+                cell_id=key,
+                run_at=run_at,
+                prompt_sha=psha,
+                desc_sha=scenario.desc_sha,
+                inputs=dict(gen.get("inputs", {})),
+                outputs=outputs,
+                timing_s=timing,
+                cost_usd=cost,
+                scores=scores,
+                cache={"image": "miss", "judges": "miss"},
+            )
+        except Exception as exc:
+            err = f"{type(exc).__name__}: {exc}"
+            log(f"FAILED {cell.label}: {err}")
+            report["cells"].append(
+                {"cell_key": key, "label": cell.label, "status": "failed", "error": err}
+            )
+            continue
         cache.store(key, record, jpeg)
         report["cells"].append(record)
         log(f"ran {cell.label}: scores={scores} (${record['cost_usd']['total']:.3f})")

--- a/apps/modal-backend/tests/matrix_bench/runner.py
+++ b/apps/modal-backend/tests/matrix_bench/runner.py
@@ -1,0 +1,281 @@
+"""Matrix bench chassis — scenarios x arms x models x prompt-variants.
+
+DRY-RUN IS THE DEFAULT. Without MATRIX_BENCH_RUN=1 the runner walks the
+sweep, resolves the cache, prints the per-cell table (cached? / est $) and
+the total to-bill figure, touches no network, and exits 0 — that table is
+the mandatory cost preview AND the free CI smoke. With MATRIX_BENCH_RUN=1
+it runs uncached cells through injected gen/extract/judge functions, hard-
+capped by the budget ledger (charge BEFORE every paid call).
+
+Run it (standalone, .env auto-loaded, judge pinned to Gemini):
+    cd apps/modal-backend && .venv/bin/python -m tests.matrix_bench.runner
+or:  make eval-matrix-dry   /   make eval-matrix
+
+Scenario types plug in via `run_matrix(scenarios=...)` — the recon bench
+(tests/recon_bench) registers the map-corpus scenarios; the chassis itself
+is scenario-agnostic and fully testable with mock functions.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from tests.matrix_bench._budget import JUDGE_CALL_FLAT, BudgetExceeded, Ledger
+from tests.matrix_bench._cache import CellCache, cell_key, text_sha
+from tests.matrix_bench._record import (
+    SWEEPS_DIR,
+    Cell,
+    expand_cells,
+    load_prompt,
+    load_sweep,
+    new_record,
+)
+
+_REPORTS = Path(__file__).resolve().parent / "reports"
+
+# Extraction (detector + segmenter + view estimate) — flat, mirrors spend.py's
+# honest-coarse style.
+EXTRACT_FLAT = 0.01
+
+# gen_fn(cell, scenario_payload, prompt_template) -> {"jpeg": bytes,
+#   "model": str, "inputs": {...}}  (inputs = the rendered prompt + refs etc.)
+GenFn = Callable[[Cell, Any, str], dict[str, Any]]
+# judge_fn(cell, scenario_payload, jpeg) -> (score, cost_usd)
+JudgeFn = Callable[[Cell, Any, bytes], tuple[float, float]]
+# extract_fn(cell, scenario_payload, jpeg) -> (outputs dict, cost_usd)
+ExtractFn = Callable[[Cell, Any, bytes], tuple[dict[str, Any], float]]
+# score_fn(cell, scenario_payload, outputs, judge_scores) -> scores (incl composite)
+ScoreFn = Callable[[Cell, Any, dict[str, Any], dict[str, float]], dict[str, float]]
+
+
+@dataclass(frozen=True)
+class Scenario:
+    id: str
+    desc_sha: str  # digest of the scenario's ground truth — part of cell identity
+    payload: Any = None  # opaque to the chassis; scenario types interpret
+
+
+def estimate_cell(
+    cell: Cell, n_judges: int, has_extract: bool
+) -> float:
+    from providers import spend
+
+    return (
+        spend.estimate_image(cell.model)
+        + n_judges * JUDGE_CALL_FLAT
+        + (EXTRACT_FLAT if has_extract else 0.0)
+    )
+
+
+def _table(rows: list[tuple[Cell, bool, float]]) -> str:
+    lines = [f"{'cell':60} {'cached':>6} {'est $':>7}"]
+    for cell, cached, est in rows:
+        lines.append(f"{cell.label[:60]:60} {'yes' if cached else 'no':>6} {est:>7.3f}")
+    return "\n".join(lines)
+
+
+def run_matrix(
+    scenarios: list[Scenario],
+    sweep: dict[str, Any],
+    *,
+    gen_fn: GenFn,
+    judge_fns: dict[str, JudgeFn] | None = None,
+    extract_fn: ExtractFn | None = None,
+    score_fn: ScoreFn | None = None,
+    live: bool = False,
+    allow_partial: bool = False,
+    cache: CellCache | None = None,
+    ledger: Ledger | None = None,
+    prompts_dir: Path | None = None,
+    report_path: Path | None = None,
+    run_at: str = "",
+    log: Callable[[str], None] = print,
+) -> dict[str, Any]:
+    judge_fns = judge_fns or {}
+    missing_judges = [j for j in sweep["judges"] if j not in judge_fns]
+    if live and missing_judges:
+        raise ValueError(f"sweep names judges with no implementation: {missing_judges}")
+    cache = cache or CellCache()
+    by_id = {s.id: s for s in scenarios}
+    cells = expand_cells(sweep, [s.id for s in scenarios])
+
+    # Resolve every cell against the cache BEFORE any spend — the preview.
+    resolved: list[tuple[Cell, str, str, dict[str, Any] | None, float]] = []
+    for cell in cells:
+        template = load_prompt(cell.variant, prompts_dir)
+        psha = text_sha(template)
+        key = cell_key(
+            cell.scenario_id, by_id[cell.scenario_id].desc_sha,
+            cell.arm, cell.model, psha, cell.params,
+        )
+        cached = cache.load(key)
+        est = (
+            0.0
+            if cached is not None
+            else estimate_cell(cell, len(sweep["judges"]), extract_fn is not None)
+        )
+        resolved.append((cell, key, psha, cached, est))
+
+    to_bill = round(sum(est for *_, est in resolved), 4)
+    log(_table([(c, cached is not None, est) for c, _, _, cached, est in resolved]))
+    log(f"total to-bill: ${to_bill:.2f} ({sum(1 for *_, c, _ in resolved if c is None)} uncached cells)")
+
+    report: dict[str, Any] = {
+        "sweep": sweep["name"],
+        "run_at": run_at,
+        "live": live,
+        "to_bill_usd": to_bill,
+        "cells": [],
+        "stopped_reason": None,
+    }
+
+    if not live:
+        report["cells"] = [
+            cached
+            if cached is not None
+            else {"cell_key": key, "status": "would_run", "label": cell.label,
+                  "est_usd": round(est, 4)}
+            for cell, key, _, cached, est in resolved
+        ]
+        _write_report(report, report_path)
+        return report
+
+    ledger = ledger or Ledger(cap_usd=float(sweep["budget_usd"]))
+    if to_bill > ledger.remaining_usd + 1e-9 and not allow_partial:
+        raise BudgetExceeded(
+            f"sweep needs ${to_bill:.2f} but only ${ledger.remaining_usd:.2f} "
+            "remains under the cap — trim the sweep, raise MATRIX_BUDGET_USD, "
+            "or set MATRIX_ALLOW_PARTIAL=1 to run until the cap"
+        )
+
+    for cell, key, psha, cached, est in resolved:
+        if cached is not None:
+            report["cells"].append(cached)
+            continue
+        try:
+            ledger.charge(est)
+        except BudgetExceeded:
+            report["stopped_reason"] = f"budget exhausted before {cell.label}"
+            log(f"STOP: {report['stopped_reason']}")
+            break
+
+        scenario = by_id[cell.scenario_id]
+        template = load_prompt(cell.variant, prompts_dir)
+        timing: dict[str, float] = {}
+        cost: dict[str, float] = {}
+
+        t0 = time.monotonic()
+        gen = gen_fn(cell, scenario.payload, template)
+        timing["gen"] = time.monotonic() - t0
+        jpeg: bytes = gen["jpeg"]
+        from providers import spend
+
+        cost["image"] = spend.estimate_image(gen.get("model") or cell.model)
+
+        outputs: dict[str, Any] = {"model": gen.get("model") or cell.model}
+        if extract_fn is not None:
+            t0 = time.monotonic()
+            extracted, ex_cost = extract_fn(cell, scenario.payload, jpeg)
+            timing["extract"] = time.monotonic() - t0
+            cost["extract"] = ex_cost
+            outputs.update(extracted)
+
+        judge_scores: dict[str, float] = {}
+        t0 = time.monotonic()
+        judge_cost = 0.0
+        for name in sweep["judges"]:
+            score, j_cost = judge_fns[name](cell, scenario.payload, jpeg)
+            judge_scores[name] = score
+            judge_cost += j_cost
+        timing["judges"] = time.monotonic() - t0
+        cost["judges"] = judge_cost
+
+        scores = (
+            score_fn(cell, scenario.payload, outputs, judge_scores)
+            if score_fn is not None
+            else dict(judge_scores)
+        )
+
+        record = new_record(
+            cell,
+            cell_id=key,
+            run_at=run_at,
+            prompt_sha=psha,
+            desc_sha=scenario.desc_sha,
+            inputs=dict(gen.get("inputs", {})),
+            outputs=outputs,
+            timing_s=timing,
+            cost_usd=cost,
+            scores=scores,
+            cache={"image": "miss", "judges": "miss"},
+        )
+        cache.store(key, record, jpeg)
+        report["cells"].append(record)
+        log(f"ran {cell.label}: scores={scores} (${record['cost_usd']['total']:.3f})")
+
+    report["spent_usd"] = round(ledger.spent_usd, 4)
+    _write_report(report, report_path)
+    return report
+
+
+def _write_report(report: dict[str, Any], path: Path | None) -> None:
+    out = path or (_REPORTS / "matrix_latest.json")
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=1))
+
+
+def _load_env() -> None:
+    """Best-effort .env load + pin the judge to Gemini (not the .env's qwen
+    VLM, which rate-limits — see memory project_qwen_ratelimit)."""
+    env_path = Path(__file__).resolve().parents[2] / ".env"
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+    os.environ.setdefault("WORLD_BENCH_JUDGE_MODEL", "google/gemini-3-flash-preview")
+
+
+def main() -> int:
+    _load_env()
+    sweep_path = Path(os.environ.get("MATRIX_SWEEP", "")) if os.environ.get(
+        "MATRIX_SWEEP"
+    ) else SWEEPS_DIR / "default.json"
+    sweep = load_sweep(sweep_path)
+    if os.environ.get("MATRIX_BUDGET_USD"):
+        sweep["budget_usd"] = float(os.environ["MATRIX_BUDGET_USD"])
+
+    # Scenario providers register here as they land. "corpus:*" → the
+    # map-corpus reconstruction scenarios (tests/recon_bench, PR B4).
+    try:
+        from tests.recon_bench.runner import corpus_scenarios, recon_fns
+    except ImportError:
+        print(
+            "matrix: no scenario providers available yet — the recon bench "
+            "(tests/recon_bench) registers the map-corpus scenarios. "
+            "Sweep + cache + budget validated; nothing to run."
+        )
+        return 0
+
+    scenarios = corpus_scenarios(sweep["scenarios"])
+    fns = recon_fns(sweep)
+    report = run_matrix(
+        scenarios,
+        sweep,
+        live=os.environ.get("MATRIX_BENCH_RUN") == "1",
+        allow_partial=os.environ.get("MATRIX_ALLOW_PARTIAL") == "1",
+        run_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        **fns,
+    )
+    return 0 if report.get("stopped_reason") is None else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/modal-backend/tests/matrix_bench/sweeps/default.json
+++ b/apps/modal-backend/tests/matrix_bench/sweeps/default.json
@@ -1,0 +1,22 @@
+{
+  "name": "default",
+  "scenarios": ["corpus:*"],
+  "arms": ["graph"],
+  "models": [
+    "fal-ai/nano-banana",
+    "fal-ai/nano-banana-2",
+    "fal-ai/nano-banana-pro"
+  ],
+  "variants": ["recon_base.v1"],
+  "params": { "aspect_ratio": "16:9" },
+  "judges": ["style_pair", "map_plausibility", "prompt_alignment"],
+  "composite_weights": {
+    "presence": 0.2,
+    "pos_aligned": 0.25,
+    "size": 0.1,
+    "height_order": 0.15,
+    "style_pair": 0.15,
+    "map_plausibility": 0.15
+  },
+  "budget_usd": 3.0
+}

--- a/apps/modal-backend/tests/matrix_bench/sweeps/recon.json
+++ b/apps/modal-backend/tests/matrix_bench/sweeps/recon.json
@@ -1,0 +1,20 @@
+{
+  "name": "recon",
+  "scenarios": ["corpus:*"],
+  "arms": ["graph", "direct"],
+  "models": ["fal-ai/nano-banana"],
+  "variants": ["recon_base.v1"],
+  "params": { "aspect_ratio": "16:9" },
+  "judges": ["style_pair", "map_plausibility", "prompt_alignment"],
+  "composite_weights": {
+    "presence": 0.2,
+    "pos_aligned": 0.2,
+    "pos_raw": 0.05,
+    "size": 0.1,
+    "height_order": 0.1,
+    "style_pair": 0.15,
+    "map_plausibility": 0.1,
+    "prompt_alignment": 0.1
+  },
+  "budget_usd": 1.5
+}

--- a/apps/modal-backend/tests/recon_bench/__init__.py
+++ b/apps/modal-backend/tests/recon_bench/__init__.py
@@ -1,0 +1,5 @@
+"""Reconstruction bench — regenerate each ground-truth corpus map from its
+authored description, extract what actually got drawn, and score it against
+the ground truth (presence, position raw + aligned, size, heights) plus VLM
+judges (style vs the reference scan, plausibility, prompt alignment). Plugs
+the corpus scenarios into the matrix chassis (tests/matrix_bench)."""

--- a/apps/modal-backend/tests/recon_bench/_align.py
+++ b/apps/modal-backend/tests/recon_bench/_align.py
@@ -1,0 +1,144 @@
+"""Coordinate-frame alignment + geometric scoring. Pure, golden-tested.
+
+A regenerated map can have the right RELATIVE layout while the whole
+composition shifts or rescales — that is a render-register difference, not
+a reconstruction failure. So we score positions twice: `pos_raw` (absolute
+placement in the shared frame) and `pos_aligned` (after fitting a
+similarity transform: uniform scale 0.5..2 + translation, optionally
+x-flipped, NO rotation — maps are upright). Fewer than 2 label matches
+can't anchor a transform → aligned := raw, flagged unalignable.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import hypot, log2
+from typing import Any
+
+FRAME_W = 100.0
+FRAME_H = 60.0
+# A matched entity scores 0 when it lands this fraction of the frame
+# diagonal away from ground truth (linear falloff in between).
+_POS_TOLERANCE_FRAC = 0.25
+
+Point = tuple[float, float]
+
+
+@dataclass(frozen=True)
+class Alignment:
+    scale: float
+    tx: float
+    ty: float
+    flip_x: bool
+    residual: float  # RMS distance after transform, frame units
+    matched: int
+
+    def apply(self, p: Point) -> Point:
+        x = (FRAME_W - p[0]) if self.flip_x else p[0]
+        return (self.scale * x + self.tx, self.scale * p[1] + self.ty)
+
+
+def fit_alignment(pairs: list[tuple[Point, Point]]) -> Alignment | None:
+    """Least-squares uniform scale + translation over (expected, observed)
+    centre pairs; tries the x-flipped register too and keeps the lower
+    residual. None when <2 pairs (nothing to anchor)."""
+    if len(pairs) < 2:
+        return None
+    best: Alignment | None = None
+    for flip in (False, True):
+        exp = [((FRAME_W - e[0]) if flip else e[0], e[1]) for e, _ in pairs]
+        obs = [o for _, o in pairs]
+        n = len(pairs)
+        ex = sum(p[0] for p in exp) / n
+        ey = sum(p[1] for p in exp) / n
+        ox = sum(p[0] for p in obs) / n
+        oy = sum(p[1] for p in obs) / n
+        num = sum(
+            (e[0] - ex) * (o[0] - ox) + (e[1] - ey) * (o[1] - oy)
+            for e, o in zip(exp, obs, strict=True)
+        )
+        den = sum((e[0] - ex) ** 2 + (e[1] - ey) ** 2 for e in exp)
+        s = num / den if den > 1e-9 else 1.0
+        s = max(0.5, min(2.0, s))
+        tx = ox - s * ex
+        ty = oy - s * ey
+        residual = (
+            sum(
+                (s * e[0] + tx - o[0]) ** 2 + (s * e[1] + ty - o[1]) ** 2
+                for e, o in zip(exp, obs, strict=True)
+            )
+            / n
+        ) ** 0.5
+        cand = Alignment(s, tx, ty, flip, residual, n)
+        if best is None or cand.residual < best.residual:
+            best = cand
+    return best
+
+
+def _pos_score(dist: float) -> float:
+    tol = _POS_TOLERANCE_FRAC * hypot(FRAME_W, FRAME_H)
+    return max(0.0, 1.0 - dist / tol)
+
+
+def geo_scores(
+    expected: dict[str, dict[str, Any]],
+    observed: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Geometric scorecard. Both sides keyed by normalized label, each entry
+    {pos: (x, y), diag: float} in frame units (diag = footprint diagonal —
+    the size proxy). Returns presence, pos_raw, pos_aligned, size, the
+    fitted alignment (or None) and the unalignable flag."""
+    if not expected:
+        return {
+            "presence": 0.0, "pos_raw": 0.0, "pos_aligned": 0.0, "size": 0.0,
+            "alignment": None, "unalignable": True,
+        }
+    matched = sorted(set(expected) & set(observed))
+    presence = len(matched) / len(expected)
+    if not matched:
+        return {
+            "presence": 0.0, "pos_raw": 0.0, "pos_aligned": 0.0, "size": 0.0,
+            "alignment": None, "unalignable": True,
+        }
+    pairs = [(expected[k]["pos"], observed[k]["pos"]) for k in matched]
+    pos_raw = sum(
+        _pos_score(hypot(e[0] - o[0], e[1] - o[1])) for e, o in pairs
+    ) / len(pairs)
+
+    align = fit_alignment(pairs)
+    if align is None:
+        pos_aligned, size_scale = pos_raw, 1.0
+    else:
+        pos_aligned = sum(
+            _pos_score(hypot(*(a - b for a, b in zip(align.apply(e), o, strict=True))))
+            for e, o in pairs
+        ) / len(pairs)
+        size_scale = align.scale
+
+    # Size: footprint diagonal ratio vs the fitted scale, within x2 falloff
+    # in log space (same generosity as height_abs_score).
+    size_terms = []
+    for k in matched:
+        ed, od = expected[k].get("diag", 0.0), observed[k].get("diag", 0.0)
+        if ed > 0 and od > 0:
+            size_terms.append(max(0.0, 1.0 - abs(log2((od / ed) / size_scale))))
+    size = sum(size_terms) / len(size_terms) if size_terms else 0.0
+
+    return {
+        "presence": presence,
+        "pos_raw": pos_raw,
+        "pos_aligned": pos_aligned,
+        "size": size,
+        "alignment": (
+            {
+                "scale": round(align.scale, 3),
+                "tx": round(align.tx, 2),
+                "ty": round(align.ty, 2),
+                "flip_x": align.flip_x,
+                "residual": round(align.residual, 2),
+                "matched": align.matched,
+            }
+            if align
+            else None
+        ),
+        "unalignable": align is None,
+    }

--- a/apps/modal-backend/tests/recon_bench/runner.py
+++ b/apps/modal-backend/tests/recon_bench/runner.py
@@ -1,0 +1,336 @@
+"""Reconstruction bench — description → regenerated map → compare.
+
+Two arms per corpus scenario:
+  graph  — the PRODUCT path: prose → plan_world_from_description →
+           layout_solver → layout clause → render. Measures the whole
+           describe-a-place pipeline.
+  direct — ground-truth entities → layout clause → render. Isolates the
+           image model from the planner (a low graph score with a high
+           direct score blames the planning, not the paint).
+
+Per cell: render → detect + segment + anchored heights → geometric scores
+(presence / pos_raw / pos_aligned / size / height order + abs) → VLM judges
+(style vs the reference scan, plausibility, prompt alignment) → composite
+via the sweep's weights. Everything rides the matrix chassis: disk cache,
+hard budget cap, dry-run by default.
+
+Run:  make eval-recon          (RECON_BENCH_RUN=1, sweeps/recon.json)
+Dry:  .venv/bin/python -m tests.recon_bench.runner   (cost preview, $0)
+Needs `make corpus-fetch` first (the style judge compares against the
+reference scans).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from tests.map_corpus import description_sha, image_path, load_descriptions
+from tests.matrix_bench._budget import JUDGE_CALL_FLAT
+from tests.matrix_bench._record import Cell, load_sweep, render_prompt
+from tests.matrix_bench.runner import EXTRACT_FLAT, Scenario, run_matrix
+from tests.recon_bench._align import FRAME_H, FRAME_W, geo_scores
+
+_REPORT = Path(__file__).resolve().parent / "reports" / "recon_latest.json"
+_SWEEP = Path(__file__).resolve().parents[1] / "matrix_bench" / "sweeps" / "recon.json"
+
+
+def corpus_scenarios(specs: list[str]) -> list[Scenario]:
+    """Resolve sweep scenario specs: "corpus:*" → every VERIFIED corpus
+    description; "corpus:<map_id>" → that one (must be verified)."""
+    verified = {d["map_id"]: d for d in load_descriptions(status="verified")}
+    wanted: list[dict[str, Any]] = []
+    for spec in specs:
+        if spec == "corpus:*":
+            wanted.extend(verified.values())
+        elif spec.startswith("corpus:"):
+            map_id = spec.split(":", 1)[1]
+            if map_id not in verified:
+                raise SystemExit(
+                    f"scenario {spec!r} is not a VERIFIED corpus description — "
+                    "review the draft and flip review.status first"
+                )
+            wanted.append(verified[map_id])
+    seen: set[str] = set()
+    out = []
+    for d in wanted:
+        if d["map_id"] in seen:
+            continue
+        seen.add(d["map_id"])
+        out.append(Scenario(id=d["map_id"], desc_sha=description_sha(d), payload=d))
+    return out
+
+
+def _norm(label: str) -> str:
+    return " ".join(label.lower().split())
+
+
+def _expected_layout(desc: dict[str, Any]) -> tuple[list[dict[str, Any]], list[tuple[str, float, str]] | None]:
+    """Ground-truth entities → ProjectedEntity bins (for the layout clause)
+    + relative-height tuples (label, ratio, anchor) for its HEIGHTS block."""
+    from providers.geometry import project_top_down
+
+    ents = [
+        {
+            "id": e["ref"],
+            "label": e["label"],
+            "pos": e["pos"],
+            "footprint": e["footprint"],
+            "height": e.get("height_m") or 4.0,
+        }
+        for e in desc["entities"]
+    ]
+    expected = project_top_down(ents, FRAME_W, FRAME_H)
+    real = sorted(
+        ((e["label"], float(e["height_m"])) for e in desc["entities"] if e.get("height_m")),
+        key=lambda t: t[1],
+    )
+    heights = None
+    if len(real) >= 2:
+        anchor_label, anchor_h = real[0]
+        heights = [(label, h / anchor_h, anchor_label) for label, h in real[1:]]
+    return expected, heights
+
+
+def _graph_layout(desc: dict[str, Any], loop: asyncio.AbstractEventLoop) -> list[dict[str, Any]]:
+    """The product path: prose → scene graph → solved geos → bins."""
+    from providers.geometry import project_top_down
+    from providers.layout_solver import solve_layout
+    from providers.llm import plan_world_from_description
+
+    graph = loop.run_until_complete(plan_world_from_description(desc["description"]))
+    solved = solve_layout(graph)
+    ents = [
+        {
+            "id": str(g.get("id") or g.get("label") or i),
+            "label": str(g.get("label") or ""),
+            "pos": g["pos"],
+            "footprint": g["footprint"],
+            "height": g.get("height") or 4.0,
+        }
+        for i, g in enumerate(solved.geos)
+    ]
+    return project_top_down(ents, FRAME_W, FRAME_H)
+
+
+def recon_fns(sweep: dict[str, Any]) -> dict[str, Any]:
+    """The chassis plug: gen/extract/judge/score functions. One persistent
+    event loop for every async provider call (a per-call asyncio.run would
+    orphan the cached HTTP clients)."""
+    from providers import heights as heights_lib
+    from providers import judge
+    from providers.detector import detect
+    from providers.image import generate_image
+    from providers.prompt_library.layout import layout_constraints
+    from providers.segmenter import segment
+
+    loop = asyncio.new_event_loop()
+    weights: dict[str, float] = dict(sweep.get("composite_weights", {}))
+
+    def _await(make_coro: Any) -> Any:
+        """Run an async provider call with ONE retry — OpenRouter
+        occasionally times a single request out, and a bench cell costs
+        real money to redo. `make_coro` is a factory (a coroutine can't be
+        awaited twice)."""
+        try:
+            return loop.run_until_complete(make_coro())
+        except Exception:
+            time.sleep(5)
+            return loop.run_until_complete(make_coro())
+
+    def gen_fn(cell: Cell, desc: dict[str, Any], template: str) -> dict[str, Any]:
+        expected, heights = _expected_layout(desc)
+        if cell.arm == "graph":
+            layout = _graph_layout(desc, loop)
+            clause = layout_constraints(layout, heights=heights)
+        elif cell.arm == "direct":
+            clause = layout_constraints(expected, heights=heights)
+        else:
+            raise ValueError(f"unknown recon arm: {cell.arm!r}")
+        prompt = render_prompt(
+            template,
+            style=desc["style"],
+            description=desc["description"],
+            layout_clause=clause,
+        )
+        img = loop.run_until_complete(
+            generate_image(
+                prompt=prompt,
+                aspect_ratio=str(cell.params.get("aspect_ratio", "16:9")),
+                model_override=cell.model,
+            )
+        )
+        return {
+            "jpeg": img.jpeg_bytes,
+            "model": img.model,
+            "inputs": {"prompt_text": prompt, "layout_clause": clause, "arm": cell.arm},
+        }
+
+    def extract_fn(
+        cell: Cell, desc: dict[str, Any], jpeg: bytes
+    ) -> tuple[dict[str, Any], float]:
+        labels = [e["label"] for e in desc["entities"]]
+        detections = _await(lambda: detect(jpeg, labels))
+        segments = _await(lambda: segment(jpeg, labels))
+        inferred = heights_lib.infer_heights_m(list(segments))
+        return (
+            {
+                "detections": detections,
+                "segments": segments,
+                "heights_m": inferred,
+            },
+            EXTRACT_FLAT,
+        )
+
+    def _style_judge(cell: Cell, desc: dict[str, Any], jpeg: bytes) -> tuple[float, float]:
+        ref = image_path(desc["map_id"])
+        if not ref.exists():
+            raise SystemExit(
+                f"{ref} missing — run `make corpus-fetch` before the recon bench "
+                "(the style judge compares against the reference scan)"
+            )
+        r = _await(lambda: judge.score_style_pair(ref.read_bytes(), jpeg))
+        return r.score, JUDGE_CALL_FLAT
+
+    def _plausibility_judge(
+        cell: Cell, desc: dict[str, Any], jpeg: bytes
+    ) -> tuple[float, float]:
+        r = _await(
+            lambda: judge.score_map_plausibility(jpeg, desc["genre"], desc["description"])
+        )
+        return r.score, JUDGE_CALL_FLAT
+
+    def _alignment_judge(
+        cell: Cell, desc: dict[str, Any], jpeg: bytes
+    ) -> tuple[float, float]:
+        r = _await(
+            lambda: judge.score_prompt_alignment(desc["description"], jpeg)
+        )
+        return r.score, JUDGE_CALL_FLAT
+
+    def score_fn(
+        cell: Cell,
+        desc: dict[str, Any],
+        outputs: dict[str, Any],
+        judge_scores: dict[str, float],
+    ) -> dict[str, float]:
+        expected = {
+            _norm(e["label"]): {
+                "pos": (e["pos"]["x"], e["pos"]["y"]),
+                "diag": (e["footprint"]["w"] ** 2 + e["footprint"]["d"] ** 2) ** 0.5,
+            }
+            for e in desc["entities"]
+        }
+        observed = {
+            _norm(d["label"]): {
+                "pos": (d["x_pct"] * FRAME_W, d["y_pct"] * FRAME_H),
+                "diag": (
+                    (d["w_pct"] * FRAME_W) ** 2 + (d["h_pct"] * FRAME_H) ** 2
+                ) ** 0.5,
+            }
+            for d in outputs.get("detections", [])
+        }
+        geo = geo_scores(expected, observed)
+        expected_h = {
+            _norm(e["label"]): float(e["height_m"])
+            for e in desc["entities"]
+            if e.get("height_m")
+        }
+        observed_h = {
+            _norm(k): v for k, v in (outputs.get("heights_m") or {}).items()
+        }
+        scores: dict[str, float] = {
+            "presence": round(geo["presence"], 3),
+            "pos_raw": round(geo["pos_raw"], 3),
+            "pos_aligned": round(geo["pos_aligned"], 3),
+            "size": round(geo["size"], 3),
+            "height_order": round(
+                heights_lib.height_order_score(expected_h, observed_h), 3
+            ),
+            "height_abs": round(
+                heights_lib.height_abs_score(expected_h, observed_h), 3
+            ),
+            # judges arrive 0-10; composite consumes 0-1
+            **{k: round(v / 10.0, 3) for k, v in judge_scores.items()},
+        }
+        used = {k: w for k, w in weights.items() if k in scores and w > 0}
+        if used:
+            total = sum(used.values())
+            scores["composite"] = round(
+                sum(scores[k] * w for k, w in used.items()) / total, 3
+            )
+        return scores
+
+    return {
+        "gen_fn": gen_fn,
+        "extract_fn": extract_fn,
+        "judge_fns": {
+            "style_pair": _style_judge,
+            "map_plausibility": _plausibility_judge,
+            "prompt_alignment": _alignment_judge,
+        },
+        "score_fn": score_fn,
+    }
+
+
+def _load_env() -> None:
+    env_path = Path(__file__).resolve().parents[2] / ".env"
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+    os.environ.setdefault("WORLD_BENCH_JUDGE_MODEL", "google/gemini-3-flash-preview")
+
+
+def main() -> int:
+    _load_env()
+    sweep = load_sweep(_SWEEP)
+    if os.environ.get("MATRIX_BUDGET_USD"):
+        sweep["budget_usd"] = float(os.environ["MATRIX_BUDGET_USD"])
+    scenarios = corpus_scenarios(sweep["scenarios"])
+    if not scenarios:
+        print("recon: no VERIFIED corpus descriptions — review the drafts first.")
+        return 1
+    live = os.environ.get("RECON_BENCH_RUN") == "1"
+    report = run_matrix(
+        scenarios,
+        sweep,
+        live=live,
+        allow_partial=os.environ.get("MATRIX_ALLOW_PARTIAL") == "1",
+        run_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        report_path=_REPORT,
+        **recon_fns(sweep),
+    )
+    if live:
+        cells = [c for c in report["cells"] if "scores" in c]
+        composites = [
+            c["scores"]["composite"] for c in cells if "composite" in c.get("scores", {})
+        ]
+        if composites:
+            mean = sum(composites) / len(composites)
+            print(f"recon composite mean: {mean:.3f} over {len(composites)} cells")
+            try:
+                from tests._baseline import compare
+
+                for name, key in (
+                    ("recon_fidelity", "composite"),
+                    ("recon_height_order", "height_order"),
+                ):
+                    vals = [c["scores"][key] for c in cells if key in c.get("scores", {})]
+                    if vals:
+                        v = compare(name, sum(vals) / len(vals), len(vals))
+                        print(f"  {v.status}: {v.detail}")
+            except KeyError:
+                print("  (no committed baseline yet — commit one from this run)")
+    json.dumps(report)  # smoke: the report is JSON-serializable
+    return 0 if report.get("stopped_reason") is None else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/modal-backend/tests/recon_bench/test_recon.py
+++ b/apps/modal-backend/tests/recon_bench/test_recon.py
@@ -1,0 +1,157 @@
+"""Recon-bench gate (free): the alignment fit recovers synthetic
+shift/scale/flip transforms, the geometric scorecard behaves at the edges,
+the expected-layout builder produces correct bins + height ratios, and
+corpus scenario resolution honours the verified-only contract."""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests.recon_bench._align import Alignment, fit_alignment, geo_scores
+from tests.recon_bench.runner import _expected_layout, corpus_scenarios
+
+# --- alignment fit -----------------------------------------------------------
+
+
+def _pairs(transform, pts: list[tuple[float, float]]):
+    return [(p, transform(p)) for p in pts]
+
+
+PTS = [(10.0, 10.0), (50.0, 30.0), (90.0, 50.0), (30.0, 45.0)]
+
+
+def test_fit_recovers_translation() -> None:
+    a = fit_alignment(_pairs(lambda p: (p[0] + 7, p[1] - 3), PTS))
+    assert a is not None and not a.flip_x
+    assert a.scale == pytest.approx(1.0, abs=1e-6)
+    assert (a.tx, a.ty) == (pytest.approx(7.0), pytest.approx(-3.0))
+    assert a.residual == pytest.approx(0.0, abs=1e-6)
+
+
+def test_fit_recovers_scale_and_flip() -> None:
+    a = fit_alignment(_pairs(lambda p: (1.5 * p[0] - 10, 1.5 * p[1] + 5), PTS))
+    assert a is not None and a.scale == pytest.approx(1.5) and not a.flip_x
+    flipped = fit_alignment(_pairs(lambda p: (100.0 - p[0], p[1]), PTS))
+    assert flipped is not None and flipped.flip_x
+    assert flipped.residual == pytest.approx(0.0, abs=1e-6)
+
+
+def test_fit_clamps_scale_and_needs_two_points() -> None:
+    a = fit_alignment(_pairs(lambda p: (5 * p[0], 5 * p[1]), PTS))
+    assert a is not None and a.scale == 2.0  # clamped, residual stays honest
+    assert a.residual > 0
+    assert fit_alignment([(PTS[0], PTS[0])]) is None
+
+
+def test_alignment_apply_round_trips() -> None:
+    a = Alignment(scale=1.5, tx=-10.0, ty=5.0, flip_x=False, residual=0.0, matched=4)
+    assert a.apply((10.0, 10.0)) == (pytest.approx(5.0), pytest.approx(20.0))
+
+
+# --- geometric scorecard -----------------------------------------------------
+
+
+def _entry(x: float, y: float, diag: float = 8.0) -> dict[str, Any]:
+    return {"pos": (x, y), "diag": diag}
+
+
+def test_geo_scores_perfect_reconstruction() -> None:
+    truth = {"tower": _entry(20, 10), "harbor": _entry(70, 40), "wood": _entry(40, 50)}
+    s = geo_scores(truth, dict(truth))
+    assert s["presence"] == 1.0
+    assert s["pos_raw"] == pytest.approx(1.0)
+    assert s["pos_aligned"] == pytest.approx(1.0)
+    assert s["size"] == pytest.approx(1.0)
+    assert not s["unalignable"]
+
+
+def test_geo_scores_shifted_layout_scores_high_aligned_low_raw() -> None:
+    truth = {"tower": _entry(20, 10), "harbor": _entry(70, 40), "wood": _entry(40, 50)}
+    shifted = {k: _entry(v["pos"][0] + 20, v["pos"][1] + 8) for k, v in truth.items()}
+    s = geo_scores(truth, shifted)
+    assert s["pos_aligned"] == pytest.approx(1.0)  # relative layout intact
+    assert s["pos_raw"] < 0.6  # absolute register drifted
+    assert s["alignment"]["tx"] == pytest.approx(20.0)
+
+
+def test_geo_scores_misses_and_empty() -> None:
+    truth = {"tower": _entry(20, 10), "harbor": _entry(70, 40)}
+    s = geo_scores(truth, {"tower": _entry(20, 10)})
+    assert s["presence"] == 0.5
+    assert s["unalignable"]  # one match can't anchor a transform
+    assert s["pos_aligned"] == s["pos_raw"]
+    empty = geo_scores(truth, {})
+    assert empty["presence"] == 0.0 and empty["pos_raw"] == 0.0
+    assert geo_scores({}, {})["presence"] == 0.0
+
+
+# --- expected layout builder -------------------------------------------------
+
+
+def _desc() -> dict[str, Any]:
+    return {
+        "map_id": "t",
+        "genre": "fantasy",
+        "style": "ink",
+        "description": "a tower north of a harbor",
+        "frame": {"w": 100.0, "h": 60.0},
+        "entities": [
+            {
+                "ref": "tower", "kind": "place", "label": "The Tower",
+                "visual": "", "pos": {"x": 50.0, "y": 12.0},
+                "footprint": {"w": 6.0, "d": 6.0}, "height_m": 30.0,
+                "height_rel": 1.0, "border": None,
+            },
+            {
+                "ref": "harbor", "kind": "place", "label": "The Harbor",
+                "visual": "", "pos": {"x": 50.0, "y": 48.0},
+                "footprint": {"w": 20.0, "d": 10.0}, "height_m": 6.0,
+                "height_rel": 0.2, "border": None,
+            },
+        ],
+        "relations": [],
+        "review": {"status": "verified", "by": "t", "date": "t"},
+    }
+
+
+def test_expected_layout_bins_and_heights() -> None:
+    expected, heights = _expected_layout(_desc())
+    by = {e["label"]: e for e in expected}
+    assert by["The Tower"]["h_pos"] == "center"
+    assert by["The Tower"]["v_pos"] == "top"
+    assert by["The Harbor"]["v_pos"] == "bottom"
+    # heights anchor on the SHORTEST real height (the harbor, 6 m)
+    assert heights == [("The Tower", pytest.approx(5.0), "The Harbor")]
+
+
+def test_expected_layout_needs_two_real_heights() -> None:
+    d = _desc()
+    d["entities"][1]["height_m"] = None
+    _, heights = _expected_layout(d)
+    assert heights is None
+
+
+# --- scenario resolution -----------------------------------------------------
+
+
+def test_corpus_scenarios_verified_only_and_deduped() -> None:
+    scenarios = corpus_scenarios(["corpus:*", "corpus:fantasy-treasure-island"])
+    ids = [s.id for s in scenarios]
+    assert len(ids) == len(set(ids)), "specs must dedupe"
+    assert "fantasy-treasure-island" in ids
+    # drafts are excluded by contract
+    from tests.map_corpus import load_descriptions
+
+    drafts = {d["map_id"] for d in load_descriptions(status="vlm_draft")}
+    assert not drafts & set(ids)
+
+
+def test_corpus_scenarios_rejects_unverified() -> None:
+    from tests.map_corpus import load_descriptions
+
+    drafts = [d["map_id"] for d in load_descriptions(status="vlm_draft")]
+    if not drafts:
+        pytest.skip("no drafts in the corpus right now")
+    with pytest.raises(SystemExit, match="not a VERIFIED"):
+        corpus_scenarios([f"corpus:{drafts[0]}"])

--- a/apps/modal-backend/tests/test_matrix_bench.py
+++ b/apps/modal-backend/tests/test_matrix_bench.py
@@ -1,0 +1,296 @@
+"""Matrix-bench chassis gate (free): cell identity, cache hit/miss, the
+budget refusal order (charge BEFORE the call), dry-run cost math, Pareto
+goldens, prompt rendering, and a full mock-provider end-to-end — the whole
+loop without spending a cent."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.matrix_bench._budget import BudgetExceeded, Ledger
+from tests.matrix_bench._cache import (
+    CellCache,
+    JudgeCache,
+    cell_key,
+    params_sha,
+)
+from tests.matrix_bench._pareto import (
+    aggregate_configs,
+    near_best_findings,
+    pareto_front,
+)
+from tests.matrix_bench._record import (
+    Cell,
+    expand_cells,
+    load_sweep,
+    render_prompt,
+    validate_record,
+)
+from tests.matrix_bench.runner import Scenario, run_matrix
+
+# --- cell identity ---------------------------------------------------------
+
+
+def test_cell_key_stable_golden() -> None:
+    """The key must NEVER drift across refactors — a drift invalidates every
+    cached cell and silently re-bills the whole matrix."""
+    key = cell_key("s1", "d" * 12, "graph", "fal-ai/nano-banana", "p" * 12, {"a": 1})
+    assert key == cell_key("s1", "d" * 12, "graph", "fal-ai/nano-banana", "p" * 12, {"a": 1})
+    assert len(key) == 20
+    assert key == "59a039bb0a00651525a2"
+
+
+def test_cell_key_sensitive_to_every_component() -> None:
+    base = ("s1", "d" * 12, "graph", "m", "p" * 12, {"a": 1})
+    k0 = cell_key(*base)
+    variants = [
+        ("s2", "d" * 12, "graph", "m", "p" * 12, {"a": 1}),
+        ("s1", "e" * 12, "graph", "m", "p" * 12, {"a": 1}),
+        ("s1", "d" * 12, "direct", "m", "p" * 12, {"a": 1}),
+        ("s1", "d" * 12, "graph", "m2", "p" * 12, {"a": 1}),
+        ("s1", "d" * 12, "graph", "m", "q" * 12, {"a": 1}),
+        ("s1", "d" * 12, "graph", "m", "p" * 12, {"a": 2}),
+    ]
+    assert all(cell_key(*v) != k0 for v in variants)
+
+
+def test_params_sha_order_insensitive() -> None:
+    assert params_sha({"a": 1, "b": 2}) == params_sha({"b": 2, "a": 1})
+
+
+# --- budget ----------------------------------------------------------------
+
+
+def test_ledger_charges_before_the_call_and_never_partially() -> None:
+    ledger = Ledger(cap_usd=1.0)
+    ledger.charge(0.6)
+    with pytest.raises(BudgetExceeded):
+        ledger.charge(0.5)  # would cross — refused BEFORE any spend
+    assert ledger.spent_usd == 0.6  # the failed charge mutated nothing
+    ledger.charge(0.4)  # exactly to the cap is fine
+    assert ledger.remaining_usd == 0.0
+
+
+# --- sweep / prompts -------------------------------------------------------
+
+
+def _sweep(**over: Any) -> dict[str, Any]:
+    s: dict[str, Any] = {
+        "name": "t",
+        "scenarios": ["corpus:*"],
+        "arms": ["graph"],
+        "models": ["fal-ai/nano-banana"],
+        "variants": ["v1"],
+        "judges": ["j"],
+        "params": {},
+        "budget_usd": 1.0,
+        "composite_weights": {},
+    }
+    s.update(over)
+    return s
+
+
+def test_load_sweep_validates(tmp_path: Path) -> None:
+    p = tmp_path / "bad.json"
+    p.write_text('{"name": "x"}')
+    with pytest.raises(ValueError, match="missing keys"):
+        load_sweep(p)
+
+
+def test_expand_cells_scenario_outermost() -> None:
+    cells = expand_cells(
+        _sweep(models=["m1", "m2"], variants=["v1", "v2"]), ["s1", "s2"]
+    )
+    assert len(cells) == 8
+    # Whole scenarios complete before the next starts (budget-partial runs
+    # then cover full scenarios, not a ragged diagonal).
+    assert [c.scenario_id for c in cells[:4]] == ["s1"] * 4
+
+
+def test_render_prompt_fills_and_rejects_missing() -> None:
+    assert render_prompt("map of {style}!", style="ink") == "map of ink!"
+    with pytest.raises(KeyError, match="style"):
+        render_prompt("map of {style}", description="x")
+
+
+# --- cache -----------------------------------------------------------------
+
+
+def test_cell_cache_roundtrip_and_corrupt_is_miss(tmp_path: Path) -> None:
+    cache = CellCache(tmp_path)
+    assert cache.load("k1") is None
+    cache.store("k1", {"cell_key": "k1"}, jpeg=b"\xff\xd8jpeg")
+    assert cache.load("k1") == {"cell_key": "k1"}
+    assert cache.image_path("k1").read_bytes() == b"\xff\xd8jpeg"
+    (tmp_path / "k1" / "record.json").write_text("{not json")
+    assert cache.load("k1") is None  # corrupt = miss, the cell just re-runs
+
+
+def test_judge_cache_roundtrip(tmp_path: Path) -> None:
+    jc = JudgeCache(tmp_path)
+    assert jc.load("j1") is None
+    jc.store("j1", {"score": 7.0})
+    assert jc.load("j1") == {"score": 7.0}
+
+
+# --- pareto ----------------------------------------------------------------
+
+
+def _rec(model: str, variant: str, quality: float, cost: float, lat: float) -> dict[str, Any]:
+    return {
+        "model": model,
+        "prompt_variant": variant,
+        "scores": {"composite": quality},
+        "cost_usd": {"total": cost},
+        "timing_s": {"gen": lat},
+    }
+
+
+def test_pareto_front_drops_dominated() -> None:
+    configs = aggregate_configs(
+        [
+            _rec("pro", "v1", 0.9, 0.15, 12.0),
+            _rec("nano", "v1", 0.85, 0.04, 5.0),
+            _rec("mid", "v1", 0.80, 0.08, 10.0),  # dominated by nano everywhere
+        ]
+    )
+    front = pareto_front(configs)
+    names = {c["model"] for c in front}
+    assert names == {"pro", "nano"}
+
+
+def test_near_best_findings_surfaces_the_tradeoff() -> None:
+    configs = aggregate_configs(
+        [
+            _rec("pro", "v1", 0.9, 0.15, 12.0),
+            _rec("nano", "v1", 0.85, 0.04, 5.0),
+        ]
+    )
+    findings = near_best_findings(configs)
+    assert len(findings) == 1
+    assert "nano @ v1" in findings[0]
+    assert "94% of the best" in findings[0]
+    assert "27% of its cost" in findings[0]
+
+
+# --- the loop, end to end (mock providers, $0) ------------------------------
+
+
+def _scenario() -> Scenario:
+    return Scenario(id="s1", desc_sha="d" * 12, payload={"style": "ink"})
+
+
+def _prompts(tmp_path: Path) -> Path:
+    d = tmp_path / "prompts"
+    d.mkdir()
+    (d / "v1.txt").write_text("map in {style}")
+    return d
+
+
+def test_dry_run_estimates_without_calling_anything(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    def gen(cell: Cell, payload: Any, template: str) -> dict[str, Any]:
+        calls.append("gen")
+        return {"jpeg": b"x", "model": cell.model, "inputs": {}}
+
+    report = run_matrix(
+        [_scenario()],
+        _sweep(),
+        gen_fn=gen,
+        judge_fns={"j": lambda c, p, b: (0.5, 0.005)},
+        live=False,
+        cache=CellCache(tmp_path / "cache"),
+        prompts_dir=_prompts(tmp_path),
+        report_path=tmp_path / "report.json",
+        log=lambda s: None,
+    )
+    assert calls == []  # dry-run touches nothing paid
+    assert report["live"] is False
+    # nano-banana $0.039 + 1 judge x $0.005
+    assert report["to_bill_usd"] == pytest.approx(0.044)
+    assert report["cells"][0]["status"] == "would_run"
+    assert (tmp_path / "report.json").exists()
+
+
+def test_live_mock_end_to_end_then_full_cache_hit(tmp_path: Path) -> None:
+    gen_calls: list[str] = []
+
+    def gen(cell: Cell, payload: Any, template: str) -> dict[str, Any]:
+        gen_calls.append(cell.label)
+        return {
+            "jpeg": b"\xff\xd8fake",
+            "model": cell.model,
+            "inputs": {"prompt_text": render_prompt(template, **payload)},
+        }
+
+    def judge(cell: Cell, payload: Any, jpeg: bytes) -> tuple[float, float]:
+        return 7.5, 0.005
+
+    def score(
+        cell: Cell, payload: Any, outputs: dict[str, Any], judges: dict[str, float]
+    ) -> dict[str, float]:
+        return {**judges, "composite": judges["j"] / 10.0}
+
+    kwargs: dict[str, Any] = dict(
+        gen_fn=gen,
+        judge_fns={"j": judge},
+        score_fn=score,
+        cache=CellCache(tmp_path / "cache"),
+        prompts_dir=_prompts(tmp_path),
+        report_path=tmp_path / "report.json",
+        run_at="2026-06-12T00:00:00Z",
+        log=lambda s: None,
+    )
+    first = run_matrix([_scenario()], _sweep(), live=True, **kwargs)
+    assert gen_calls == ["s1/graph/fal-ai/nano-banana/v1"]
+    rec = first["cells"][0]
+    assert validate_record(rec) == []
+    assert rec["scores"]["composite"] == pytest.approx(0.75)
+    assert rec["inputs"]["prompt_text"] == "map in ink"
+    assert rec["cost_usd"]["total"] == pytest.approx(0.039 + 0.005)
+    assert first["stopped_reason"] is None
+
+    second = run_matrix([_scenario()], _sweep(), live=True, **kwargs)
+    assert gen_calls == ["s1/graph/fal-ai/nano-banana/v1"]  # no re-bill
+    assert second["to_bill_usd"] == 0.0
+    assert second["cells"][0]["cell_key"] == rec["cell_key"]
+
+
+def test_preflight_refuses_over_cap_unless_partial(tmp_path: Path) -> None:
+    def gen(cell: Cell, payload: Any, template: str) -> dict[str, Any]:
+        return {"jpeg": b"x", "model": cell.model, "inputs": {}}
+
+    sweep = _sweep(models=["fal-ai/nano-banana-pro"], budget_usd=0.01)
+    kwargs: dict[str, Any] = dict(
+        gen_fn=gen,
+        judge_fns={"j": lambda c, p, b: (1.0, 0.005)},
+        cache=CellCache(tmp_path / "cache"),
+        prompts_dir=_prompts(tmp_path),
+        report_path=tmp_path / "report.json",
+        log=lambda s: None,
+    )
+    with pytest.raises(BudgetExceeded, match="trim the sweep"):
+        run_matrix([_scenario()], sweep, live=True, **kwargs)
+    # allow_partial runs to the cap, then stops with a reason — no raise.
+    report = run_matrix(
+        [_scenario()], sweep, live=True, allow_partial=True, **kwargs
+    )
+    assert report["stopped_reason"] is not None
+    assert report["cells"] == []
+
+
+def test_live_refuses_unimplemented_judges(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="no implementation"):
+        run_matrix(
+            [_scenario()],
+            _sweep(judges=["ghost"]),
+            gen_fn=lambda c, p, t: {"jpeg": b"x", "inputs": {}},
+            judge_fns={},
+            live=True,
+            cache=CellCache(tmp_path / "cache"),
+            prompts_dir=_prompts(tmp_path),
+            log=lambda s: None,
+        )


### PR DESCRIPTION
Track B, PR 4 of 5. Stacked on #67 (+ includes #65's chassis commits via merge — merge #65 and #67 first and this diff collapses to just the recon bench). First live run cost $0.32.

## What it adds

The round-trip eval: regenerate each **verified** corpus map from its authored description, extract what actually got drawn, score against ground truth.

- **Two arms** per scenario: `graph` (product path — prose → `plan_world_from_description` → layout solver → clause → render) vs `direct` (ground-truth entities → clause → render). A low graph score with a high direct score blames the planning, not the paint.
- **`_align.py`** (pure, golden-tested): least-squares similarity fit (uniform scale 0.5–2 + translation, optional x-flip, no rotation) over label-matched centres → `pos_raw` (absolute register) AND `pos_aligned` (relative layout). Fewer than 2 matches → flagged unalignable.
- **Scores per cell**: presence, pos_raw/aligned, size (diag ratio vs fitted scale), height_order + height_abs (B2's anchored ladder), plus 3 judges — `score_style_pair` vs the reference scan, new `score_map_plausibility` (genre coherence), `score_prompt_alignment` — folded into a weighted composite (weights live in `sweeps/recon.json`).
- **Chassis hardening** (found by the first real run): a flaky provider call (OpenRouter ConnectTimeout) now records a *failed cell* and the sweep continues — cached cells stay cached, the failed cell re-bills next pass; recon's provider calls get one retry.

## First live results (3 maps × 2 arms, nano-banana)

Composite mean **0.689** over 5 cells (1 timeout cell) → committed as the `recon_fidelity` baseline (0.69 ± 0.12, n_min 4). Already diagnostic:
- `pos_raw` ≈ 0.02–0.54 while `pos_aligned` ≈ 0.63–0.84 → generated maps keep the **relative layout** but drift the absolute register — the exact distinction the aligned metric exists to make.
- `direct` > `graph` on Mars (0.741 vs 0.667) → the describe→solve pipeline loses placement signal vs ground-truth layout.
- Heights only scored on the manor map → label-matching between corpus labels and segmenter output needs care (visible, measurable, improvable — the point of the system).

## Verification
11 new free tests (alignment goldens incl. flip/clamp, scorecard edges, layout-builder bins + height ratios, verified-only scenario contract) + chassis failure-path coverage; full `pytest -m "not paid"`, `ruff`, `mypy` green. Dry-run previews $0.38 before any spend; re-run shows cached cells at $0.00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)