### PR TITLE
feat(world): seed new sessions' world-mode default from NEXT_PUBLIC_WORLD_MODE

### DIFF
--- a/apps/web/hooks/useWorldMode.ts
+++ b/apps/web/hooks/useWorldMode.ts
@@ -16,9 +16,17 @@ export interface WorldModeState {
 const DOM_LABELS_DEFAULT = ["1", "true", "yes"].includes(
   (process.env.NEXT_PUBLIC_DOM_LABELS ?? "").toLowerCase(),
 );
+// Seed default for NEW sessions (build-time): a deploy that lives in world
+// mode (the demo stack) starts every session with it ON instead of silently
+// reverting to classic explainers — the "why did consistency regress"
+// footgun is that world mode is per-session and used to always seed off.
+// A session's own toggle still wins once stored.
+const WORLD_DEFAULT = ["1", "true", "yes"].includes(
+  (process.env.NEXT_PUBLIC_WORLD_MODE ?? "").toLowerCase(),
+);
 
 const DEFAULT: WorldModeState = {
-  enabled: false,
+  enabled: WORLD_DEFAULT,
   autonomy: "auto",
   domLabels: DOM_LABELS_DEFAULT,
 };
@@ -46,7 +54,8 @@ export function useWorldMode(sessionId: string) {
       }
       const parsed = JSON.parse(raw) as Partial<WorldModeState>;
       setState({
-        enabled: Boolean(parsed.enabled),
+        enabled:
+          typeof parsed.enabled === "boolean" ? parsed.enabled : WORLD_DEFAULT,
         autonomy: parsed.autonomy === "semi" ? "semi" : "auto",
         domLabels:
           typeof parsed.domLabels === "boolean"


### PR DESCRIPTION
The "why did consistency regress" footgun from live testing: world mode is per-session and always seeded OFF, so a new session silently reverts to classic explainer taps — none of the anchoring/continuation machinery runs. New build-time seed `NEXT_PUBLIC_WORLD_MODE` (same pattern as `NEXT_PUBLIC_DOM_LABELS`): set =1 and new sessions start in world mode; a session's stored toggle still wins; repo default unchanged.

Env: added `NEXT_PUBLIC_WORLD_MODE=1` to `apps/web/.env.local` (not in git).

🤖 Generated with [Claude Code](https://claude.com/claude-code)