### PR TITLE
feat(world): scene-level closeups — the ladder recurses inside entered scenes

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -1497,7 +1497,12 @@ async def _event_stream(
         # explainer. Empty string = "not yet decided / fall back to explainer".
         effective_world_mode = _world_mode_on(body.world_mode)
         render_mode = (body.render_mode or "").strip().lower()
-        if render_mode not in ("place_scene", "place_submap", "explainer"):
+        if render_mode not in (
+            "place_scene",
+            "place_submap",
+            "place_closeup",
+            "explainer",
+        ):
             render_mode = ""
         # World Mode spatial anchor — what's around the tapped spot + directions,
         # threaded into the planner so the entered place keeps its neighbours.
@@ -1825,6 +1830,9 @@ async def _event_stream(
                 body.image_model or model_router.resolve_model("zoom_continue")
             ),
             label_free=body.suppress_map_labels,
+            # place_closeup zooms into a PERSPECTIVE scene — the cartographic
+            # wording would fight the reference pixels.
+            register="view" if render_mode == "place_closeup" else "map",
         )
         # The enter edit is a view CHANGE on the SAME place: the region crop
         # carries the look, this text carries the move inside + everything the

--- a/apps/modal-backend/providers/image_edit.py
+++ b/apps/modal-backend/providers/image_edit.py
@@ -126,6 +126,7 @@ def build_zoom_instruction(
     view: dict | None = None,
     family: str | None = None,
     label_free: bool = False,
+    register: str = "map",
 ) -> str:
     """Delegates to prompt_library.instructions (the body moved verbatim;
     view=None is byte-identical to the pre-grammar string — pinned by
@@ -144,6 +145,7 @@ def build_zoom_instruction(
         view=cast("_ViewSpec | None", view),
         family=family,
         label_free=label_free,
+        register=register,
     )
 
 

--- a/apps/modal-backend/providers/model_router.py
+++ b/apps/modal-backend/providers/model_router.py
@@ -70,7 +70,7 @@ def select_operation(render_mode: str | None, has_region: bool) -> str:
 
     Everything else is a fresh generation. (outpaint/inpaint/upscale are invoked
     explicitly by callers — the repair loop — not chosen here.)"""
-    if render_mode == "place_submap" and has_region:
+    if render_mode in ("place_submap", "place_closeup") and has_region:
         return "zoom_continue"
     if render_mode == "place_scene":
         return "enter_scene"

--- a/apps/modal-backend/providers/prompt_library/instructions.py
+++ b/apps/modal-backend/providers/prompt_library/instructions.py
@@ -39,21 +39,37 @@ def _legacy_zoom_instruction(
     page_title: str,
     facts: list[str],
     layout_clause: str = "",
+    register: str = "map",
 ) -> str:
+    """register="map" is the original, golden-pinned string. register="view"
+    (place_closeup: zooming into a thing inside a PERSPECTIVE scene) swaps the
+    cartographic words for view-neutral ones — same skeleton, the reference
+    pixels carry the camera."""
     title = page_title.strip() or "this place"
+    noun = "map" if register == "map" else "view"
+    viewpoint = (
+        "from the SAME overhead map viewpoint"
+        if register == "map"
+        else "from the SAME viewpoint the reference shows"
+    )
+    drift = (
+        "switch to an eye-level or interior view"
+        if register == "map"
+        else "change the camera angle or projection"
+    )
     text = (
         f'Zoom into "{title}" — the area at the centre of this image — and draw a '
-        "closer, richer map of it. Keep the exact walls, buildings, towers and "
+        f"closer, richer {noun} of it. Keep the exact walls, buildings, towers and "
         "landmarks the reference already shows, in the same hand-drawn engraving "
-        "style, palette and line work, from the SAME overhead map viewpoint; do "
-        "not reinvent them, restyle them, or switch to an eye-level or interior "
-        "view. As you move closer, elaborate them with finer architectural detail"
+        f"style, palette and line work, {viewpoint}; do "
+        f"not reinvent them, restyle them, or {drift}"
+        ". As you move closer, elaborate them with finer architectural detail"
     )
     named = [f.strip() for f in facts if f and f.strip()]
     if named:
         text += ", working in the features that belong here: " + "; ".join(named[:8])
     text += (
-        ". A closer, faithful continuation of this exact map, not a new scene. "
+        f". A closer, faithful continuation of this exact {noun}, not a new scene. "
         "Keep any lettering sparse and legible — no garbled text."
     )
     if layout_clause.strip():
@@ -429,13 +445,16 @@ def build_zoom_instruction(
     view: ViewSpec | None = None,
     family: str | None = None,
     label_free: bool = False,
+    register: str = "map",
 ) -> str:
     """Zoom-continue: same place, SAME camera, finer detail. view=None ->
     today's exact string. With a view, the keep-camera fragment is spelled per
     projection in PRESERVE form — any projection is honored, none is ever a
     change (Kontext's native grammar; harmless on nano/gpt). label_free
     (DOM-labels mode) swaps the lettering guard for the full no-text
-    directive; default off keeps every instruction byte-identical."""
+    directive. register="view" (place_closeup: the source is a perspective
+    SCENE, not a map) swaps the cartographic words on the legacy skeleton;
+    defaults keep every instruction byte-identical."""
     if label_free:
         text = build_zoom_instruction(
             page_title,
@@ -444,16 +463,17 @@ def build_zoom_instruction(
             style_anchor=style_anchor,
             view=view,
             family=family,
+            register=register,
         )
         if LETTERING_GUARD in text:
             return text.replace(LETTERING_GUARD, NO_LETTERING)
         return f"{text} {NO_LETTERING}"
     if view is None:
-        return _legacy_zoom_instruction(page_title, facts, layout_clause)
+        return _legacy_zoom_instruction(page_title, facts, layout_clause, register)
     proj = str(view.get("projection") or "")
     keep = camera.keep_view_fragment(view)
     if not keep:
-        return _legacy_zoom_instruction(page_title, facts, layout_clause)
+        return _legacy_zoom_instruction(page_title, facts, layout_clause, register)
     title = page_title.strip() or "this place"
     noun = "map" if proj == "top_down" else "view"
     drift = (

--- a/apps/modal-backend/providers/prompt_library/policy.py
+++ b/apps/modal-backend/providers/prompt_library/policy.py
@@ -130,6 +130,10 @@ def default_view(
             focus_kind,
             focus_footprint,
         )
+    if rmode == "place_closeup":
+        # A closeup of something inside a SCENE: the reference pixels dictate
+        # the register (Kontext preserve-form) — never state a camera.
+        return None
     if rmode == "place_submap":
         # WITH a region crop this is a Kontext zoom-continue: projection is
         # dictated by the reference pixels (preserve-form rides the inherited

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -111,6 +111,7 @@ import {
 import { matchEntityLabel } from "@/lib/entity-label-match";
 import { focusOnMap } from "@/lib/click-route";
 import { selectNeighbors } from "@/lib/scale-neighbors";
+import { sceneCloseupSpec } from "@/lib/scene-closeup";
 import { childrenOf, projectTopDown } from "@/lib/world-geometry";
 import { viewNeutralAppearance } from "@/lib/appearance";
 import { useImageMorph } from "@/hooks/useImageMorph";
@@ -2273,6 +2274,19 @@ export default function PlayPage() {
         }
       }
       const worldTap = geoTap ?? fallbackTap;
+      // Scene-level closeup (the ladder inside entered scenes): a tap on a
+      // codex-localized entity zooms it before entering. The image-registered
+      // bbox beats the bearing-recovered geometry, so this WINS over geoTap
+      // when both resolve (spread last below).
+      const sceneCloseup =
+        worldEnabled && page.sceneView && page.sceneView.level !== "map"
+          ? sceneCloseupSpec(
+              worldState.entities,
+              page.nodeId,
+              { x_pct: click.x_pct, y_pct: click.y_pct },
+              page.sceneView,
+            )
+          : null;
       // Conditioning refs are built AFTER routing so the region crop can BE
       // the routing window (closeup/submap: the reference IS the promise; a
       // transition tap from a closeup uses the whole frame-filling image as
@@ -2280,9 +2294,13 @@ export default function PlayPage() {
       // tight). Classic taps keep the click-centered crop, byte-identical.
       let condition = { urls: [] as string[], roles: [] as string[] };
       try {
-        const regionSpec = worldTap
-          ? regionBoxFor(worldTap, page.sceneView ?? null)
-          : null;
+        const regionSpec = sceneCloseup
+          ? sceneCloseup.kind === "closeup"
+            ? { box: sceneCloseup.regionBox }
+            : ({ whole: true } as const)
+          : worldTap
+            ? regionBoxFor(worldTap, page.sceneView ?? null)
+            : null;
         condition = await buildConditionRefs({
           parentDataUrl: currentImage,
           styleDataUrl: styleRefUrl !== currentImage ? styleRefUrl : null,
@@ -2401,6 +2419,24 @@ export default function PlayPage() {
                 ? { prefetched_surroundings: worldTap.surroundings }
                 : {}),
             }
+          : {}),
+        // Scene-level ladder (spread after worldTap so the image-registered
+        // bbox closeup wins over the bearing-recovered geometry route).
+        ...(sceneCloseup
+          ? sceneCloseup.kind === "closeup"
+            ? {
+                render_mode: "place_closeup" as const,
+                scene_view: {
+                  ...sceneCloseup.sceneView,
+                  node_id: page.nodeId ?? "",
+                },
+                expected_layout: [],
+                prefetched_subject: sceneCloseup.name,
+              }
+            : {
+                render_mode: "place_scene" as const,
+                prefetched_subject: sceneCloseup.name,
+              }
           : {}),
         // The world-off zoom-cut: same submap continuation a world-mode submap
         // tap rides (Kontext on the region crop), so the river page is a CUT of

--- a/apps/web/lib/scene-closeup.test.ts
+++ b/apps/web/lib/scene-closeup.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import type { Entity, SceneView } from "@openflipbook/config";
+
+import { sceneCloseupSpec } from "./scene-closeup";
+
+function entity(id: string, name: string, bbox?: { x_pct: number; y_pct: number; w_pct: number; h_pct: number }): Entity {
+  return {
+    id,
+    kind: "place",
+    name,
+    aliases: [],
+    appearance: "stone building",
+    reference_image_url: null,
+    facts: [],
+    state: {},
+    first_seen_node_id: "n1",
+    last_seen_node_id: "n1",
+    appears_on_node_ids: ["n1"],
+    appearance_bboxes: bbox ? { n1: bbox } : {},
+    pinned_by_user: false,
+    confidence: 0.8,
+    updated_at: "t",
+  };
+}
+
+const sceneView = (over: Partial<SceneView> = {}): SceneView => ({
+  node_id: "n1",
+  level: "building",
+  observer: {
+    pos: { x: 60, y: 38 },
+    eye_height: 1.7,
+    gaze: -1.2,
+    pitch: 0.2,
+    fov: Math.PI / 2,
+  },
+  map_crop: null,
+  focus_id: "geo_palace",
+  scale_tier: "place",
+  ...over,
+});
+
+describe("sceneCloseupSpec (the ladder inside entered scenes)", () => {
+  const hall = entity("hall", "The Great Hall", {
+    x_pct: 0.4,
+    y_pct: 0.3,
+    w_pct: 0.2,
+    h_pct: 0.25,
+  });
+
+  it("a tap on a localized entity → closeup with a padded, clamped box", () => {
+    const spec = sceneCloseupSpec([hall], "n1", { x_pct: 0.5, y_pct: 0.4 }, sceneView());
+    expect(spec).not.toBeNull();
+    if (spec?.kind !== "closeup") throw new Error("expected closeup");
+    expect(spec.name).toBe("The Great Hall");
+    // padded ×1.6 around the bbox centre
+    expect(spec.regionBox.w).toBeCloseTo(0.32, 5);
+    expect(spec.regionBox.h).toBeCloseTo(0.4, 5);
+    expect(spec.regionBox.x + spec.regionBox.w / 2).toBeCloseTo(0.5, 5);
+    // the scene_view keeps the scene's register + descends one rung
+    expect(spec.sceneView.level).toBe("building");
+    expect(spec.sceneView.closeup).toBe(true);
+    expect(spec.sceneView.focus_id).toBe("geo_hall");
+    expect(spec.sceneView.scale_tier).toBe("room");
+  });
+
+  it("the tap on the entity whose closeup you are ON → transition", () => {
+    const spec = sceneCloseupSpec(
+      [hall],
+      "n1",
+      { x_pct: 0.5, y_pct: 0.4 },
+      sceneView({ closeup: true, focus_id: "geo_hall" }),
+    );
+    expect(spec).toEqual({ kind: "transition", name: "The Great Hall" });
+  });
+
+  it("a frame-filling bbox skips the rung → transition", () => {
+    const big = entity("keep", "The Keep", {
+      x_pct: 0.05,
+      y_pct: 0.05,
+      w_pct: 0.9,
+      h_pct: 0.9,
+    });
+    const spec = sceneCloseupSpec([big], "n1", { x_pct: 0.5, y_pct: 0.5 }, sceneView());
+    expect(spec).toEqual({ kind: "transition", name: "The Keep" });
+  });
+
+  it("null on map frames, missed taps, and unlocalized entities", () => {
+    expect(
+      sceneCloseupSpec([hall], "n1", { x_pct: 0.5, y_pct: 0.4 }, sceneView({ level: "map" })),
+    ).toBeNull();
+    expect(
+      sceneCloseupSpec([hall], "n1", { x_pct: 0.05, y_pct: 0.05 }, sceneView()),
+    ).toBeNull();
+    expect(
+      sceneCloseupSpec([entity("ghost", "Unlocalized")], "n1", { x_pct: 0.5, y_pct: 0.4 }, sceneView()),
+    ).toBeNull();
+  });
+
+  it("tiny entities get the minimum context fraction", () => {
+    const well = entity("well", "The Well", {
+      x_pct: 0.48,
+      y_pct: 0.48,
+      w_pct: 0.04,
+      h_pct: 0.04,
+    });
+    const spec = sceneCloseupSpec([well], "n1", { x_pct: 0.5, y_pct: 0.5 }, sceneView());
+    if (spec?.kind !== "closeup") throw new Error("expected closeup");
+    expect(spec.regionBox.w).toBeCloseTo(0.18, 5);
+    expect(spec.regionBox.h).toBeCloseTo(0.18, 5);
+  });
+});

--- a/apps/web/lib/scene-closeup.ts
+++ b/apps/web/lib/scene-closeup.ts
@@ -1,0 +1,73 @@
+import type { Entity, SceneView } from "@openflipbook/config";
+import { finerTier } from "@openflipbook/config";
+
+import { entityAtPoint } from "./entity-hit";
+
+/**
+ * Scene-level closeup (the descent ladder inside entered scenes). Geometry
+ * inside perspective scenes is bearing-recovered, NOT image-registered — so
+ * the only exact crop source is the codex's per-node `appearance_bboxes`.
+ * A tap on a localized entity zooms it (Kontext `place_closeup`); the tap on
+ * the entity whose closeup you're already on transitions (enter).
+ */
+
+const PAD = 1.6;
+const MIN_FRAC = 0.18;
+const DEGENERATE_FRAC = 0.85;
+
+export type SceneCloseupSpec =
+  | {
+      kind: "closeup";
+      name: string;
+      regionBox: { x: number; y: number; w: number; h: number };
+      sceneView: SceneView;
+    }
+  | { kind: "transition"; name: string };
+
+export function sceneCloseupSpec(
+  entities: Entity[],
+  nodeId: string | null,
+  click: { x_pct: number; y_pct: number },
+  currentView: SceneView | null | undefined,
+): SceneCloseupSpec | null {
+  // Map frames have their own (geometry-registered) ladder.
+  if (!currentView || currentView.level === "map") return null;
+  const hit = entityAtPoint(entities, nodeId, click.x_pct, click.y_pct);
+  if (!hit || !hit.entity.name.trim()) return null;
+  // The seeding convention: a codex entity's geo id is geo_<entity_id>
+  // (deriveGeoFromExtraction), so the closeup's focus links up once the
+  // entity's geometry lands.
+  const geoId = `geo_${hit.entity.id}`;
+  if (currentView.closeup === true && currentView.focus_id === geoId) {
+    return { kind: "transition", name: hit.entity.name };
+  }
+  const cx = hit.bbox.x_pct + hit.bbox.w_pct / 2;
+  const cy = hit.bbox.y_pct + hit.bbox.h_pct / 2;
+  const w = Math.min(Math.max(hit.bbox.w_pct * PAD, MIN_FRAC), 1);
+  const h = Math.min(Math.max(hit.bbox.h_pct * PAD, MIN_FRAC), 1);
+  if (w >= DEGENERATE_FRAC && h >= DEGENERATE_FRAC) {
+    // Already fills the frame — a closeup would be a no-op; go in.
+    return { kind: "transition", name: hit.entity.name };
+  }
+  return {
+    kind: "closeup",
+    name: hit.entity.name,
+    regionBox: {
+      x: Math.min(Math.max(cx - w / 2, 0), 1 - w),
+      y: Math.min(Math.max(cy - h / 2, 0), 1 - h),
+      w,
+      h,
+    },
+    sceneView: {
+      node_id: "", // the caller stamps the generating node's id
+      level: currentView.level,
+      observer: currentView.observer ?? null,
+      map_crop: null,
+      focus_id: geoId,
+      closeup: true,
+      ...(currentView.scale_tier
+        ? { scale_tier: finerTier(currentView.scale_tier) }
+        : {}),
+    },
+  };
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -77,7 +77,14 @@ export type VideoTier = "fast" | "balanced" | "pro";
 // subject is drawn â an immersive place you've stepped into, a closer
 // cartographic map of a sub-area, or today's labelled explainer diagram.
 export type Autonomy = "auto" | "semi";
-export type RenderMode = "place_scene" | "place_submap" | "explainer";
+// place_closeup = the descent ladder's closeup rung on a NON-map frame (a
+// Kontext zoom of a thing inside a perspective scene). Backend accepts it
+// since the same release; old backends coerce unknown modes to the fresh path.
+export type RenderMode =
+  | "place_scene"
+  | "place_submap"
+  | "place_closeup"
+  | "explainer";
 // The click-resolver's read of what was tapped (drives RenderMode in world mode).
 export type EnterAs = "scene" | "submap" | "explainer";
 


### PR DESCRIPTION
Ladder PR 5 of 5 — completes the descent ladder plan.

Inside an entered scene, a tap on a codex-localized entity now **zooms it** (new `place_closeup` render mode → Kontext `zoom_continue` on the entity's image-registered bbox, padded ×1.6, min 18% context) — and the tap on the entity whose closeup you're already on **transitions** (`place_scene` with the whole image as the region). Palace → courtyard → a hall → inside it: one step per tap, all the way down.

- **Wire**: `RenderMode += "place_closeup"` — backend allowlist + router (mirrors `place_submap`) + policy (states **no camera**: the reference pixels carry the register). Both halves in one PR/deploy.
- **Zoom instruction `register="view"`**: place_closeup sources are perspective scenes, not maps — *"a closer, richer view… from the SAME viewpoint the reference shows"*. `register="map"` default is byte-identical; **frozen goldens untouched**.
- **Crop source: codex bboxes only** — geometry inside scenes is bearing-recovered, not image-registered, and would mis-crop. No bbox → existing flow stands (and the geo-localize auto-retry from #72 keeps filling bboxes in).
- Transition detection reuses the `SceneView.closeup` flag; `focus_id = geo_<entity_id>` follows the seeding convention so the closeup links up once the entity's geometry lands.

Tests: 5 helper cases (padded box, transition, degenerate→transition, null matrix, min-context) + router/policy/instruction coverage rides existing suites. 602 vitest + tsc + full backend not-paid + goldens green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)