### PR TITLE
feat(world): the closeup rung — first tap on a place is a faithful Kontext zoom

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -182,6 +182,10 @@ class SceneView(BaseModel):
     level: str
     observer: ObserverPose | None = None
     map_crop: MapCrop | None = None
+    # Closeup rung (tap descent ladder): this frame is a TIGHT zoom on
+    # focus_id — the next tap on that entity transitions (enters) instead of
+    # zooming again. Mirrors the optional TS field (schema-parity gated).
+    closeup: bool | None = None
     # The entity you ENTERED to get here (the tapped place's geo id). geo-tap.ts
     # sets it and the extract route reads it to anchor the child frame; without
     # it the field was silently dropped on validation, breaking the round-trip.

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -2358,8 +2358,10 @@ export default function PlayPage() {
               // sub-map is a true zoom of the tapped region. A scene first-enter
               // keeps the (reprojecting) fresh path until B2 wires the guarded
               // scene→scene continuation. Spread last so it wins.
+              // closeup + submap both ride the Kontext zoom-continue (the
+              // high-consistency op); only a true transition tap enters.
               render_mode:
-                worldTap.kind === "submap" ? "place_submap" : "place_scene",
+                worldTap.kind === "scene" ? "place_scene" : "place_submap",
               // The geometric tap KNOWS which entity you hit (by coordinates) —
               // make it the subject so tapping the Tower of Art enters the Tower,
               // overriding the looser VLM read that picked its container. Spread

--- a/apps/web/lib/click-route.test.ts
+++ b/apps/web/lib/click-route.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { MapCrop, ObserverPose, SceneView, WorldEntityGeo } from "@openflipbook/config";
 
-import { routeClick, routeToFocus } from "./click-route";
+import { entityCloseupCrop, routeClick, routeToFocus } from "./click-route";
 
 function geo(
   id: string,
@@ -50,9 +50,15 @@ function norm(a: number): number {
 }
 
 describe("routeClick (P6 coordinate-driven mode detection)", () => {
-  it("tap a place on the map → enter a scene facing it", () => {
+  it("transition tap (on the place's own closeup) → enter a scene facing it", () => {
     const map = { entities: [geo("tower", 50, 50, { height: 20 })], bounds: CROP };
-    const r = routeClick(map, mapView(CROP), { x_pct: 0.5, y_pct: 0.5 }, ASPECT);
+    const closeupView: SceneView = {
+      ...mapView(CROP),
+      map_crop: { x: 41, y: 41, w: 18, h: 18 },
+      focus_id: "tower",
+      closeup: true,
+    };
+    const r = routeClick(map, closeupView, { x_pct: 0.5, y_pct: 0.5 }, ASPECT);
     expect(r.kind).toBe("scene");
     if (r.kind === "scene") {
       expect(r.focus_id).toBe("tower");
@@ -66,9 +72,15 @@ describe("routeClick (P6 coordinate-driven mode detection)", () => {
     }
   });
 
-  it("short place → street level, not building", () => {
+  it("short place → street level on the transition tap, not building", () => {
     const map = { entities: [geo("hut", 50, 50, { height: 4 })], bounds: CROP };
-    const r = routeClick(map, mapView(CROP), { x_pct: 0.5, y_pct: 0.5 }, ASPECT);
+    const closeupView: SceneView = {
+      ...mapView(CROP),
+      map_crop: { x: 41, y: 44, w: 18, h: 12 },
+      focus_id: "hut",
+      closeup: true,
+    };
+    const r = routeClick(map, closeupView, { x_pct: 0.5, y_pct: 0.5 }, ASPECT);
     expect(r.kind === "scene" && r.level).toBe("street");
   });
 
@@ -132,9 +144,11 @@ describe("routeClick (P6 coordinate-driven mode detection)", () => {
 describe("routeToFocus (enter a place resolved by NAME)", () => {
   it("synthesizes the same scene route a footprint hit would", () => {
     const focus = geo("tower", 60, 30, { height: 18 });
+    // The footprint hit's SCENE form fires on the transition tap (the
+    // closeup frame of this same focus) — compare against that.
     const byHit = routeClick(
       { entities: [focus], bounds: CROP },
-      mapView(CROP),
+      { ...mapView(CROP), focus_id: "tower", closeup: true },
       { x_pct: 0.6, y_pct: 0.3 },
       ASPECT,
     );
@@ -154,5 +168,84 @@ describe("routeToFocus (enter a place resolved by NAME)", () => {
     expect(routeToFocus(geo("hut", 10, 10, { height: 4 }), { x: 0, y: 0 }).level).toBe(
       "street",
     );
+  });
+});
+
+describe("the descent ladder (closeup rung)", () => {
+  it("first tap on a place → closeup crop, not enter", () => {
+    const map = { entities: [geo("palace", 50, 50, { footprint: { w: 10, d: 8 }, height: 18 })], bounds: CROP };
+    const r = routeClick(map, mapView(CROP), { x_pct: 0.5, y_pct: 0.5 }, ASPECT);
+    expect(r.kind).toBe("closeup");
+    if (r.kind === "closeup") {
+      expect(r.focus_id).toBe("palace");
+      // window centred on the entity, footprint x margin as a frame fraction
+      expect(r.crop.x + r.crop.w / 2).toBeCloseTo(50, 5);
+      expect(r.crop.y + r.crop.h / 2).toBeCloseTo(50, 5);
+      expect(r.crop.w).toBeCloseTo(18, 3); // max(10*1.6/100, 8*1.6/100, 0.18) = 0.18 -> 18
+    }
+  });
+
+  it("tap on the place whose closeup you are ON → transition (enter)", () => {
+    const palace = geo("palace", 50, 50, { footprint: { w: 10, d: 8 }, height: 18 });
+    const map = { entities: [palace], bounds: CROP };
+    const closeupView: SceneView = {
+      node_id: "n-close",
+      level: "map",
+      observer: null,
+      map_crop: { x: 41, y: 41, w: 18, h: 18 },
+      focus_id: "palace",
+      closeup: true,
+    };
+    const r = routeClick(map, closeupView, { x_pct: 0.5, y_pct: 0.5 }, ASPECT);
+    expect(r.kind).toBe("scene");
+    if (r.kind === "scene") expect(r.focus_id).toBe("palace");
+  });
+
+  it("plain submap focus_id (no closeup flag) still closeups, never enters", () => {
+    const palace = geo("palace", 50, 50, { footprint: { w: 10, d: 8 } });
+    const map = { entities: [palace], bounds: CROP };
+    const submapView: SceneView = {
+      node_id: "n-sub",
+      level: "map",
+      observer: null,
+      map_crop: { x: 30, y: 30, w: 40, h: 40 },
+      focus_id: "palace", // nearest-entity bookkeeping, NOT a closeup
+    };
+    const r = routeClick(map, submapView, { x_pct: 0.5, y_pct: 0.5 }, ASPECT);
+    expect(r.kind).toBe("closeup");
+  });
+
+  it("frame-filling place skips the rung (degenerate guard) → enter", () => {
+    const huge = geo("realm", 50, 50, { footprint: { w: 90, d: 90 }, height: 18 });
+    const map = { entities: [huge], bounds: CROP };
+    const r = routeClick(map, mapView(CROP), { x_pct: 0.5, y_pct: 0.5 }, ASPECT);
+    expect(r.kind).toBe("scene");
+  });
+
+  it("scene frames (observer set) keep entering directly", () => {
+    const observer: ObserverPose = { pos: { x: 0, y: 0 }, eye_height: 1.7, gaze: 0, fov: Math.PI / 2 };
+    const map = { entities: [geo("hut", 50, 0, { height: 5 })], bounds: CROP };
+    const r = routeClick(map, sceneView(observer), { x_pct: 0.5, y_pct: 0.5 }, ASPECT);
+    expect(r.kind).toBe("scene");
+  });
+});
+
+describe("entityCloseupCrop", () => {
+  const frame = { x: 0, y: 0, w: 100, h: 60 };
+  it("clamps to the frame for edge entities", () => {
+    const c = entityCloseupCrop(geo("gate", 2, 2, { footprint: { w: 30, d: 6 } }), frame);
+    expect(c.x).toBeGreaterThanOrEqual(0);
+    expect(c.y).toBeGreaterThanOrEqual(0);
+    expect(c.x + c.w).toBeLessThanOrEqual(100);
+    expect(c.y + c.h).toBeLessThanOrEqual(60);
+  });
+  it("tiny entities get the min fraction (context for Kontext)", () => {
+    const c = entityCloseupCrop(geo("well", 50, 30, { footprint: { w: 1, d: 1 } }), frame);
+    expect(c.w).toBeCloseTo(18, 5);
+    expect(c.h).toBeCloseTo(10.8, 5);
+  });
+  it("preserves the frame aspect (w/h ratio)", () => {
+    const c = entityCloseupCrop(geo("uni", 40, 30, { footprint: { w: 20, d: 6 } }), frame);
+    expect(c.w / c.h).toBeCloseTo(100 / 60, 5);
   });
 });

--- a/apps/web/lib/click-route.ts
+++ b/apps/web/lib/click-route.ts
@@ -31,6 +31,9 @@ export interface ClickPoint {
 }
 
 export type ClickRoute =
+  // The closeup rung (tap descent ladder): a TIGHT zoom on the tapped place —
+  // the high-consistency Kontext continuation, one step closer per tap.
+  | { kind: "closeup"; crop: MapCrop; focus_id: string }
   | { kind: "submap"; crop: MapCrop; focus_id: string | null }
   | { kind: "scene"; level: ViewLevel; observer: ObserverPose; focus_id: string }
   | { kind: "explainer"; focus_id: string | null };
@@ -113,6 +116,42 @@ function cropCentre(crop: MapCrop): WorldVec2 {
   return { x: crop.x + crop.w / 2, y: crop.y + crop.h / 2 };
 }
 
+// Closeup sizing: the entity's footprint with breathing room, expressed as a
+// FRACTION of the frame on both axes so the crop keeps the frame's aspect
+// (the property the submap window and the click crop already have).
+const CLOSEUP_MARGIN = 1.6;
+// Tiny entities keep enough surroundings for Kontext to anchor against.
+const CLOSEUP_MIN_FRAC = 0.18;
+// A crop this close to the whole frame is no zoom at all — skip the rung
+// (prevents the infinite-closeup loop on frame-filling places).
+const CLOSEUP_DEGENERATE_FRAC = 0.85;
+
+/** The closeup window for a place: footprint × margin, aspect-preserving,
+ *  clamped inside the frame. Pure; exported for the conditioning crop. */
+export function entityCloseupCrop(
+  focus: WorldEntityGeo,
+  frame: MapCrop,
+  margin = CLOSEUP_MARGIN,
+  minFrac = CLOSEUP_MIN_FRAC,
+): MapCrop {
+  const frac = Math.min(
+    Math.max(
+      (focus.footprint.w * margin) / frame.w,
+      (focus.footprint.d * margin) / frame.h,
+      minFrac,
+    ),
+    1,
+  );
+  const w = frame.w * frac;
+  const h = frame.h * frac;
+  return {
+    x: Math.min(Math.max(focus.pos.x - w / 2, frame.x), frame.x + frame.w - w),
+    y: Math.min(Math.max(focus.pos.y - h / 2, frame.y), frame.y + frame.h - h),
+    w,
+    h,
+  };
+}
+
 /** The scene route for a known focus entity, exactly as a geometric hit on
  *  its footprint would synthesize it. Exported so a tap resolved by NAME (the
  *  map's lettering names a mapped place) can enter that place too. */
@@ -142,8 +181,24 @@ export function routeClick(
       ? focusOnMap(entities, view.map_crop, click)
       : null;
 
-  // A place under the finger → enter it.
+  // A place under the finger → the descent ladder: first a CLOSEUP (the
+  // faithful Kontext zoom), and only the tap on the place whose closeup you
+  // are already on TRANSITIONS into it (enter). Scene frames (observer set)
+  // keep entering directly — scene-level closeups are a later rung.
   if (focus && focus.kind === "place") {
+    if (view.map_crop && !view.observer) {
+      const alreadyCloseup =
+        view.closeup === true && view.focus_id === focus.id;
+      if (!alreadyCloseup) {
+        const crop = entityCloseupCrop(focus, view.map_crop);
+        const degenerate =
+          crop.w >= view.map_crop.w * CLOSEUP_DEGENERATE_FRAC &&
+          crop.h >= view.map_crop.h * CLOSEUP_DEGENERATE_FRAC;
+        if (!degenerate) {
+          return { kind: "closeup", crop, focus_id: focus.id };
+        }
+      }
+    }
     const from = view.observer?.pos ?? cropCentre(view.map_crop ?? map.bounds);
     return routeToFocus(focus, from);
   }

--- a/apps/web/lib/geo-tap.test.ts
+++ b/apps/web/lib/geo-tap.test.ts
@@ -36,6 +36,22 @@ function geo(
 
 const CROP: MapCrop = { x: 0, y: 0, w: 100, h: 80 };
 
+// The descent ladder: a plain map tap on a place now yields a CLOSEUP; the
+// scene route fires on the TRANSITION tap (the tap on the place whose
+// closeup you are already on). These helpers build that context.
+const closeupViewOf = (
+  focusId: string,
+  crop: { x: number; y: number; w: number; h: number },
+): SceneView => ({
+  node_id: "n-close",
+  level: "map",
+  observer: null,
+  map_crop: crop,
+  focus_id: focusId,
+  closeup: true,
+});
+
+
 describe("geoTapRequest (close the geometric tap loop)", () => {
   it("tapping a place → scene_view (observer); a FIRST enter steers by nothing", () => {
     const map = {
@@ -48,7 +64,16 @@ describe("geoTapRequest (close the geometric tap loop)", () => {
       ],
       bounds: CROP,
     };
-    const t = geoTapRequest(map, "n1", { x_pct: 60 / 100, y_pct: 30 / 60 }, 16 / 9);
+    // The ladder: entering happens on the TRANSITION tap — from the clock's
+    // own closeup frame (centred on it; click coords live in that crop).
+    const t = geoTapRequest(
+      map,
+      "n1",
+      { x_pct: 0.5, y_pct: 0.5 },
+      16 / 9,
+      undefined,
+      closeupViewOf("clock", { x: 51, y: 21, w: 18, h: 18 }),
+    );
     expect(t).not.toBeNull();
     expect(t!.focus_id).toBe("clock");
     expect(t!.focus_label).toBe("clock tower"); // drives the entered subject
@@ -141,7 +166,14 @@ describe("geoTapRequest (close the geometric tap loop)", () => {
       ],
       bounds: CROP,
     };
-    const t = geoTapRequest(map, "n1", { x_pct: 30 / 100, y_pct: 18 / 60 }, 16 / 9);
+    const t = geoTapRequest(
+      map,
+      "n1",
+      { x_pct: 0.5, y_pct: 0.5 },
+      16 / 9,
+      undefined,
+      closeupViewOf("uu", { x: 21, y: 9, w: 18, h: 18 }),
+    );
     expect(t).not.toBeNull();
     expect(t!.scene_view.focus_id).toBe("uu");
     const ids = t!.expected_layout.map((p) => p.id);
@@ -162,18 +194,23 @@ describe("geoTapRequest (close the geometric tap loop)", () => {
       ],
       bounds: CROP,
     };
-    const click = { x_pct: 30 / 100, y_pct: 18 / 60 };
-    const def = geoTapRequest(map, "n1", click, 16 / 9)!;
+    const click = { x_pct: 0.5, y_pct: 0.5 };
+    const transition = closeupViewOf("uu", { x: 21, y: 9, w: 18, h: 18 });
+    const def = geoTapRequest(map, "n1", click, 16 / 9, undefined, transition)!;
     const custom = {
       ...def.scene_view.observer!,
       pos: { x: 31, y: 25 },
       gaze: -Math.PI / 2,
       pitch: 0.3,
     };
-    const t = geoTapRequest(map, "n1", click, 16 / 9, {
-      observer: custom,
-      level: "eye",
-    })!;
+    const t = geoTapRequest(
+      map,
+      "n1",
+      click,
+      16 / 9,
+      { observer: custom, level: "eye" },
+      transition,
+    )!;
     // the popover's adjusted pose + level win over the synthesized ones
     expect(t.scene_view.observer).toEqual(custom);
     expect(t.scene_view.level).toBe("eye");
@@ -197,13 +234,24 @@ describe("geoTapRequest (close the geometric tap loop)", () => {
     expect(t!.layout_entities.length).toBeGreaterThanOrEqual(2);
   });
 
-  it("tapping a place still routes to a scene (not a submap)", () => {
+  it("the ladder: plain place tap → closeup; transition tap → scene", () => {
     const map = {
       entities: [geo("clock", "clock tower", 60, 30, { height: 18 })],
       bounds: CROP,
     };
-    const t = geoTapRequest(map, "n1", { x_pct: 60 / 100, y_pct: 30 / 60 }, 16 / 9);
-    expect(t!.kind).toBe("scene");
+    const first = geoTapRequest(map, "n1", { x_pct: 60 / 100, y_pct: 30 / 60 }, 16 / 9);
+    expect(first!.kind).toBe("closeup");
+    expect(first!.scene_view.closeup).toBe(true);
+    expect(first!.focus_id).toBe("clock");
+    const second = geoTapRequest(
+      map,
+      "n1",
+      { x_pct: 0.5, y_pct: 0.5 },
+      16 / 9,
+      undefined,
+      closeupViewOf("clock", { x: 51, y: 21, w: 18, h: 18 }),
+    );
+    expect(second!.kind).toBe("scene");
   });
 
   it("routes a tap through the image frame, not the entities' tight bounds (live-bug regression)", () => {
@@ -222,7 +270,7 @@ describe("geoTapRequest (close the geometric tap loop)", () => {
     // tap the University's image position: 54.5% across, 21.5/60 down
     const t = geoTapRequest(map, "n1", { x_pct: 0.545, y_pct: 21.5 / 60 }, 16 / 9);
     expect(t).not.toBeNull();
-    expect(t!.kind).toBe("scene");
+    expect(t!.kind).toBe("closeup"); // the ladder's first rung
     expect(t!.focus_id).toBe("uni"); // would miss if routed via bounds
   });
 
@@ -442,8 +490,16 @@ describe("geoTapForEntity (W2: enter the place the lettering names)", () => {
       visual: "an 800-foot stone tower",
     });
     const map = { entities: [tower], bounds: CROP };
-    // Footprint hit at the tower's centre (frame is 100×60 → y_pct = 30/60).
-    const byHit = geoTapRequest(map, "n1", { x_pct: 0.6, y_pct: 0.5 }, 16 / 9);
+    // The footprint hit's SCENE form fires on the transition tap (the
+    // closeup frame of this same focus) — compare against that.
+    const byHit = geoTapRequest(
+      map,
+      "n1",
+      { x_pct: 0.5, y_pct: 0.5 },
+      16 / 9,
+      undefined,
+      closeupViewOf("tower", { x: 51, y: 21, w: 18, h: 18 }),
+    );
     const byName = geoTapForEntity(map, "n1", tower, 16 / 9);
     expect(byName.kind).toBe("scene");
     expect(byName.focus_id).toBe("tower");

--- a/apps/web/lib/geo-tap.ts
+++ b/apps/web/lib/geo-tap.ts
@@ -28,8 +28,10 @@ export const MAP_IMAGE_FRAME: MapCrop = { x: 0, y: 0, w: 100, h: 60 };
 
 export interface GeoTap {
   // "scene" = enter a place (perspective, has an observer). "submap" = stay in
-  // map mode + crop a region (top-down, no observer).
-  kind: "scene" | "submap";
+  // map mode + crop a region (top-down, no observer). "closeup" = the descent
+  // ladder's first rung: a TIGHT zoom on one place (rides the same Kontext
+  // continuation as a submap; scene_view.closeup marks the frame).
+  kind: "scene" | "submap" | "closeup";
   scene_view: SceneView;
   expected_layout: ProjectedEntity[];
   // The scene's contents (the focus's children, resolved to absolute world
@@ -163,6 +165,11 @@ export function geoTapRequest(
     level: "map",
     observer: null,
     map_crop: routingFrame,
+    // The ladder's transition detection: routeClick enters (instead of
+    // closeup-ing again) only when the tap hits the place this frame is
+    // already a closeup OF. Plain submaps carry focus_id without closeup.
+    ...(currentView?.focus_id ? { focus_id: currentView.focus_id } : {}),
+    ...(currentView?.closeup ? { closeup: true } : {}),
   };
   const route = routeClick(candidates, mapView, click, aspect);
   if (route.kind === "explainer") return null;
@@ -173,6 +180,22 @@ export function geoTapRequest(
   // scene_view so a node's rung is consistent however it was reached. Optional —
   // only when the source frame carries a rung (PR A seeds it).
   const childTier = childTierFor(currentView, byId, route.focus_id ?? null);
+
+  // The descent ladder's first rung: a tight Kontext zoom on the tapped
+  // place. Rides the submap machinery (same scene_view shape, same
+  // place_submap wire mode) with the closeup flag marking the frame.
+  if (route.kind === "closeup") {
+    return buildSubmapTap(
+      map.entities,
+      candidates.entities,
+      nodeId,
+      route.crop,
+      route.focus_id,
+      childTier,
+      override?.view,
+      "closeup",
+    );
+  }
 
   // Tap on empty map area that still holds a cluster → stay in MAP mode + crop
   // the region (a sub-map), instead of entering a single place.
@@ -210,16 +233,18 @@ function buildSubmapTap(
   focusId: string | null,
   childTier: ScaleTier | undefined,
   view?: ViewSpec,
+  kind: "submap" | "closeup" = "submap",
 ): GeoTap {
   const byId = new Map(allEntities.map((e) => [e.id, e]));
   return {
-    kind: "submap",
+    kind,
     scene_view: {
       node_id: nodeId,
       level: "map",
       observer: null,
       map_crop: crop,
       focus_id: focusId,
+      ...(kind === "closeup" ? { closeup: true } : {}),
       ...(childTier ? { scale_tier: childTier } : {}),
       ...(view ? { view } : {}),
     },

--- a/apps/web/lib/world-geo-schema.test.ts
+++ b/apps/web/lib/world-geo-schema.test.ts
@@ -50,6 +50,7 @@ const sceneView: SceneView = {
   level: "eye",
   observer: observerPose,
   map_crop: null,
+  closeup: false,
   focus_id: "g1",
   scale_tier: "city",
   view: viewSpec,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -648,6 +648,11 @@ export interface SceneView {
   level: ViewLevel;
   observer: ObserverPose | null;
   map_crop: MapCrop | null;
+  // Closeup rung (tap descent ladder): this frame is a TIGHT zoom on
+  // `focus_id` (the entity fills the view) — the next tap on that entity
+  // TRANSITIONS (enters) instead of zooming again. Absent on plain submaps,
+  // whose focus_id is just the nearest entity to an empty-area tap.
+  closeup?: boolean;
   // The entity you ENTERED to get here (the tapped place). Its sub-entities seed
   // into this place's child frame (parent_id = its geo) so the interior layout
   // stays consistent across re-entries. Null for a top-level map view.

--- a/packages/config/src/world-geo-fixture.json
+++ b/packages/config/src/world-geo-fixture.json
@@ -1,45 +1,155 @@
 {
   "_comment": "Single source of truth for the geometric-world wire shapes. The P0 schema-parity gate (apps/web/lib/world-geo-schema.test.ts + apps/modal-backend/tests/test_geo_schema.py) asserts both the TS interfaces and the Pydantic mirrors match these key sets. Edit here when a shape changes; both gates will fail until both sides follow.",
   "keys": {
-    "WorldVec2": ["x", "y"],
-    "WorldEntityGeo": ["id", "entity_id", "kind", "label", "pos", "height", "elevation", "footprint", "scale", "scale_tier", "heading", "visual", "state", "confidence", "source", "updated_at", "border", "height_m"],
-    "ObserverPose": ["pos", "eye_height", "gaze", "pitch", "fov"],
-    "MapCrop": ["x", "y", "w", "h"],
-    "ViewSpec": ["projection", "pitch_deg", "azimuth_deg", "camera_height", "fov_deg", "source"],
-    "SceneView": ["node_id", "level", "observer", "map_crop", "focus_id", "scale_tier", "view"],
-    "ProjectedEntity": ["id", "label", "x_pct", "y_pct", "w_pct", "h_pct", "depth", "h_pos", "v_pos", "size"],
-    "WorldMapSnapshot": ["session_id", "entities", "bounds", "schema_version", "updated_at"]
+    "WorldVec2": [
+      "x",
+      "y"
+    ],
+    "WorldEntityGeo": [
+      "id",
+      "entity_id",
+      "kind",
+      "label",
+      "pos",
+      "height",
+      "elevation",
+      "footprint",
+      "scale",
+      "scale_tier",
+      "heading",
+      "visual",
+      "state",
+      "confidence",
+      "source",
+      "updated_at",
+      "border",
+      "height_m"
+    ],
+    "ObserverPose": [
+      "pos",
+      "eye_height",
+      "gaze",
+      "pitch",
+      "fov"
+    ],
+    "MapCrop": [
+      "x",
+      "y",
+      "w",
+      "h"
+    ],
+    "ViewSpec": [
+      "projection",
+      "pitch_deg",
+      "azimuth_deg",
+      "camera_height",
+      "fov_deg",
+      "source"
+    ],
+    "SceneView": [
+      "node_id",
+      "level",
+      "observer",
+      "map_crop",
+      "focus_id",
+      "scale_tier",
+      "view",
+      "closeup"
+    ],
+    "ProjectedEntity": [
+      "id",
+      "label",
+      "x_pct",
+      "y_pct",
+      "w_pct",
+      "h_pct",
+      "depth",
+      "h_pos",
+      "v_pos",
+      "size"
+    ],
+    "WorldMapSnapshot": [
+      "session_id",
+      "entities",
+      "bounds",
+      "schema_version",
+      "updated_at"
+    ]
   },
-  "shared_shapes": ["WorldVec2", "ObserverPose", "MapCrop", "ViewSpec", "SceneView", "ProjectedEntity"],
+  "shared_shapes": [
+    "WorldVec2",
+    "ObserverPose",
+    "MapCrop",
+    "ViewSpec",
+    "SceneView",
+    "ProjectedEntity"
+  ],
   "samples": {
-    "WorldVec2": { "x": 10, "y": 20 },
+    "WorldVec2": {
+      "x": 10,
+      "y": 20
+    },
     "WorldEntityGeo": {
       "id": "g1",
       "entity_id": "e1",
       "kind": "place",
       "label": "Lighthouse",
-      "pos": { "x": 10, "y": 20 },
+      "pos": {
+        "x": 10,
+        "y": 20
+      },
       "height": 12,
       "elevation": 0,
-      "footprint": { "w": 4, "d": 4 },
+      "footprint": {
+        "w": 4,
+        "d": 4
+      },
       "scale": 1,
       "scale_tier": "place",
       "heading": 0,
       "visual": "red-and-white striped tower",
-      "state": { "lit": true },
+      "state": {
+        "lit": true
+      },
       "confidence": 0.9,
       "source": "user",
       "updated_at": "2026-06-06T00:00:00Z",
       "border": [
-        { "x": 8, "y": 18 },
-        { "x": 12, "y": 18 },
-        { "x": 12, "y": 22 },
-        { "x": 8, "y": 22 }
+        {
+          "x": 8,
+          "y": 18
+        },
+        {
+          "x": 12,
+          "y": 18
+        },
+        {
+          "x": 12,
+          "y": 22
+        },
+        {
+          "x": 8,
+          "y": 22
+        }
       ],
       "height_m": 30
     },
-    "ObserverPose": { "pos": { "x": 0, "y": 0 }, "eye_height": 1.7, "gaze": 0, "pitch": 0, "fov": 1.2 },
-    "MapCrop": { "x": 0, "y": 0, "w": 100, "h": 60 },
+    "ObserverPose": {
+      "pos": {
+        "x": 0,
+        "y": 0
+      },
+      "eye_height": 1.7,
+      "gaze": 0,
+      "pitch": 0,
+      "fov": 1.2
+    },
+    "MapCrop": {
+      "x": 0,
+      "y": 0,
+      "w": 100,
+      "h": 60
+    },
     "ViewSpec": {
       "projection": "eye_level",
       "pitch_deg": -10,
@@ -51,7 +161,16 @@
     "SceneView": {
       "node_id": "n1",
       "level": "eye",
-      "observer": { "pos": { "x": 0, "y": 0 }, "eye_height": 1.7, "gaze": 0, "pitch": 0, "fov": 1.2 },
+      "observer": {
+        "pos": {
+          "x": 0,
+          "y": 0
+        },
+        "eye_height": 1.7,
+        "gaze": 0,
+        "pitch": 0,
+        "fov": 1.2
+      },
       "map_crop": null,
       "focus_id": "g1",
       "scale_tier": "city",
@@ -62,7 +181,8 @@
         "camera_height": "eye",
         "fov_deg": 90,
         "source": "user"
-      }
+      },
+      "closeup": false
     },
     "ProjectedEntity": {
       "id": "g1",
@@ -79,7 +199,12 @@
     "WorldMapSnapshot": {
       "session_id": "s1",
       "entities": [],
-      "bounds": { "x": 0, "y": 0, "w": 100, "h": 60 },
+      "bounds": {
+        "x": 0,
+        "y": 0,
+        "w": 100,
+        "h": 60
+      },
       "schema_version": 1,
       "updated_at": "2026-06-06T00:00:00Z"
     }


### PR DESCRIPTION
Ladder PR 2 of 5. The core of the descent ladder (user's ask: *"first a very close closeup of it, consistent with the parent — a closeup layer; click again → go inside"*).

- **First tap on a place → closeup**: `entityCloseupCrop` (footprint × 1.6, aspect-preserving, min 18% of frame, clamped) rides the **proven `place_submap` → Kontext `zoom_continue`** path — the op the user called "awesome consistency". No more premature scene re-renders from map taps.
- **Transition detection**: only the tap on the place whose closeup you're *already on* enters (`SceneView.closeup` flag — additive, parity-gated TS+Pydantic in one commit). Plain submaps carry `focus_id` as nearest-entity bookkeeping *without* being closeups — keying on focus_id alone would have made first taps from submaps enter prematurely.
- **Degenerate guard**: a place covering ≥85% of the frame skips the rung (no infinite-closeup loop).
- **Zero wire change**: closeups send `render_mode: place_submap`; old backends byte-compatible. Scene frames keep entering directly (scene-level closeups = PR 5).
- Revisit interplay verified: a closeup can never revisit-match itself (`parentId` check); re-tapping the palace on the city map reopens its saved closeup, and the ladder continues from there.

Tests: route matrix (closeup / transition / plain-submap focus / degenerate / scene-frame), crop math (clamp/min/aspect), old "place tap → scene" contract tests rewritten to the transition form. 593 vitest + tsc + both parity gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)