### PR TITLE
docs(ui)+fix: full UI audit + the top cheap fixes

### DIFF
--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -2908,6 +2908,17 @@ export default function PlayPage() {
               </span>
             </button>
           )}
+          {worldEnabled && (
+            <button
+              type="button"
+              onClick={() => setWorldEnabled(false)}
+              title="World Mode is ON — a tap ENTERS the tapped place (classic explore explains it instead). Click to switch back."
+              className="pointer-events-auto absolute start-3 top-3 z-10 flex select-none items-center gap-1 rounded-full border border-emerald-700/40 bg-emerald-50/85 px-2.5 py-1 text-xs font-medium text-emerald-900 backdrop-blur transition hover:bg-emerald-100"
+            >
+              <span aria-hidden>🌍</span>
+              <span>World — tap enters places</span>
+            </button>
+          )}
           <div className="relative aspect-[16/9] w-full">
             <div className="relative h-full w-full">
               {fallbackVideoUrl && showVideo ? (
@@ -3370,7 +3381,7 @@ export default function PlayPage() {
       {/* Hide the coach while the Around tray is open — both are pinned to
           bottom-centre, so they'd overlap; mid-bloom the hint is noise anyway.
           It returns when the tray is closed. */}
-      {phase === "ready" && !helpOpen && !bloom && (
+      {phase === "ready" && !helpOpen && !bloom && history.items.length <= 1 && (
         <FirstRunCoach onShowHelp={() => setHelpOpen(true)} />
       )}
 

--- a/apps/web/components/PlayPage/Breadcrumb.test.tsx
+++ b/apps/web/components/PlayPage/Breadcrumb.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { Crumb } from "@/lib/breadcrumb";
+
+import Breadcrumb from "./Breadcrumb";
+
+const crumb = (n: number): Crumb => ({ nodeId: `n${n}`, title: `Step ${n}` });
+const trail = (len: number): Crumb[] =>
+  Array.from({ length: len }, (_, i) => crumb(i + 1));
+
+describe("Breadcrumb (deep-trail collapse, A4)", () => {
+  it("short trails render every crumb, no ellipsis", () => {
+    render(<Breadcrumb crumbs={trail(4)} onJump={() => {}} />);
+    for (let i = 1; i <= 4; i++) {
+      expect(screen.getByText(`Step ${i}`)).toBeTruthy();
+    }
+    expect(screen.queryByText("…")).toBeNull();
+  });
+
+  it("deep trails collapse to root › … › last two", () => {
+    render(<Breadcrumb crumbs={trail(7)} onJump={() => {}} />);
+    expect(screen.getByText("Step 1")).toBeTruthy(); // root stays jumpable
+    expect(screen.getByText("Step 6")).toBeTruthy();
+    expect(screen.getByText("Step 7")).toBeTruthy();
+    expect(screen.queryByText("Step 3")).toBeNull(); // middle hidden
+    expect(screen.getByText("…")).toBeTruthy();
+  });
+
+  it("the ellipsis expands the full trail; ancestors still jump", () => {
+    const onJump = vi.fn();
+    render(<Breadcrumb crumbs={trail(7)} onJump={onJump} />);
+    fireEvent.click(screen.getByText("…"));
+    expect(screen.getByText("Step 3")).toBeTruthy();
+    fireEvent.click(screen.getByText("Step 3"));
+    expect(onJump).toHaveBeenCalledWith("n3");
+  });
+
+  it("a single crumb renders nothing (you haven't gone in yet)", () => {
+    const { container } = render(
+      <Breadcrumb crumbs={trail(1)} onJump={() => {}} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/apps/web/components/PlayPage/Breadcrumb.tsx
+++ b/apps/web/components/PlayPage/Breadcrumb.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useState } from "react";
+
 import type { Crumb } from "@/lib/breadcrumb";
 
 interface Props {
@@ -15,15 +17,39 @@ function short(title: string): string {
 // — the leftmost is the map you started from); the current page is plain text.
 // Hidden until you've actually gone in (a single crumb is just the current page).
 export default function Breadcrumb({ crumbs, onJump }: Props) {
+  // Deep trails collapse to root › … › last two (presentation only — the
+  // data stays intact; "…" expands the full trail). A4 cheap fix.
+  const [expanded, setExpanded] = useState(false);
   if (crumbs.length < 2) return null;
+  const collapsed = !expanded && crumbs.length > 4;
+  const visible: (Crumb | "ellipsis")[] = collapsed
+    ? [crumbs[0]!, "ellipsis", ...crumbs.slice(-2)]
+    : crumbs;
   return (
     <nav
       aria-label="Location"
       data-testid="breadcrumb"
       className="flex flex-wrap items-center gap-0.5 text-xs"
     >
-      {crumbs.map((c, i) => {
-        const isLast = i === crumbs.length - 1;
+      {visible.map((c, i) => {
+        if (c === "ellipsis") {
+          return (
+            <span key="ellipsis" className="flex items-center gap-0.5">
+              <span aria-hidden className="px-0.5 opacity-40">
+                ›
+              </span>
+              <button
+                type="button"
+                onClick={() => setExpanded(true)}
+                title={`Show all ${crumbs.length} steps`}
+                className="rounded px-1 py-0.5 opacity-70 hover:bg-[var(--color-ink)]/10 hover:opacity-100"
+              >
+                …
+              </button>
+            </span>
+          );
+        }
+        const isLast = i === visible.length - 1;
         return (
           <span key={c.nodeId} className="flex items-center gap-0.5">
             {i > 0 && (

--- a/apps/web/components/PlayPage/FirstRunCoach.tsx
+++ b/apps/web/components/PlayPage/FirstRunCoach.tsx
@@ -20,7 +20,7 @@ export function FirstRunCoach({ onShowHelp }: Props) {
       aria-live="polite"
       className="pointer-events-none fixed inset-x-0 bottom-6 z-40 flex justify-center px-4"
     >
-      <div className="pointer-events-auto flex max-w-full items-center gap-2.5 overflow-x-auto rounded-full border border-[var(--color-edge)] bg-[var(--color-canvas)]/95 px-4 py-2 text-sm shadow-lg backdrop-blur">
+      <div className="pointer-events-auto flex max-w-[92vw] flex-wrap items-center justify-center gap-2.5 rounded-full border border-[var(--color-edge)] bg-[var(--color-canvas)]/95 px-4 py-2 text-sm shadow-lg backdrop-blur">
         {/* The two moves, side by side, so the in/around duality is obvious. */}
         <span className="whitespace-nowrap opacity-80">Tap to go in</span>
         <span className="opacity-40">·</span>

--- a/apps/web/components/PlayPage/WorldMiniMap.tsx
+++ b/apps/web/components/PlayPage/WorldMiniMap.tsx
@@ -72,6 +72,16 @@ export default function WorldMiniMap({
   if (entities.length === 0) return null;
   const bounds = local ? localBounds(kids!) : submap ? crop! : worldBounds;
   const byId = new Map<string, FrameNode>(entities.map((e) => [e.id, e]));
+  // Label budget: tiny SVG text collides fast, so only the biggest
+  // footprints get names — every entity keeps its dot. (A4 cheap fix.)
+  const labelIds = new Set(
+    [...entities]
+      .sort(
+        (a, b) => b.footprint.w * b.footprint.d - a.footprint.w * a.footprint.d,
+      )
+      .slice(0, 6)
+      .map((e) => e.id),
+  );
 
   const W = 208;
   const H = 148;
@@ -154,7 +164,7 @@ export default function WorldMiniMap({
                 r={nested ? 2 : 3}
                 fill={KIND_COLOR[e.kind] ?? "#64748b"}
               />
-              {!nested && (
+              {!nested && labelIds.has(e.id) && (
                 <text x={p.x + 4} y={p.y + 3} fontSize={7} fill="#334155">
                   {e.label.length > 14 ? e.label.slice(0, 13) + "…" : e.label}
                 </text>

--- a/docs/UI_AUDIT.md
+++ b/docs/UI_AUDIT.md
@@ -1,0 +1,93 @@
+# UI audit — the whole journey, both modes, and the debt list
+
+A single pass over everything a user touches, from first load to a deep
+world session. Written June 2026 alongside the world-mode reliability run
+(PRs #63–#70); line references are approximate by design — find by name.
+
+## The journey, first load → deep session
+
+1. **First load** (`app/play/page.tsx`): the query toolbar (`QueryToolbar`)
+   with locale/theme/tier knobs, the **world pill** (off by default; `auto`
+   / `semi` / `labels` sub-pills appear when on), and the style gallery
+   (`StyleGallery`, sessionStorage-dismissable) for picking a visual anchor.
+2. **First generation**: query → `/api/generate-page` (SSE: `status` →
+   `progress` draft → `final`) → `persistNode` → async entity extraction
+   (`/api/world/{id}/extract`) seeds the codex + geo map a beat later.
+3. **Exploring (classic mode)**: hover shows the red crosshair
+   (`HoverCrosshair`); a tap explains the thing under the cursor (topical
+   depth). `E` blooms Around (breadth). Shift+drag annotates a stroke;
+   ⌘/Ctrl-click floats a hint input; Edit mode drags a region for
+   mask-scoped edits. The `FirstRunCoach` pill teaches tap/around — now
+   only until the first tap-child exists.
+4. **World mode** (the pill, or the on-figure chip): a tap ENTERS the place
+   under the finger. Routing is geometric first (`geoTapRequest` over the
+   seeded 100×60 frame), then label-match (lettering names a mapped place,
+   #63), then the submap zoom-cut degrade (#63) — never the fresh
+   reinvention path. Pulsing emerald rings mark enterable places and the
+   crosshair flips to an "enter" ring over them (#64). Entered places
+   persist and a re-tap REOPENS the saved node.
+5. **Inside a place**: `SpatialPath` (geo breadcrumb), `WorldMiniMap`
+   (top-right coordinate inset, local frame), `GeometryOverlay` boxes via
+   the `⊞ geo` toggle, the Codex panel for entities. Zoom out / step back
+   in the top bar; `Breadcrumb` collapses deep trails to root › … › last
+   two.
+6. **Atlas** (`/atlas/{session}` or the `↗ atlas` button): the zoomable
+   session map — depth-coloured tiles, dotted enter-edges, entity pins,
+   camera-gaze anchors, mini-map.
+7. **Sharing**: permalink per node (`/n/{id}`), exports (PDF/ZIP/GIF) via
+   the context menu, publish-to-gallery.
+
+## The two modes (and when to use which)
+
+|                      | Classic explore                  | World mode                                  |
+| -------------------- | -------------------------------- | ------------------------------------------- |
+| A tap means          | "explain THIS"                   | "take me INTO this place"                   |
+| Best for             | concepts, diagrams, topics       | maps, places, anything with WHERE           |
+| Output of a tap      | a labelled explainer page        | a scene or a closer sub-map (Kontext zoom)  |
+| Geography            | none (each page standalone)      | one numeric world; landmarks stay put       |
+| Re-tap a place       | a new explainer                  | reopens the saved node                      |
+| Visible indicator    | —                                | 🌍 chip on the figure + rings on places     |
+| Labels               | baked into the image             | optional DOM labels (`labels` pill, #70)    |
+
+Rule of thumb: if the image is a MAP (or you care where things are), turn
+world on. If you're reading about a topic, leave it off — the classic tap
+is better at "what is this".
+
+## Debt list (prioritized; ✅ = fixed in this run)
+
+1. ✅ **Un-anchored world taps reinvented the scene** — the fresh path
+   ignores image refs (#63: label-match + submap degrade).
+2. ✅ **No enter affordance** — rings + enter cursor + coach hint (#64).
+3. ✅ **Baked lettering garbles + hijacks clicks** — DOM-labels mode (#70).
+4. ✅ **No persistent mode indicator** — the toolbar pill was the only
+   signal; now the 🌍 chip sits on the figure and toggles off in place.
+5. ✅ **FirstRunCoach overlapped the Pin-style chip** and clipped its text
+   (`overflow-x-auto`); it also never went away. Now wraps, and renders
+   only until the first tap-child exists.
+6. ✅ **WorldMiniMap label soup** — every dot got SVG text; collisions were
+   guaranteed. Now only the 6 largest footprints carry names.
+7. ✅ **Breadcrumb overflow** on deep trails — collapses to root › … › last
+   two with an expander.
+8. **`⊞ geo` and entity-chip toggles are buried** — discoverable only by
+   reading the toolbar; a keyboard shortcut (`G`) and a hint would help.
+9. **Entity chips need `appearance_bboxes[nodeId]`** — pre-Phase-4 extracts
+   show no on-image affordance even when the codex knows the entity; a
+   placeholder ("not yet localized") would close the gap.
+10. **Hover-prefetch is invisible** — silent VLM warming on hover has no
+    debug surface; a dev HUD toggle would make cost behaviour visible.
+11. **`view.layout_register_mismatch` silently suppresses layout steering**
+    (backend) — logged but invisible to the user; the eval track
+    (`tests/recon_bench`) is the right place to measure how much it costs.
+12. **Edit-verdict chip can overlap narrow screens** — toast-corner
+    placement would be safer.
+13. **Mobile pass** — breadcrumbs, codex panel and the geo inset all want a
+    ≤390px audit; only the coach and breadcrumb were touched here.
+
+## Where the eval system hooks in
+
+The reconstruction bench (`make eval-recon`) and the matrix sweep
+(`make eval-matrix-dry` → `eval-matrix`) measure the generation half of
+everything above: layout fidelity (raw vs aligned register), heights,
+style, plausibility, per-model cost. UI changes that alter prompts (e.g.
+DOM-labels mode) should run the recon bench before/after — `recon_fidelity`
+in `tests/eval_baselines.json` is the gate.


### PR DESCRIPTION
Track A, PR 4 of 4 — closes out the plan. Stacked on #70 (the audit describes DOM-labels mode truthfully).

## docs/UI_AUDIT.md

The single-pass walkthrough the user asked for: first load → style pick → classic explore → world mode → inside places → atlas → permalinks/exports; an explicit **two-modes table** (classic tap = "explain this" vs world tap = "enter this"; when to use which, what each produces, how re-taps behave); and a prioritized debt list — **7 items fixed across this run (#63–#70), 6 still open** with concrete proposed fixes (buried toggles, unlocalized-entity placeholders, prefetch visibility, the `layout_register_mismatch` suppression, edit-verdict chip, mobile pass).

## Cheap fixes bundled (UI-only, no flags, no wire changes)

1. **Visible mode indicator** — a "🌍 World — tap enters places" chip on the figure whenever world mode is ON; clicking it switches back to classic in place. Addresses "sometimes places are selected, sometimes a name…" confusion about what a tap will do.
2. **FirstRunCoach** — renders only until the first tap-child exists, and wraps instead of clipping (it used to overlap the Pin-style chip: "…e on the image to explore.").
3. **WorldMiniMap** — label budget: only the 6 largest footprints get SVG names; every entity keeps its dot. Ends the overlapping-text soup in the top-right inset.
4. **Breadcrumb** — deep trails collapse to `root › … › last two`; the ellipsis expands the full trail. Presentation only, `buildBreadcrumb` untouched.

## Verification
New `Breadcrumb.test.tsx` (collapse threshold, expand, jump-through, single-crumb null); full vitest (558) + `tsc` green; world-OFF screens pixel-identical except the absent chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)