### PR TITLE
fix(world): zoom-aware step-in judge for the enter loop

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -357,6 +357,17 @@ def _heights_for_view(body: GenerateBody) -> list[tuple[str, float, str]] | None
     return [(n, h / anchor_h, anchor_name) for n, h in real[1:]]
 
 
+def _same_place_judge(judge_mod: Any) -> Any:
+    """The render loop's same-place axis. Default: the zoom-aware step-in
+    judge (a city-wide redraw of a tapped courtyard scores 10/10 on plain
+    same-place — a wider view of a place IS that place — and sailed through
+    the loop live). ENTER_STEP_IN_JUDGE=false reverts byte-for-byte to the
+    plain continuation judge."""
+    if env_flag("ENTER_STEP_IN_JUDGE", "true"):
+        return judge_mod.score_step_in
+    return judge_mod.score_continuation
+
+
 def _view_grammar_on() -> bool:
     """The view grammar (a deliberate camera per render). Default ON; =false
     is a strict kill-switch — every render byte-identical to pre-grammar."""
@@ -1965,7 +1976,7 @@ async def _event_stream(
                     projection=str((enter_view or {}).get("projection") or ""),
                     region_bytes=render_loop.data_url_bytes(enter_source),
                     judge_conformance=judge.score_view_conformance,
-                    judge_same_place=judge.score_continuation,
+                    judge_same_place=_same_place_judge(judge),
                     config=loop_cfg,
                     judge_detail=_judge_detail,
                     # The medium gate: the entered view must look drawn by the

--- a/apps/modal-backend/providers/judge.py
+++ b/apps/modal-backend/providers/judge.py
@@ -151,6 +151,37 @@ async def score_continuation(region_crop: bytes, candidate: bytes) -> JudgeResul
     )
 
 
+async def score_step_in(region_crop: bytes, candidate: bytes) -> JudgeResult:
+    """Production twin of score_continuation with the ZOOM DIRECTION made
+    explicit. The live failure it exists for: an "enter" edit that redraws
+    the WHOLE CITY around the tapped courtyard scores 10/10 on plain
+    same-place (a wider view of a place IS that place) and sails through
+    the render loop. A step IN must be closer/tighter than its reference —
+    wider is a failure even when the place is right. The enter bench keeps
+    score_continuation so its committed baseline stays comparable."""
+    system = (
+        "You judge whether image 2 is a faithful STEP INTO image 1. Image 1 is "
+        "a cropped region of a map showing a specific place. Image 2 is a "
+        "generated view that is SUPPOSED to be that same place seen CLOSER or "
+        "from within — a tighter framing covering LESS area than image 1. "
+        "Score 0-10: 10 = unmistakably the same place, clearly closer or "
+        "inside; 5 = the same place at roughly the SAME framing (no step in); "
+        "0-2 = a different place, OR a WIDER view that shows more area around "
+        "the place (zoomed out — e.g. the whole city around a tapped "
+        "courtyard). Zooming OUT is a failure no matter how consistent."
+        ' Return JSON exactly: {"score": <0-10 number>, "rationale": "<one short sentence>"}.'
+    )
+    user_text = (
+        "Image 1: the tapped map region (the reference). Image 2: the entered "
+        "view. Is image 2 that same place seen CLOSER (high) — or the same "
+        "framing (5), a wider/zoomed-out view (low), or a different place "
+        "(low)? Score 0-10."
+    )
+    return await _ask_judge(
+        system, user_text, [_image_block(region_crop), _image_block(candidate)]
+    )
+
+
 async def score_prompt_alignment(prompt: str, image: bytes) -> JudgeResult:
     system = (
         "You are a prompt-alignment judge. Score on a 0-10 scale how "

--- a/apps/modal-backend/tests/test_generate_enter.py
+++ b/apps/modal-backend/tests/test_generate_enter.py
@@ -270,3 +270,16 @@ async def test_world_off_submap_request_still_zoom_continues(
     cont.assert_awaited_once()
     edit.assert_not_awaited()
     gen.assert_not_awaited()
+
+
+def test_same_place_judge_defaults_to_step_in(monkeypatch) -> None:
+    """The loop's same-place axis is zoom-aware by default — a city-wide
+    redraw of a tapped courtyard must not pass as 'the same place'.
+    ENTER_STEP_IN_JUDGE=false reverts to the plain continuation judge."""
+    import generate
+    from providers import judge
+
+    monkeypatch.delenv("ENTER_STEP_IN_JUDGE", raising=False)
+    assert generate._same_place_judge(judge) is judge.score_step_in
+    monkeypatch.setenv("ENTER_STEP_IN_JUDGE", "false")
+    assert generate._same_place_judge(judge) is judge.score_continuation

--- a/apps/modal-backend/tests/test_generate_view.py
+++ b/apps/modal-backend/tests/test_generate_view.py
@@ -346,6 +346,9 @@ def _mock_judges(
     medium = AsyncMock(return_value=JudgeResult(score=9.0, rationale="", raw=""))
     monkeypatch.setattr(judge_mod, "score_view_conformance", conf)
     monkeypatch.setattr(judge_mod, "score_continuation", same)
+    # Production's same-place axis defaults to the zoom-aware step-in judge
+    # (ENTER_STEP_IN_JUDGE) — same mock, same axis.
+    monkeypatch.setattr(judge_mod, "score_step_in", same)
     monkeypatch.setattr(judge_mod, "score_feature_articulation", detail)
     monkeypatch.setattr(judge_mod, "score_style_pair", medium)
     return conf, same
@@ -458,6 +461,11 @@ async def test_view_loop_medium_drift_retries(
     monkeypatch.setattr(
         judge_mod,
         "score_continuation",
+        AsyncMock(return_value=JudgeResult(score=9.0, rationale="", raw="")),
+    )
+    monkeypatch.setattr(
+        judge_mod,
+        "score_step_in",
         AsyncMock(return_value=JudgeResult(score=9.0, rationale="", raw="")),
     )
     monkeypatch.setattr(


### PR DESCRIPTION
Live failure with receipts: tapping the palace **courtyard** produced a redraw of the **whole city**, and the render loop accepted it instantly —

```
view.loop attempt=0 conformance=10.0 same_place=10.0 detail=10.0 medium=9.0 accepted=true
```

`score_continuation` asks "is this the same place?" — and a wider view of a place *is* that place. The judge measures identity, not **zoom direction**; a "step inside" coming back wider than its reference sailed through at 10/10.

Fix: `score_step_in` — the same single VLM call, with direction in the rubric (10 = closer/inside, 5 = same framing, 0–2 = wider/zoomed-out **or** different place). Production's loop uses it by default; `ENTER_STEP_IN_JUDGE=false` reverts byte-for-byte. The enter **bench** keeps `score_continuation`, so the committed `enter_same_place` baseline stays comparable — measuring the new axis in the bench would be a deliberate re-baseline.

Tests: gate unit test (default + kill-switch); loop mocks cover the new axis. Full `pytest -m "not paid"`, ruff, mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)