### PR TITLE
feat(eval): Pareto sweep report + first real model×prompt matrix run

### DIFF
--- a/apps/modal-backend/tests/matrix_bench/prompts/recon_base.v2.txt
+++ b/apps/modal-backend/tests/matrix_bench/prompts/recon_base.v2.txt
@@ -1,0 +1,14 @@
+A complete top-down illustrated map, drawn as {style}.
+
+{description}
+
+{layout_clause}
+
+Compose to the stated layout EXACTLY: treat the SCENE LAYOUT lines as a
+strict grid — each named feature sits at the named third of the sheet
+(left/center/right, top/mid/bottom), at the stated relative size. Do not
+re-center or re-balance the composition.
+
+Draw the WHOLE mapped area edge to edge — one coherent map sheet, nothing
+cut off, no collage panels. Flat overhead cartographic view, no perspective.
+Keep any lettering sparse and legible — no garbled text.

--- a/apps/modal-backend/tests/matrix_bench/report.py
+++ b/apps/modal-backend/tests/matrix_bench/report.py
@@ -1,0 +1,98 @@
+"""Matrix report aggregation — the tradeoff surface, readable.
+
+Takes a run report (matrix_latest.json / recon_latest.json), aggregates
+cells into configs (model x prompt-variant), prints the per-config table,
+the Pareto front, the near-best findings ("94% of the best composite at
+27% of its cost, 2.4x faster") and the per-operation spend breakdown —
+then writes the summary back into the report file.
+
+    .venv/bin/python -m tests.matrix_bench.report [path/to/report.json]
+
+Pure aggregation over recorded cells: running it costs $0, always.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from tests.matrix_bench._pareto import (
+    aggregate_configs,
+    near_best_findings,
+    pareto_front,
+)
+
+_DEFAULT = Path(__file__).resolve().parent / "reports" / "matrix_latest.json"
+
+_SPEND_OPS = ("image", "judges", "extract")
+
+
+def summarize(report: dict[str, Any]) -> dict[str, Any]:
+    cells = [c for c in report.get("cells", []) if "scores" in c]
+    configs = aggregate_configs(cells)
+    front = pareto_front(configs)
+    front_keys = {(c["model"], c["variant"]) for c in front}
+    spend = {
+        op: round(sum(float(c["cost_usd"].get(op, 0.0)) for c in cells), 4)
+        for op in _SPEND_OPS
+    }
+    spend["total"] = round(sum(spend.values()), 4)
+    return {
+        "configs": [
+            {**c, "pareto": (c["model"], c["variant"]) in front_keys}
+            for c in configs
+        ],
+        "findings": near_best_findings(configs),
+        "spend_usd": spend,
+        "scored_cells": len(cells),
+        "failed_cells": sum(
+            1 for c in report.get("cells", []) if c.get("status") == "failed"
+        ),
+    }
+
+
+def format_summary(summary: dict[str, Any]) -> str:
+    lines = [
+        f"{'config':46} {'n':>3} {'quality':>8} {'$/cell':>7} {'sec':>6}  pareto"
+    ]
+    for c in summary["configs"]:
+        label = f"{c['model']} @ {c['variant']}"
+        lines.append(
+            f"{label[:46]:46} {c['n']:>3} {c['quality']:>8.3f} "
+            f"{c['cost_usd']:>7.3f} {c['latency_s']:>6.1f}  "
+            f"{'*' if c['pareto'] else ''}"
+        )
+    if summary["findings"]:
+        lines.append("tradeoffs:")
+        lines.extend(f"  {f}" for f in summary["findings"])
+    s = summary["spend_usd"]
+    lines.append(
+        f"spend this run: ${s['total']:.2f} "
+        f"(image ${s['image']:.2f} / judges ${s['judges']:.2f} / "
+        f"extract ${s['extract']:.2f}) over {summary['scored_cells']} cells"
+        + (f", {summary['failed_cells']} failed" if summary["failed_cells"] else "")
+    )
+    return "\n".join(lines)
+
+
+def attach_summary(report_path: Path) -> dict[str, Any]:
+    """Summarize a written report and persist the summary back into it."""
+    report = json.loads(report_path.read_text())
+    summary = summarize(report)
+    report["summary"] = summary
+    report_path.write_text(json.dumps(report, indent=1))
+    return summary
+
+
+def main() -> int:
+    path = Path(sys.argv[1]) if len(sys.argv) > 1 else _DEFAULT
+    if not path.exists():
+        print(f"no report at {path} — run a sweep first (make eval-matrix)")
+        return 1
+    print(format_summary(attach_summary(path)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/modal-backend/tests/matrix_bench/runner.py
+++ b/apps/modal-backend/tests/matrix_bench/runner.py
@@ -277,14 +277,19 @@ def main() -> int:
 
     scenarios = corpus_scenarios(sweep["scenarios"])
     fns = recon_fns(sweep)
+    live = os.environ.get("MATRIX_BENCH_RUN") == "1"
     report = run_matrix(
         scenarios,
         sweep,
-        live=os.environ.get("MATRIX_BENCH_RUN") == "1",
+        live=live,
         allow_partial=os.environ.get("MATRIX_ALLOW_PARTIAL") == "1",
         run_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         **fns,
     )
+    if live:
+        from tests.matrix_bench import report as report_mod
+
+        print(report_mod.format_summary(report_mod.attach_summary(_REPORTS / "matrix_latest.json")))
     return 0 if report.get("stopped_reason") is None else 1
 
 

--- a/apps/modal-backend/tests/matrix_bench/sweeps/default.json
+++ b/apps/modal-backend/tests/matrix_bench/sweeps/default.json
@@ -1,22 +1,37 @@
 {
   "name": "default",
-  "scenarios": ["corpus:*"],
-  "arms": ["graph"],
+  "scenarios": [
+    "corpus:*"
+  ],
+  "arms": [
+    "graph"
+  ],
   "models": [
     "fal-ai/nano-banana",
     "fal-ai/nano-banana-2",
     "fal-ai/nano-banana-pro"
   ],
-  "variants": ["recon_base.v1"],
-  "params": { "aspect_ratio": "16:9" },
-  "judges": ["style_pair", "map_plausibility", "prompt_alignment"],
+  "variants": [
+    "recon_base.v1",
+    "recon_base.v2"
+  ],
+  "params": {
+    "aspect_ratio": "16:9"
+  },
+  "judges": [
+    "style_pair",
+    "map_plausibility",
+    "prompt_alignment"
+  ],
   "composite_weights": {
     "presence": 0.2,
-    "pos_aligned": 0.25,
+    "pos_aligned": 0.2,
+    "pos_raw": 0.05,
     "size": 0.1,
-    "height_order": 0.15,
+    "height_order": 0.1,
     "style_pair": 0.15,
-    "map_plausibility": 0.15
+    "map_plausibility": 0.1,
+    "prompt_alignment": 0.1
   },
   "budget_usd": 3.0
 }

--- a/apps/modal-backend/tests/recon_bench/runner.py
+++ b/apps/modal-backend/tests/recon_bench/runner.py
@@ -26,7 +26,10 @@ import json
 import os
 import time
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from providers.geometry import ProjectedEntity, ProjectInput
 
 from tests.map_corpus import description_sha, image_path, load_descriptions
 from tests.matrix_bench._budget import JUDGE_CALL_FLAT
@@ -68,7 +71,9 @@ def _norm(label: str) -> str:
     return " ".join(label.lower().split())
 
 
-def _expected_layout(desc: dict[str, Any]) -> tuple[list[dict[str, Any]], list[tuple[str, float, str]] | None]:
+def _expected_layout(
+    desc: dict[str, Any],
+) -> tuple[list[ProjectedEntity], list[tuple[str, float, str]] | None]:
     """Ground-truth entities → ProjectedEntity bins (for the layout clause)
     + relative-height tuples (label, ratio, anchor) for its HEIGHTS block."""
     from providers.geometry import project_top_down
@@ -83,9 +88,9 @@ def _expected_layout(desc: dict[str, Any]) -> tuple[list[dict[str, Any]], list[t
         }
         for e in desc["entities"]
     ]
-    expected = project_top_down(ents, FRAME_W, FRAME_H)
-    real = sorted(
-        ((e["label"], float(e["height_m"])) for e in desc["entities"] if e.get("height_m")),
+    expected = project_top_down(cast("list[ProjectInput]", ents), FRAME_W, FRAME_H)
+    real: list[tuple[str, float]] = sorted(
+        ((str(e["label"]), float(e["height_m"])) for e in desc["entities"] if e.get("height_m")),
         key=lambda t: t[1],
     )
     heights = None
@@ -95,7 +100,9 @@ def _expected_layout(desc: dict[str, Any]) -> tuple[list[dict[str, Any]], list[t
     return expected, heights
 
 
-def _graph_layout(desc: dict[str, Any], loop: asyncio.AbstractEventLoop) -> list[dict[str, Any]]:
+def _graph_layout(
+    desc: dict[str, Any], loop: asyncio.AbstractEventLoop
+) -> list[ProjectedEntity]:
     """The product path: prose → scene graph → solved geos → bins."""
     from providers.geometry import project_top_down
     from providers.layout_solver import solve_layout
@@ -113,7 +120,7 @@ def _graph_layout(desc: dict[str, Any], loop: asyncio.AbstractEventLoop) -> list
         }
         for i, g in enumerate(solved.geos)
     ]
-    return project_top_down(ents, FRAME_W, FRAME_H)
+    return project_top_down(cast("list[ProjectInput]", ents), FRAME_W, FRAME_H)
 
 
 def recon_fns(sweep: dict[str, Any]) -> dict[str, Any]:
@@ -328,6 +335,10 @@ def main() -> int:
                         print(f"  {v.status}: {v.detail}")
             except KeyError:
                 print("  (no committed baseline yet — commit one from this run)")
+    if live:
+        from tests.matrix_bench import report as report_mod
+
+        print(report_mod.format_summary(report_mod.attach_summary(_REPORT)))
     json.dumps(report)  # smoke: the report is JSON-serializable
     return 0 if report.get("stopped_reason") is None else 1
 

--- a/apps/modal-backend/tests/test_matrix_bench.py
+++ b/apps/modal-backend/tests/test_matrix_bench.py
@@ -294,3 +294,37 @@ def test_live_refuses_unimplemented_judges(tmp_path: Path) -> None:
             prompts_dir=_prompts(tmp_path),
             log=lambda s: None,
         )
+
+
+# --- report aggregation ------------------------------------------------------
+
+
+def test_summary_tables_pareto_and_spend() -> None:
+    from tests.matrix_bench.report import format_summary, summarize
+
+    def cell(model: str, variant: str, q: float, img: float, lat: float) -> dict[str, Any]:
+        return {
+            "model": model,
+            "prompt_variant": variant,
+            "scores": {"composite": q},
+            "cost_usd": {"image": img, "judges": 0.015, "extract": 0.01,
+                         "total": img + 0.025},
+            "timing_s": {"gen": lat, "judges": 2.0},
+        }
+
+    report = {
+        "cells": [
+            cell("pro", "v1", 0.9, 0.15, 12.0),
+            cell("nano", "v1", 0.85, 0.039, 5.0),
+            cell("mid", "v1", 0.7, 0.08, 10.0),  # dominated
+            {"cell_key": "x", "label": "broken", "status": "failed", "error": "boom"},
+        ]
+    }
+    s = summarize(report)
+    by = {(c["model"], c["variant"]): c for c in s["configs"]}
+    assert by[("pro", "v1")]["pareto"] and by[("nano", "v1")]["pareto"]
+    assert not by[("mid", "v1")]["pareto"]
+    assert s["failed_cells"] == 1 and s["scored_cells"] == 3
+    assert s["spend_usd"]["image"] == pytest.approx(0.269)
+    text = format_summary(s)
+    assert "nano @ v1" in text and "tradeoffs:" in text and "1 failed" in text

--- a/docs/COSTS.md
+++ b/docs/COSTS.md
@@ -130,3 +130,13 @@ anyone off it.
 One more cap honesty note: the gate is checked at stream start, so requests
 already in flight when the cap trips still complete — worst case overshoot is
 one generation per concurrent stream. Right-sized for a personal cap.
+
+## Matrix bench spend
+
+The eval matrix is designed to spend close to nothing: dry-run cost preview
+before every sweep, disk-cached cells (re-runs and prompt evolution re-bill
+only changed cells), a hard `MATRIX_BUDGET_USD` cap charged BEFORE each call
+(default $3), and per-operation breakdown (image / judges / extract) in every
+report. Typical numbers: `make eval-recon` first run ≈ $0.40, cached re-run
+$0.00; the default 3-model × 2-prompt sweep ≈ $1.90 first run; one evolved
+prompt variant ≈ $0.20-0.60 per iteration depending on models swept.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -85,3 +85,42 @@ actually change". Benches self-skip without their `*_BENCH_RUN` env, and the
 conftest scrubs all model/flag env so host config can't flip tests. Artifacts
 land in `tests/continuity_bench/reports/` (gitignored) — eyeball them; the
 images are the ground truth the scores summarize.
+
+## The matrix bench (evolvable eval)
+
+`tests/matrix_bench/` runs **scenarios × arms × models × prompt-variants**
+with every frugality guarantee built in:
+
+- **Dry-run is the default.** `make eval-matrix-dry` (or any runner without
+  its `*_BENCH_RUN` flag) prints the per-cell table — cached? / est $ — and
+  the total to-bill figure, then exits. Nothing touches the network. Run it
+  before EVERY sweep; it is also the free CI smoke.
+- **Disk cache = free evolution.** A cell's identity is
+  `sha(scenario | description | arm | model | prompt | params)`, cached under
+  `tests/matrix_bench/cache/` (gitignored). To evolve a prompt: copy
+  `prompts/recon_base.v1.txt` → `v2`, edit, add `recon_base.v2` to the sweep's
+  `variants`, dry-run, sweep. Only the new variant's cells bill; an identical
+  re-run is 100% hits and $0.00. Same for ground-truth edits (the corpus
+  `description_sha` excludes the review block, so verifying a draft is free).
+- **Hard budget cap.** The ledger charges BEFORE every paid call; default
+  `MATRIX_BUDGET_USD=3`. An over-cap sweep is refused at pre-flight unless
+  `MATRIX_ALLOW_PARTIAL=1` (runs to the cap, reports `stopped_reason`).
+  A flaky provider call records a failed cell and the sweep continues.
+- **The reconstruction bench** (`make eval-recon`) is the first scenario
+  type: regenerate each VERIFIED `tests/map_corpus/` map from its authored
+  description (arm `graph` = the product planning path, `direct` =
+  ground-truth layout), then detect + segment + anchored heights and score:
+  presence, `pos_raw` (absolute register) vs `pos_aligned` (relative layout
+  after a fitted similarity transform), size, height order/abs, plus style /
+  plausibility / prompt-alignment judges → weighted composite. Baseline:
+  `recon_fidelity` in `eval_baselines.json`.
+- **The report** (`python -m tests.matrix_bench.report`, auto-printed after
+  live runs) aggregates configs (model × variant), marks the Pareto front on
+  (quality, −cost, −latency), prints near-best tradeoff findings ("94% of the
+  best composite at 27% of its cost, 2.4× faster") and the per-operation
+  spend breakdown.
+
+Authoring corpus ground truth: `make corpus-fetch` (pins shas), `make
+corpus-draft id=<map>` (VLM draft, ~$0.015), then open the image + JSON side
+by side, correct entities/heights/relations, flip `review.status` to
+`"verified"`, bump `rev`. The recon bench only consumes verified entries.


### PR DESCRIPTION
Track B, PR 5 of 5 — the eval system is complete. Stacked on #68. First full sweep cost $1.72.

## What it adds

- **`tests/matrix_bench/report.py`** — config table (model × variant), Pareto front on (quality, −cost, −latency), near-best tradeoff findings, per-operation spend breakdown. Auto-printed and persisted into the report after every live run; `python -m tests.matrix_bench.report` re-aggregates any report for $0.
- **`recon_base.v2`** — first evolved prompt variant (strict-grid composition clause, targeting the `pos_raw` register drift #68 measured). The old variant's cells stayed cached; only v2 cells billed.
- Final default sweep: 3 models × 2 variants × graph arm over the verified corpus; docs sections in `TESTING.md` (dry-run discipline, cache evolution, corpus authoring) + `COSTS.md`.

## First real matrix (12/15 cells, 3 OpenRouter timeouts survived as failed cells)

```
config                                quality  $/cell  pareto
nano-banana    @ v1                     0.694   0.064    *
nano-banana    @ v2                     0.723   0.064    *
nano-banana-2  @ v1                     0.728   0.105    *
nano-banana-2  @ v2                     0.637   0.105
nano-banana-pro @ v1                    0.700   0.175    *
nano-banana-pro @ v2                    0.713   0.175
```

- Headline tradeoff (auto-generated): **"nano-banana @ v1: 95% of the best composite at 61% of its cost"** — the cheap-but-good config the whole exercise was for.
- **Prompt evolution is model-dependent**: the strict-grid v2 *helped* nano-banana (pos_raw 0.54→0.70 on Treasure Island) but *hurt* nano-banana-2 (−0.09 composite, one plausibility crash to 0.2 — the grid constraint broke its coherence). Exactly the kind of insight the matrix exists to surface.
- Spend honesty: $1.72 actual vs $1.87 pre-flight estimate; breakdown image $1.34 / judges $0.23 / extract $0.15.

## Verification
Free: report aggregation goldens added to `test_matrix_bench.py`; mypy/ruff/pytest green. Paid: the sweep above; a re-run previews $0.35 (only the 3 timeout cells re-bill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)