### PR TITLE
fix(world): the proven ladder becomes the docker default experience

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -12,6 +12,13 @@ RUN pnpm install --frozen-lockfile
 FROM base AS builder
 WORKDIR /repo
 ENV NEXT_TELEMETRY_DISABLED=1
+# Client flags are inlined at BUILD time (NEXT_PUBLIC_*): without these args
+# the image silently ships the flag-off bundle — demo-stack sessions seeded
+# world mode OFF while local dev (.env.local) had it on.
+ARG NEXT_PUBLIC_WORLD_MODE
+ARG NEXT_PUBLIC_DOM_LABELS
+ENV NEXT_PUBLIC_WORLD_MODE=$NEXT_PUBLIC_WORLD_MODE \
+    NEXT_PUBLIC_DOM_LABELS=$NEXT_PUBLIC_DOM_LABELS
 COPY --from=deps /repo/node_modules ./node_modules
 COPY --from=deps /repo/apps/web/node_modules ./apps/web/node_modules
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json tsconfig.base.json ./

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -238,7 +238,7 @@ async function persistNode(
 // planner's `final_prompt` — the rich paragraph the image model rendered
 // from. The VLM needs both to reliably name entities; a title alone is
 // usually too thin ("Lantern Room" without the keeper's name in scope).
-function triggerExtraction(args: {
+async function triggerExtraction(args: {
   sessionId: string;
   nodeId: string;
   imageDataUrl: string;
@@ -249,26 +249,27 @@ function triggerExtraction(args: {
   sceneView?: SceneView | null;
   traceId: string | null;
 }): Promise<{ added: number; updated: number } | null> {
-  const t0 = nowMs();
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
   };
   if (args.traceId) headers[TRACE_HEADER] = args.traceId;
-  return fetch(
-    `/api/world/${encodeURIComponent(args.sessionId)}/extract`,
-    {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        node_id: args.nodeId,
-        image_data_url: args.imageDataUrl,
-        caption: args.caption,
-        scene_description: args.sceneDescription ?? null,
-        scene_view: args.sceneView ?? null,
-      }),
-    }
-  )
-    .then(async (res) => {
+  const attempt = async (): Promise<{ added: number; updated: number } | null> => {
+    const t0 = nowMs();
+    try {
+      const res = await fetch(
+        `/api/world/${encodeURIComponent(args.sessionId)}/extract`,
+        {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            node_id: args.nodeId,
+            image_data_url: args.imageDataUrl,
+            caption: args.caption,
+            scene_description: args.sceneDescription ?? null,
+            scene_view: args.sceneView ?? null,
+          }),
+        }
+      );
       if (!res.ok) {
         hudEmit("world:extract_error", {
           status: res.status,
@@ -298,12 +299,23 @@ function triggerExtraction(args: {
         added: payload.added_ids?.length ?? 0,
         updated: payload.updated_ids?.length ?? 0,
       };
-    })
-    .catch(() => {
+    } catch {
       // Best-effort. The codex view will refetch on its own if a user
       // opens it; nothing to roll back here.
       return null;
-    });
+    }
+  };
+  const first = await attempt();
+  // The first extraction after a generation occasionally stores NOTHING
+  // (the ladder-proof harness hit it on 3 of 12 runs) and a map with zero
+  // entities dead-ends every tap until the user finds "localize now". A
+  // 0/0 merge on a freshly rendered page is near-certain flake — re-fire
+  // once; the route's diff-merge makes the second pass idempotent.
+  if (first && first.added === 0 && first.updated === 0) {
+    await new Promise((r) => setTimeout(r, 4000));
+    return attempt();
+  }
+  return first;
 }
 
 export default function PlayPage() {
@@ -2398,6 +2410,12 @@ export default function PlayPage() {
               // high-consistency op); only a true transition tap enters.
               render_mode:
                 worldTap.kind === "scene" ? "place_scene" : "place_submap",
+              // Magnified baked lettering always garbles ("The Great kee") —
+              // closeups render text-free regardless of the labels pill; the
+              // name lives in the page title / DOM labels.
+              ...(worldTap.kind === "closeup"
+                ? { suppress_map_labels: true }
+                : {}),
               // The geometric tap KNOWS which entity you hit (by coordinates) —
               // make it the subject so tapping the Tower of Art enters the Tower,
               // overriding the looser VLM read that picked its container. Spread

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,6 +135,14 @@ services:
     build:
       context: .
       dockerfile: apps/web/Dockerfile
+      # NEXT_PUBLIC_* are inlined at BUILD time, so runtime env_file can't
+      # carry them — they must arrive as build args or the image ships the
+      # flag-off bundle (the "why did consistency regress" footgun: world
+      # mode seeded OFF in every fresh docker session). Both follow the root
+      # .env's WORLD_MODE so the single-file demo stays single-file.
+      args:
+        NEXT_PUBLIC_WORLD_MODE: ${NEXT_PUBLIC_WORLD_MODE:-${WORLD_MODE:-false}}
+        NEXT_PUBLIC_DOM_LABELS: ${NEXT_PUBLIC_DOM_LABELS:-${WORLD_MODE:-false}}
     container_name: openflipbook-web
     restart: unless-stopped
     # Same posture as the backend: the root .env (single-file demo) carries


### PR DESCRIPTION
Three gaps the ladder-proof campaign surfaced, closed product-side:

- **Build args for client flags**: `NEXT_PUBLIC_WORLD_MODE` / `NEXT_PUBLIC_DOM_LABELS` now reach the web image as build args (Next inlines `NEXT_PUBLIC_*` at build; runtime env_file can't carry them). Both follow the root `.env`'s `WORLD_MODE`, so fresh docker sessions finally seed world mode ON instead of silently reverting to classic — the "why did consistency regress" footgun. Bare clones without `.env` keep the classic default.
- **Extraction flake**: `triggerExtraction` re-fires once (4s later) when a fresh page's merge lands 0 added + 0 updated — the first post-gen extraction occasionally stores nothing (harness hit it on 3/12 runs) and a zero-entity map dead-ends every tap until the user finds "localize now". The route's diff-merge makes the second pass idempotent.
- **Closeup lettering**: closeup taps always send `suppress_map_labels` — magnified baked lettering garbles ("The Great kee"); the name lives in the page title and DOM labels. Submaps/scenes keep following the labels pill.

## Test plan
- [x] 602 web tests, tsc clean, eslint 0 errors (9 pre-existing warnings)
- [x] `docker compose config` resolves the nested build-arg defaults (`WORLD_MODE=1` → both args "1")
- [ ] Harness re-run post-deploy (with #85's F2) — harbor + castle

🤖 Generated with [Claude Code](https://claude.com/claude-code)