### PR TITLE
feat(world): DOM labels + label-free maps (flag-gated)

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -264,6 +264,10 @@ class GenerateBody(BaseModel):
     # topic. `render_mode` is an explicit framing override; otherwise the click
     # classifier's `enter_as` decides. `autonomy` is carried for symmetry.
     world_mode: bool = False
+    # DOM-labels mode (NEXT_PUBLIC_DOM_LABELS): map/explainer renders carry
+    # NO baked text — names ride a client overlay built from entity data.
+    # Optional + default False: old clients omit it, prompts byte-identical.
+    suppress_map_labels: bool = False
     autonomy: str = "auto"
     render_mode: str | None = None
     # B2 logical AROUND (SCALE_AROUND_LOGICAL): the same-scale neighbours the client
@@ -1313,8 +1317,12 @@ async def _event_stream(
                 prompt = plan.prompt
                 if expand_style_lock:
                     prompt = f"Style: {expand_style_lock}\n\n{prompt}"
-                if plan.facts:
+                if plan.facts and not body.suppress_map_labels:
                     prompt += "\n\nLabels to include:\n- " + "\n- ".join(plan.facts)
+                if body.suppress_map_labels:
+                    from providers.prompt_library.style import NO_LETTERING
+
+                    prompt += f"\n\n{NO_LETTERING}"
                 if expand_cond_preamble:
                     prompt = expand_cond_preamble + prompt
                 img = await image_provider.generate_image(
@@ -1543,6 +1551,7 @@ async def _event_stream(
             world_context=world_context_payload,
             render_mode=render_mode or "explainer",
             surroundings=surroundings_for_plan,
+            label_free=body.suppress_map_labels,
         )
 
         composed_prompt = plan.prompt
@@ -1558,8 +1567,18 @@ async def _event_stream(
         # annotated diagram (floating captions), breaking the seamless step-in.
         # The scene still carries that content via plan.prompt; maps/explainers
         # keep their labels.
-        if plan.facts and render_mode != "place_scene":
+        if (
+            plan.facts
+            and render_mode != "place_scene"
+            and not body.suppress_map_labels
+        ):
             composed_prompt += "\n\nLabels to include:\n- " + "\n- ".join(plan.facts)
+        if body.suppress_map_labels and render_mode != "place_scene":
+            # DOM-labels mode: belt + suspenders at the image-prompt level too
+            # (the planner was already asked for a label-free page).
+            from providers.prompt_library.style import NO_LETTERING
+
+            composed_prompt += f"\n\n{NO_LETTERING}"
         # MODERATE_PROMPTS (default off): one cheap LLM check on the composed
         # prompt before any image dollars are spent — a public deployment's
         # opt-in. Fail-open inside (providers/moderation.py); a block is a
@@ -1695,6 +1714,7 @@ async def _event_stream(
             family=camera_lib.model_family(
                 body.image_model or model_router.resolve_model("zoom_continue")
             ),
+            label_free=body.suppress_map_labels,
         )
         # The enter edit is a view CHANGE on the SAME place: the region crop
         # carries the look, this text carries the move inside + everything the

--- a/apps/modal-backend/providers/image_edit.py
+++ b/apps/modal-backend/providers/image_edit.py
@@ -125,6 +125,7 @@ def build_zoom_instruction(
     style_anchor: str | None = None,
     view: dict | None = None,
     family: str | None = None,
+    label_free: bool = False,
 ) -> str:
     """Delegates to prompt_library.instructions (the body moved verbatim;
     view=None is byte-identical to the pre-grammar string — pinned by
@@ -142,6 +143,7 @@ def build_zoom_instruction(
         style_anchor=style_anchor,
         view=cast("_ViewSpec | None", view),
         family=family,
+        label_free=label_free,
     )
 
 

--- a/apps/modal-backend/providers/llm.py
+++ b/apps/modal-backend/providers/llm.py
@@ -1044,13 +1044,17 @@ def _spatial_anchor_clause(render_mode: str | None, surroundings: str | None) ->
     )
 
 
-def _render_base_instruction(render_mode: str | None) -> str:
+def _render_base_instruction(
+    render_mode: str | None, *, label_free: bool = False
+) -> str:
     """The opening planner instruction, keyed by World Mode render mode.
 
     `place_scene` → an immersive scene the reader steps into (no diagram
     labels); `place_submap` → a closer cartographic map of a sub-area;
     `explainer` (default, and every classic non-world call) → today's
-    labelled visual-explainer page, verbatim.
+    labelled visual-explainer page, verbatim. `label_free` (DOM-labels mode,
+    suppress_map_labels) asks for the same page with NO baked text — names
+    ride a client overlay; default off keeps every prompt byte-identical.
     """
     rmode = (render_mode or "explainer").lower()
     if rmode == "place_scene":
@@ -1066,12 +1070,18 @@ def _render_base_instruction(render_mode: str | None) -> str:
             "the JSON."
         )
     if rmode == "place_submap":
+        named = (
+            "laid out clearly but NOT named in the image — no lettering, no "
+            "text, no cartouches; the interface overlays names separately"
+            if label_free
+            else "laid out and named"
+        )
         return (
             "You design a closer MAP of just this district/area — a zoom of the "
             "parent map into this region, in the same cartographic style. Return "
             "JSON with keys: page_title (<=8 words, the area's name), prompt "
             "(<=120 words describing an illustrated map of this sub-area — its "
-            "streets, sub-districts and landmarks laid out and named, drawn as a "
+            f"streets, sub-districts and landmarks {named}, drawn as a "
             "map and not a scene), facts (3-6 named sub-areas or landmarks shown "
             "on the map). Do not include any text outside the JSON."
         )
@@ -1086,6 +1096,17 @@ def _render_base_instruction(render_mode: str | None) -> str:
             "wider view of the SAME world and NOT a new invention), facts (3-6 "
             "named sibling areas or landmarks that share this container). Do not "
             "include any text outside the JSON."
+        )
+    if label_free:
+        return (
+            "You design a visual-explainer page for a given user query. Return "
+            "JSON with keys: page_title (<=8 words, title case), prompt (<=120 "
+            "words, a rich description of a single illustrated image suitable "
+            "for an image model — include layout hints but NO text in the "
+            "image: no labels, lettering, annotations or callouts; the "
+            "interface overlays names separately), facts (list of 3-6 short "
+            "factual details the illustration should depict). Do not include "
+            "any text outside the JSON."
         )
     return (
         "You design a visual-explainer page for a given user query. Return "
@@ -1109,6 +1130,7 @@ async def plan_page(
     world_context: list[dict[str, Any]] | None = None,
     render_mode: str | None = None,
     surroundings: str | None = None,
+    label_free: bool = False,
 ) -> PagePlan:
     """Produce a page title, image-gen prompt, and factual snippets for the query.
 
@@ -1129,7 +1151,7 @@ async def plan_page(
     # scene the reader has stepped into, or a closer cartographic sub-map.
     # `explainer` (the default) is today's behaviour, untouched.
     rmode = (render_mode or "explainer").lower()
-    system_parts = [_render_base_instruction(rmode)]
+    system_parts = [_render_base_instruction(rmode, label_free=label_free)]
     has_parent_frame = bool(
         (parent_title and parent_title.strip())
         or (parent_query and parent_query.strip())

--- a/apps/modal-backend/providers/prompt_library/instructions.py
+++ b/apps/modal-backend/providers/prompt_library/instructions.py
@@ -16,7 +16,11 @@ One transform per prompt; the full invariant block restates on every call.
 from __future__ import annotations
 
 from providers.prompt_library import camera
-from providers.prompt_library.style import LETTERING_GUARD, medium_lock
+from providers.prompt_library.style import (
+    LETTERING_GUARD,
+    NO_LETTERING,
+    medium_lock,
+)
 from providers.prompt_library.types import ViewSpec
 
 # Gemini-family edits drift aspect without this (research/10 §4.6). Text guard
@@ -411,11 +415,26 @@ def build_zoom_instruction(
     style_anchor: str | None = None,
     view: ViewSpec | None = None,
     family: str | None = None,
+    label_free: bool = False,
 ) -> str:
     """Zoom-continue: same place, SAME camera, finer detail. view=None ->
     today's exact string. With a view, the keep-camera fragment is spelled per
     projection in PRESERVE form — any projection is honored, none is ever a
-    change (Kontext's native grammar; harmless on nano/gpt)."""
+    change (Kontext's native grammar; harmless on nano/gpt). label_free
+    (DOM-labels mode) swaps the lettering guard for the full no-text
+    directive; default off keeps every instruction byte-identical."""
+    if label_free:
+        text = build_zoom_instruction(
+            page_title,
+            facts,
+            layout_clause,
+            style_anchor=style_anchor,
+            view=view,
+            family=family,
+        )
+        if LETTERING_GUARD in text:
+            return text.replace(LETTERING_GUARD, NO_LETTERING)
+        return f"{text} {NO_LETTERING}"
     if view is None:
         return _legacy_zoom_instruction(page_title, facts, layout_clause)
     proj = str(view.get("projection") or "")

--- a/apps/modal-backend/providers/prompt_library/style.py
+++ b/apps/modal-backend/providers/prompt_library/style.py
@@ -10,6 +10,13 @@ from __future__ import annotations
 
 MEDIUM_GUARD = "NOT a photograph, no photorealism"
 LETTERING_GUARD = "Keep any lettering sparse and legible — no garbled text."
+# DOM-labels mode (suppress_map_labels): the image carries NO baked text at
+# all — names live in a client overlay built from entity data. Fixes both the
+# garbled-lettering problem and clicks landing on text instead of places.
+NO_LETTERING = (
+    "Do not write ANY names, lettering, text, or cartouches into the image — "
+    "the interface overlays names separately."
+)
 
 
 def medium_lock(style_anchor: str | None, *, ref_name: str = "the reference") -> str:

--- a/apps/modal-backend/tests/test_label_free_prompts.py
+++ b/apps/modal-backend/tests/test_label_free_prompts.py
@@ -1,0 +1,54 @@
+"""DOM-labels mode gate (free): label_free planner instructions ask for
+text-free pages, the zoom instruction swaps the lettering guard for the full
+no-text directive, and — critically — the DEFAULT (flag off) stays
+byte-identical everywhere."""
+from __future__ import annotations
+
+from providers.llm import _render_base_instruction
+from providers.prompt_library.instructions import build_zoom_instruction
+from providers.prompt_library.style import LETTERING_GUARD, NO_LETTERING
+
+
+def test_default_instructions_byte_identical() -> None:
+    for mode in ("explainer", "place_submap", "place_scene", None):
+        assert _render_base_instruction(mode) == _render_base_instruction(
+            mode, label_free=False
+        )
+    assert build_zoom_instruction("T", ["f"]) == build_zoom_instruction(
+        "T", ["f"], label_free=False
+    )
+
+
+def test_label_free_submap_asks_for_no_lettering() -> None:
+    base = _render_base_instruction("place_submap")
+    free = _render_base_instruction("place_submap", label_free=True)
+    assert "laid out and named" in base
+    assert "laid out and named" not in free
+    assert "no lettering" in free.lower()
+
+
+def test_label_free_explainer_swaps_labels_for_layout() -> None:
+    base = _render_base_instruction("explainer")
+    free = _render_base_instruction("explainer", label_free=True)
+    assert "include labels" in base
+    assert "NO text in the" in free
+    assert "visible as labels" not in free
+
+
+def test_label_free_scene_unchanged() -> None:
+    # Scenes never carried labels — label_free must not perturb them.
+    assert _render_base_instruction("place_scene") == _render_base_instruction(
+        "place_scene", label_free=True
+    )
+
+
+def test_zoom_instruction_swaps_lettering_guard() -> None:
+    base = build_zoom_instruction("The Palace", ["the maze garden"])
+    free = build_zoom_instruction(
+        "The Palace", ["the maze garden"], label_free=True
+    )
+    assert LETTERING_GUARD in base
+    assert LETTERING_GUARD not in free
+    assert NO_LETTERING in free
+    # Everything else identical.
+    assert base.replace(LETTERING_GUARD, NO_LETTERING) == free

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -78,6 +78,7 @@ import Breadcrumb from "@/components/PlayPage/Breadcrumb";
 import SpatialPath from "@/components/PlayPage/SpatialPath";
 import { buildBreadcrumb } from "@/lib/breadcrumb";
 import { EntityHoverOverlay } from "@/components/PlayPage/EntityHoverOverlay";
+import { MapLabelOverlay } from "@/components/PlayPage/MapLabelOverlay";
 import { ContextMenu, type ContextMenuItem } from "@/components/PlayPage/ContextMenu";
 import { HoverCrosshair } from "@/components/PlayPage/HoverCrosshair";
 import { HintPrompt } from "@/components/PlayPage/HintPrompt";
@@ -594,8 +595,10 @@ export default function PlayPage() {
   const {
     enabled: worldEnabled,
     autonomy: worldAutonomy,
+    domLabels: worldDomLabels,
     setEnabled: setWorldEnabled,
     setAutonomy: setWorldAutonomy,
+    setDomLabels: setWorldDomLabels,
   } = useWorldMode(sessionId);
   const [styleGalleryDismissed, dismissStyleGallery] =
     useStyleGalleryDismissed(sessionId);
@@ -1086,9 +1089,11 @@ export default function PlayPage() {
         ...(devModel ? { image_model: devModel } : {}),
         output_locale: resolveOutputLocale(outputLocale),
         ...(styleAnchor ? { session_style_anchor: styleAnchor.style } : {}),
+        // DOM-labels mode: the root map renders text-free; names overlay.
+        ...(worldEnabled && worldDomLabels ? { suppress_map_labels: true } : {}),
       });
     },
-    [input, sessionId, page, generate, imageTier, loopWire, devModel, outputLocale, styleAnchor]
+    [input, sessionId, page, generate, imageTier, loopWire, devModel, outputLocale, styleAnchor, worldEnabled, worldDomLabels]
   );
 
   // B1 — "Describe a place": turn the input description into a logical object
@@ -2231,6 +2236,7 @@ export default function PlayPage() {
           ? {
               world_mode: true,
               autonomy: worldAutonomy,
+              ...(worldDomLabels ? { suppress_map_labels: true } : {}),
               ...(enterAsToRenderMode(worldResolved?.enter_as) !== "explainer"
                 ? { render_mode: enterAsToRenderMode(worldResolved?.enter_as) }
                 : {}),
@@ -2701,6 +2707,8 @@ export default function PlayPage() {
         setWorldMode={setWorldEnabled}
         autonomy={worldAutonomy}
         setAutonomy={setWorldAutonomy}
+        domLabels={worldDomLabels}
+        setDomLabels={setWorldDomLabels}
       />
 
       {worldEnabled && (
@@ -3058,6 +3066,19 @@ export default function PlayPage() {
                 onSelect={() => setCodexOpen(true)}
                 imgRef={imgRef}
               />
+              {worldEnabled &&
+                worldDomLabels &&
+                phase === "ready" &&
+                streamStatus === "off" &&
+                (!page?.sceneView || page.sceneView.level === "map") && (
+                  <MapLabelOverlay
+                    nodeId={page?.nodeId ?? null}
+                    entities={worldState.entities}
+                    geoEntities={geoMap.entities}
+                    currentView={page?.sceneView ?? null}
+                    imgRef={imgRef}
+                  />
+                )}
               {geoOverlayOn && page?.nodeId && (
                 <GeometryOverlay
                   nodeId={page.nodeId}

--- a/apps/web/components/PlayPage/MapLabelOverlay.tsx
+++ b/apps/web/components/PlayPage/MapLabelOverlay.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useMemo, type RefObject } from "react";
+import type { Entity, SceneView, WorldEntityGeo } from "@openflipbook/config";
+
+import { useContainRect } from "@/hooks/useContainRect";
+import { MAP_IMAGE_FRAME } from "@/lib/geo-tap";
+import {
+  anchorsFromGeo,
+  layoutLabels,
+  type LabelInput,
+} from "@/lib/map-labels";
+
+interface Props {
+  /** The page the labels overlay. */
+  nodeId: string | null;
+  /** Codex entities — preferred anchor source (bbox on THIS node). */
+  entities: Entity[];
+  /** Geo map entities — the fallback anchor source on map frames. */
+  geoEntities: WorldEntityGeo[];
+  /** The frame the page shows; labels render only on map frames. */
+  currentView: SceneView | null;
+  imgRef?: RefObject<HTMLImageElement | null>;
+}
+
+/**
+ * DOM place-name labels (DOM-labels mode). With `suppress_map_labels` the
+ * image renders text-free; this overlay draws the names from entity data —
+ * always crisp, never garbled, and a click on a name can never be mistaken
+ * for a click on a place (pointer-events pass through). Labels are only
+ * ADDED for known entities; old maps with baked lettering keep it (a DOM
+ * duplicate over a baked name resolves itself as label-free renders accrue).
+ */
+export function MapLabelOverlay({
+  nodeId,
+  entities,
+  geoEntities,
+  currentView,
+  imgRef,
+}: Props) {
+  const content = useContainRect(imgRef);
+  const placed = useMemo(() => {
+    if (currentView && currentView.level !== "map") return [];
+    // Preferred: codex entities localized on THIS page (bbox centres).
+    const fromBBoxes: LabelInput[] = [];
+    if (nodeId) {
+      for (const e of entities) {
+        const bbox = e.appearance_bboxes?.[nodeId];
+        if (!bbox || !e.name.trim()) continue;
+        fromBBoxes.push({
+          id: e.id,
+          name: e.name.trim(),
+          xPct: bbox.x_pct + bbox.w_pct / 2,
+          yPct: bbox.y_pct + bbox.h_pct / 2,
+        });
+      }
+    }
+    if (fromBBoxes.length > 0) return layoutLabels(fromBBoxes);
+    // Fallback: top-level geo footprints through the seeded map frame.
+    const frame = currentView?.map_crop ?? MAP_IMAGE_FRAME;
+    const topLevel = geoEntities.filter((e) => (e.parent_id ?? null) === null);
+    return layoutLabels(anchorsFromGeo(topLevel, frame));
+  }, [nodeId, entities, geoEntities, currentView]);
+
+  if (placed.length === 0) return null;
+
+  return (
+    <div aria-hidden className="pointer-events-none absolute inset-0 z-10">
+      {placed.map((l) => {
+        const left = content
+          ? `${content.offsetX + l.leftPct * content.width}px`
+          : `${l.leftPct * 100}%`;
+        const top = content
+          ? `${content.offsetY + l.topPct * content.height}px`
+          : `${l.topPct * 100}%`;
+        return (
+          <span
+            key={l.id}
+            data-label-id={l.id}
+            className="absolute rounded-sm border border-[var(--color-edge)] bg-[var(--color-canvas)]/85 px-1 py-px font-serif text-[11px] leading-tight tracking-wide text-[var(--color-ink)] shadow-sm backdrop-blur-[1px]"
+            style={{ left, top }}
+          >
+            {l.name}
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/components/PlayPage/QueryToolbar.tsx
+++ b/apps/web/components/PlayPage/QueryToolbar.tsx
@@ -33,6 +33,8 @@ interface Props {
   setWorldMode: (on: boolean) => void;
   autonomy: Autonomy;
   setAutonomy: (a: Autonomy) => void;
+  domLabels: boolean;
+  setDomLabels: (on: boolean) => void;
 }
 
 export function QueryToolbar({
@@ -58,6 +60,8 @@ export function QueryToolbar({
   setWorldMode,
   autonomy,
   setAutonomy,
+  domLabels,
+  setDomLabels,
 }: Props) {
   return (
     <>
@@ -198,6 +202,22 @@ export function QueryToolbar({
                 {a}
               </button>
             ))}
+          {worldMode && (
+            <button
+              type="button"
+              onClick={() => setDomLabels(!domLabels)}
+              aria-pressed={domLabels}
+              title="DOM labels — maps render with no baked text; place names overlay the image (crisper lettering, names never break clicks)"
+              className={
+                "px-2.5 py-1 transition-colors " +
+                (domLabels
+                  ? "bg-[var(--color-ink)] text-[var(--color-canvas)]"
+                  : "hover:bg-[var(--color-ink)]/5")
+              }
+            >
+              labels
+            </button>
+          )}
         </div>
         <button
           type="submit"

--- a/apps/web/hooks/useWorldMode.ts
+++ b/apps/web/hooks/useWorldMode.ts
@@ -7,9 +7,21 @@ import type { Autonomy } from "@openflipbook/config";
 export interface WorldModeState {
   enabled: boolean;
   autonomy: Autonomy;
+  // DOM labels: maps render label-free and names overlay in the DOM
+  // (MapLabelOverlay) — fixes garbled lettering + clicks landing on text.
+  // Seeded by NEXT_PUBLIC_DOM_LABELS (build-time), per-session persisted.
+  domLabels: boolean;
 }
 
-const DEFAULT: WorldModeState = { enabled: false, autonomy: "auto" };
+const DOM_LABELS_DEFAULT = ["1", "true", "yes"].includes(
+  (process.env.NEXT_PUBLIC_DOM_LABELS ?? "").toLowerCase(),
+);
+
+const DEFAULT: WorldModeState = {
+  enabled: false,
+  autonomy: "auto",
+  domLabels: DOM_LABELS_DEFAULT,
+};
 
 function storageKey(sessionId: string): string {
   return `openflipbook.worldMode.${sessionId}`;
@@ -36,6 +48,10 @@ export function useWorldMode(sessionId: string) {
       setState({
         enabled: Boolean(parsed.enabled),
         autonomy: parsed.autonomy === "semi" ? "semi" : "auto",
+        domLabels:
+          typeof parsed.domLabels === "boolean"
+            ? parsed.domLabels
+            : DOM_LABELS_DEFAULT,
       });
     } catch {
       setState(DEFAULT);
@@ -59,11 +75,17 @@ export function useWorldMode(sessionId: string) {
     (autonomy: Autonomy) => setState((s) => ({ ...s, autonomy })),
     [],
   );
+  const setDomLabels = useCallback(
+    (domLabels: boolean) => setState((s) => ({ ...s, domLabels })),
+    [],
+  );
 
   return {
     enabled: state.enabled,
     autonomy: state.autonomy,
+    domLabels: state.domLabels,
     setEnabled,
     setAutonomy,
+    setDomLabels,
   } as const;
 }

--- a/apps/web/lib/map-labels.test.ts
+++ b/apps/web/lib/map-labels.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { anchorsFromGeo, layoutLabels, type PlacedLabel } from "./map-labels";
+
+function overlapArea(a: PlacedLabel, b: PlacedLabel): number {
+  const w =
+    Math.min(a.leftPct + a.wPct, b.leftPct + b.wPct) -
+    Math.max(a.leftPct, b.leftPct);
+  const h =
+    Math.min(a.topPct + a.hPct, b.topPct + b.hPct) -
+    Math.max(a.topPct, b.topPct);
+  return Math.max(0, w) * Math.max(0, h);
+}
+
+describe("layoutLabels (DOM label collision avoidance)", () => {
+  it("a lone label sits centred just above its anchor, inside the frame", () => {
+    const placed = layoutLabels([
+      { id: "a", name: "Patrician's Palace", xPct: 0.5, yPct: 0.4 },
+    ]);
+    const l = placed[0]!;
+    expect(l.leftPct + l.wPct / 2).toBeCloseTo(0.5, 5);
+    expect(l.topPct).toBeLessThan(0.4);
+    expect(l.topPct).toBeGreaterThanOrEqual(0);
+  });
+
+  it("colliding labels resolve to zero overlap", () => {
+    const placed = layoutLabels([
+      { id: "a", name: "The Guild Quarter", xPct: 0.5, yPct: 0.3 },
+      { id: "b", name: "The Thieves' Guild", xPct: 0.5, yPct: 0.3 },
+      { id: "c", name: "The Fools' Guild", xPct: 0.51, yPct: 0.31 },
+    ]);
+    expect(placed).toHaveLength(3);
+    for (let i = 0; i < placed.length; i++) {
+      for (let j = i + 1; j < placed.length; j++) {
+        expect(overlapArea(placed[i]!, placed[j]!)).toBe(0);
+      }
+    }
+  });
+
+  it("edge anchors clamp into the frame; long names truncate", () => {
+    const placed = layoutLabels([
+      { id: "edge", name: "North Gate", xPct: 0.99, yPct: 0.01 },
+      {
+        id: "long",
+        name: "The Extraordinarily Long Named University of Wizardry",
+        xPct: 0.5,
+        yPct: 0.5,
+      },
+    ]);
+    for (const l of placed) {
+      expect(l.leftPct).toBeGreaterThanOrEqual(0);
+      expect(l.leftPct + l.wPct).toBeLessThanOrEqual(1);
+      expect(l.topPct).toBeGreaterThanOrEqual(0);
+      expect(l.topPct + l.hPct).toBeLessThanOrEqual(1);
+    }
+    expect(placed.find((l) => l.id === "long")!.name.endsWith("…")).toBe(true);
+  });
+});
+
+describe("anchorsFromGeo", () => {
+  it("projects frame coords to 0..1 and drops blanks + out-of-frame", () => {
+    const frame = { x: 0, y: 0, w: 100, h: 60 };
+    const anchors = anchorsFromGeo(
+      [
+        { id: "a", label: "Palace", pos: { x: 50, y: 30 } },
+        { id: "b", label: "  ", pos: { x: 10, y: 10 } },
+        { id: "c", label: "Far Away", pos: { x: 500, y: 30 } },
+      ],
+      frame,
+    );
+    expect(anchors).toEqual([{ id: "a", name: "Palace", xPct: 0.5, yPct: 0.5 }]);
+  });
+});

--- a/apps/web/lib/map-labels.ts
+++ b/apps/web/lib/map-labels.ts
@@ -1,0 +1,101 @@
+import type { WorldVec2 } from "@openflipbook/config";
+
+/**
+ * Pure label layout for the DOM-labels overlay (MapLabelOverlay): greedy
+ * collision avoidance over normalized (0..1) label boxes. Labels prefer to
+ * sit just above their anchor point; an overlapping label nudges DOWN below
+ * the colliding one (cartographic convention: never sideways, the anchor
+ * line stays readable), then clamps into the frame.
+ */
+
+export interface LabelInput {
+  id: string;
+  name: string;
+  // Anchor point in normalized image space (0..1) — the entity's centre.
+  xPct: number;
+  yPct: number;
+}
+
+export interface PlacedLabel extends LabelInput {
+  // Top-left of the label box, normalized; the component renders from these.
+  leftPct: number;
+  topPct: number;
+  wPct: number;
+  hPct: number;
+}
+
+// Box-size estimate in normalized units: ~per-character width and line
+// height for the small cartouche font, relative to a typical map render.
+const CHAR_W = 0.0075;
+const LINE_H = 0.035;
+const GAP = 0.006;
+const MAX_NAME = 28;
+
+function overlaps(a: PlacedLabel, b: PlacedLabel): boolean {
+  return (
+    a.leftPct < b.leftPct + b.wPct &&
+    b.leftPct < a.leftPct + a.wPct &&
+    a.topPct < b.topPct + b.hPct &&
+    b.topPct < a.topPct + a.hPct
+  );
+}
+
+const clamp01 = (v: number, span: number): number =>
+  Math.min(Math.max(v, 0), 1 - span);
+
+export function layoutLabels(items: LabelInput[]): PlacedLabel[] {
+  // Stable order: top-to-bottom, then left-to-right — northern labels claim
+  // their spot first, southern ones nudge around them.
+  const sorted = [...items].sort(
+    (a, b) => a.yPct - b.yPct || a.xPct - b.xPct || (a.id < b.id ? -1 : 1),
+  );
+  const placed: PlacedLabel[] = [];
+  for (const item of sorted) {
+    const name =
+      item.name.length > MAX_NAME
+        ? `${item.name.slice(0, MAX_NAME - 1)}…`
+        : item.name;
+    const wPct = Math.min(name.length * CHAR_W, 0.5);
+    const box: PlacedLabel = {
+      ...item,
+      name,
+      wPct,
+      hPct: LINE_H,
+      leftPct: clamp01(item.xPct - wPct / 2, wPct),
+      // Prefer sitting just above the anchor.
+      topPct: clamp01(item.yPct - LINE_H - GAP, LINE_H),
+    };
+    // Nudge below each collider in placement order; one pass per existing
+    // label is enough for a greedy, non-overlapping result.
+    let moved = true;
+    let guard = 0;
+    while (moved && guard < 20) {
+      moved = false;
+      guard += 1;
+      for (const other of placed) {
+        if (overlaps(box, other)) {
+          box.topPct = clamp01(other.topPct + other.hPct + GAP, box.hPct);
+          moved = true;
+        }
+      }
+    }
+    placed.push(box);
+  }
+  return placed;
+}
+
+/** Anchor points from geo entities seeded in `frame` (top-level map). */
+export function anchorsFromGeo(
+  entities: { id: string; label: string; pos: WorldVec2 }[],
+  frame: { x: number; y: number; w: number; h: number },
+): LabelInput[] {
+  return entities
+    .filter((e) => e.label.trim())
+    .map((e) => ({
+      id: e.id,
+      name: e.label.trim(),
+      xPct: (e.pos.x - frame.x) / frame.w,
+      yPct: (e.pos.y - frame.y) / frame.h,
+    }))
+    .filter((a) => a.xPct >= 0 && a.xPct <= 1 && a.yPct >= 0 && a.yPct <= 1);
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -159,6 +159,10 @@ export interface GenerateRequestBody {
   world_mode?: boolean;
   autonomy?: Autonomy;
   render_mode?: RenderMode;
+  // DOM-labels mode (NEXT_PUBLIC_DOM_LABELS): map/explainer renders carry NO
+  // baked text — names ride a client overlay built from entity data. Optional
+  // + default-absent: old clients omit it, prompts stay byte-identical.
+  suppress_map_labels?: boolean;
   // B2 logical AROUND (mode:"expand", SCALE_AROUND_LOGICAL). The same-scale
   // neighbours the client already knows from geometry (excluded) + the focus's
   // rung, so the bloom proposes NEW peers at that scale. Ignored unless the flag


### PR DESCRIPTION
Track A, PR 3 of 4 (plan: world-mode reliability + evolvable eval). Off main; independent of #63/#64.

## Why

Baked-in lettering is the root of two problems the user hit: models garble map text, and clicks land on *names* instead of *places*. In DOM-labels mode the image renders with **no baked text** and the UI overlays place names from entity data — always crisp, and a label can never intercept a tap (`pointer-events-none`).

## How

- **Toggle**: a `labels` pill beside world/auto/semi (`useWorldMode.domLabels` — per-session persisted, seeded by `NEXT_PUBLIC_DOM_LABELS`, default OFF).
- **Wire**: optional `suppress_map_labels` on `GenerateRequestBody` ↔ `GenerateBody` — the field-parity gate covers it; absent = today's bytes, old client/new backend and vice versa both fine.
- **Backend**: label-free planner instructions for `place_submap` + `explainer` (scenes never had labels — untouched, tested); "Labels to include" blocks skipped on the main and Around/expand paths; the `NO_LETTERING` directive appended at the image-prompt level; `build_zoom_instruction(label_free=…)` swaps the lettering guard for the full no-text directive. **Flag-off prompts are byte-identical** — pinned by `test_label_free_prompts.py`.
- **Overlay**: `MapLabelOverlay` (codex bbox anchors, geo-footprint fallback through the seeded 100×60 frame) + pure `lib/map-labels.ts` — greedy collision layout (prefer above-anchor, nudge down below colliders, clamp, truncate).
- **Mixed worlds**: labels only added for known entities, never removed; old maps with baked lettering keep it and resolve as label-free renders accrue.

## Verification
- New: `map-labels.test.ts` (zero-overlap after layout, clamping, truncation, geo anchor projection), `test_label_free_prompts.py` (default byte-identity + label-free variants for each render mode + the zoom guard swap).
- Full `pytest -m "not paid"`, `mypy`, `ruff`, full vitest, `tsc` — green. (Found and fixed a fun one mid-PR: a branch-local import of `LETTERING_GUARD` shadowed the module-level name → `UnboundLocalError` on the legacy path; the frozen-golden tests caught it.)
- Manual: world ON + labels ON → new map renders with no lettering, DOM names track resize/zoom; labels OFF → identical to today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)