### PR TITLE
feat(world): sightline-culled surroundings — the backdrop shows what the camera can see

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -246,6 +246,13 @@ class GenerateBody(BaseModel):
     # the resolver's spatial-anchor note back so the planner can keep the
     # entered place's neighbours where the parent map had them.
     prefetched_surroundings: str | None = None
+    # Sightline-culled surroundings (client geometry: the observer pose's view
+    # frustum decided what is in sight). When true, prefetched_surroundings is
+    # VIEW-relative (frame positions, not map bearings) and surroundings_behind
+    # lists the mapped landmarks that are NOT visible — banned from the
+    # backdrop by name. Absent -> legacy map-bearing wording (parity).
+    surroundings_pov: bool = False
+    surroundings_behind: str | None = None
     # Multi-turn refer (SAMA / MM-Conv pattern): when the user rejects a
     # resolved subject and taps again nearby, the client forwards the
     # rejected phrase so the VLM picks something different.
@@ -1512,6 +1519,8 @@ async def _event_stream(
         # World Mode spatial anchor — what's around the tapped spot + directions,
         # threaded into the planner so the entered place keeps its neighbours.
         surroundings_for_plan: str | None = None
+        surroundings_pov_effective = False
+        surroundings_behind_effective: str | None = None
         # View-grammar signals: the classifier's locale-proof place FORM
         # (interior/complex/landscape/generic) and the resolved subject BEFORE
         # the user-hint fold (the policy matches names against it).
@@ -1545,6 +1554,10 @@ async def _event_stream(
                 style_anchor = cleaned_style or None
                 subject_context = cleaned_subject_context or None
                 surroundings_for_plan = cleaned_surroundings or None
+                surroundings_pov_effective = bool(body.surroundings_pov)
+                surroundings_behind_effective = (
+                    _sanitize_hint(body.surroundings_behind, 240) or None
+                )
                 yield _sse(
                     {
                         "type": "status",
@@ -1872,6 +1885,8 @@ async def _event_stream(
             view=enter_view,
             family=enter_family,
             style_ref=bool(_condition_url_for_role(body, "style")),
+            surroundings_pov=surroundings_pov_effective,
+            surroundings_behind=surroundings_behind_effective,
         )
 
         # 3. Image gen — with progressive fast-tier draft.

--- a/apps/modal-backend/providers/image_edit.py
+++ b/apps/modal-backend/providers/image_edit.py
@@ -162,6 +162,8 @@ def build_enter_instruction(
     view: dict | None = None,
     family: str | None = None,
     style_ref: bool = False,
+    surroundings_pov: bool = False,
+    surroundings_behind: str | None = None,
 ) -> str:
     """Delegates to prompt_library.instructions (the body moved verbatim;
     view=None is byte-identical to the pre-grammar string). With a view, the
@@ -183,6 +185,8 @@ def build_enter_instruction(
         view=cast("_ViewSpec | None", view),
         family=family,
         style_ref=style_ref,
+        surroundings_pov=surroundings_pov,
+        surroundings_behind=surroundings_behind,
     )
 
 

--- a/apps/modal-backend/providers/prompt_library/instructions.py
+++ b/apps/modal-backend/providers/prompt_library/instructions.py
@@ -85,6 +85,8 @@ def _legacy_enter_instruction(
     subject_context: str | None = None,
     surroundings: str | None = None,
     layout_clause: str = "",
+    surroundings_pov: bool = False,
+    surroundings_behind: str | None = None,
 ) -> str:
     title = page_title.strip() or "this place"
     anchor = f'"{title}"'
@@ -101,7 +103,9 @@ def _legacy_enter_instruction(
     if named:
         text += ", working in what belongs here: " + "; ".join(named[:8])
     text += "."
-    if surroundings and surroundings.strip():
+    if surroundings_pov:
+        text += _pov_surroundings_text(surroundings, surroundings_behind)
+    elif surroundings and surroundings.strip():
         text += (
             " Through openings and beyond the walls, keep the neighbours where "
             f"the map placed them: {surroundings.strip()}"
@@ -218,10 +222,51 @@ def _invariants_sentence(named: list[str], view: ViewSpec) -> str:
     return text + ". Keep their relative positions as seen from this viewpoint."
 
 
-def _surroundings_sentence(surroundings: str | None) -> str:
+def _pov_surroundings_text(surroundings: str | None, behind: str | None) -> str:
+    """Sightline-culled surroundings (client geometry: observer pose + view
+    frustum decided what the camera can actually see). View-relative wording;
+    everything outside the frustum is BANNED from the backdrop by name, and
+    an empty visible list is said out loud as an empty backdrop. The live
+    failure this kills: the lighthouse enter faced open sea, and the
+    map-bearing neighbours ("to the east, the docks") were painted into the
+    background anyway."""
+    s = (surroundings or "").strip()
+    b = (behind or "").strip()
+    if not s and not b:
+        return ""
+    text = ""
+    if s:
+        text += f" From this viewpoint the only mapped landmarks in sight are: {s}"
+        if not text.endswith("."):
+            text += "."
+        text += (
+            " They stay exactly where stated, distant — do NOT widen or pull "
+            "back the framing to include more."
+        )
+    else:
+        text += (
+            " No other mapped landmark is visible from this viewpoint — beyond "
+            "the subject the backdrop stays open and empty (sky, terrain or "
+            "water, as the reference implies); do NOT introduce distant "
+            "buildings, docks, piers, towers or streets."
+        )
+    if b:
+        text += f" Out of frame behind the camera (NOT visible, do not draw): {b}."
+    return text
+
+
+def _surroundings_sentence(
+    surroundings: str | None,
+    *,
+    pov: bool = False,
+    behind: str | None = None,
+) -> str:
     """Neighbours framed EXPLICITLY as map bearings — the instruction's own
     facing is view-relative, and mixing registers silently is the A2
-    contradiction this grammar exists to kill."""
+    contradiction this grammar exists to kill. pov=True (sightline-culled
+    client geometry) swaps to the view-relative wording instead."""
+    if pov:
+        return _pov_surroundings_text(surroundings, behind)
     if not (surroundings and surroundings.strip()):
         return ""
     text = (
@@ -272,6 +317,8 @@ def _enter_nano(
     layout_clause: str,
     view: ViewSpec,
     style_ref: bool,
+    surroundings_pov: bool = False,
+    surroundings_behind: str | None = None,
 ) -> str:
     anchor = f'"{title}"'
     if subject_context and subject_context.strip():
@@ -288,7 +335,9 @@ def _enter_nano(
     proj = str(view.get("projection") or "")
     text += _transform_sentence(view)
     text += " " + _invariants_sentence(named, view)
-    text += _surroundings_sentence(surroundings)
+    text += _surroundings_sentence(
+        surroundings, pov=surroundings_pov, behind=surroundings_behind
+    )
     text += " " + _medium_sentence(proj, style_anchor, ref_name)
     text += f" {ASPECT_GUARD}"
     if layout_clause.strip():
@@ -306,6 +355,8 @@ def _enter_gpt(
     layout_clause: str,
     view: ViewSpec,
     style_ref: bool,
+    surroundings_pov: bool = False,
+    surroundings_behind: str | None = None,
 ) -> str:
     proj = str(view.get("projection") or "")
     ctx = (
@@ -353,7 +404,9 @@ def _enter_gpt(
         text += ", and their left/right relations as the map implies."
     else:
         text += ", and their relative positions as seen from this viewpoint."
-    if surroundings and surroundings.strip():
+    if surroundings_pov:
+        text += _pov_surroundings_text(surroundings, surroundings_behind)
+    elif surroundings and surroundings.strip():
         text += (
             " Keep the neighbours where the map placed them (map bearings): "
             f"{surroundings.strip()}"
@@ -387,6 +440,8 @@ def _enter_kontext(
     surroundings: str | None,
     layout_clause: str,
     view: ViewSpec,
+    surroundings_pov: bool = False,
+    surroundings_behind: str | None = None,
 ) -> str:
     """FORCED fallback only — Kontext rotates the subject, not the camera
     (3.33/10 same-place on view change). Scene-level phrasing, full medium in
@@ -425,7 +480,9 @@ def _enter_kontext(
         f", and the same {medium} medium — not a photograph, no photorealism. "
         + LETTERING_GUARD
     )
-    if surroundings and surroundings.strip():
+    if surroundings_pov:
+        text += _pov_surroundings_text(surroundings, surroundings_behind)
+    elif surroundings and surroundings.strip():
         text += f" Beyond the walls keep: {surroundings.strip()}"
         if not text.endswith("."):
             text += "."
@@ -574,6 +631,8 @@ def build_enter_instruction(
     view: ViewSpec | None = None,
     family: str | None = None,
     style_ref: bool = False,
+    surroundings_pov: bool = False,
+    surroundings_behind: str | None = None,
 ) -> str:
     """Enter: a view CHANGE that keeps the place. view=None -> today's exact
     string. All four projections are honored — top_down renders the place as
@@ -586,6 +645,8 @@ def build_enter_instruction(
             subject_context=subject_context,
             surroundings=surroundings,
             layout_clause=layout_clause,
+            surroundings_pov=surroundings_pov,
+            surroundings_behind=surroundings_behind,
         )
     title = page_title.strip() or "this place"
     named = [f.strip() for f in facts if f and f.strip()]
@@ -595,18 +656,24 @@ def build_enter_instruction(
             title, named,
             style_anchor=style_anchor, subject_context=subject_context,
             surroundings=surroundings, layout_clause=layout_clause, view=view,
+            surroundings_pov=surroundings_pov,
+            surroundings_behind=surroundings_behind,
         )
     if fam == "gpt_image":
         return _enter_gpt(
             title, named,
             style_anchor=style_anchor, subject_context=subject_context,
             surroundings=surroundings, layout_clause=layout_clause, view=view,
+            surroundings_pov=surroundings_pov,
+            surroundings_behind=surroundings_behind,
             style_ref=style_ref,
         )
     return _enter_nano(
         title, named,
         style_anchor=style_anchor, subject_context=subject_context,
         surroundings=surroundings, layout_clause=layout_clause, view=view,
+        surroundings_pov=surroundings_pov,
+        surroundings_behind=surroundings_behind,
         style_ref=style_ref,
     )
 

--- a/apps/modal-backend/tests/test_prompt_library.py
+++ b/apps/modal-backend/tests/test_prompt_library.py
@@ -550,3 +550,64 @@ def test_faithful_zoom_is_detailed_inset() -> None:
     v = image_edit.build_zoom_instruction("The Keep", [], "", faithful=True, register="view")
     assert "from the SAME viewpoint the reference shows" in v
     assert "cartographer" not in v
+
+
+def test_pov_surroundings_sightline_cull() -> None:
+    """Sightline-culled surroundings (surroundings_pov): view-relative wording,
+    an explicit behind-the-camera ban list, and the empty-backdrop line when
+    nothing is in the frustum — the lighthouse-faces-the-sea fix. pov absent
+    keeps every legacy byte (golden parity)."""
+    base: dict = {
+        "style_anchor": "sepia ink",
+        "subject_context": None,
+        "layout_clause": "",
+    }
+    legacy = image_edit.build_enter_instruction(
+        "The Lighthouse", [], surroundings="to the east, the docks", **base
+    )
+    assert legacy == image_edit.build_enter_instruction(
+        "The Lighthouse",
+        [],
+        surroundings="to the east, the docks",
+        surroundings_pov=False,
+        **base,
+    )
+    # Visible list: view-relative framing + the ban list; no map-bearing talk.
+    pov = image_edit.build_enter_instruction(
+        "The Lighthouse",
+        [],
+        surroundings="at the far left of frame far off, the Sea Wall",
+        surroundings_pov=True,
+        surroundings_behind="The Docks; Town Houses",
+        **base,
+    )
+    assert "From this viewpoint the only mapped landmarks in sight are" in pov
+    assert (
+        "Out of frame behind the camera (NOT visible, do not draw): "
+        "The Docks; Town Houses." in pov
+    )
+    assert "map placed them" not in pov
+    # Nothing in the frustum: the backdrop is declared EMPTY.
+    empty = image_edit.build_enter_instruction(
+        "The Lighthouse",
+        [],
+        surroundings=None,
+        surroundings_pov=True,
+        surroundings_behind="The Docks",
+        **base,
+    )
+    assert "No other mapped landmark is visible from this viewpoint" in empty
+    assert "do NOT introduce distant buildings" in empty
+    # The view-grammar (nano family) path words POV the same way.
+    pov_view = image_edit.build_enter_instruction(
+        "The Lighthouse",
+        [],
+        surroundings=None,
+        surroundings_pov=True,
+        surroundings_behind="The Docks",
+        view={"projection": "eye_level"},
+        family="nano",
+        **base,
+    )
+    assert "No other mapped landmark is visible from this viewpoint" in pov_view
+    assert "The Docks" in pov_view

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -2441,6 +2441,17 @@ export default function PlayPage() {
               ...(worldTap.surroundings
                 ? { prefetched_surroundings: worldTap.surroundings }
                 : {}),
+              // Sightline-culled (scene taps): the surroundings are VIEW-relative
+              // and the out-of-frustum landmarks ride as an explicit do-not-draw
+              // list — what the camera can't see never bleeds into the backdrop.
+              ...(worldTap.surroundings_pov
+                ? {
+                    surroundings_pov: true,
+                    ...(worldTap.surroundings_behind
+                      ? { surroundings_behind: worldTap.surroundings_behind }
+                      : {}),
+                  }
+                : {}),
             }
           : {}),
         // Scene-level ladder (spread after worldTap so the image-registered

--- a/apps/web/lib/geo-tap.test.ts
+++ b/apps/web/lib/geo-tap.test.ts
@@ -5,6 +5,7 @@ import type { MapCrop, SceneView, WorldEntityGeo } from "@openflipbook/config";
 import {
   degradedSubmapTap,
   describeSurroundings,
+  describeVisibleSurroundings,
   frameCropToImageBox,
   geoTapForEntity,
   geoTapRequest,
@@ -670,5 +671,65 @@ describe("conditioning crop alignment (the reference IS the promise)", () => {
     expect(regionBoxFor({ ...tap, focus_id: "other" }, closeupView)).toBeNull();
     // entering without a closeup context keeps the classic crop
     expect(regionBoxFor(tap, null)).toBeNull();
+  });
+});
+
+describe("describeVisibleSurroundings (the sightline cull)", () => {
+  // The lighthouse failure, reconstructed: tower on the west point, observer
+  // approaches from the south looking NORTH (gaze -PI/2, y grows down), the
+  // docks and town lie east — BEHIND the camera's frustum, where the old
+  // bearing wording still painted them into the backdrop.
+  const lighthouse = geo("lh", "The Lighthouse", 20, 30, {
+    footprint: { w: 6, d: 6 },
+  });
+  const docks = geo("dk", "The Docks", 60, 32);
+  const town = geo("tw", "Town Houses", 70, 22);
+  const seaRock = geo("sr", "Gull Rock", 15, 8, { visual: "a bare sea stack" });
+  const observer = {
+    pos: { x: 20, y: 42 },
+    eye_height: 1.7,
+    gaze: -Math.PI / 2,
+    pitch: 0,
+    fov: Math.PI / 2,
+  };
+
+  it("culls out-of-frustum landmarks into `behind`, keeps in-view ones", () => {
+    const r = describeVisibleSurroundings(
+      "lh",
+      [lighthouse, docks, town, seaRock],
+      observer,
+    );
+    expect(r.visible).toContain("Gull Rock (a bare sea stack)");
+    expect(r.visible).not.toContain("Docks");
+    expect(r.visible).not.toContain("Town Houses");
+    expect(r.behind).toContain("The Docks");
+    expect(r.behind).toContain("Town Houses");
+  });
+
+  it("nothing in the frustum → empty visible, everything in behind", () => {
+    const r = describeVisibleSurroundings("lh", [lighthouse, docks, town], observer);
+    expect(r.visible).toBe("");
+    expect(r.behind).toBe("The Docks; Town Houses");
+  });
+
+  it("orders in-view mates left to right and words the frame side", () => {
+    // Looking EAST (gaze 0): north neighbour = left of frame, south = right.
+    const east = { ...observer, pos: { x: 20, y: 30 }, gaze: 0 };
+    const north = geo("n", "North Tower", 50, 12);
+    const south = geo("s", "South Gate", 50, 48);
+    const r = describeVisibleSurroundings("lh", [lighthouse, south, north], east);
+    const iN = r.visible.indexOf("North Tower");
+    const iS = r.visible.indexOf("South Gate");
+    expect(iN).toBeGreaterThanOrEqual(0);
+    expect(iS).toBeGreaterThan(iN);
+    expect(r.visible.slice(0, iN)).toContain("left");
+    expect(r.visible.slice(iN, iS + 10)).toContain("right");
+  });
+
+  it("unknown focus → empty", () => {
+    expect(describeVisibleSurroundings("ghost", [lighthouse], observer)).toEqual({
+      visible: "",
+      behind: "",
+    });
   });
 });

--- a/apps/web/lib/geo-tap.ts
+++ b/apps/web/lib/geo-tap.ts
@@ -47,6 +47,13 @@ export interface GeoTap {
   // stone, concentric rings, moss-covered) across zoom levels, even as the angle
   // changes between map and scene.
   focus_visual: string | null;
+  // Sightline-culled surroundings (scene taps only): `surroundings` becomes
+  // VIEW-relative (frame positions from the observer pose) and
+  // `surroundings_behind` names the out-of-frustum landmarks the instruction
+  // bans from the backdrop. Unset on submap/closeup taps (map register has
+  // no camera).
+  surroundings_pov?: boolean;
+  surroundings_behind?: string;
   // The focus's FRAME-MATES drawn straight from the geo (their real bearings +
   // appearance descriptors), e.g. "to the north-east, The Citadel (square-towered
   // stone bastion on a rise); to the south, The Docks (masted ships)". Fed as the
@@ -98,6 +105,75 @@ export function describeSurroundings(
       .map((m) => `to the ${m.dir}, ${m.label}${m.visual ? ` (${m.visual})` : ""}`)
       .join("; ") + "."
   );
+}
+
+/** Sightline-aware surroundings for an ENTERED scene: the observer pose's view
+ *  frustum decides what the camera can actually see. In-frustum frame-mates are
+ *  described by their place IN FRAME (left/ahead/right + a distance word, sorted
+ *  left-to-right); everything else lands in `behind` — the explicit NOT-visible
+ *  list the instruction bans from the backdrop. The live failure this kills: the
+ *  lighthouse enter faced open sea, and the bearing-worded neighbours ("to the
+ *  east, the docks") were painted into the background anyway. Pure. */
+export function describeVisibleSurroundings(
+  focusId: string,
+  entities: WorldEntityGeo[],
+  observer: ObserverPose,
+  max = 5,
+): { visible: string; behind: string } {
+  const focus = entities.find((e) => e.id === focusId);
+  if (!focus) return { visible: "", behind: "" };
+  const parent = focus.parent_id ?? null;
+  const half = (observer.fov > 0 ? observer.fov : Math.PI / 2) / 2;
+  // A touch past the frustum edge still reads as "edge of frame".
+  const EDGE_PAD = 0.15;
+  // Distance words scale with the focus itself (world units are scale-free).
+  const unit = Math.max(focus.footprint.w, focus.footprint.d, 8);
+  const seen: { label: string; visual: string; angle: number; dist: number }[] = [];
+  const hidden: { label: string; dist: number }[] = [];
+  for (const m of entities) {
+    if (m.id === focusId || (m.parent_id ?? null) !== parent || !m.label.trim()) {
+      continue;
+    }
+    const bearing = Math.atan2(m.pos.y - observer.pos.y, m.pos.x - observer.pos.x);
+    let d = bearing - observer.gaze;
+    while (d > Math.PI) d -= 2 * Math.PI;
+    while (d < -Math.PI) d += 2 * Math.PI;
+    const dist = Math.hypot(m.pos.x - observer.pos.x, m.pos.y - observer.pos.y);
+    if (Math.abs(d) <= half + EDGE_PAD) {
+      seen.push({ label: m.label.trim(), visual: (m.visual ?? "").trim(), angle: d, dist });
+    } else {
+      hidden.push({ label: m.label.trim(), dist });
+    }
+  }
+  // Screen coords (y down): a positive gaze-relative angle is to the RIGHT.
+  seen.sort((a, b) => a.angle - b.angle);
+  hidden.sort((a, b) => a.dist - b.dist);
+  const side = (a: number): string =>
+    a < -half * 0.6
+      ? "at the far left of frame"
+      : a < -0.2
+        ? "ahead to the left"
+        : a > half * 0.6
+          ? "at the far right of frame"
+          : a > 0.2
+            ? "ahead to the right"
+            : "straight ahead";
+  const distWord = (d: number): string =>
+    d < unit * 3 ? "close by" : d < unit * 8 ? "in the middle distance" : "far off";
+  const visible = seen
+    .slice(0, max)
+    .map(
+      (m) =>
+        `${side(m.angle)} ${distWord(m.dist)}, ${m.label}${m.visual ? ` (${m.visual})` : ""}`,
+    )
+    .join("; ");
+  return {
+    visible: visible ? visible + "." : "",
+    behind: hidden
+      .slice(0, 6)
+      .map((h) => h.label)
+      .join("; "),
+  };
 }
 
 /**
@@ -282,6 +358,7 @@ function buildSceneTap(
     kids.length > 0
       ? kids.map((k) => ({ ...k, pos: resolveAbsolutePos(k.id, byId) ?? k.pos }))
       : [];
+  const pov = describeVisibleSurroundings(focusId, allEntities, observer);
   return {
     kind: "scene",
     scene_view: {
@@ -301,7 +378,11 @@ function buildSceneTap(
     focus_id: focusId,
     focus_label: byId.get(focusId)?.label ?? null,
     focus_visual: byId.get(focusId)?.visual ?? null,
-    surroundings: describeSurroundings(focusId, allEntities),
+    // Sightline-culled: what the observer pose can actually see, not the
+    // focus's compass neighbours — see describeVisibleSurroundings.
+    surroundings: pov.visible,
+    surroundings_pov: true,
+    surroundings_behind: pov.behind,
   };
 }
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -137,6 +137,12 @@ export interface GenerateRequestBody {
   // Citadel NE") carried back so the planner keeps the entered place's
   // neighbours where the parent map had them. Mirrors GenerateBody.
   prefetched_surroundings?: string;
+  // Sightline-culled surroundings (world geometry): prefetched_surroundings is
+  // VIEW-relative (frame positions from the observer pose, not map bearings)
+  // and surroundings_behind names the mapped landmarks OUTSIDE the view
+  // frustum - banned from the backdrop. Absent -> legacy bearing wording.
+  surroundings_pov?: boolean;
+  surroundings_behind?: string;
   // Multi-turn refer (SAMA / MM-Conv): when the user rejects a resolved
   // subject and taps again nearby, the client forwards the rejected
   // phrase so the VLM picks something different next time.


### PR DESCRIPTION
Live catch on the lighthouse enter: the observer faces open sea, yet the docks and town render in the background. `describeSurroundings` words frame-mates as compass bearings around the FOCUS, and the enter instruction commands "keep the neighbours where the map placed them... distant glimpses at the edges of frame" — every neighbour, regardless of where the camera stands or looks. The geometry that knows better (observer pos + gaze + FOV, entity positions) already existed for `expected_layout`; the surroundings text never used it.

- **`describeVisibleSurroundings`** (geo-tap): frustum-culls frame-mates against the observer pose — in-view mates worded by their place IN FRAME (left/ahead/right + distance, sorted left→right), the rest in a behind list. Scene taps send `surroundings_pov` + `surroundings_behind` (additive, parity-gated).
- **`_pov_surroundings_text`** (all four enter builders): view-relative wording, an explicit "out of frame behind the camera — do not draw" ban list, and when NOTHING is in the frustum the backdrop is declared open and empty. POV only applies on the prefetched geo path — VLM click-resolve fallback keeps legacy wording; defaults keep every legacy byte (goldens untouched).

## Test plan
- [x] 610 web tests (4 new sightline-cull cases incl. the lighthouse reconstruction), tsc
- [x] Backend full not-paid suite + new POV pin test (legacy parity, ban list, empty-backdrop line, view-grammar path); ruff + mypy
- [ ] Harness re-prove: harbor enter judged on a sightline axis post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)