### PR TITLE
fix(world): anti-widen clause in the view-aware enter instructions

### DIFF
--- a/apps/modal-backend/providers/prompt_library/instructions.py
+++ b/apps/modal-backend/providers/prompt_library/instructions.py
@@ -214,6 +214,13 @@ def _surroundings_sentence(surroundings: str | None) -> str:
     )
     if not text.endswith("."):
         text += "."
+    # Anti-widen: the live failure was the model zooming OUT to fit every
+    # named neighbour into frame (a courtyard tap re-drawing the whole city,
+    # 10/10 on plain same-place). The neighbours are context, not subjects.
+    text += (
+        " The neighbours stay distant glimpses at the edges of frame — do NOT "
+        "widen or pull back the framing to include them."
+    )
     return text
 
 
@@ -337,6 +344,12 @@ def _enter_gpt(
         )
         if not text.endswith("."):
             text += "."
+        # Anti-widen (see _surroundings_sentence): neighbours are context,
+        # not subjects — never a reason to pull the camera back.
+        text += (
+            " The neighbours stay distant glimpses at the edges of frame — do "
+            "NOT widen or pull back the framing to include them."
+        )
     text += " " + _medium_sentence(proj, style_anchor, ref_name)
     text += (
         " Constraints: "

--- a/apps/modal-backend/tests/test_prompt_library.py
+++ b/apps/modal-backend/tests/test_prompt_library.py
@@ -231,6 +231,9 @@ def test_enter_eye_level_nano_template() -> None:
     assert "exactly these landmarks: The Inner Bailey; The Watch Bell" in s
     assert "left/right relations" in s  # NE facing is north-ish: map LR holds
     assert "(map bearings, not view directions)" in s  # register fix (V1 f13)
+    # Anti-widen (the courtyard-tap-redraws-the-city failure): neighbours are
+    # context, never a reason to pull the camera back.
+    assert "do NOT widen or pull back the framing" in s
     assert "striped lighthouse" in s
     assert "Keep the exact art medium of Image 2" in s
     assert "Do not change the input aspect ratio." in s
@@ -272,6 +275,8 @@ def test_enter_gpt_and_kontext_families() -> None:
     assert "Preserve: the architecture and building shapes" in g
     assert "Constraints:" in g and g.index("Preserve:") < g.index("Constraints:")
     assert "Eye-level first-person view only" in g
+    # Anti-widen rides the gpt builder's surroundings clause too.
+    assert "do NOT widen or pull back the framing" in g
     k = _rich_enter(view={"projection": "eye_level"}, family="kontext")
     assert k.startswith("Change the view to ground level inside this exact")
     assert "while preserving its exact architecture" in k


### PR DESCRIPTION
Ladder PR 4 of 5. The surroundings sentence — *"keep the neighbours where the map placed them: North Gate… Brass Bridge…"* — read as an invitation to widen until every named neighbour fit the frame (the courtyard-tap → whole-city failure). Both view-aware enter builders now append: *"The neighbours stay distant glimpses at the edges of frame — do NOT widen or pull back the framing to include them."*

- `_legacy_enter_instruction` / `_enter_kontext` untouched — legacy byte-identity is the kill-switch contract; **frozen goldens unchanged**, two new substring pins added.
- **Measured before shipping** (the repo's discipline): `make eval-enter-drift` with the clause → **PASS** — edit same-place mean **9.0/10**, medium 9.67, lift 1.67 within ±2.0 of the committed 2.33 baseline.

The full anti-widen pincer across this run: #78 makes the enter *start* from a tight frame-filling reference, this PR *tells* it not to widen, #75 *gates* it if it widens anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)