### PR TITLE
feat(world): F2 closeup context floor 0.18 → 0.28; hop1 judge reads identity

### DIFF
--- a/apps/modal-backend/tests/ladder_judge.py
+++ b/apps/modal-backend/tests/ladder_judge.py
@@ -3,8 +3,13 @@
     .venv/bin/python -m tests.ladder_judge <run_dir>
 
 For each scenario dir with {1_region_promised.jpg, 2_closeup.jpg, 3_enter.jpg}:
-  hop1 (map region → closeup): score_step_in + score_continuation
+  hop1 (map region → closeup): score_continuation PRIMARY (+ step_in recorded)
   hop2 (closeup → enter):      score_step_in
+hop1's primary is IDENTITY, not zoom: the promised region is already the
+zoomed window, so a perfect faithful magnification reads as "same framing,
+sharper" — step_in ~5-6 with continuation 10 — while a DRIFTED closeup reads
+as "zoomed in" (step_in 8, continuation 2). The two anti-correlate on
+map-register pairs; only hop2 measures descent.
 Writes scores.json per scenario and a summary into <run_dir>/scores.json.
 Secondary signal only — the eyes-on subagent verdicts are primary.
 PAID: ~5 Gemini calls per scenario (~$0.03).
@@ -65,8 +70,8 @@ async def _run(run_dir: Path) -> int:
         if row:
             rows.append(row)
             print(
-                f"{row['scenario']:8} hop1 step_in={row.get('hop1_step_in')} "
-                f"cont={row.get('hop1_continuation')} | hop2 step_in={row.get('hop2_step_in')}"
+                f"{row['scenario']:8} hop1 cont={row.get('hop1_continuation')} "
+                f"(step_in={row.get('hop1_step_in')}) | hop2 step_in={row.get('hop2_step_in')}"
             )
     (run_dir / "scores.json").write_text(json.dumps(rows, indent=1))
     print(f"wrote {run_dir / 'scores.json'}")

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -12,6 +12,13 @@ RUN pnpm install --frozen-lockfile
 FROM base AS builder
 WORKDIR /repo
 ENV NEXT_TELEMETRY_DISABLED=1
+# Client flags are inlined at BUILD time (NEXT_PUBLIC_*): without these args
+# the image silently ships the flag-off bundle — demo-stack sessions seeded
+# world mode OFF while local dev (.env.local) had it on.
+ARG NEXT_PUBLIC_WORLD_MODE
+ARG NEXT_PUBLIC_DOM_LABELS
+ENV NEXT_PUBLIC_WORLD_MODE=$NEXT_PUBLIC_WORLD_MODE \
+    NEXT_PUBLIC_DOM_LABELS=$NEXT_PUBLIC_DOM_LABELS
 COPY --from=deps /repo/node_modules ./node_modules
 COPY --from=deps /repo/apps/web/node_modules ./apps/web/node_modules
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json tsconfig.base.json ./

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -238,7 +238,7 @@ async function persistNode(
 // planner's `final_prompt` — the rich paragraph the image model rendered
 // from. The VLM needs both to reliably name entities; a title alone is
 // usually too thin ("Lantern Room" without the keeper's name in scope).
-function triggerExtraction(args: {
+async function triggerExtraction(args: {
   sessionId: string;
   nodeId: string;
   imageDataUrl: string;
@@ -249,26 +249,27 @@ function triggerExtraction(args: {
   sceneView?: SceneView | null;
   traceId: string | null;
 }): Promise<{ added: number; updated: number } | null> {
-  const t0 = nowMs();
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
   };
   if (args.traceId) headers[TRACE_HEADER] = args.traceId;
-  return fetch(
-    `/api/world/${encodeURIComponent(args.sessionId)}/extract`,
-    {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        node_id: args.nodeId,
-        image_data_url: args.imageDataUrl,
-        caption: args.caption,
-        scene_description: args.sceneDescription ?? null,
-        scene_view: args.sceneView ?? null,
-      }),
-    }
-  )
-    .then(async (res) => {
+  const attempt = async (): Promise<{ added: number; updated: number } | null> => {
+    const t0 = nowMs();
+    try {
+      const res = await fetch(
+        `/api/world/${encodeURIComponent(args.sessionId)}/extract`,
+        {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            node_id: args.nodeId,
+            image_data_url: args.imageDataUrl,
+            caption: args.caption,
+            scene_description: args.sceneDescription ?? null,
+            scene_view: args.sceneView ?? null,
+          }),
+        }
+      );
       if (!res.ok) {
         hudEmit("world:extract_error", {
           status: res.status,
@@ -298,12 +299,23 @@ function triggerExtraction(args: {
         added: payload.added_ids?.length ?? 0,
         updated: payload.updated_ids?.length ?? 0,
       };
-    })
-    .catch(() => {
+    } catch {
       // Best-effort. The codex view will refetch on its own if a user
       // opens it; nothing to roll back here.
       return null;
-    });
+    }
+  };
+  const first = await attempt();
+  // The first extraction after a generation occasionally stores NOTHING
+  // (the ladder-proof harness hit it on 3 of 12 runs) and a map with zero
+  // entities dead-ends every tap until the user finds "localize now". A
+  // 0/0 merge on a freshly rendered page is near-certain flake — re-fire
+  // once; the route's diff-merge makes the second pass idempotent.
+  if (first && first.added === 0 && first.updated === 0) {
+    await new Promise((r) => setTimeout(r, 4000));
+    return attempt();
+  }
+  return first;
 }
 
 export default function PlayPage() {
@@ -2398,6 +2410,12 @@ export default function PlayPage() {
               // high-consistency op); only a true transition tap enters.
               render_mode:
                 worldTap.kind === "scene" ? "place_scene" : "place_submap",
+              // Magnified baked lettering always garbles ("The Great kee") —
+              // closeups render text-free regardless of the labels pill; the
+              // name lives in the page title / DOM labels.
+              ...(worldTap.kind === "closeup"
+                ? { suppress_map_labels: true }
+                : {}),
               // The geometric tap KNOWS which entity you hit (by coordinates) —
               // make it the subject so tapping the Tower of Art enters the Tower,
               // overriding the looser VLM read that picked its container. Spread

--- a/apps/web/lib/click-route.test.ts
+++ b/apps/web/lib/click-route.test.ts
@@ -181,7 +181,7 @@ describe("the descent ladder (closeup rung)", () => {
       // window centred on the entity, footprint x margin as a frame fraction
       expect(r.crop.x + r.crop.w / 2).toBeCloseTo(50, 5);
       expect(r.crop.y + r.crop.h / 2).toBeCloseTo(50, 5);
-      expect(r.crop.w).toBeCloseTo(18, 3); // max(10*1.6/100, 8*1.6/100, 0.18) = 0.18 -> 18
+      expect(r.crop.w).toBeCloseTo(28, 3); // max(10*1.6/100, 8*1.6/100, 0.28) = 0.28 -> 28
     }
   });
 
@@ -241,8 +241,8 @@ describe("entityCloseupCrop", () => {
   });
   it("tiny entities get the min fraction (context for Kontext)", () => {
     const c = entityCloseupCrop(geo("well", 50, 30, { footprint: { w: 1, d: 1 } }), frame);
-    expect(c.w).toBeCloseTo(18, 5);
-    expect(c.h).toBeCloseTo(10.8, 5);
+    expect(c.w).toBeCloseTo(28, 5);
+    expect(c.h).toBeCloseTo(16.8, 5);
   });
   it("preserves the frame aspect (w/h ratio)", () => {
     const c = entityCloseupCrop(geo("uni", 40, 30, { footprint: { w: 20, d: 6 } }), frame);

--- a/apps/web/lib/click-route.ts
+++ b/apps/web/lib/click-route.ts
@@ -121,7 +121,12 @@ function cropCentre(crop: MapCrop): WorldVec2 {
 // (the property the submap window and the click crop already have).
 const CLOSEUP_MARGIN = 1.6;
 // Tiny entities keep enough surroundings for Kontext to anchor against.
-const CLOSEUP_MIN_FRAC = 0.18;
+// 0.18 → 0.28 (F2, ladder-proof harbor): when the map draws a place as a
+// bare ICON on terrain, an 18%-of-frame reference carries so few real
+// pixels that the magnification invents architecture around it (the
+// lighthouse grew a walled yard). More surrounding map in the reference
+// anchors the symbol→building translation to what is actually drawn.
+const CLOSEUP_MIN_FRAC = 0.28;
 // Big landmarks still deserve a real zoom: the crop caps below the frame so
 // the closeup rung always descends. (The proof harness caught a palace whose
 // EXTRACTED footprint was 39x33 on the 100x60 frame — margin pushed the crop

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,6 +135,14 @@ services:
     build:
       context: .
       dockerfile: apps/web/Dockerfile
+      # NEXT_PUBLIC_* are inlined at BUILD time, so runtime env_file can't
+      # carry them — they must arrive as build args or the image ships the
+      # flag-off bundle (the "why did consistency regress" footgun: world
+      # mode seeded OFF in every fresh docker session). Both follow the root
+      # .env's WORLD_MODE so the single-file demo stays single-file.
+      args:
+        NEXT_PUBLIC_WORLD_MODE: ${NEXT_PUBLIC_WORLD_MODE:-${WORLD_MODE:-false}}
+        NEXT_PUBLIC_DOM_LABELS: ${NEXT_PUBLIC_DOM_LABELS:-${WORLD_MODE:-false}}
     container_name: openflipbook-web
     restart: unless-stopped
     # Same posture as the backend: the root .env (single-file demo) carries


### PR DESCRIPTION
Stacked on #84. The ladder proof's one marginal (harbor):

- **F2**: when the map draws a place as a bare ICON on terrain, an 18%-of-frame reference carries so few real pixels that the magnification invents architecture around it (the lighthouse grew a walled yard). A 28% floor keeps more of the actually-drawn map in the Kontext reference to anchor the symbol→building translation. Big-footprint crops unchanged (the floor only binds on small entities).
- **ladder_judge**: hop1's primary numeric is now continuation (identity) — the promised region is already the zoomed window, so a PERFECT faithful magnification scores step_in ~5–6 while a DRIFTED closeup scores 8+; the two anti-correlate on map-register pairs. Only hop2 measures descent. Campaign evidence in `ladder-proof-runs/REPORT.md`.

## Test plan
- [x] 602 web tests (2 floor pins updated), tsc clean, ruff + mypy clean
- [ ] `make ladder-proof` re-run on harbor (the marginal) + castle (small-keep regression sentinel), fresh adversarial judges

🤖 Generated with [Claude Code](https://claude.com/claude-code)