### PR TITLE
fix(world): cap the closeup crop; degenerate-skip only on frame-filling footprints

### DIFF
--- a/apps/web/lib/click-route.ts
+++ b/apps/web/lib/click-route.ts
@@ -122,12 +122,18 @@ function cropCentre(crop: MapCrop): WorldVec2 {
 const CLOSEUP_MARGIN = 1.6;
 // Tiny entities keep enough surroundings for Kontext to anchor against.
 const CLOSEUP_MIN_FRAC = 0.18;
-// A crop this close to the whole frame is no zoom at all — skip the rung
-// (prevents the infinite-closeup loop on frame-filling places).
+// Big landmarks still deserve a real zoom: the crop caps below the frame so
+// the closeup rung always descends. (The proof harness caught a palace whose
+// EXTRACTED footprint was 39x33 on the 100x60 frame — margin pushed the crop
+// to 88% and the old >=0.85 guard skipped the rung entirely.)
+const CLOSEUP_MAX_FRAC = 0.72;
+// Skip the rung only when the FOOTPRINT ITSELF effectively fills the frame —
+// then a closeup genuinely is a no-op and the tap should enter.
 const CLOSEUP_DEGENERATE_FRAC = 0.85;
 
 /** The closeup window for a place: footprint × margin, aspect-preserving,
- *  clamped inside the frame. Pure; exported for the conditioning crop. */
+ *  capped below the frame, clamped inside it. Pure; exported for the
+ *  conditioning crop. */
 export function entityCloseupCrop(
   focus: WorldEntityGeo,
   frame: MapCrop,
@@ -140,7 +146,7 @@ export function entityCloseupCrop(
       (focus.footprint.d * margin) / frame.h,
       minFrac,
     ),
-    1,
+    CLOSEUP_MAX_FRAC,
   );
   const w = frame.w * frac;
   const h = frame.h * frac;
@@ -190,12 +196,18 @@ export function routeClick(
       const alreadyCloseup =
         view.closeup === true && view.focus_id === focus.id;
       if (!alreadyCloseup) {
-        const crop = entityCloseupCrop(focus, view.map_crop);
+        // Degenerate only when the FOOTPRINT fills the frame (a closeup of
+        // the whole frame is a no-op) — a big landmark still gets its zoom
+        // via the capped crop.
         const degenerate =
-          crop.w >= view.map_crop.w * CLOSEUP_DEGENERATE_FRAC &&
-          crop.h >= view.map_crop.h * CLOSEUP_DEGENERATE_FRAC;
+          focus.footprint.w >= view.map_crop.w * CLOSEUP_DEGENERATE_FRAC &&
+          focus.footprint.d >= view.map_crop.h * CLOSEUP_DEGENERATE_FRAC;
         if (!degenerate) {
-          return { kind: "closeup", crop, focus_id: focus.id };
+          return {
+            kind: "closeup",
+            crop: entityCloseupCrop(focus, view.map_crop),
+            focus_id: focus.id,
+          };
         }
       }
     }

--- a/apps/web/scripts/ladder-proof.mjs
+++ b/apps/web/scripts/ladder-proof.mjs
@@ -143,9 +143,29 @@ async function cropViaCanvas(page, srcUrl, box) {
   );
 }
 
-async function pollTargetEntity(session, matcher, timeoutMs = 150_000) {
+async function retriggerExtraction(session, node, caption) {
+  // The first post-generation extraction is occasionally empty (the same
+  // flake the product's localize-now button covers) — re-trigger it the
+  // way the client would.
+  try {
+    await fetch(`${BASE}/api/world/${encodeURIComponent(session)}/extract`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        node_id: node.id,
+        image_data_url: node.image_url,
+        caption: caption.slice(0, 1400),
+        scene_description: caption.slice(0, 1600),
+        scene_view: null,
+      }),
+    });
+  } catch { /* best-effort */ }
+}
+
+async function pollTargetEntity(session, matcher, timeoutMs = 240_000, retrigger = null) {
   const deadline = Date.now() + timeoutMs;
   let places = [];
+  let retriggered = 0;
   while (Date.now() < deadline) {
     const m = await api(`/api/world/${encodeURIComponent(session)}/map`);
     places = (m?.entities ?? []).filter(
@@ -153,6 +173,13 @@ async function pollTargetEntity(session, matcher, timeoutMs = 150_000) {
     );
     const hit = places.find((e) => matcher.test(e.label));
     if (hit) return { entity: hit, fallback: false };
+    // Two chances to recover from an empty first extraction.
+    const elapsed = timeoutMs - (deadline - Date.now());
+    if (retrigger && places.length === 0 && elapsed > 60_000 * (retriggered + 1) && retriggered < 2) {
+      retriggered += 1;
+      log("  (extraction empty — re-triggering, attempt", retriggered + ")");
+      await retrigger();
+    }
     await sleep(4000);
   }
   if (places.length > 0) {
@@ -243,7 +270,12 @@ async function runScenario(browser, scenario) {
     log(scenario.id, "root saved", rootNode.id);
 
     // ── Hop 1: tap the target place → expect a CLOSEUP ──
-    const { entity, fallback } = await pollTargetEntity(sessionId, scenario.target);
+    const { entity, fallback } = await pollTargetEntity(
+      sessionId,
+      scenario.target,
+      240_000,
+      () => retriggerExtraction(sessionId, rootNode, scenario.query),
+    );
     manifest.target = {
       label: entity.label,
       pos: entity.pos,


### PR DESCRIPTION
## What

Proof-harness catch (`ladder-proof-runs/fixed2/city`): the extracted palace footprint was 39x33 on the 100x60 frame — margin x1.6 pushed the closeup crop to 88% of the frame and the >=0.85 degenerate guard **skipped the closeup rung entirely**, sending the tap down the old direct-enter path (premature aerial, no closeup).

- `entityCloseupCrop` caps at **0.72 of the frame**: big landmarks still get a real, descending zoom.
- The degenerate skip now tests the **raw footprint** (>=0.85 of frame) — only true frame-fillers, where a closeup genuinely is a no-op, enter directly.
- Harness: extraction re-trigger after 60s of empty polling (the first-extraction flake the product's localize-now covers).

## Test plan
- [x] 602 web tests pass, tsc clean
- [ ] Ladder proof re-run on city (the scenario that caught it) after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)