### PR TITLE
fix(world): route submap taps through the displayed crop, not the seeded frame

### DIFF
--- a/apps/web/lib/geo-tap.test.ts
+++ b/apps/web/lib/geo-tap.test.ts
@@ -470,3 +470,85 @@ describe("geoTapForEntity (W2: enter the place the lettering names)", () => {
     expect(t.surroundings).toContain("Brass Bridge");
   });
 });
+
+describe("submap click register (the displayed frame, not the seeded frame)", () => {
+  // A submap node displays only its crop window. Before the fix, taps were
+  // routed through the full MAP_IMAGE_FRAME — a click at image centre meant
+  // frame centre (50,30), not the crop's centre.
+  const submapView = (crop: { x: number; y: number; w: number; h: number }): SceneView => ({
+    node_id: "n-sub",
+    level: "map",
+    observer: null,
+    map_crop: crop,
+  });
+
+  it("a centre click on a submap resolves the entity at the CROP centre", () => {
+    const inCrop = geo("palace", "Patrician's Palace", 55, 25); // crop centre
+    const atFrameCentre = geo("decoy", "Frame Centre Decoy", 50, 30);
+    const map = { entities: [inCrop, atFrameCentre], bounds: CROP };
+    const t = geoTapRequest(
+      map,
+      "n-sub",
+      { x_pct: 0.5, y_pct: 0.5 },
+      16 / 9,
+      undefined,
+      submapView({ x: 40, y: 15, w: 30, h: 20 }), // centre = (55, 25)
+    );
+    expect(t).not.toBeNull();
+    expect(t!.focus_id).toBe("palace");
+  });
+
+  it("submap-of-submap windows shrink geometrically with the crop", () => {
+    // Empty-area tap inside a submap → the next window is a fraction of the
+    // CROP, not of the full frame.
+    // Two small-footprint entities NEAR the tap (inside the next window)
+    // but not under it — an empty-area tap that still warrants a submap.
+    const map = {
+      entities: [
+        geo("a", "A", 64, 31, { footprint: { w: 2, d: 2 } }),
+        geo("b", "B", 70, 35, { footprint: { w: 2, d: 2 } }),
+      ],
+      bounds: CROP,
+    };
+    const t = geoTapRequest(
+      map,
+      "n-sub",
+      { x_pct: 0.9, y_pct: 0.9 }, // world (67, 33) in the crop below
+      16 / 9,
+      undefined,
+      submapView({ x: 40, y: 15, w: 30, h: 20 }),
+    );
+    expect(t).not.toBeNull();
+    expect(t!.kind).toBe("submap");
+    expect(t!.scene_view.map_crop!.w).toBeCloseTo(30 * 0.4, 5);
+    expect(t!.scene_view.map_crop!.h).toBeCloseTo(20 * 0.4, 5);
+  });
+
+  it("degradedSubmapTap centres its window in the displayed crop", () => {
+    const map = { entities: [geo("far", "Far Away", 5, 5)], bounds: CROP };
+    const t = degradedSubmapTap(
+      map,
+      "n-sub",
+      { x_pct: 0.5, y_pct: 0.5 },
+      16 / 9,
+      submapView({ x: 40, y: 15, w: 30, h: 20 }),
+    );
+    expect(t).not.toBeNull();
+    const win = t!.scene_view.map_crop!;
+    expect(win.x + win.w / 2).toBeCloseTo(55, 5);
+    expect(win.y + win.h / 2).toBeCloseTo(25, 5);
+  });
+
+  it("children with frame-LOCAL coords cannot shadow top-level entities", () => {
+    // A child of the palace sits at LOCAL (50,30) — before the fix it was
+    // hit-tested as world coords and could steal a tap at frame centre.
+    const topLevel = geo("plaza", "Sator Square", 50, 30);
+    const child = geo("hall", "The Great Hall", 50, 30, {
+      parent_id: "palace",
+      footprint: { w: 30, d: 30 },
+    });
+    const map = { entities: [topLevel, child, geo("palace", "Palace", 80, 50)], bounds: CROP };
+    const t = geoTapRequest(map, "n1", { x_pct: 0.5, y_pct: 0.5 }, 16 / 9);
+    expect(t!.focus_id).toBe("plaza");
+  });
+});

--- a/apps/web/lib/geo-tap.ts
+++ b/apps/web/lib/geo-tap.ts
@@ -137,18 +137,32 @@ export function geoTapRequest(
       ? currentView.focus_id ?? null
       : null;
   // The entities the tap can land on: the whole map at top level, else the
-  // current place's children (in their local frame).
+  // current place's children (in their local frame). At map level, only
+  // TOP-LEVEL entities are hit-testable — children carry coords LOCAL to
+  // their parent's frame, and hit-testing those as world coords lets a
+  // child at local (50,30) shadow a real landmark (the hover affordance
+  // already filters this way; the tap path didn't).
   const candidates = insideId
     ? { entities: childrenOf(map.entities, insideId), bounds: map.bounds }
-    : map;
+    : {
+        entities: map.entities.filter((e) => (e.parent_id ?? null) === null),
+        bounds: map.bounds,
+      };
   if (candidates.entities.length === 0) return null;
-  // Route the click through the image-world frame the entities were SEEDED in —
-  // not their tight bounding box (map.bounds), which lands taps off the footprint.
+  // Route the click through the frame the image actually DISPLAYS: a submap/
+  // closeup node shows only its crop window, so a click at image centre means
+  // the CROP's centre — not the seeded frame's. (Entity seeding and the hover
+  // affordance already map through the crop; this restores symmetry.) Top-
+  // level maps and entered interiors keep the seeded MAP_IMAGE_FRAME.
+  const routingFrame =
+    !insideId && currentView?.level === "map" && currentView.map_crop
+      ? currentView.map_crop
+      : MAP_IMAGE_FRAME;
   const mapView: SceneView = {
     node_id: nodeId,
     level: "map",
     observer: null,
-    map_crop: MAP_IMAGE_FRAME,
+    map_crop: routingFrame,
   };
   const route = routeClick(candidates, mapView, click, aspect);
   if (route.kind === "explainer") return null;
@@ -297,11 +311,13 @@ export function degradedSubmapTap(
   // Map frames only — inside an entered place the classic tap stands (its
   // frame isn't the map the cut would continue).
   if (currentView && currentView.level !== "map") return null;
+  // Same displayed-frame routing as geoTapRequest: a submap node's click
+  // coords live in its crop window, not the seeded frame.
   const mapView: SceneView = {
     node_id: nodeId,
     level: "map",
     observer: null,
-    map_crop: MAP_IMAGE_FRAME,
+    map_crop: currentView?.map_crop ?? MAP_IMAGE_FRAME,
   };
   const route = routeClick(map, mapView, click, aspect, {
     minSubmapEntities: 0,


### PR DESCRIPTION
Ladder PR 1 of 5 (tap descent ladder plan). Two latent register bugs that break "tap again from the closeup":

1. **Submap taps misregistered**: a submap/closeup node displays only its crop window, but `geoTapRequest`/`degradedSubmapTap` routed clicks through the full `MAP_IMAGE_FRAME` — a click at image centre meant frame centre, not crop centre. Entity *seeding* and the hover affordance already map through the crop; taps now match (symmetry restored). Retroactive: saved submap nodes always persisted `map_crop`.
2. **Child shadowing**: children carry parent-LOCAL coords but were hit-tested as world coords at map level — a child at local (50,30) could steal a tap from a real landmark. Map-level taps now hit-test top-level entities only (the hover path's existing filter).

4 regression tests (crop-centre resolution, geometric window shrink, degraded-tap centring, shadowing); 585 vitest + tsc green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)