### PR TITLE
feat(world): closeups gain detail — inset-plate instruction + reference upscale

### DIFF
--- a/apps/modal-backend/providers/prompt_library/instructions.py
+++ b/apps/modal-backend/providers/prompt_library/instructions.py
@@ -441,11 +441,16 @@ def _faithful_zoom_instruction(
     layout_clause: str = "",
     register: str = "map",
 ) -> str:
-    """The CLOSEUP zoom (scene_view.closeup): a faithful MAGNIFICATION. The
-    elaborate-with-facts register invites invention — the live failure was a
-    20x12 crop of a stylized palace icon redrawn as a riverside compound
-    because the planner's city-wide facts rode in. No facts, no elaboration:
-    magnify what the reference shows and nothing else."""
+    """The CLOSEUP zoom (scene_view.closeup): a faithful magnification that
+    GAINS detail. Two failure modes bound this register. Elaborate-with-facts
+    invented structures (a 20x12 crop of a palace icon redrawn as a riverside
+    compound — the planner's city-wide facts rode in), so facts never ride a
+    magnification. But pure magnify-only overcorrected into a photocopier:
+    the same icon redrawn bigger and mushier, nothing gained — the rung felt
+    pointless. The contract: every structure the reference shows, exactly
+    where it is, rendered at the finer detail level a dedicated inset plate
+    of that landmark would carry. New detail belongs INSIDE existing
+    structures; nothing new appears."""
     title = page_title.strip() or "this place"
     noun = "map" if register == "map" else "view"
     viewpoint = (
@@ -453,17 +458,26 @@ def _faithful_zoom_instruction(
         if register == "map"
         else "from the SAME viewpoint the reference shows"
     )
+    plate = (
+        "A master cartographer's close-up inset of this exact map"
+        if register == "map"
+        else "A faithful close-up of this exact view at finer detail"
+    )
     text = (
         f'Zoom into "{title}" — the area at the centre of this image — and '
-        "MAGNIFY it faithfully. Draw exactly the walls, buildings, towers and "
-        "landmarks the reference already shows, in the same style, palette "
-        f"and line work, {viewpoint}; keep their exact arrangement, "
-        "proportions and relative positions. Do NOT add structures, water, "
-        "roads, or features that are not in the reference; do not reinvent "
-        "or restyle anything — only sharpen the existing detail as you "
-        f"magnify. A closer, faithful magnification of this exact {noun}, "
-        "not a new scene. Keep any lettering sparse and legible — no "
-        "garbled text."
+        f"redraw it as a DETAILED INSET of this exact {noun}: the same "
+        "place, magnified, drawn at a much finer level of detail. Keep "
+        "exactly the walls, buildings, towers and landmarks the reference "
+        "shows — the same arrangement, proportions and relative positions, "
+        f"the same style, palette and line work, {viewpoint}. Render each "
+        f"of those structures with the fine-grained detail the wider {noun} "
+        "was too small to show: individual stones and roof tiles, windows "
+        "and doorways, stairs, timbers, battlements, foliage — the "
+        "small-scale texture that belongs to what is already drawn, in the "
+        "same hand. Do NOT add new structures, water, roads, or features "
+        "that are not in the reference; do not move, mirror, restyle or "
+        f"reinterpret anything. {plate}, not a new scene. Keep any "
+        "lettering sparse and legible — no garbled text."
     )
     if layout_clause.strip():
         text += "\n\n" + layout_clause.strip()

--- a/apps/modal-backend/tests/test_prompt_library.py
+++ b/apps/modal-backend/tests/test_prompt_library.py
@@ -527,21 +527,26 @@ def test_register_reminder_and_retry_feedback() -> None:
     assert feedback.retry_feedback_clause("top_down") == ""
 
 
-def test_faithful_zoom_is_pure_magnification() -> None:
-    """The closeup rung (F1): no facts, no 'elaborate' — magnify only. The
-    live failure was planner facts (river, bridges) painted into a 20x12
-    closeup of a palace icon."""
+def test_faithful_zoom_is_detailed_inset() -> None:
+    """The closeup rung: no facts ride in (anti-invention — planner facts
+    painted a river into a palace closeup), but the magnification GAINS
+    detail (anti-photocopier — magnify-only redrew the same icon bigger and
+    mushier, and the rung felt pointless). Every structure kept in place;
+    fine detail rendered INSIDE what is already drawn."""
     s = image_edit.build_zoom_instruction(
         "The High Palace", ["a river", "two bridges"], "", faithful=True
     )
-    assert "MAGNIFY it faithfully" in s
-    assert "Do NOT add structures, water, roads" in s
+    assert "DETAILED INSET" in s
+    assert "much finer level of detail" in s
+    assert "Do NOT add new structures, water, roads" in s
+    assert "do not move, mirror, restyle" in s
     # facts NEVER ride a magnification
     assert "a river" not in s and "working in the features" not in s
     # default stays byte-identical (golden contract)
     assert image_edit.build_zoom_instruction("T", ["f"]) == image_edit.build_zoom_instruction(
         "T", ["f"], faithful=False
     )
-    # the view register variant
+    # the view register variant swaps the cartographic framing
     v = image_edit.build_zoom_instruction("The Keep", [], "", faithful=True, register="view")
     assert "from the SAME viewpoint the reference shows" in v
+    assert "cartographer" not in v

--- a/apps/web/lib/image-condition.test.ts
+++ b/apps/web/lib/image-condition.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { cropBox, orderedRefs } from "./image-condition";
+import { cropBox, orderedRefs, regionUpscale } from "./image-condition";
 
 /**
  * Pure core of the image-conditioning reference stack: where the region crop
@@ -35,6 +35,22 @@ describe("cropBox", () => {
     const b = cropBox(0.5, 0.5, 2);
     expect(b.w).toBe(1);
     expect(b.x).toBe(0);
+  });
+});
+
+describe("regionUpscale (the anti-postage-stamp reference)", () => {
+  it("tiny crops hit the upscale cap", () => {
+    expect(regionUpscale(200)).toBe(3); // 1024/200 > 3 → capped
+  });
+  it("mid crops scale to the target width", () => {
+    expect(regionUpscale(512)).toBeCloseTo(2, 6); // 1024/512
+  });
+  it("big crops never shrink", () => {
+    expect(regionUpscale(1024)).toBe(1);
+    expect(regionUpscale(2000)).toBe(1);
+  });
+  it("degenerate width is a no-op", () => {
+    expect(regionUpscale(0)).toBe(1);
   });
 });
 

--- a/apps/web/lib/image-condition.ts
+++ b/apps/web/lib/image-condition.ts
@@ -82,6 +82,22 @@ export async function cropRegion(
   return cropRegionRect(src, cropBox(xPct, yPct, frac));
 }
 
+// The models redraw at ~1MP from whatever we hand them: a 0.28-fraction crop
+// of a ~1.3k-wide map is a ~370px postage stamp, and a model told to stay
+// faithful to a postage stamp paints mush (the photocopier closeup). Upscale
+// the crop canvas with smooth interpolation so the reference arrives at a
+// workable size — the information is the same; the interpolation is ours
+// instead of the provider's nearest-neighbour.
+const REGION_TARGET_WIDTH = 1024;
+const REGION_MAX_UPSCALE = 3;
+
+/** Upscale factor for a crop of source width `sw` (pure): reach
+ *  REGION_TARGET_WIDTH, never more than REGION_MAX_UPSCALE, never shrink. */
+export function regionUpscale(sw: number): number {
+  if (sw <= 0) return 1;
+  return Math.min(REGION_MAX_UPSCALE, Math.max(1, REGION_TARGET_WIDTH / sw));
+}
+
 /** Crop an exact normalized box of `src` → a JPEG data URL (the general form;
  *  the ladder passes the routing window so the reference IS the promise). */
 export async function cropRegionRect(
@@ -98,11 +114,14 @@ export async function cropRegionRect(
   const sy = box.y * img.naturalHeight;
   const sw = Math.max(1, box.w * img.naturalWidth);
   const sh = Math.max(1, box.h * img.naturalHeight);
+  const scale = regionUpscale(sw);
   const canvas = document.createElement("canvas");
-  canvas.width = Math.round(sw);
-  canvas.height = Math.round(sh);
+  canvas.width = Math.round(sw * scale);
+  canvas.height = Math.round(sh * scale);
   const ctx = canvas.getContext("2d");
   if (!ctx) return src;
+  ctx.imageSmoothingEnabled = true;
+  ctx.imageSmoothingQuality = "high";
   ctx.drawImage(img, sx, sy, sw, sh, 0, 0, canvas.width, canvas.height);
   return canvas.toDataURL("image/jpeg", 0.9);
 }


### PR DESCRIPTION
User verdict on the shipped closeups: faithful but **pointless** — the magnify-only instruction (F1) overcorrected from inventing structures into a photocopier: the same map icon redrawn bigger and mushier, nothing gained by the rung.

Two levers, one diagnosis (a model told to stay faithful to a postage stamp, forbidden from adding anything, paints mush):

- `_faithful_zoom_instruction` becomes the **DETAILED INSET** register: every structure kept exactly in place (the invention ban stays — no new structures/water/roads, no moving/mirroring/restyling), but each rendered with the fine-grained detail the wider map was too small to show (stones, roof tiles, windows, timbers) — a cartographer's inset plate, not a photocopy.
- `cropRegionRect` upscales the region crop to ~1024px (cap 3×, smooth interpolation) before it becomes the Kontext input / enter source: a 0.28-fraction crop of a ~1.3k map was a ~370px reference.

## Test plan
- [x] 606 web tests (4 new `regionUpscale` pins), tsc, eslint
- [x] Full backend not-paid suite; inset pin test replaces the magnify-only pin; ruff + mypy
- [ ] Harness re-prove on castle + harbor with a detail-gain judge axis (post-deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)