### PR TITLE
fix(world): faithful-magnify closeups + ground-level enters + the ladder proof harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ apps/modal-backend/tests/**/cache/
 # Ground-truth corpus images (fetched by scripts/fetch_corpus.py; text-only
 # descriptions + the sha-pinned manifest are what git tracks).
 apps/modal-backend/tests/map_corpus/images/
+
+# Ladder proof runs (e2e artifacts: images + manifests + reports).
+ladder-proof-runs/

--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -272,6 +272,10 @@ class GenerateBody(BaseModel):
     # NO baked text — names ride a client overlay built from entity data.
     # Optional + default False: old clients omit it, prompts byte-identical.
     suppress_map_labels: bool = False
+    # The transition tap's origin (tap descent ladder): the SOURCE frame was a
+    # closeup of the entered place — the establishing shot already happened,
+    # so the enter descends to ground level instead of another aerial.
+    from_closeup: bool = False
     autonomy: str = "auto"
     render_mode: str | None = None
     # B2 logical AROUND (SCALE_AROUND_LOGICAL): the same-scale neighbours the client
@@ -505,6 +509,7 @@ def _view_spec_for(
             has_observer=bool(sv and sv.observer is not None),
             has_region=has_region,
             place_form=place_form,
+            from_closeup=bool(body.from_closeup),
             subject=subject,
             subject_context=subject_context,
             focus_kind=str(focus.get("kind") or "") if focus else None,
@@ -1833,6 +1838,10 @@ async def _event_stream(
             # place_closeup zooms into a PERSPECTIVE scene — the cartographic
             # wording would fight the reference pixels.
             register="view" if render_mode == "place_closeup" else "map",
+            # The closeup rung magnifies faithfully: no planner facts, no
+            # "elaborate" — the facts channel is how city-wide context leaked
+            # into closeups (the invented-riverside-palace failure).
+            faithful=bool(body.scene_view and body.scene_view.closeup),
         )
         # The enter edit is a view CHANGE on the SAME place: the region crop
         # carries the look, this text carries the move inside + everything the

--- a/apps/modal-backend/providers/image_edit.py
+++ b/apps/modal-backend/providers/image_edit.py
@@ -127,6 +127,7 @@ def build_zoom_instruction(
     family: str | None = None,
     label_free: bool = False,
     register: str = "map",
+    faithful: bool = False,
 ) -> str:
     """Delegates to prompt_library.instructions (the body moved verbatim;
     view=None is byte-identical to the pre-grammar string — pinned by
@@ -146,6 +147,7 @@ def build_zoom_instruction(
         family=family,
         label_free=label_free,
         register=register,
+        faithful=faithful,
     )
 
 

--- a/apps/modal-backend/providers/prompt_library/instructions.py
+++ b/apps/modal-backend/providers/prompt_library/instructions.py
@@ -436,6 +436,40 @@ def _enter_kontext(
 
 # --- Public builders -------------------------------------------------------------
 
+def _faithful_zoom_instruction(
+    page_title: str,
+    layout_clause: str = "",
+    register: str = "map",
+) -> str:
+    """The CLOSEUP zoom (scene_view.closeup): a faithful MAGNIFICATION. The
+    elaborate-with-facts register invites invention — the live failure was a
+    20x12 crop of a stylized palace icon redrawn as a riverside compound
+    because the planner's city-wide facts rode in. No facts, no elaboration:
+    magnify what the reference shows and nothing else."""
+    title = page_title.strip() or "this place"
+    noun = "map" if register == "map" else "view"
+    viewpoint = (
+        "from the SAME overhead map viewpoint"
+        if register == "map"
+        else "from the SAME viewpoint the reference shows"
+    )
+    text = (
+        f'Zoom into "{title}" — the area at the centre of this image — and '
+        "MAGNIFY it faithfully. Draw exactly the walls, buildings, towers and "
+        "landmarks the reference already shows, in the same style, palette "
+        f"and line work, {viewpoint}; keep their exact arrangement, "
+        "proportions and relative positions. Do NOT add structures, water, "
+        "roads, or features that are not in the reference; do not reinvent "
+        "or restyle anything — only sharpen the existing detail as you "
+        f"magnify. A closer, faithful magnification of this exact {noun}, "
+        "not a new scene. Keep any lettering sparse and legible — no "
+        "garbled text."
+    )
+    if layout_clause.strip():
+        text += "\n\n" + layout_clause.strip()
+    return text.strip()
+
+
 def build_zoom_instruction(
     page_title: str,
     facts: list[str],
@@ -446,6 +480,7 @@ def build_zoom_instruction(
     family: str | None = None,
     label_free: bool = False,
     register: str = "map",
+    faithful: bool = False,
 ) -> str:
     """Zoom-continue: same place, SAME camera, finer detail. view=None ->
     today's exact string. With a view, the keep-camera fragment is spelled per
@@ -453,8 +488,9 @@ def build_zoom_instruction(
     change (Kontext's native grammar; harmless on nano/gpt). label_free
     (DOM-labels mode) swaps the lettering guard for the full no-text
     directive. register="view" (place_closeup: the source is a perspective
-    SCENE, not a map) swaps the cartographic words on the legacy skeleton;
-    defaults keep every instruction byte-identical."""
+    SCENE, not a map) swaps the cartographic words on the legacy skeleton.
+    faithful (closeup rung) switches to pure magnification — no facts, no
+    elaboration. Defaults keep every instruction byte-identical."""
     if label_free:
         text = build_zoom_instruction(
             page_title,
@@ -464,10 +500,16 @@ def build_zoom_instruction(
             view=view,
             family=family,
             register=register,
+            faithful=faithful,
         )
         if LETTERING_GUARD in text:
             return text.replace(LETTERING_GUARD, NO_LETTERING)
         return f"{text} {NO_LETTERING}"
+    if faithful:
+        # The closeup rung ignores the view-aware variants too — the
+        # reference pixels carry the camera, and facts never ride a
+        # magnification.
+        return _faithful_zoom_instruction(page_title, layout_clause, register)
     if view is None:
         return _legacy_zoom_instruction(page_title, facts, layout_clause, register)
     proj = str(view.get("projection") or "")

--- a/apps/modal-backend/providers/prompt_library/policy.py
+++ b/apps/modal-backend/providers/prompt_library/policy.py
@@ -103,6 +103,7 @@ def default_view(
     has_region: bool = False,
     enter_as: str | None = None,
     place_form: str | None = None,
+    from_closeup: bool = False,
     subject: str | None = None,
     subject_context: str | None = None,
     focus_kind: str | None = None,
@@ -129,6 +130,7 @@ def default_view(
             subject_context,
             focus_kind,
             focus_footprint,
+            from_closeup=from_closeup,
         )
     if rmode == "place_closeup":
         # A closeup of something inside a SCENE: the reference pixels dictate
@@ -161,7 +163,15 @@ def _scene_view(
     subject_context: str | None,
     focus_kind: str | None,
     focus_footprint: tuple[float, float] | None,
+    from_closeup: bool = False,
 ) -> ViewSpec | None:
+    # The ladder's descent rule: entering FROM a closeup always goes to
+    # GROUND LEVEL — the closeup already was the establishing shot, so a
+    # complex/landscape place lands in its grounds/courtyard instead of yet
+    # another aerial (the live failure: step_in=2.0 on every loop attempt
+    # because nothing ever descended the camera).
+    if from_closeup:
+        return eye_level_scene()
     # S1 — the only meaningful level pill (street/building are dead constants).
     if (level or "").lower() == "eye":
         return eye_level_scene()

--- a/apps/modal-backend/tests/ladder_judge.py
+++ b/apps/modal-backend/tests/ladder_judge.py
@@ -1,0 +1,85 @@
+"""Numeric judges over a ladder-proof run's artifacts.
+
+    .venv/bin/python -m tests.ladder_judge <run_dir>
+
+For each scenario dir with {1_region_promised.jpg, 2_closeup.jpg, 3_enter.jpg}:
+  hop1 (map region → closeup): score_step_in + score_continuation
+  hop2 (closeup → enter):      score_step_in
+Writes scores.json per scenario and a summary into <run_dir>/scores.json.
+Secondary signal only — the eyes-on subagent verdicts are primary.
+PAID: ~5 Gemini calls per scenario (~$0.03).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _load_env() -> None:
+    env_path = Path(__file__).resolve().parents[1] / ".env"
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+    os.environ.setdefault("WORLD_BENCH_JUDGE_MODEL", "google/gemini-3-flash-preview")
+
+
+async def _score_dir(d: Path) -> dict | None:
+    from providers import judge
+
+    region = d / "1_region_promised.jpg"
+    closeup = d / "2_closeup.jpg"
+    enter = d / "3_enter.jpg"
+    if not closeup.exists():
+        return None
+    out: dict = {"scenario": d.name}
+    if region.exists():
+        r = region.read_bytes()
+        c = closeup.read_bytes()
+        out["hop1_step_in"] = (await judge.score_step_in(r, c)).score
+        cont = await judge.score_continuation(r, c)
+        out["hop1_continuation"] = cont.score
+        out["hop1_rationale"] = cont.rationale
+    if enter.exists():
+        c = closeup.read_bytes()
+        e = enter.read_bytes()
+        si = await judge.score_step_in(c, e)
+        out["hop2_step_in"] = si.score
+        out["hop2_rationale"] = si.rationale
+    (d / "scores.json").write_text(json.dumps(out, indent=1))
+    return out
+
+
+async def _run(run_dir: Path) -> int:
+    rows = []
+    for d in sorted(run_dir.iterdir()):
+        if not d.is_dir():
+            continue
+        row = await _score_dir(d)
+        if row:
+            rows.append(row)
+            print(
+                f"{row['scenario']:8} hop1 step_in={row.get('hop1_step_in')} "
+                f"cont={row.get('hop1_continuation')} | hop2 step_in={row.get('hop2_step_in')}"
+            )
+    (run_dir / "scores.json").write_text(json.dumps(rows, indent=1))
+    print(f"wrote {run_dir / 'scores.json'}")
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: python -m tests.ladder_judge <run_dir>")
+        return 2
+    _load_env()
+    return asyncio.run(_run(Path(sys.argv[1]).resolve()))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/modal-backend/tests/test_prompt_library.py
+++ b/apps/modal-backend/tests/test_prompt_library.py
@@ -525,3 +525,23 @@ def test_register_reminder_and_retry_feedback() -> None:
     assert "SAME place as the reference" in both and "different towers" in both
     # nothing failed -> nothing said
     assert feedback.retry_feedback_clause("top_down") == ""
+
+
+def test_faithful_zoom_is_pure_magnification() -> None:
+    """The closeup rung (F1): no facts, no 'elaborate' — magnify only. The
+    live failure was planner facts (river, bridges) painted into a 20x12
+    closeup of a palace icon."""
+    s = image_edit.build_zoom_instruction(
+        "The High Palace", ["a river", "two bridges"], "", faithful=True
+    )
+    assert "MAGNIFY it faithfully" in s
+    assert "Do NOT add structures, water, roads" in s
+    # facts NEVER ride a magnification
+    assert "a river" not in s and "working in the features" not in s
+    # default stays byte-identical (golden contract)
+    assert image_edit.build_zoom_instruction("T", ["f"]) == image_edit.build_zoom_instruction(
+        "T", ["f"], faithful=False
+    )
+    # the view register variant
+    v = image_edit.build_zoom_instruction("The Keep", [], "", faithful=True, register="view")
+    assert "from the SAME viewpoint the reference shows" in v

--- a/apps/modal-backend/tests/test_view_policy.py
+++ b/apps/modal-backend/tests/test_view_policy.py
@@ -1,0 +1,22 @@
+
+
+def test_enter_from_closeup_descends_to_ground_level() -> None:
+    """F3: the closeup WAS the establishing shot — entering from it goes to
+    ground level even for complex/landscape places (the live failure: every
+    loop attempt was another aerial, step_in=2.0, best-of-wide served)."""
+    from providers.prompt_library import policy
+
+    spec = policy.default_view(
+        render_mode="place_scene",
+        world_mode=True,
+        place_form="complex",
+        from_closeup=True,
+    )
+    assert spec is not None and spec["projection"] == "eye_level"
+    # without the signal, a complex place keeps the establishing oblique
+    base = policy.default_view(
+        render_mode="place_scene",
+        world_mode=True,
+        place_form="complex",
+    )
+    assert base is not None and base["projection"] == "oblique"

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -2375,6 +2375,11 @@ export default function PlayPage() {
               world_mode: true,
               autonomy: worldAutonomy,
               ...(worldDomLabels ? { suppress_map_labels: true } : {}),
+              // The ladder's descent signal: entering from a closeup frame
+              // goes to ground level (the closeup WAS the establishing shot).
+              ...(page.sceneView?.closeup === true
+                ? { from_closeup: true }
+                : {}),
               ...(enterAsToRenderMode(worldResolved?.enter_as) !== "explainer"
                 ? { render_mode: enterAsToRenderMode(worldResolved?.enter_as) }
                 : {}),

--- a/apps/web/scripts/ladder-proof.mjs
+++ b/apps/web/scripts/ladder-proof.mjs
@@ -1,0 +1,340 @@
+/* eslint-disable no-undef */
+// Ladder proof harness — drives the REAL app (real clicks, the actual client
+// routing/crop logic) through the tap descent ladder across five place types
+// and saves every hop's image for independent judgment.
+//
+//   node scripts/ladder-proof.mjs [runDir]
+//   LADDER_ONLY=city,castle node scripts/ladder-proof.mjs
+//
+// PAID (~$0.55/scenario on the balanced tier). Artifacts per scenario:
+//   1_map.jpg              the root map
+//   1_region_promised.jpg  the closeup crop window cut from the root map
+//   2_closeup.jpg          what the closeup tap actually produced
+//   3_enter.jpg            what the transition tap actually produced
+//   manifest.json          ids, scene_views, clicks, timings, mechanical checks
+import { chromium } from "@playwright/test";
+import fs from "node:fs";
+import path from "node:path";
+
+const BASE = process.env.LADDER_BASE ?? "http://localhost:3000";
+const RUN_DIR = path.resolve(
+  process.argv[2] ??
+    `../../ladder-proof-runs/${new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19)}`,
+);
+const ONLY = process.env.LADDER_ONLY ? process.env.LADDER_ONLY.split(",") : null;
+
+// The seeded frame every top-level map routes through (geo-tap.ts).
+const FRAME = { x: 0, y: 0, w: 100, h: 60 };
+
+const SCENARIOS = [
+  {
+    id: "city",
+    target: /palace/i,
+    query:
+      "A highly detailed 2D top-down fantasy city map of Eshmara, an ancient walled trade city on a great river: distinct districts, a grand Palace with formal gardens on the north bank, a wizards' academy with a tall spire, busy docks, two bridges, city gates — antique hand-inked cartography on aged parchment, fine serif labels",
+  },
+  {
+    id: "castle",
+    target: /keep/i,
+    query:
+      "A detailed top-down map of a lone medieval castle compound on a hill: outer curtain walls with four corner towers, a fortified gatehouse, an inner bailey, the great Keep at the centre, stables, a small chapel, kitchen gardens — hand-inked antique plan style with clear labels",
+  },
+  {
+    id: "harbor",
+    target: /lighthouse/i,
+    query:
+      "A top-down illustrated map of a small coastal harbour town: a stone Lighthouse on the rocky point, two piers with fishing boats, a fish market square, warehouses, a chandlery, the sea wall — weathered nautical chart style with labels",
+  },
+  {
+    id: "forest",
+    target: /lodge/i,
+    query:
+      "A top-down illustrated trail map of a forest national park: a timber Lodge at the heart of the park, a waterfall, a lake with a boathouse, a ranger station, winding trails through pine forest — vintage park-service poster map style with labels",
+  },
+  {
+    id: "scifi",
+    target: /command|dome/i,
+    query:
+      "A top-down schematic map of a small Mars colony: a central Command Dome, a habitat ring, greenhouse modules, a landing pad, a solar farm, a rover garage, connected by tube corridors — retro-futurist blueprint style with clear labels",
+  },
+];
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const log = (...a) => console.log(new Date().toISOString().slice(11, 19), ...a);
+
+async function api(p) {
+  try {
+    const r = await fetch(`${BASE}${p}`);
+    return r.ok ? await r.json() : null;
+  } catch {
+    return null;
+  }
+}
+
+async function saveUrl(url, dest) {
+  const r = await fetch(url);
+  if (!r.ok) throw new Error(`fetch ${url}: ${r.status}`);
+  fs.writeFileSync(dest, Buffer.from(await r.arrayBuffer()));
+}
+
+function frameCropToImageBox(crop) {
+  const c01 = (v) => Math.min(Math.max(v, 0), 1);
+  const x = c01((crop.x - FRAME.x) / FRAME.w);
+  const y = c01((crop.y - FRAME.y) / FRAME.h);
+  return {
+    x,
+    y,
+    w: Math.min(c01(crop.w / FRAME.w), 1 - x),
+    h: Math.min(c01(crop.h / FRAME.h), 1 - y),
+  };
+}
+
+async function waitStableImage(page, timeoutMs = 300_000, stableMs = 2500) {
+  const img = page.locator('img[alt^="Generated illustration"]').first();
+  await img.waitFor({ state: "visible", timeout: timeoutMs });
+  let last = "";
+  let since = Date.now();
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const src = (await img.getAttribute("src")) ?? "";
+    if (src && src === last) {
+      if (Date.now() - since >= stableMs) return src;
+    } else {
+      last = src;
+      since = Date.now();
+    }
+    await page.waitForTimeout(300);
+  }
+  throw new Error("image never stabilised");
+}
+
+async function clickAtFraction(page, xf, yf) {
+  const img = page.locator('img[alt^="Generated illustration"]').first();
+  const box = await img.boundingBox();
+  if (!box) throw new Error("no image bounding box");
+  await page.mouse.click(box.x + box.width * xf, box.y + box.height * yf);
+}
+
+async function cropViaCanvas(page, srcUrl, box) {
+  return await page.evaluate(
+    async ({ src, b }) => {
+      const img = new Image();
+      img.crossOrigin = "anonymous";
+      img.src = src;
+      await img.decode();
+      const c = document.createElement("canvas");
+      c.width = Math.max(1, Math.round(b.w * img.naturalWidth));
+      c.height = Math.max(1, Math.round(b.h * img.naturalHeight));
+      const ctx = c.getContext("2d");
+      ctx.drawImage(
+        img,
+        b.x * img.naturalWidth,
+        b.y * img.naturalHeight,
+        c.width,
+        c.height,
+        0,
+        0,
+        c.width,
+        c.height,
+      );
+      return c.toDataURL("image/jpeg", 0.92);
+    },
+    { src: srcUrl, b: box },
+  );
+}
+
+async function pollTargetEntity(session, matcher, timeoutMs = 150_000) {
+  const deadline = Date.now() + timeoutMs;
+  let places = [];
+  while (Date.now() < deadline) {
+    const m = await api(`/api/world/${encodeURIComponent(session)}/map`);
+    places = (m?.entities ?? []).filter(
+      (e) => e.kind === "place" && (e.parent_id ?? null) === null,
+    );
+    const hit = places.find((e) => matcher.test(e.label));
+    if (hit) return { entity: hit, fallback: false };
+    await sleep(4000);
+  }
+  if (places.length > 0) {
+    // Fallback: the largest-footprint place — the ladder is what's under
+    // test, not the extraction's naming.
+    const biggest = [...places].sort(
+      (a, b) => b.footprint.w * b.footprint.d - a.footprint.w * a.footprint.d,
+    )[0];
+    return { entity: biggest, fallback: true };
+  }
+  throw new Error("no place entities ever extracted");
+}
+
+async function nodeFromSession(session, nodeId) {
+  const s = await api(`/api/sessions/${encodeURIComponent(session)}`);
+  return (s?.nodes ?? []).find((n) => n.id === nodeId) ?? null;
+}
+
+async function runScenario(browser, scenario) {
+  const dir = path.join(RUN_DIR, scenario.id);
+  fs.mkdirSync(dir, { recursive: true });
+  const manifest = {
+    scenario: scenario.id,
+    query: scenario.query,
+    started_at: new Date().toISOString(),
+    checks: {},
+    errors: [],
+  };
+  const t0 = Date.now();
+  const context = await browser.newContext({ viewport: { width: 1600, height: 1000 } });
+  const page = await context.newPage();
+
+  let sessionId = null;
+  const persisted = [];
+  page.on("request", (req) => {
+    if (req.url().includes("/api/generate-page")) {
+      try {
+        const b = req.postDataJSON();
+        if (b?.session_id) sessionId = b.session_id;
+        (manifest.generate_bodies ??= []).push({
+          mode: b?.mode ?? null,
+          render_mode: b?.render_mode ?? null,
+          has_scene_view: !!b?.scene_view,
+          scene_view_closeup: b?.scene_view?.closeup ?? null,
+          world_mode: b?.world_mode ?? null,
+          condition_roles: b?.condition_roles ?? null,
+        });
+      } catch { /* best-effort capture */ }
+    }
+  });
+  page.on("response", async (res) => {
+    if (res.url().includes("/api/nodes") && res.request().method() === "POST") {
+      try {
+        persisted.push(await res.json());
+      } catch { /* best-effort capture */ }
+    }
+  });
+
+  try {
+    await page.goto(`${BASE}/play`, { waitUntil: "domcontentloaded" });
+    // World mode MUST be on — fresh contexts seed it from a build-time env
+    // var that docker builds don't carry. Click the pill if it's off.
+    const worldPill = page.locator('button:has-text("world")').first();
+    await worldPill.waitFor({ state: "visible", timeout: 30_000 });
+    if ((await worldPill.getAttribute("aria-pressed")) !== "true") {
+      await worldPill.click();
+      await page.waitForTimeout(300);
+    }
+    manifest.checks.world_pill_on =
+      (await worldPill.getAttribute("aria-pressed")) === "true";
+    await page
+      .locator('input[placeholder*="Ask about anything"]')
+      .fill(scenario.query);
+    log(scenario.id, "→ generating root map");
+    await page.locator('button:has-text("Go")').first().click();
+    await waitStableImage(page);
+    const waitNodes = async (count, timeoutMs = 360_000) => {
+      const dl = Date.now() + timeoutMs;
+      while (persisted.length < count && Date.now() < dl) await sleep(1000);
+      if (persisted.length < count) throw new Error(`node ${count} never persisted`);
+      return persisted[count - 1];
+    };
+    const rootNode = await waitNodes(1);
+    if (!sessionId) throw new Error("session id never captured");
+    manifest.session = sessionId;
+    manifest.root = { id: rootNode.id, image_url: rootNode.image_url };
+    await saveUrl(rootNode.image_url, path.join(dir, "1_map.jpg"));
+    log(scenario.id, "root saved", rootNode.id);
+
+    // ── Hop 1: tap the target place → expect a CLOSEUP ──
+    const { entity, fallback } = await pollTargetEntity(sessionId, scenario.target);
+    manifest.target = {
+      label: entity.label,
+      pos: entity.pos,
+      footprint: entity.footprint,
+      fallback_used: fallback,
+    };
+    const click1 = { x: entity.pos.x / FRAME.w, y: entity.pos.y / FRAME.h };
+    manifest.click1 = click1;
+    log(scenario.id, `→ closeup tap on "${entity.label}" @`, click1);
+    await clickAtFraction(page, click1.x, click1.y);
+    const closeupNode = await waitNodes(2);
+    await waitStableImage(page);
+    manifest.closeup = { id: closeupNode.id, image_url: closeupNode.image_url };
+    await saveUrl(closeupNode.image_url, path.join(dir, "2_closeup.jpg"));
+
+    const closeupDoc = await nodeFromSession(sessionId, closeupNode.id);
+    const sv = closeupDoc?.scene_view ?? null;
+    manifest.closeup.scene_view = sv;
+    manifest.checks.closeup_flag = sv?.closeup === true;
+    manifest.checks.closeup_has_crop = !!sv?.map_crop;
+    if (sv?.map_crop) {
+      const box = frameCropToImageBox(sv.map_crop);
+      manifest.closeup.promised_region = box;
+      const dataUrl = await cropViaCanvas(page, rootNode.image_url, box);
+      fs.writeFileSync(
+        path.join(dir, "1_region_promised.jpg"),
+        Buffer.from(dataUrl.split(",")[1], "base64"),
+      );
+    }
+    log(scenario.id, "closeup saved", closeupNode.id, "flag:", manifest.checks.closeup_flag);
+
+    // ── Hop 2: tap the same place on its closeup → expect the ENTER ──
+    const crop = sv?.map_crop ?? FRAME;
+    const clamp = (v) => Math.min(Math.max(v, 0.08), 0.92);
+    const click2 = {
+      x: clamp((entity.pos.x - crop.x) / crop.w),
+      y: clamp((entity.pos.y - crop.y) / crop.h),
+    };
+    manifest.click2 = click2;
+    log(scenario.id, "→ transition tap @", click2);
+    await clickAtFraction(page, click2.x, click2.y);
+    const enterNode = await waitNodes(3, 480_000);
+    await waitStableImage(page, 480_000);
+    manifest.enter = { id: enterNode.id, image_url: enterNode.image_url };
+    await saveUrl(enterNode.image_url, path.join(dir, "3_enter.jpg"));
+    const enterDoc = await nodeFromSession(sessionId, enterNode.id);
+    manifest.enter.scene_view = enterDoc?.scene_view ?? null;
+    manifest.checks.enter_left_map_register =
+      (enterDoc?.scene_view?.level ?? "map") !== "map";
+    log(scenario.id, "enter saved", enterNode.id);
+  } catch (err) {
+    manifest.errors.push(String(err?.message ?? err));
+    log(scenario.id, "ERROR:", String(err?.message ?? err));
+    try {
+      await page.screenshot({ path: path.join(dir, "error_state.png") });
+    } catch { /* best-effort capture */ }
+  } finally {
+    manifest.duration_s = Math.round((Date.now() - t0) / 1000);
+    fs.writeFileSync(
+      path.join(dir, "manifest.json"),
+      JSON.stringify(manifest, null, 1),
+    );
+    await context.close();
+  }
+  return manifest;
+}
+
+const browser = await chromium.launch();
+fs.mkdirSync(RUN_DIR, { recursive: true });
+log("run dir:", RUN_DIR);
+const results = [];
+for (const s of SCENARIOS) {
+  if (ONLY && !ONLY.includes(s.id)) continue;
+  results.push(await runScenario(browser, s));
+}
+await browser.close();
+fs.writeFileSync(
+  path.join(RUN_DIR, "run.json"),
+  JSON.stringify(
+    {
+      finished_at: new Date().toISOString(),
+      scenarios: results.map((m) => ({
+        scenario: m.scenario,
+        session: m.session ?? null,
+        errors: m.errors,
+        checks: m.checks,
+        duration_s: m.duration_s,
+      })),
+    },
+    null,
+    1,
+  ),
+);
+log("done:", results.length, "scenarios");

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -170,6 +170,10 @@ export interface GenerateRequestBody {
   // baked text — names ride a client overlay built from entity data. Optional
   // + default-absent: old clients omit it, prompts stay byte-identical.
   suppress_map_labels?: boolean;
+  // Tap descent ladder: the SOURCE frame of this enter was a closeup of the
+  // place — the establishing shot already happened, so the enter goes to
+  // ground level (grounds/courtyard) instead of another aerial.
+  from_closeup?: boolean;
   // B2 logical AROUND (mode:"expand", SCALE_AROUND_LOGICAL). The same-scale
   // neighbours the client already knows from geometry (excluded) + the focus's
   // rung, so the bloom proposes NEW peers at that scale. Ignored unless the flag


### PR DESCRIPTION
Built and validated against the **ladder proof harness baseline** (5 place types, real browser, real clicks — artifacts in `ladder-proof-runs/baseline*`).

Baseline scorecard (5 independent adversarial judge agents + step-in scores): **2/5 pass**. Failures: harbor + forest closeups INVENTED structures (second lighthouse + fortress; second cabin) — the zoom instruction's "elaborate… working in the features that belong here: {planner facts}" register; city enter stayed an aerial (step_in 2.0) — nothing ever descends the camera for complex places.

- **F1 faithful-magnify**: closeup zooms (`scene_view.closeup`) use `_faithful_zoom_instruction` — magnify exactly what the reference shows, NO planner facts, no elaboration. Defaults byte-identical, goldens untouched.
- **F3 ground-level enters**: new parity-gated `from_closeup` wire field; entering from a closeup always descends to eye/ground level (the closeup WAS the establishing shot).
- **Harness** (`apps/web/scripts/ladder-proof.mjs` + `tests/ladder_judge.py`): permanent e2e proof — also caught that fresh sessions ran with world mode OFF (build-time env never reached docker builds; harness asserts the pill).

Full gates green. Re-prove run follows this deploy; success claims only from the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)