### PR TITLE
fix(web): inline condition-ref store URLs in the generate proxy

### DIFF
--- a/apps/web/app/api/generate-page/route.ts
+++ b/apps/web/app/api/generate-page/route.ts
@@ -50,6 +50,23 @@ export async function POST(req: Request) {
         mutated = true;
       }
     }
+    // The conditioning stack (style/parent/region refs) has the same problem:
+    // a reopened session's refs arrive as STORE URLs — on the docker stack
+    // that's a localhost minio URL fal's servers can't fetch, and the whole
+    // edit fails with invalid_request. Inline each (best-effort, per entry;
+    // a foreign/public URL passes through unchanged).
+    if (parsed?.condition_image_urls?.length) {
+      const refs = parsed.condition_image_urls;
+      const inlinedRefs = await Promise.all(
+        refs.map(async (u) =>
+          u && !u.startsWith("data:") ? ((await inlineStoredImage(u)) ?? u) : u,
+        ),
+      );
+      if (inlinedRefs.some((u, i) => u !== refs[i])) {
+        parsed.condition_image_urls = inlinedRefs;
+        mutated = true;
+      }
+    }
     if (parsed && parsed.session_id && parsed.query && !parsed.world_context) {
       const world_context = await resolveEntitiesForPrompt({
         sessionId: parsed.session_id,


### PR DESCRIPTION
Live-testing catch (screenshot: fal `invalid_request` with `image_urls: [..., 'http://localhost:9000/openflipbook/...']`).

After a session reload, history hydrates from storage — so the **style/parent refs** in `condition_image_urls` ride as store URLs. On the docker stack that's a localhost MinIO URL fal's servers can't fetch → the whole enter/edit dies with `invalid_request`. Fresh pages send `data:` URLs, which is why this only bites taps after a refresh/permalink.

The proxy already inlined `parsed.image` for exactly this reason; this gives the conditioning stack the same treatment via `inlineStoredImage` (per-entry, best-effort; public URLs pass through unchanged).

581 vitest + tsc green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)