### PR TITLE
feat(world): the conditioning crop IS the routing window

### DIFF
--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -103,6 +103,7 @@ import {
   geoTapForEntity,
   geoTapRequest,
   MAP_IMAGE_FRAME,
+  regionBoxFor,
   wideRegionCut,
   type GeoTap,
   type GeoTapOverride,
@@ -2194,16 +2195,6 @@ export default function PlayPage() {
           : null) ??
         history.items.find((p) => p.parentId == null)?.imageDataUrl ??
         null;
-      let condition = { urls: [] as string[], roles: [] as string[] };
-      try {
-        condition = await buildConditionRefs({
-          parentDataUrl: currentImage,
-          styleDataUrl: styleRefUrl !== currentImage ? styleRefUrl : null,
-          click: { xPct: click.x_pct, yPct: click.y_pct },
-        });
-      } catch {
-        // leave condition empty → text-only generation
-      }
       // Close the geometric loop: a tap on the seeded world map → an observer
       // pose + the projected layout, so the entered scene is steered and
       // grounded by where the entities actually are. Only when World Mode is on
@@ -2282,6 +2273,28 @@ export default function PlayPage() {
         }
       }
       const worldTap = geoTap ?? fallbackTap;
+      // Conditioning refs are built AFTER routing so the region crop can BE
+      // the routing window (closeup/submap: the reference IS the promise; a
+      // transition tap from a closeup uses the whole frame-filling image as
+      // the region — the enter starts tight and the step-in judge measures
+      // tight). Classic taps keep the click-centered crop, byte-identical.
+      let condition = { urls: [] as string[], roles: [] as string[] };
+      try {
+        const regionSpec = worldTap
+          ? regionBoxFor(worldTap, page.sceneView ?? null)
+          : null;
+        condition = await buildConditionRefs({
+          parentDataUrl: currentImage,
+          styleDataUrl: styleRefUrl !== currentImage ? styleRefUrl : null,
+          click: { xPct: click.x_pct, yPct: click.y_pct },
+          ...(regionSpec && "box" in regionSpec
+            ? { regionBox: regionSpec.box }
+            : {}),
+          ...(regionSpec && "whole" in regionSpec ? { regionWhole: true } : {}),
+        });
+      } catch {
+        // leave condition empty → text-only generation
+      }
       // World OFF + a wide mapped region (the river): a fresh re-composition
       // relocates landmarks, so zoom-cut the map instead (see wideRegionCut).
       const wideCut =

--- a/apps/web/lib/geo-tap.test.ts
+++ b/apps/web/lib/geo-tap.test.ts
@@ -5,8 +5,10 @@ import type { MapCrop, SceneView, WorldEntityGeo } from "@openflipbook/config";
 import {
   degradedSubmapTap,
   describeSurroundings,
+  frameCropToImageBox,
   geoTapForEntity,
   geoTapRequest,
+  regionBoxFor,
   wideRegionCut,
 } from "./geo-tap";
 
@@ -606,5 +608,67 @@ describe("submap click register (the displayed frame, not the seeded frame)", ()
     const map = { entities: [topLevel, child, geo("palace", "Palace", 80, 50)], bounds: CROP };
     const t = geoTapRequest(map, "n1", { x_pct: 0.5, y_pct: 0.5 }, 16 / 9);
     expect(t!.focus_id).toBe("plaza");
+  });
+});
+
+describe("conditioning crop alignment (the reference IS the promise)", () => {
+  it("frameCropToImageBox maps a frame crop to displayed-image fractions", () => {
+    const frame = { x: 0, y: 0, w: 100, h: 60 };
+    expect(frameCropToImageBox({ x: 25, y: 15, w: 50, h: 30 }, frame)).toEqual({
+      x: 0.25,
+      y: 0.25,
+      w: 0.5,
+      h: 0.5,
+    });
+    // through a submap frame (nested register)
+    const sub = { x: 40, y: 15, w: 30, h: 20 };
+    expect(frameCropToImageBox({ x: 47.5, y: 20, w: 15, h: 10 }, sub)).toEqual({
+      x: 0.25,
+      y: 0.25,
+      w: 0.5,
+      h: 0.5,
+    });
+    // windows poking past the frame edge clamp
+    const edge = frameCropToImageBox({ x: 90, y: 50, w: 20, h: 20 }, frame);
+    expect(edge.x + edge.w).toBeLessThanOrEqual(1);
+    expect(edge.y + edge.h).toBeLessThanOrEqual(1);
+  });
+
+  it("regionBoxFor: closeup/submap use the routing window", () => {
+    const tap = {
+      kind: "closeup" as const,
+      focus_id: "palace",
+      scene_view: {
+        node_id: "n",
+        level: "map" as const,
+        observer: null,
+        map_crop: { x: 25, y: 15, w: 50, h: 30 },
+        focus_id: "palace",
+        closeup: true,
+      },
+    };
+    const spec = regionBoxFor(tap, null);
+    expect(spec).toEqual({ box: { x: 0.25, y: 0.25, w: 0.5, h: 0.5 } });
+  });
+
+  it("regionBoxFor: the transition tap uses the WHOLE image as the region", () => {
+    const closeupView: SceneView = {
+      node_id: "n-close",
+      level: "map",
+      observer: null,
+      map_crop: { x: 41, y: 41, w: 18, h: 18 },
+      focus_id: "palace",
+      closeup: true,
+    };
+    const tap = {
+      kind: "scene" as const,
+      focus_id: "palace",
+      scene_view: { node_id: "n", level: "building" as const, observer: null, map_crop: null },
+    };
+    expect(regionBoxFor(tap, closeupView)).toEqual({ whole: true });
+    // entering some OTHER place from this closeup keeps the classic crop
+    expect(regionBoxFor({ ...tap, focus_id: "other" }, closeupView)).toBeNull();
+    // entering without a closeup context keeps the classic crop
+    expect(regionBoxFor(tap, null)).toBeNull();
   });
 });

--- a/apps/web/lib/geo-tap.ts
+++ b/apps/web/lib/geo-tap.ts
@@ -305,6 +305,55 @@ function buildSceneTap(
   };
 }
 
+/** A frame-coords crop expressed as a normalized box of the DISPLAYED image
+ *  (the inverse of the click register): what the canvas crop should cut.
+ *  Clamped — submap windows can poke past the frame edge. Pure. */
+export function frameCropToImageBox(
+  crop: MapCrop,
+  frame: MapCrop,
+): { x: number; y: number; w: number; h: number } {
+  const clamp01 = (v: number) => Math.min(Math.max(v, 0), 1);
+  const x = clamp01((crop.x - frame.x) / frame.w);
+  const y = clamp01((crop.y - frame.y) / frame.h);
+  return {
+    x,
+    y,
+    w: Math.min(clamp01(crop.w / frame.w), 1 - x),
+    h: Math.min(clamp01(crop.h / frame.h), 1 - y),
+  };
+}
+
+/** The conditioning-region decision for a world tap (pure, unit-testable):
+ *  closeup/submap → the ROUTING window itself (the reference IS the promise);
+ *  a transition tap (entering the place whose closeup fills this frame) → the
+ *  WHOLE image as the region; anything else → null (the classic click crop). */
+export function regionBoxFor(
+  tap: Pick<GeoTap, "kind" | "focus_id" | "scene_view">,
+  currentView: SceneView | null | undefined,
+):
+  | { box: { x: number; y: number; w: number; h: number } }
+  | { whole: true }
+  | null {
+  if (
+    (tap.kind === "closeup" || tap.kind === "submap") &&
+    tap.scene_view.map_crop
+  ) {
+    const frame =
+      currentView?.level === "map" && currentView.map_crop
+        ? currentView.map_crop
+        : MAP_IMAGE_FRAME;
+    return { box: frameCropToImageBox(tap.scene_view.map_crop, frame) };
+  }
+  if (
+    tap.kind === "scene" &&
+    currentView?.closeup === true &&
+    currentView.focus_id === tap.focus_id
+  ) {
+    return { whole: true };
+  }
+  return null;
+}
+
 /** One rung FINER than the frame the tap happened in (see geoTapRequest). */
 function childTierFor(
   currentView: SceneView | null | undefined,

--- a/apps/web/lib/image-condition.test.ts
+++ b/apps/web/lib/image-condition.test.ts
@@ -56,3 +56,16 @@ describe("orderedRefs", () => {
     expect(orderedRefs({ region: null, parent: null, anchor: null }).roles).toEqual([]);
   });
 });
+
+describe("buildConditionRefs regionWhole (transition tap)", () => {
+  it("the parent IS the region — no canvas pass, no duplicate parent role", async () => {
+    const { buildConditionRefs } = await import("./image-condition");
+    const refs = await buildConditionRefs({
+      parentDataUrl: "data:image/jpeg;base64,UEFSRU5U",
+      styleDataUrl: "data:image/jpeg;base64,U1RZTEU=",
+      regionWhole: true,
+    });
+    expect(refs.roles).toEqual(["region", "style"]);
+    expect(refs.urls[0]).toBe("data:image/jpeg;base64,UEFSRU5U");
+  });
+});

--- a/apps/web/lib/image-condition.ts
+++ b/apps/web/lib/image-condition.ts
@@ -79,13 +79,21 @@ export async function cropRegion(
   yPct: number,
   frac = 0.42,
 ): Promise<string> {
+  return cropRegionRect(src, cropBox(xPct, yPct, frac));
+}
+
+/** Crop an exact normalized box of `src` → a JPEG data URL (the general form;
+ *  the ladder passes the routing window so the reference IS the promise). */
+export async function cropRegionRect(
+  src: string,
+  box: { x: number; y: number; w: number; h: number },
+): Promise<string> {
   const img = new Image();
   // Must be set before `src`. No-op for same-origin data URLs.
   img.crossOrigin = "anonymous";
   img.decoding = "async";
   img.src = src;
   await img.decode();
-  const box = cropBox(xPct, yPct, frac);
   const sx = box.x * img.naturalWidth;
   const sy = box.y * img.naturalHeight;
   const sw = Math.max(1, box.w * img.naturalWidth);
@@ -112,15 +120,34 @@ export async function buildConditionRefs(opts: {
   styleDataUrl?: string | null;
   click?: { xPct: number; yPct: number } | null;
   regionFrac?: number;
+  // Exact region window (normalized image space) — wins over click+regionFrac.
+  // The descent ladder passes its ROUTING window here, so the conditioning
+  // crop is exactly the closeup/submap the user was promised.
+  regionBox?: { x: number; y: number; w: number; h: number } | null;
+  // The whole parent IS the region (entering from a closeup that already
+  // fills the frame): no canvas pass, and the separate parent role is
+  // dropped — it would be a byte-duplicate of the region.
+  regionWhole?: boolean;
 }): Promise<ConditionRefs> {
+  if (opts.regionWhole && opts.parentDataUrl) {
+    return orderedRefs({
+      region: opts.parentDataUrl,
+      parent: null,
+      anchor: opts.anchorDataUrl ?? null,
+      style: opts.styleDataUrl ?? null,
+    });
+  }
   let region: string | null = null;
-  if (opts.parentDataUrl && opts.click) {
+  if (opts.parentDataUrl && (opts.regionBox || opts.click)) {
     try {
-      region = await cropRegion(
+      region = await cropRegionRect(
         opts.parentDataUrl,
-        opts.click.xPct,
-        opts.click.yPct,
-        opts.regionFrac ?? 0.42,
+        opts.regionBox ??
+          cropBox(
+            opts.click!.xPct,
+            opts.click!.yPct,
+            opts.regionFrac ?? 0.42,
+          ),
       );
     } catch {
       region = null;


### PR DESCRIPTION
Ladder PR 3 of 5. Until now the edit reference was a click-centered 0.42 crop — unrelated to the window the router actually promised. Now the two are the same thing:

- **Closeup/submap taps** → the conditioning region = the routing window (entity crop / submap window), mapped frame→image space via pure `frameCropToImageBox`. The Kontext source is exactly the closeup the user will see.
- **Transition taps** (entering the place whose closeup fills the frame) → `regionWhole`: the whole image is the region — the enter edit *starts* from a tight reference and the step-in judge *measures* against the same tight reference. Together with #75 this is the anti-widen pincer: tight in, tight gate.
- `buildConditionRefs` moved below routing (single call site; no latency change); classic taps byte-identical.

Tests: `frameCropToImageBox` (top-level + nested submap registers + edge clamp), `regionBoxFor` decision matrix (closeup window / transition whole / other-place / no-context), `regionWhole` role behavior. 597 vitest + tsc green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)