### PR TITLE
chore(cleanup): 2026-06-13 delta re-run (8 concerns over new code)

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -29,11 +29,15 @@ import modal
 
 if TYPE_CHECKING:
     # Type-only — the providers are imported lazily at the call sites (Modal cold
-    # start cost), but mypy needs the shapes to check the geometry boundary. The
-    # geometry TypedDict is aliased to avoid clashing with this module's Pydantic
-    # `ProjectedEntity` wire model (same shape; model_dump() yields the TypedDict).
+    # start cost), but mypy needs the shapes to check the geometry boundary and the
+    # render/edit-loop accumulators. The geometry TypedDict is aliased to avoid
+    # clashing with this module's Pydantic `ProjectedEntity` wire model (same shape;
+    # model_dump() yields the TypedDict).
     from providers.detector import Detection
+    from providers.edit_loop import EditAttempt
     from providers.geometry import ProjectedEntity as ProjectedEntityDict
+    from providers.judge import JudgeResult
+    from providers.render_loop import Attempt
     from providers.view_estimator import ViewEstimate
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -948,7 +952,7 @@ async def _event_stream(
                     inp_result = await _render_inpaint("")
                 else:
                     edit_cfg = edit_loop.edit_loop_config_from_env(body.max_attempts)
-                    edit_attempts: list[Any] = []
+                    edit_attempts: list[EditAttempt] = []
                     # The alignment judge checks the inside crop against the
                     # fill DESCRIPTION (the region's expected final content) —
                     # a raw command like "remove the tower" isn't judgeable
@@ -1054,7 +1058,7 @@ async def _event_stream(
                         )
 
                     judge_cfg = edit_loop.edit_loop_config_from_env(body.max_attempts)
-                    judged_attempts: list[Any] = []
+                    judged_attempts: list[EditAttempt] = []
                     async for judged_att in edit_loop.iter_edit_attempts(
                         _render_judged_edit,
                         source_bytes=judge_source,
@@ -2000,13 +2004,13 @@ async def _event_stream(
                 detail_features = [f for f in plan.facts if f and f.strip()]
                 detail_title = plan.page_title or effective_query
 
-                async def _judge_detail(img_bytes: bytes) -> Any:
+                async def _judge_detail(img_bytes: bytes) -> JudgeResult:
                     return await judge.score_feature_articulation(
                         img_bytes, detail_title, detail_features
                     )
 
                 loop_cfg = render_loop.loop_config_from_env(body.max_attempts)
-                loop_attempts: list[Any] = []
+                loop_attempts: list[Attempt] = []
                 async for loop_att in render_loop.iter_attempts(
                     _render_enter,
                     projection=str((enter_view or {}).get("projection") or ""),

--- a/apps/modal-backend/providers/edit_loop.py
+++ b/apps/modal-backend/providers/edit_loop.py
@@ -36,7 +36,13 @@ from PIL import Image
 from providers.judge import JudgeResult
 from providers.pixel_diff import changed_fraction
 from providers.prompt_library.feedback import edit_retry_feedback_clause
-from providers.render_loop import MAX_ATTEMPTS_CAP, Rendered, judge_concurrently
+from providers.render_loop import (
+    MAX_ATTEMPTS_CAP,
+    Rendered,
+    _env_float,
+    _score,
+    judge_concurrently,
+)
 
 
 @dataclass(frozen=True)
@@ -52,12 +58,6 @@ class EditLoopConfig:
 
 
 def edit_loop_config_from_env(max_attempts: int | None = None) -> EditLoopConfig:
-    def _f(name: str, default: float) -> float:
-        try:
-            return float(os.environ.get(name, ""))
-        except ValueError:
-            return default
-
     try:
         attempts = int(os.environ.get("EDIT_LOOP_MAX_ATTEMPTS", ""))
     except ValueError:
@@ -66,10 +66,10 @@ def edit_loop_config_from_env(max_attempts: int | None = None) -> EditLoopConfig
         attempts = min(MAX_ATTEMPTS_CAP, max_attempts)
     return EditLoopConfig(
         max_attempts=max(1, attempts),
-        accept_alignment=_f("EDIT_LOOP_ACCEPT_ALIGNMENT", 7.0),
-        accept_medium=_f("EDIT_LOOP_ACCEPT_MEDIUM", 6.0),
-        outside_change_max=_f("EDIT_LOOP_OUTSIDE_MAX", 0.02),
-        retry_budget_s=_f("EDIT_LOOP_RETRY_BUDGET_S", 240.0),
+        accept_alignment=_env_float("EDIT_LOOP_ACCEPT_ALIGNMENT", 7.0),
+        accept_medium=_env_float("EDIT_LOOP_ACCEPT_MEDIUM", 6.0),
+        outside_change_max=_env_float("EDIT_LOOP_OUTSIDE_MAX", 0.02),
+        retry_budget_s=_env_float("EDIT_LOOP_RETRY_BUDGET_S", 240.0),
     )
 
 
@@ -118,10 +118,6 @@ def inside_crop_bytes(
         return buf.getvalue()
     except Exception:
         return image_bytes
-
-
-def _score(j: JudgeResult | None) -> float:
-    return j.score if j is not None else -1.0
 
 
 def _outside_key(outside: float | None) -> float:

--- a/apps/modal-backend/providers/render_loop.py
+++ b/apps/modal-backend/providers/render_loop.py
@@ -60,13 +60,16 @@ class LoopConfig:
 MAX_ATTEMPTS_CAP = 4
 
 
-def loop_config_from_env(max_attempts: int | None = None) -> LoopConfig:
-    def _f(name: str, default: float) -> float:
-        try:
-            return float(os.environ.get(name, ""))
-        except ValueError:
-            return default
+def _env_float(name: str, default: float) -> float:
+    """Parse an env var as a float; fall back to `default` if unset/garbage.
+    Shared by the render and edit loop config readers."""
+    try:
+        return float(os.environ.get(name, ""))
+    except ValueError:
+        return default
 
+
+def loop_config_from_env(max_attempts: int | None = None) -> LoopConfig:
     try:
         attempts = int(os.environ.get("VIEW_LOOP_MAX_ATTEMPTS", ""))
     except ValueError:
@@ -75,11 +78,11 @@ def loop_config_from_env(max_attempts: int | None = None) -> LoopConfig:
         attempts = min(MAX_ATTEMPTS_CAP, max_attempts)
     return LoopConfig(
         max_attempts=max(1, attempts),
-        accept_conformance=_f("VIEW_LOOP_ACCEPT_CONFORMANCE", 7.0),
-        accept_same_place=_f("VIEW_LOOP_ACCEPT_SAME_PLACE", 6.0),
-        accept_detail=_f("VIEW_LOOP_ACCEPT_DETAIL", 6.0),
-        accept_medium=_f("VIEW_LOOP_ACCEPT_MEDIUM", 6.0),
-        retry_budget_s=_f("VIEW_LOOP_RETRY_BUDGET_S", 240.0),
+        accept_conformance=_env_float("VIEW_LOOP_ACCEPT_CONFORMANCE", 7.0),
+        accept_same_place=_env_float("VIEW_LOOP_ACCEPT_SAME_PLACE", 6.0),
+        accept_detail=_env_float("VIEW_LOOP_ACCEPT_DETAIL", 6.0),
+        accept_medium=_env_float("VIEW_LOOP_ACCEPT_MEDIUM", 6.0),
+        retry_budget_s=_env_float("VIEW_LOOP_RETRY_BUDGET_S", 240.0),
     )
 
 

--- a/apps/modal-backend/tests/continuity_bench/coherence_runner.py
+++ b/apps/modal-backend/tests/continuity_bench/coherence_runner.py
@@ -37,7 +37,7 @@ from ._score import score_continuation
 # MAP_IMAGE_FRAME / extract seed): world (x,y) ↦ image fraction (x/100, y/60).
 _FRAME_W = 100.0
 _FRAME_H = 60.0
-# Region crop size per axis (mirror of lib/image-condition.ts cropRegion default).
+# Region crop size per axis (mirror of lib/image-condition.ts region-crop default).
 _REGION_FRAC = 0.42
 _REPORTS = Path(__file__).resolve().parent / "reports"
 

--- a/apps/modal-backend/tests/continuity_bench/enter_runner.py
+++ b/apps/modal-backend/tests/continuity_bench/enter_runner.py
@@ -134,7 +134,7 @@ class CaseResult:
 
 
 def _crop_region(map_bytes: bytes, tap: tuple[float, float]) -> bytes:
-    """Pillow mirror of the client's cropRegion (frac via crop_box) — the same
+    """Pillow mirror of the client's region crop (cropBox + cropRegionRect) — the same
     region ref the frontend would send for this tap. Test-only dep (Pillow is
     not in the backend runtime)."""
     from PIL import Image

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -531,13 +531,6 @@ export async function countPresence(sessionId: string): Promise<number> {
   });
 }
 
-export interface SessionNodeEvent {
-  id: string;
-  parent_id: string | null;
-  title: string;
-  created_at: string;
-}
-
 /** A change-stream over this session's node inserts — the read-along feed.
  * Requires a replica set (the compose stack runs single-node rs0); callers
  * catch the unsupported error and degrade. */

--- a/apps/web/lib/image-condition.ts
+++ b/apps/web/lib/image-condition.ts
@@ -63,25 +63,6 @@ export function orderedRefs(refs: {
   return { urls, roles };
 }
 
-/**
- * Crop a `frac`-sized region around (xPct,yPct) of `src` (a data URL or an
- * http(s) URL) → a JPEG data URL. `crossOrigin="anonymous"` keeps the canvas
- * untainted when `src` is a persisted blob on another origin (R2/Minio), so
- * `toDataURL` doesn't throw a SecurityError — that's what made the region crop
- * (the "from corners" signal) silently drop on continued sessions. Needs the
- * blob store to send CORS headers (Minio does by default; R2 needs CORS
- * enabled). Best-effort; on any failure the caller falls back to whole-parent
- * conditioning.
- */
-export async function cropRegion(
-  src: string,
-  xPct: number,
-  yPct: number,
-  frac = 0.42,
-): Promise<string> {
-  return cropRegionRect(src, cropBox(xPct, yPct, frac));
-}
-
 // The models redraw at ~1MP from whatever we hand them: a 0.28-fraction crop
 // of a ~1.3k-wide map is a ~370px postage stamp, and a model told to stay
 // faithful to a postage stamp paints mush (the photocopier closeup). Upscale
@@ -105,7 +86,11 @@ export async function cropRegionRect(
   box: { x: number; y: number; w: number; h: number },
 ): Promise<string> {
   const img = new Image();
-  // Must be set before `src`. No-op for same-origin data URLs.
+  // `crossOrigin="anonymous"` keeps the canvas untainted when `src` is a blob on
+  // another origin (R2/Minio), so `toDataURL` doesn't throw a SecurityError — that's
+  // what made the region crop silently drop on continued sessions (needs CORS headers
+  // on the blob store: Minio sends them by default, R2 needs them enabled). Must be
+  // set before `src`; no-op for same-origin data URLs.
   img.crossOrigin = "anonymous";
   img.decoding = "async";
   img.src = src;

--- a/docs/PLAN_EDITING.md
+++ b/docs/PLAN_EDITING.md
@@ -24,7 +24,7 @@ predate everything we now know.
 | NL entity editor (codex → "move the lighthouse north") | Shipped (`/edit-entities`, GeoEditPanel, blast radius). | Edits the WORLD MODEL (coordinates) only — never the pixels. The two systems don't talk. |
 | Grounding repair (auto `add a X / move the Y`) | Shipped, flag-gated, system-driven. | Never user-triggerable; its `repair_instruction` machinery is exactly a "fix this" primitive going unused by humans. |
 | Inpaint | SMOKE-VERIFIED (2026-06-10, `tests/edit_bench/mask_smoke.py`): `fal-ai/flux-pro/v1/fill` is a true compositor — inside 0.395 changed, outside 0.0000, white=inpaint, dims kept. It is the PRIMARY. `openai/gpt-image-2/edit` accepts `mask_url` but repaints the whole canvas under every convention (outside 0.28/0.999/1.0; no-mask churn floor 0.089) — not an inpaint fallback. | Provider function + UI still to wire (E1). |
-| Region machinery | `cropRegion` (TS) / `crop_box` (py) ship for enter-conditioning. | Not exposed as a selection tool. |
+| Region machinery | `cropRegionRect` (TS) / `crop_box` (py) ship for enter-conditioning. | Not exposed as a selection tool. |
 | The new assets (reuse these, don't rebuild) | `providers/judge.py` (5 judges incl. `score_prompt_alignment` + `score_feature_articulation`), `providers/render_loop.py` (critic-guided retries, keep-best, feedback clauses), `prompt_library` (medium locks, registers), `routeClick` (geo hit-test: we KNOW what you clicked). | — |
 
 ## E1 — Select area → "fix this and that" (the headline)

--- a/docs/cleanup/2026-06-13-rerun/00-summary.md
+++ b/docs/cleanup/2026-06-13-rerun/00-summary.md
@@ -14,7 +14,7 @@ to remove and four annotations to tighten — everything else KEEP. No TS↔Pyda
 
 | # | Concern | Verdict | Action / commit |
 |---|---------|---------|-----------------|
-| 1 | Dedup / DRY | new code strongly DRY | No AUTO. 1 report-only (`edit_loop` duplicates `render_loop`'s `_score`/`_f`; paid path). `_clamp01` in segmenter/detector = KEEP (prior 07 decision). |
+| 1 | Dedup / DRY | new code strongly DRY | 1 dedup landed on request (`843a653`): lifted the env-float parser to a shared `render_loop._env_float`, imported `_score` rather than redefining. `_clamp01` in segmenter/detector = KEEP (prior 07 decision). |
 | 2 | Shared types / TS↔Pydantic | **clean** | No drift: 40 TS == 40 Py request fields; 8 new fields (`max_attempts`, `verify`, `edit_mask`, `edit_region`, `surroundings_pov/behind`, `suppress_map_labels`, `from_closeup`) at parity. New closeup code imports config types rather than redeclaring. 3 low report-only intra-web tidies. |
 | 3 | Unused (knip + ruff F401) | 1 dead export | Removed `SessionNodeEvent` (db.ts, 0 refs anywhere). Python `ruff F401` clean. 3 known false positives (theme-init.js, ladder-proof.mjs, record-mappan.ts) excluded. `6064f48` |
 | 4 | Circular (madge) | **clean** | 218 TS files, 0 cycles. Python providers a DAG (manual import-graph check; new files are leaves). No change. |
@@ -25,11 +25,10 @@ to remove and four annotations to tighten — everything else KEEP. No TS↔Pyda
 
 ## Report-only (handed back for your call — none auto-applied)
 
-1. **`edit_loop._score` + `_f` duplicate `render_loop`** — byte-identical. It's the paid
-   render/edit path, so not auto-touched per the safe-auto bar. Safe slice: `edit_loop` already
-   imports 3 symbols from `render_loop`; importing `_score` and lifting the `_f` env-float parser
-   removes the copy. The loop skeletons themselves should stay parallel siblings (different
-   judges/configs).
+1. **`edit_loop._score` + `_f` duplicate `render_loop`** — DONE on request (`843a653`): lifted the
+   env-float parser to a shared `render_loop._env_float` and imported `_score` rather than
+   redefining it. The loop skeletons stay parallel siblings (different judges/configs); behavior
+   unchanged, `make eval` green.
 2. **generate.py `result` / `judged_image` stay `Any`** — reassigned across branches mixing
    `render_loop.conclude(...).image` (typed `Rendered`) with `GeneratedImage`-only attribute reads
    (`.mime_type`/`.model`); the `Any` is deliberate protocol-erasure (one site already carries a

--- a/docs/cleanup/2026-06-13-rerun/00-summary.md
+++ b/docs/cleanup/2026-06-13-rerun/00-summary.md
@@ -1,0 +1,48 @@
+# Cleanup re-run — 2026-06-13 (delta over the closeup/ladder/POV program)
+
+The eight concerns ran Jun 7 (`7de5779`) + a delta re-run Jun 9 (`beedb82`). Since then
+157 commits added ~7.8k TS + ~14k Py lines — the closeup rung, scene-closeups, the
+conditioning-crop routing window, sightline-culled POV-surroundings (PRs #64–#87) — none
+through cleanup. This is a full-tree re-audit of all eight concerns concentrated on that new
+code; each concern's standard is its original `0N` doc plus the Jun 9 rerun. Run decisions:
+**delta-over-baseline**, **cover TS + Python**, **safe-auto / risky-report**.
+
+**Outcome: the discipline held again.** Across ~22k new lines the audit found two dead symbols
+to remove and four annotations to tighten — everything else KEEP. No TS↔Pydantic contract drift
+(the strengthened field-equality gate absorbed 8 new request fields at parity), 0 circular deps,
+0 error-hiding, 0 slop comments.
+
+| # | Concern | Verdict | Action / commit |
+|---|---------|---------|-----------------|
+| 1 | Dedup / DRY | new code strongly DRY | No AUTO. 1 report-only (`edit_loop` duplicates `render_loop`'s `_score`/`_f`; paid path). `_clamp01` in segmenter/detector = KEEP (prior 07 decision). |
+| 2 | Shared types / TS↔Pydantic | **clean** | No drift: 40 TS == 40 Py request fields; 8 new fields (`max_attempts`, `verify`, `edit_mask`, `edit_region`, `surroundings_pov/behind`, `suppress_map_labels`, `from_closeup`) at parity. New closeup code imports config types rather than redeclaring. 3 low report-only intra-web tidies. |
+| 3 | Unused (knip + ruff F401) | 1 dead export | Removed `SessionNodeEvent` (db.ts, 0 refs anywhere). Python `ruff F401` clean. 3 known false positives (theme-init.js, ladder-proof.mjs, record-mappan.ts) excluded. `6064f48` |
+| 4 | Circular (madge) | **clean** | 218 TS files, 0 cycles. Python providers a DAG (manual import-graph check; new files are leaves). No change. |
+| 5 | Weak types | 4 annotations (TS: 0) | generate.py loop accumulators typed: `loop_attempts: list[Attempt]`, `edit_attempts`/`judged_attempts: list[EditAttempt]`, `_judge_detail -> JudgeResult` (TYPE_CHECKING imports). TS added 0 weak types. `result`/`judged_image` `Any` = load-bearing protocol-erasure, KEEP. `83e3262` |
+| 6 | Defensive (fail-loud) | **0 removals** | ~50 new handlers, all guard real boundaries (network/IO, untrusted VLM/LLM JSON, base64, browser quirk, observability). The new pure-logic layer has no try/catch at all. 0 error-hiding. No change. |
+| 7 | Legacy / fallback | 1 dead path | Removed `cropRegion` (image-condition.ts) — orphaned by the conditioning-crop refactor (`6018503`); CORS rationale relocated to `cropRegionRect`, 3 references re-pointed. `_legacy_*_instruction`, the 5 new product flags, `PROVIDER_FALLBACK` etc. are all live + tested = KEEP. `6064f48` |
+| 8 | Comments / slop | **0 edits** | New code carries zero in-motion / PR / audit / stub narration; INV-*/ladder/closeup vocabulary + why-rationale intact. No change. |
+
+## Report-only (handed back for your call — none auto-applied)
+
+1. **`edit_loop._score` + `_f` duplicate `render_loop`** — byte-identical. It's the paid
+   render/edit path, so not auto-touched per the safe-auto bar. Safe slice: `edit_loop` already
+   imports 3 symbols from `render_loop`; importing `_score` and lifting the `_f` env-float parser
+   removes the copy. The loop skeletons themselves should stay parallel siblings (different
+   judges/configs).
+2. **generate.py `result` / `judged_image` stay `Any`** — reassigned across branches mixing
+   `render_loop.conclude(...).image` (typed `Rendered`) with `GeneratedImage`-only attribute reads
+   (`.mime_type`/`.model`); the `Any` is deliberate protocol-erasure (one site already carries a
+   comment saying so). Recommend KEEP.
+3. **3 low intra-web type tidies (#2)** — e.g. `scene-closeup.ts` `regionBox: {x,y,w,h}` vs
+   `EditRegionBox`; cosmetic, not a config consolidation.
+
+## Notes
+
+- The new senders reuse the conditional-spread pattern that hid the earlier
+  `prefetched_surroundings` / `focus_id` drifts, but the full `GenerateBody`↔`GenerateRequestBody`
+  field-equality gate now catches that class — and did: zero divergence this delta.
+- `make eval` types `providers obs.py generate.py` (which covers `llm.py` via `providers`), so the
+  generate.py annotations above are gate-verified — green at `83e3262`.
+
+Per-concern detail in the `0N-*.md` files in this directory.

--- a/docs/cleanup/2026-06-13-rerun/01-unused-code.md
+++ b/docs/cleanup/2026-06-13-rerun/01-unused-code.md
@@ -1,0 +1,68 @@
+# Cleanup re-run — 2026-06-13 · Concern #3 Unused code (knip + ruff F401)
+
+DELTA pass over the +157 commits / ~7.8k TS + ~14k Py added since `beedb82`
+(closeup / ladder / POV program, PRs #64–#87). Prior standard: `docs/cleanup/01-unused-code.md`;
+prior delta: `docs/cleanup/00-rerun-2026-06-09.md`. Prior KEEPs treated as default.
+
+## Assessment
+
+The discipline held again. **Python is spotless** — `ruff check --select F401` =
+`All checks passed!` (zero unused imports). On the TS side knip surfaced 27 items;
+every prior-KEEP export/type re-confirmed still in-file-used, and the dependency /
+binary false-positives that dogged earlier runs are **gone this run** (none flagged).
+Only **one genuinely-dead symbol** appeared in the new code: the orphan interface
+`SessionNodeEvent` (zero refs anywhere). One pre-existing export, `cropRegion`, was
+silently refactor-orphaned of code callers since `beedb82` but is named as a
+cross-language mirror anchor in two Python bench comments + a planning doc, so it is
+REPORT-ONLY (removing it would orphan documented references, and the body logic is
+the reference impl the Python `crop_box` mirrors).
+
+## Tooling output (fresh, this run)
+
+- **`ruff check --select F401 apps/modal-backend`** → `All checks passed!` (0 hits).
+- **`knip --config knip.json`** (run from `apps/web`, where knip 6.16.1 lives) →
+  2 "unused files" (both known FPs), 10 "unused exports", 15 "unused exported types".
+  No unused dependencies, no unlisted binaries (cleaner than Jun-7 / Jun-9 runs).
+
+## Findings
+
+| Severity | Verdict | file:line | symbol | Verification done | new/old |
+|---|---|---|---|---|---|
+| **low** | **AUTO-remove** | `apps/web/lib/db.ts:534` | `SessionNodeEvent` (interface) | `rg -ni 'SessionNodeEvent'` across the whole repo (all globs, incl md/json, minus node_modules/lock) → **only its own definition line**. Dynamic-pattern probe (`rg 'NodeEvent\|node_event\|nodeEvent'`) → no string-key/alias use. The live read-along feed at `app/api/session/[sessionId]/events/route.ts:78-88` sends an **inline** `{type:"node_added", node:{…}}` payload, typed client-side via `IncomingNode` (`hooks/useSharedSession.ts:69` — which IS used), never via `SessionNodeEvent`. The sibling `watchSessionNodes()` uses `NodeDoc`. Not a barrel/re-export (no `lib/index.ts`). Same class as the prior runs' removed `hasWSStreaming` / `PlanWorldRequestBody`. | **NEW** (`c0075f1`, after `beedb82`) |
+| **low** | **REPORT-ONLY** | `apps/web/lib/image-condition.ts:76` | `cropRegion` (async fn) | No **code** caller: `rg '\bcropRegion\b'` (ts/tsx/py/mjs, all dirs) → only its def (`:76`) + body (`:82`, which calls `cropRegionRect`). It was a prior-KEEP ("called by buildConditionStack") but the refactor in `6018503`/`4682050` made `buildConditionStack` (`:162`) call the extracted `cropRegionRect` directly, orphaning `cropRegion`. **Held for report** because it is named as the canonical cross-language reference impl: `enter_runner.py:137` ("Pillow mirror of the client's cropRegion"), `coherence_runner.py:40` ("mirror of lib/image-condition.ts cropRegion default"), `docs/PLAN_EDITING.md:27`. Same cross-lang-anchor rationale the prior report used for `EntityGeoEdit`. Removal needs those mirrors re-pointed at `cropRegionRect`/`cropBox` first. | **OLD def, NEWLY orphaned** |
+| info | DO-NOT-TOUCH | `public/theme-init.js` | (file) | Known FP. Loaded via runtime `<script src="/theme-init.js" />` at `app/layout.tsx:72` (confirmed) — knip can't see runtime script tags. | old |
+| info | DO-NOT-TOUCH | `scripts/ladder-proof.mjs` | (file) | Known FP. Makefile `ladder-proof` target + user's uncommitted edits (shows as `M` in git status). | old |
+| info | KEEP | `apps/web/lib/modal.ts:13` | `SHARED_TOKEN_HEADER` | Used in-file at `:17` (`{[SHARED_TOKEN_HEADER]: token}`) **and** is the TS half of the `x-openflipbook-token` auth header mirrored by `generate.py:65` (literal match confirmed; also exercised in `test_deploy_safety.py`). Cross-language contract. | NEW |
+| info | KEEP | `apps/web/lib/image-condition.ts:103` | `cropRegionRect` | Used in-file: called at `:82` (by `cropRegion`) and `:162` (by `buildConditionStack`). Live. | NEW |
+| info | KEEP | `apps/web/lib/waterfall-segments.ts:41` | `IDLE_GAP_MS` | Used in-file at `:65` and `:88`. | NEW |
+| info | KEEP | `apps/web/hooks/useSharedSession.ts:5` | `IncomingNode` (interface) | Used in-file at `:16`, `:30`, `:69` — the actual typed shape of the `node_added` SSE payload. | NEW |
+| info | KEEP | `apps/web/lib/db.ts:425` | `PublishedSessionDoc` (interface) | Used in-file as `Collection<PublishedSessionDoc>` generic at `:443-444`. MongoDB schema surface. | NEW |
+| info | KEEP | `apps/web/lib/db.ts:499` | `PresenceDoc` (interface) | Used in-file as `Collection<PresenceDoc>` generic at `:505-506`. MongoDB schema surface. | NEW |
+| info | KEEP | `apps/web/lib/scale-neighbors.ts:5` | `LogicalNeighbor` (interface) | Used in-file at `:16` (`neighbors: LogicalNeighbor[]`). | NEW |
+| info | KEEP (test-only) | `apps/web/lib/world-map.ts:113,136,174` | `applyGeoUpsert`, `recomputeBounds`, `applyEntityEdit` | Re-exported via `__test` object (`:443`) destructured by `world-map.test.ts`; also used internally (15/9/12 refs). Prior adjudication. | old |
+| info | KEEP (test-only) | `apps/web/lib/world.ts:617` | `scoreEntitiesForContinuity` | Re-exported via `__test` (`:899`), consumed by `world(-helpers).test.ts`; 16 internal refs. Prior adjudication. | old |
+| info | KEEP (in-file) | `lib/styles.ts:79`, `lib/world-overlay.ts:24` | `PRESET_ANCHOR_PREFIX` (3 refs), `viewScale` (3 refs) | In-file usage re-confirmed; prior KEEP. | old |
+| info | KEEP (in-file) | `components/time-scrubber.tsx:5`, `hooks/usePrefetchCache.ts:5,10`, `hooks/useWorldState.ts:12`, `lib/db.ts:98,103,320`, `lib/image-condition.ts:11`, `lib/trace-types.ts:28,36` | `ScrubberFrame`, `PrefetchPoint`, `PrefetchBBox`, `WorldStateView`, `ClickInParent`, `NodeSource`, `ErrorDoc`, `ConditionRole`, `AbortStageRow`, `AbortEntry` | Each ≥2 in-file refs (field/array/param/reducer-state types). All prior-KEEP, re-confirmed. | old |
+
+## Why only one AUTO-remove
+
+`SessionNodeEvent` is provably dead: a single repo-wide case-insensitive grep returns
+nothing but its own declaration, there is no dynamic/string-key indirection, it is not
+a barrel re-export, and the feature it documents (the read-along SSE feed) is fully
+typed by other means. It is safe to delete the 6-line interface with no further
+re-pointing. Everything else knip flags is either an in-file-used `export` (an
+encapsulation question for the types workstream, not dead code), a test-only export
+reached through the `__test` bridge, a MongoDB collection-generic schema type, or a
+cross-language mirror anchor — none of which are dead.
+
+`cropRegion` is the one judgment call: it has no live code caller after the closeup
+refactor, but three docs/Python comments name it as the reference implementation the
+backend's `crop_box` mirrors. Per the standing cross-language rule (and the
+`generate.py`-adjacent caution), it is REPORT-ONLY: if the cleanup wants it gone, the
+two bench comments + `PLAN_EDITING.md` should first be re-pointed at `cropRegionRect`.
+
+## Excluded known false positives (per brief)
+
+- `public/theme-init.js` — runtime `<script>` in `app/layout.tsx:72`. Excluded.
+- `scripts/ladder-proof.mjs` — Makefile target + user's uncommitted edits. Excluded.
+- `record-mappan.ts` — whitelisted in `knip.json` entries; did not appear in output. Excluded.

--- a/docs/cleanup/2026-06-13-rerun/02-circular-deps.md
+++ b/docs/cleanup/2026-06-13-rerun/02-circular-deps.md
@@ -1,0 +1,112 @@
+# Cleanup re-run 2026-06-13 — Concern #4 Circular dependencies (madge + Python DAG)
+
+DELTA verification over the 157 commits added since `beedb82` (closeup / ladder /
+POV; PRs #64–#87). Standard: `docs/cleanup/02-circular-deps.md`. The prior
+re-run (`docs/cleanup/00-rerun-2026-06-09.md`) recorded **Clean**; that is the
+default and the bar to re-confirm. This pass is verification-only — no source or
+config was changed.
+
+## Verdict: CLEAN (no change)
+
+Both the TypeScript madge guard and a manual Python import-graph audit confirm the
+tree is still cycle-free. No back-edge was introduced by the new code.
+
+## 1. TypeScript — madge (verbatim)
+
+Command (the repo's `check:circular`, run from `apps/web`):
+
+```bash
+pnpm exec madge --circular --extensions ts,tsx --ts-config tsconfig.json \
+  app components hooks lib instrumentation.ts instrumentation-client.ts
+```
+
+Result:
+
+```
+Processed 218 files (660ms) (1 warning)
+
+✔ No circular dependency found!
+```
+
+- 218 files (up from 179 at the 2026-06-09 re-run; +39 from the closeup/ladder/POV
+  work) — **zero cycles**.
+- The single "warning" is the same informational non-resolvable-reference skip
+  counter documented in the standard (a JSON/`resolveJsonModule` import), not a
+  cycle; it does not affect the exit code. madge exits 0.
+
+## 2. Python backend — manual DAG audit (no cycle-checker installed)
+
+`apps/modal-backend` is outside madge's reach and has no Python cycle-checker
+installed (none was installed for this pass, per scope). I mapped the
+intra-package import graph of the production source with
+`rg -n "^(from |import )"` and confirmed it is a DAG.
+
+**Modules audited (production source):** `generate.py`, `obs.py`, `_env.py`,
+`local_server.py`, and all of `providers/*.py` + `providers/prompt_library/*.py`
+— including the task-named `model_router.py` and `image.py`. (`ltx_stream.py`,
+`ltxf.py` are standalone Modal entrypoints; `providers/video.py` imports only
+`._common`/`.image`.)
+
+### Layering (top-level / module-scope edges only)
+
+Every top-level intra-package import points *downward* toward leaves — no
+upward/back-edge exists:
+
+- **Leaves (no intra-package top-level imports):** `_env`, `_common`,
+  `prompt_library.types`, `prompt_library.style`, `geometry`, `pixel_diff`,
+  `judge`, `model_router`, `detector`, `breaker`, `spend`, `ratelimit`,
+  `view_estimator`, `geometry_checks`, `heights`, and `layout_solver`
+  (stdlib-only: `math`, `dataclasses`, `typing`).
+- `image` → `_common`. `inpaint` / `image_edit` / `video` → `_common`, `image`,
+  `model_router`.
+- `prompt_library`: `types` ← `style` ← `camera`(→`geometry`,`types`) ←
+  `policy`(→`types`) ← `layout`(→`geometry`) ← `instructions`(→`camera`,`style`,
+  `types`) ← `feedback`(→`camera`) ← `__init__` (aggregator) ← `geometry_prompt`
+  (→`prompt_library.layout`). Acyclic.
+- `render_loop` → `judge`, `prompt_library.feedback`.
+- `edit_loop` → `judge`, `pixel_diff`, `prompt_library.feedback`, `render_loop`.
+- `grounding` → `detector`, `geometry`.
+- **`generate.py`**: its only *top-level* intra-package import is
+  `from _env import env_flag`. All other references to `obs`, `providers.*`, and
+  `prompt_library.*` are **function-local (lazy) imports** resolved at call time,
+  not import time. Nothing imports `generate` except `local_server` (the FastAPI
+  entrypoint) and tests — `generate` is a top-of-graph sink.
+- **`obs.py`**: module-level imports are stdlib + `fastapi` only — **zero** edges
+  into `providers`/`generate`. Providers reach it via lazy `from obs import …`
+  inside function bodies, so it is a clean sink with no return edge.
+
+### Suspect edge checked: `llm` ↔ `layout_solver`
+
+`providers/llm.py` lazily imports `EmptyRegion, PlannedEntity, PlannedRelation,
+SceneGraph` from `.layout_solver` (function-local, under `TYPE_CHECKING`/at call
+sites). `layout_solver.py` imports **only stdlib** (`math`, `dataclasses`,
+`typing`) — no edge back to `llm`. **No cycle.**
+
+### New files since `beedb82` — spot-check for back-edges
+
+`git diff --name-only beedb82..HEAD -- 'apps/modal-backend/**/*.py'` lists the new
+production modules `heights.py`, `geometry_checks.py`, `geometry_prompt.py`,
+`image_edit.py`, `inpaint.py`, `view_estimator.py`, `render_loop.py`,
+`edit_loop.py`, and the `prompt_library/*` split. Checked each one's top-level
+imports:
+
+- `heights`, `geometry_checks`, `view_estimator`, `layout_solver` → **leaves** (no
+  intra-package top-level edges).
+- `geometry_prompt` → `prompt_library.layout` (downward).
+- `image_edit` → `_common`, `image` (downward).
+- `render_loop` / `edit_loop` → `judge` / `pixel_diff` / `prompt_library.feedback`
+  / `render_loop` (all downward).
+
+No new top-level edge points upward. The new code is a DAG; the providers package
+remains a DAG, consistent with the 2026-06-09 finding.
+
+## Summary
+
+| Check | Files | Cycles |
+|---|---|---|
+| madge (`apps/web`, `check:circular`) | 218 | 0 — `✔ No circular dependency found!` |
+| Python `apps/modal-backend` (manual DAG audit) | full production source | 0 — DAG, all top-level edges downward; lazy imports only at call time |
+
+**CLEAN — no change.** No HIGH (or any) finding. The `check:circular` guard wired
+into `make eval` continues to gate the TS side; the Python graph was verified by
+hand and is a DAG.

--- a/docs/cleanup/2026-06-13-rerun/03-legacy.md
+++ b/docs/cleanup/2026-06-13-rerun/03-legacy.md
@@ -1,0 +1,46 @@
+# Cleanup re-run — 2026-06-13 · Concern #7 (deprecated / legacy / dead code paths)
+
+DELTA pass over `git diff beedb82..HEAD` (157 commits, ~7.8k TS + ~14k Py): the
+closeup/ladder/POV-surroundings program (PRs #64–#87). Standard + prior decisions:
+`docs/cleanup/03-legacy.md`; prior delta `docs/cleanup/00-rerun-2026-06-09.md` (concern 3 = Clean).
+
+## Assessment
+
+The ladder/closeup program iterated hard on tap-routing and the conditioning crop,
+but it iterated *in place* — each step refactored the single live path rather than
+forking a parallel one, so almost nothing superseded was left behind. The one real
+find is a dead 4-arg wrapper: `cropRegion` in `image-condition.ts`, which commit
+`6018503` ("the conditioning crop IS the routing window") orphaned by switching
+`buildConditionRefs` to call `cropRegionRect` directly. Everything else flagged by
+the keyword sweep is a live default, an LLM byte-identity prompt-contract
+(`_legacy_*` instruction builders), an external-API tolerance, or a documented +
+tested + env-gated toggle — all matching prior KEEP verdicts, none stale.
+
+## Findings
+
+| Severity | Disposition | File:line | The path | Evidence superseded / not | Conflicts |
+|---|---|---|---|---|---|
+| Low | **AUTO-remove** | `apps/web/lib/image-condition.ts:76-83` | `export async function cropRegion(src, xPct, yPct, frac=0.42)` — the click-centered crop wrapper | **Genuinely superseded + zero callers.** Pre-`6018503`, `buildConditionRefs` called `cropRegion` (old `image-condition.ts:119`). Commit `6018503` rewrote it to call `cropRegionRect(parentDataUrl, regionBox ?? cropBox(...))` directly (now `:162`). Repo-wide `grep -rn "cropRegion" apps/web --include='*.{ts,tsx}'` excluding `cropRegionRect` returns **only its own definition** — 0 non-test callers, 0 test refs, not in `knip.json`. `cropBox` (its only dependency) stays live (used at `:165`), so deletion is the 8 lines only. The 4-arg form is now exactly `cropRegionRect(src, cropBox(x,y,frac))` — a thin dead wrapper. | **#3** (knip flags unused exports; this is its natural owner) · loosely #1/#5 (dead wrapper / one-call dedup) |
+| — | KEEP | `apps/modal-backend/providers/prompt_library/instructions.py:38,80` (`_legacy_zoom_instruction`, `_legacy_enter_instruction`) | the pre-grammar `view=None` byte-identity prompt builders | **Live default branch, test-guarded.** Called at `:585,589` (zoom: `view is None` / no keep-fragment) and `:641` (enter: `view is None` or projection ∉ ENTER set). Test `tests/test_generate_view.py:121-126` asserts the flag-off enter equals `_legacy_enter_instruction` verbatim. Multi-way dispatch (faithful / label_free / view-aware / legacy), all arms reachable. "legacy" = the documented byte-identity contract for old renders, not dead. Same class as prior KEEP (LLM prompt prose + byte-identity). | matches prior KEEP |
+| — | KEEP | `apps/modal-backend/providers/prompt_library/instructions.py:496` (`_faithful_zoom_instruction`) | the closeup-rung magnification string (`33acc21`) | **New live path, not an orphan.** Reached via `build_zoom_instruction` `:583` (`if faithful:`), driven from `generate.py:1857` `faithful=bool(body.scene_view and body.scene_view.closeup)`. The closeup rung reused the existing zoom/Kontext path with a `faithful` flag — it did NOT fork then abandon a parallel closeup builder. No superseded sibling exists. | — |
+| — | KEEP / REPORT-ONLY | `generate.py` flags: `ENTER_STEP_IN_JUDGE`, `EDIT_JUDGE`, `ENTER_EDIT_REF`, `SCALE_OUTWARD_EDIT_REF`, `SCALE_OUTWARD_OUTPAINT` | the new ladder/closeup product toggles | **Each wired in `generate.py` AND has a dedicated test** (`test_generate_enter.py`, `test_generate_edit_judge.py`, `test_generate_view.py`, `test_generate_ascend.py`) with explicit "flag-off is byte-identical legacy" assertions. A flag + test reaching a branch = NOT dead (HARD RULE → REPORT-ONLY at most), and these live in `generate.py` (REPORT-ONLY regardless). `SCALE_OUTWARD_OUTPAINT` was already an explicit prior KEEP (documented+tested+env-gated). The "old / legacy bytes" comments are the *measured BEFORE baseline*, not dead branches. | matches prior KEEP (#28/SCALE_OUTWARD) |
+| — | KEEP | `apps/web/lib/geo-tap.ts:81` (`describeSurroundings`) vs `:117` (`describeVisibleSurroundings`) | non-POV vs sightline-culled surroundings | **Not an old/new pair — two coexisting modes.** `describeSurroundings` is live at `:332` (non-POV branch); `describeVisibleSurroundings` is the POV/sightline branch (`3bd0abc`). Both have non-test callers + 6 tests each. POV is selected by `surroundings_pov`, not a replacement. | — |
+| — | KEEP | `providers/image.py` (`PROVIDER_FALLBACK`, `fallback_chain`, `FALLBACK_CHAINS`) | Wave-4 failover chain | env-gated (`PROVIDER_FALLBACK`, off by default) + fully tested (`tests/test_provider_fallback.py`). Live graceful-degradation feature, not superseded code. | — |
+| — | KEEP | `apps/web/app/play/page.tsx:~2328-2339` (`wideRegionCut`) + `:14134-14170` diff (W1/W2 `fallbackTap` chain) | world-OFF zoom-cut + geo-route fallback | live product degradation paths; `wideRegionCut` has 4 non-test callers + 6 tests; the `fallbackTap` chain is the documented degrade-to-faithful-zoom routing (`3fe29d9`). KEEP. | — |
+| — | KEEP | misc keyword hits across the diff | "old blind coin-flip" critic comment (`generate.py:295`), "old fresh path scored 3" (test prose), "legacy renders keep hardcoded text" (view contract docs), `confidence: 0.0 # a fallback is never trusted`, etc. | All explanatory comments / prompt prose / measured baselines / genuine product defaults. No dual code path. Comment polish is concern #8's remit. | #8 (comments) |
+
+## Net
+
+- **AUTO-remove: 1** — `cropRegion` (`image-condition.ts:76-83`), proven 0 callers / 0 tests, superseded by `cropRegionRect` in `6018503`. (Concern #3 / knip is the alternative owner — coordinate to avoid a double-edit.)
+- **REPORT-ONLY: 0 net new** — the five `generate.py` toggles are tested+wired (not dead); listed for visibility only, no action.
+- **KEEP: all other keyword hits** — `_legacy_*` builders (byte-identity LLM contract), `_faithful_zoom_instruction` (new live path), the env-gated tested flags, the two surroundings modes, the Wave-4 fallback chain, `wideRegionCut`, and the comment-only hits. Consistent with both prior passes' verdicts.
+
+## Method
+
+`git diff beedb82..HEAD -- 'apps/web/**/*.{ts,tsx}' 'packages/**/*.ts' 'apps/modal-backend/**/*.py'` →
+keyword sweep `deprecated|legacy|superseded|no longer|obsolete|old|_v1|_v2|fallback|todo|fixme|hack`
+on added lines; traced the brief's named commits (`6018503`, `33acc21`, `d025f8e`,
+`cf29848`, `2389670`, `6f4d274`, `249fb65`); enumerated every exported fn in the
+iterated TS libs (`geo-tap`, `click-route`, `scene-closeup`, `geo-to-edit`,
+`image-condition`) + the new Wave libs and counted non-test vs test callers; verified
+each Python product flag is both wired in `generate.py` and test-covered.

--- a/docs/cleanup/2026-06-13-rerun/04-types.md
+++ b/docs/cleanup/2026-06-13-rerun/04-types.md
@@ -1,0 +1,90 @@
+# Cleanup re-run 2026-06-13 — Concern #2: shared types + TS↔Pydantic drift
+
+Delta pass over the closeup/ladder/POV-surroundings program (PRs #64–#87, 157
+commits since `beedb82`). Standard = `docs/cleanup/04-types.md` + the 2026-06-09
+re-run; prior KEEPs are the default.
+
+## Assessment
+
+**No TS↔Pydantic contract drift exists in the new code — sub-goal A is clean.**
+The schema-parity gate the prior runs strengthened did its job: every new request
+field landed on BOTH the TS `GenerateRequestBody` and the Pydantic `GenerateBody`
+(field sets are 40-for-40 identical, verified directly), and `WorldContextEntity`
+gained `location_hint` on both sides at parity. The new geo shapes (`ViewSpec`,
+`SceneView.closeup`/`view`, `WorldEntityGeo.border`/`height_m`) are fixture-gated
+in `test_geo_schema.py` (17 tests, all green on HEAD). Response/event additions
+(`EditVerdict`, `image_op`, `session_spend_estimate`, the `draft` stage) are
+TS-source-of-truth, emitted as matching Python dicts, and consumed by typed web
+readers — consistent with prior practice (events are not Pydantic-gated). For
+sub-goal B: the new code is disciplined — it **imports** `EntityBBox`,
+`NodeRelation`, `ScaleKind`, `SceneView`, etc. from `@openflipbook/config` rather
+than redeclaring them, introduces **zero** new `: any`/`as any`, and adds **zero**
+fresh standalone redeclarations of an exported config type. The only consolidation
+notes are pre-existing inline `relation`/`scale` string unions (the delta merely
+added the `"edit"` value to them) and two `{x,y,w,h}` region aliases that mirror an
+inline-only wire shape — all REPORT-ONLY or KEEP.
+
+## Sub-goal A — TS↔Pydantic contract drift: NONE FOUND
+
+Traced every new field on a Pydantic request/response model and every `fetch`
+body in the changed `app/api/**/route.ts` + `page.tsx` senders.
+
+- **`GenerateBody` ↔ `GenerateRequestBody`** — 8 new request fields this delta
+  (`max_attempts`, `verify`, `edit_mask`, `edit_region`, `surroundings_pov`,
+  `surroundings_behind`, `suppress_map_labels`, `from_closeup`) + nested
+  `EditRegion`, `ViewSpec`, `SceneView.closeup`/`view`. **All present on both
+  sides.** Direct field-name diff: 40 TS fields == 40 Py fields, zero divergence
+  either direction. The gate's `test_generate_body_carries_geo_round_trip_fields`
+  asserts FULL set-equality (the assertion the prior run added to close the
+  `prefetched_surroundings` / `focus_id` hole); its TS-interface regex captures
+  all 40 fields, so the equality is real, not falsely satisfied. The new senders
+  use conditional spreads (`...(cond ? { surroundings_pov: true } : {})`) — the
+  same excess-property-check-bypassing pattern that hid the prior bugs — but the
+  full-equality gate now catches that class, and it is green.
+- **`WorldContextEntity`** — gained `location_hint` on both TS and Pydantic;
+  field sets at parity (gated by `test_world_context_entity_mirror_matches_ts`).
+- **`EditVerdict` (new), `image_op`, `session_spend_estimate`, `draft` stage** —
+  TS is the source of truth; Python emits plain dicts whose keys match field-for-
+  field (`generate.py:991`, `:1112`, `:1009`/`:1107`/`:1150`/`:2184`, `:1008`/
+  `:2199`, `:2101`), and the web reads them through the typed `evt`
+  (`page.tsx:818`, `:835` → `formatEditVerdict(v: EditVerdict)`). Not Pydantic-
+  gated, by the same design as the rest of the event stream — REPORT-ONLY, no
+  action (collapsing a TS↔dict event mirror is out of scope per brief).
+- **`ModerateTextBody` (new, `{text: str}`)** — internal `/moderate-text` endpoint
+  (gallery publish, `app/api/gallery/publish/route.ts:50`); inline `{text}` body +
+  inline `{allowed,reason}` response, no `@openflipbook/config` type expected
+  (same as other internal endpoints). Not a contract surface.
+- `AnimateBody`, `ResolveClickBody`, `ExtractEntitiesBody`, `EditEntitiesBody`,
+  `PlanWorldBody` — **unchanged** this delta. Session events/presence routes are
+  pure Mongo (no Python call) — they never cross the boundary.
+
+## Sub-goal B — duplicate type defs in new code
+
+| severity | AUTO/REPORT-ONLY | file:line | issue | recommended change | conflicts-with |
+| --- | --- | --- | --- | --- | --- |
+| info | — | `apps/web/lib/entity-hit.ts:1`, `lib/scene-closeup.ts:1`, `lib/world-geometry.ts`, `lib/world-map.ts`, `components/PlayPage/EntityHoverOverlay.tsx` | The new closeup/ladder code **already imports** `EntityBBox`, `SceneView`, `Entity`, `finerTier` from `@openflipbook/config`. No `{x_pct,y_pct,w_pct,h_pct}` redeclaration introduced. | None — note of correct practice. | — |
+| low | REPORT-ONLY | `apps/web/app/api/nodes/route.ts:22-23` | `relation?: "descend"\|"expand"\|"ascend"\|"edit"` == `NodeRelation`; `scale?: "component"\|"peer"\|"container"` == `ScaleKind` (no `\| null`). Pre-existing inline unions; the delta only added the `"edit"` value. File already imports `{ ScaleTier, SceneView }` from config. | Could import `NodeRelation`/`ScaleKind` (inline union → imported type = behavior-preserving AUTO). Not a documented KEEP, but pre-dates the delta and was left by both prior runs (their tables covered geometry shapes/DTOs, not these string unions) — treat as implicit KEEP unless the team wants the tidy. | Extends prior 04-types KEEP scope (no contradiction). |
+| low | REPORT-ONLY | `apps/web/lib/node-kind.ts:32` | `relation?: NodeRelation \| null` written inline; file already imports `{ ViewLevel }` from config. | Import `NodeRelation`, write `NodeRelation \| null` (removes the literal dup, keeps null). Low value. | — |
+| info | KEEP | `apps/web/lib/db.ts:126/127,152/153,171/172` | `relation`/`scale` inline unions on `NodeDoc`/`NodeInsert` (carry `\| null`) and `NodeRow` (no null). | **KEEP** — the brief's explicit note: db.ts variants carry `\| null` storage semantics (a real difference). The Mongo-document layer's local storage contract. | Matches prior 04-types db.ts KEEP. |
+| info | KEEP | `apps/web/app/play/page.tsx:188` | `relation?: "descend"\|"expand"\|"edit"` — a deliberate SUBSET of `NodeRelation` (omits `"ascend"`; client-create never makes an ascend node here). `scale` (`:189`) == `ScaleKind`. | **KEEP** the `relation` subset (narrowing is intentional, not `NodeRelation`). `scale` is importable but trivial. | — |
+| info | KEEP | `apps/web/lib/edit-mask.ts:6` `EditRegionBox {x,y,w,h}` | Local named alias for `edit_region?: {x,y,w,h}`, which config exposes **only inline** on `GenerateRequestBody` (no standalone export). Author already documents the mirror in the docstring. | **KEEP** — same class as the prior run's `{x_pct,y_pct}` click-point KEEP: config has no standalone exported type, so adding/removing a shared alias is additive, not a redeclaration removal. | Matches prior 04-types `{x_pct,y_pct}` KEEP rationale. |
+| low | REPORT-ONLY | `apps/web/lib/scene-closeup.ts:22` `regionBox: {x,y,w,h}` | Inline anonymous shape structurally == `EditRegionBox` (same 0..1 natural-image region semantics) in sibling new code; `scene-closeup.ts` doesn't import `edit-mask`. | Intra-web tidy: reuse `EditRegionBox` from `lib/edit-mask.ts`. NOT a config consolidation; small. | — |
+
+## Verification
+
+```
+apps/modal-backend $ python3 -m pytest tests/test_geo_schema.py -q   # 17 passed
+# GenerateBody  ↔ GenerateRequestBody : 40 == 40 fields, 0 divergence (direct diff)
+# WorldContextEntity TS ↔ Py          : field-set parity (incl. new location_hint)
+# delta TS new ': any' / 'as any'     : 0
+# delta TS new standalone redecl of an exported config type : 0
+```
+
+## Net
+
+0 AUTO changes warranted, 0 contract drift. The strengthened gate from the prior
+runs absorbed the entire +7.8k-TS / +14k-Py program without a single new
+TS↔Pydantic divergence. Sub-goal B surfaces only pre-existing inline `relation`/
+`scale` unions (REPORT-ONLY consolidation, implicitly KEEP) and the documented
+db.ts `| null` storage KEEP; the one genuinely-new near-dup (`scene-closeup.ts`
+`regionBox` vs `EditRegionBox`) is an intra-web tidy, not a config matter.

--- a/docs/cleanup/2026-06-13-rerun/05-dedup.md
+++ b/docs/cleanup/2026-06-13-rerun/05-dedup.md
@@ -1,0 +1,103 @@
+# Cleanup re-run — 2026-06-13 · Concern #1 DRY/dedup (delta over `beedb82`)
+
+Scope: ONLY the ~7.8k TS + ~14k Python lines added since `beedb82` (the
+closeup/ladder/POV-surroundings program, PRs #64–#87). Standard = the prior
+`docs/cleanup/05-dedup.md` (extracted `optimisticReplace`/`envFlag`/`modalUrl`;
+`_frame_dims`/`_err_json`/`_gate_json`) + the 2026-06-09 re-run (which added
+`_FRAME_DIMS` and the err/gate envelopes). Prior KEEP decisions are the default.
+
+## Critical assessment
+
+The new code is, again, strongly DRY — and conspicuously so where it matters.
+The largest new Python subsystems already share their seams by construction:
+`generate.py` routes every SSE frame through one `_sse()` helper and gates spend
+/ rate-limit through `_rate_limited()` + `cap_exceeded()`; `judge.py`'s eight
+score functions all funnel through one `_ask_judge`/`_parse_judgement`/`_image_block`;
+the `prompt_library/*` modules are tables-of-prose + one assembler each;
+`inpaint.py` reuses `image.py`'s fal plumbing rather than re-rolling it; and the
+proxy `/api/*` routes only gained `...modalAuthHeaders()` (itself a shared helper)
+on top of the already-KEEP'd modal-dispatch shape. The candidate clusters the
+brief named — JSON-parse-400, Mongo env-guard-503, `if(!res.ok)`, the modal
+dispatch, demo BASE_URL defaults — are all either pre-existing-and-settled-KEEP,
+trivial 2-line guards that read clearer inline, or already factored. The one
+*genuine* new duplication is the `edit_loop.py` ↔ `render_loop.py` sibling pair
+(byte-identical `_score` + `_f`, parallel `conclude`/`iter_*` skeletons) — but it
+is the paid render/edit path, so it is REPORT-ONLY by the bar, not an AUTO fix.
+Net: no AUTO change is warranted; one REPORT-ONLY consolidation worth recording.
+
+## Findings
+
+| Sev | Tag | file:line | Issue | Recommended change | Conflicts |
+|-----|-----|-----------|-------|--------------------|-----------|
+| Med | REPORT-ONLY | `providers/edit_loop.py:123` ↔ `providers/render_loop.py:117` (`_score`); `edit_loop.py:55` ↔ `render_loop.py:64` (`_f`); plus parallel `conclude`/`conclude_edit` + `iter_attempts`/`iter_edit_attempts` skeletons | `edit_loop` is documented as "the render loop's sibling (same DI shape, keep-best, degrade-on-judge-failure rules)" and already imports `MAX_ATTEMPTS_CAP, Rendered, judge_concurrently` from `render_loop` — yet redefines `_score` **byte-identically** and re-rolls the same `_f` env-float parser, the same first-accepted-then-strict-tuple-improve `conclude`, and the same attempt-loop spine (abort → attempt-0-propagates / retry-quiet-fail → `judge_concurrently` → budget-stop → fold-feedback). The axis arity genuinely differs (edit: outside/alignment/medium; view: conformance/same_place/detail/medium). | REPORT-ONLY: both loops are called from `generate.py`'s paid render/edit flow (`generate.py:950/1056/2010`). Safe slice: also import `_score` from `render_loop` (delete the duplicate) and lift the `_f` parser to a shared `_loop_config_float(name, default)`. The `conclude`/`iter_*` skeletons should be left as parallel siblings — unifying them needs a generic over the axis set and would obscure each loop's accept rule. Verify under `make eval` + the edit/view benches before any change. | — |
+| Low | REPORT-ONLY (KEEP-leaning) | `providers/segmenter.py:37` `_clamp01` (NEW) ≡ `providers/detector.py:35` `_clamp01` (OLD) | Byte-identical 6-line untrusted-VLM-coordinate clamp (`try float(); except → 0.0; max(0,min(1))`) now in both VLM-output parsers. | KEEP, per priors. Only 2 copies of a trivial coercion; no appropriate shared home (the prior 05-dedup explicitly ruled `_common.py` "provider-IO-specific" and declined to create a generic math/util module — that's why `env_flag` went to `_env.py`); and it's a fail-loud guard the defensive concern wants kept local. If ever consolidated, it lands next to `detector`/`segmenter` parsing, not in `_common.py`. | **07-defensive** KEEP on `providers/detector.py:36 _clamp01` ("untrusted value"). |
+
+## Verified-and-KEEP (candidate clusters that are NOT new duplication)
+
+- **Modal-dispatch across `app/api/*` proxy routes** (`animate`, `resolve-click`,
+  `status`, `trace/recent`, `trace/abort-stats`, `precompute-candidates`,
+  `models`) — all PRE-EXISTING at `beedb82`; the only change since is adding
+  `...modalAuthHeaders()` (the SHARED_TOKEN gate), which is itself already a
+  shared helper. The dispatch shape was the prior **05-dedup §3** documented
+  KEEP (POST-abort vs GET-timeout sub-variants would need 4-5 flags to merge).
+  No new evidence to overturn it.
+- **Mongo env-guard-503** (`if (!env.MONGODB_URI || !env.MONGODB_DB) → 503`):
+  pre-existing in 12 route files and KEPT by both prior runs; the 4 new files
+  (`gallery/publish`, `session/events`, `session/presence`, `export/[nodeId]`)
+  add the same ~5-line guard. Adding more copies of an already-settled trivial
+  guard is not new logic; the guard also varies (`{ok:false,…}` vs `{error:…}`,
+  different messages). `requireMongo` in `lib/env.ts` exists but THROWS
+  (`EnvMissingError`) for `db.ts`'s internal use — a different shape from the
+  route-level early-return-Response. KEEP.
+- **`invalid JSON` 400** (5 sites: `gallery/publish`, `plan-world`, `extract`,
+  `entity`, `edit-entities`): the 2-line `try { await req.json() } catch { 400 }`.
+  Trivial, reads clearer inline; the bodies/types differ per route. KEEP.
+- **`MODAL_API_URL not set` 503** (12 sites): pre-existing pattern, varies
+  (`{error}` vs `{ok:false,error}`). KEEP, consistent with §3.
+- **TS clamp helpers** — NEW `edit-mask.ts:16 clamp01(n)` (NaN→0) is identical
+  to the PRIVATE `image-click.ts:89 clamp01`; NEW `geo-tap.ts:396 clamp01(v)`
+  (no NaN guard) and `map-labels.ts:43 clamp01(v, span)` (different 2-arg
+  semantics) diverge. The prior cleanup already left 4+ clamp variants
+  (`image-click`, `image-condition` `clamp(v,lo,hi)`, `scale-tree` `clampScale`,
+  `world-geometry` `clampFootprint`) un-consolidated; signatures + NaN handling
+  differ, and a shared clamp util is a module the prior run deliberately avoided.
+  KEEP (aligns with **07-defensive** KEEP on `_clamp01`).
+- **TS compass/direction helpers** — `geo-tap.ts:68 cardinal(dx,dy)` (atan2 →
+  8-wind), `geo-to-edit.ts:16 compassFor(dx,dy)` (drop-minor-axis → 1-2 word
+  combo + "in place"), `location-phrase.ts:11 locationPhrase(geo,frame)` (3×3
+  grid + span). Same superficial `(dx,dy)→string` shape, genuinely different
+  algorithms/vocabularies for different callers; each exported + tested.
+  Consolidating would force one grammar onto all and change behavior. KEEP.
+- **Python `_f`/`max(0.0,float(env or 0.0))` env reads** — `spend.daily_cap()`
+  ↔ `ratelimit.rpm()` share the `max(0.0, float(os.environ.get(NAME,"") or 0.0))`
+  /`except ValueError` 1-liner (2×, different vars). Trivial. KEEP.
+  (The loop-module `_f` is the Med finding above.)
+- **`spend`/`ratelimit`/`breaker`/`moderation`** — deliberate tiny sibling
+  modules sharing only a *posture* (in-process `threading.Lock` + `reset_for_tests`
+  + "per-container, reset on restart"), not logic. Each module's locked state and
+  reset differ. KEEP.
+- **`feedback.py` trailing-period idiom** (`if not text.endswith("."): text+="."`,
+  ~6×) — trivial 2-line idiom; the two feedback functions emit genuinely
+  different prose. It feeds the paid render path (REPORT-ONLY territory anyway).
+  KEEP.
+- **Intentional TS↔Python mirrors** (REPORT-ONLY + deliberate, like the
+  out-of-scope geometry engines): `heights.py:_TIER_METERS` ("Mirrors
+  SCALE_TIER_METERS in packages/config … kept in sync by hand"); `camera.py`
+  `compass_word`/`gaze_to_compass` ("same names and the same Math.round
+  semantics as geo-tap.ts cardinal()"). Hand-synced contract mirrors. KEEP.
+- **Demo-recorder `BASE_URL` default** (`process.env.DEMO_BASE_URL ?? "…:3000"`)
+  — NEW `record-ankh.ts`/`record-fresh-nav.ts`/`record-mappan.ts` repeat the
+  1-line default the pre-existing recorders already had (KEPT). They are
+  standalone `pnpm tsx` scripts that don't import each other, use different env
+  names (`DEMO_BASE_URL`/`LADDER_BASE`/`PERF_BASE_URL`) and defaults (`:3000`
+  vs `:3137`). A shared const among throwaway scripts adds coupling, not
+  clarity. KEEP.
+- **`judge.py`, `pixel_diff.py`, `inpaint.py`, `geometry_checks.py`,
+  `mock.py`, `prompt_library/camera.py`** — all single-responsibility and
+  already-factored; `geometry_checks._num` (`float|None`, rejects bool/NaN) is a
+  distinct helper from the clamps, not a dup. No action.
+
+## Green gate (for any REPORT-ONLY work, if later taken)
+
+- `make eval` (repo root) + the edit-region / view continuity benches for the
+  loop-module item; the loops sit on the paid path, so neither item is AUTO.

--- a/docs/cleanup/2026-06-13-rerun/06-weak-types.md
+++ b/docs/cleanup/2026-06-13-rerun/06-weak-types.md
@@ -1,0 +1,107 @@
+# Cleanup re-run — 2026-06-13 · Concern #5 (weak types) — DELTA over `beedb82..HEAD`
+
+Standard: `docs/cleanup/06-weak-types.md` (the SDK-tolerance/boundary-`Any` = KEEP
+doctrine) + the `00-rerun-2026-06-09.md` delta (which added 4 annotations:
+`parse_scene_graph`/`plan_world_from_description` → `SceneGraph`). This pass audits
+the +7.8k TS / +14k Py added since `beedb82` (PRs #64–#87: closeup / ladder / POV /
+edit-loop / render-loop / segmenter / public-deploy safety).
+
+## Assessment (TS vs Python)
+
+**TS is clean — nothing to do.** The delta added **zero** `any`, `as any`,
+`as unknown as`, `@ts-*`, or non-null `!.` assertions in source. The only three new
+weak-type tokens are *correct* boundary `unknown`: an SSE serializer arg
+(`obj: unknown`), a type-guard input (`isKnobs(v: unknown)`), and a
+`JSON.parse(...) as unknown` deliberately narrowed before validation — the
+exemplary safe pattern. All KEEP.
+
+**Python is also overwhelmingly clean, and the standard holds.** Every added `Any`
+in the strict provider layer (`mock`, `llm`, `moderation`, `judge`, `inpaint`,
+`segmenter`, `geometry_checks`) is case-(a) boundary: OpenAI-SDK response/messages
+read structurally, raw VLM/LLM-JSON validator *inputs*, fal request-arg builders,
+or a mock that mirrors the SDK's own loose shapes — these already pass strict mypy
+(`warn_return_any`) because they were written honestly. The one place with a
+genuinely-knowable strong type is **`generate.py`'s loop plumbing**: three
+`list[Any]` accumulators actually hold `render_loop.Attempt` / `edit_loop.EditAttempt`
+dataclasses, and one closure typed `-> Any` returns `JudgeResult`. Those are the
+only real findings (4 REPORT-ONLY annotations in the loose-gated entry-point file).
+
+## Counts
+
+| | KEEP (boundary/correct) | AUTO | REPORT-ONLY |
+|---|---|---|---|
+| **TS source** | 3 | 0 | 0 |
+| **Python source** | ~20 added `Any` sites | 0 | 4 |
+
+(AUTO = 0 by design: the 4 real findings all live in `generate.py`, which is in the
+*loose* mypy override — the standard + this run's mandate both say verify-against-tests
+or REPORT-ONLY there, never blind-annotate the framework entry point.)
+
+---
+
+## Findings table
+
+| sev | verdict | file:line | current weak type | researched strong type + evidence | conflicts |
+|---|---|---|---|---|---|
+| low | **REPORT-ONLY** | `generate.py:2009` | `loop_attempts: list[Any]` | **`list[render_loop.Attempt]`**. The `async for loop_att in render_loop.iter_attempts(...)` yields `Attempt` (`render_loop.py:161` `iter_attempts[ImageT: Rendered] -> AsyncIterator[Attempt]`). The only reads are `.accepted`/`.conformance`/`.index`/`.image.jpeg_bytes` — all real `Attempt` fields (`render_loop.py:86`). `render_loop` is runtime-imported in the enclosing `if view_loop:` block (`generate.py:1980`), so the symbol resolves. REPORT-ONLY: `generate.py` is loose-gated; confirm `make eval` mypy green before landing. | none |
+| low | **REPORT-ONLY** | `generate.py:951` | `edit_attempts: list[Any]` | **`list[edit_loop.EditAttempt]`**. `edit_loop.iter_edit_attempts(...)` yields `EditAttempt` (`edit_loop.py:149`→`AsyncIterator[EditAttempt]`, dataclass at `:77`). `edit_loop` imported at the top of the inpaint branch (`generate.py:~895`). Reads (`.accepted`/`.alignment`/`.index`/`.image.jpeg_bytes`) are all `EditAttempt` fields. | none |
+| low | **REPORT-ONLY** | `generate.py:1057` | `judged_attempts: list[Any]` | **`list[edit_loop.EditAttempt]`** — identical to `:951` (the whole-image judged-edit twin; `edit_loop` imported at `generate.py:1040`). | none |
+| low | **REPORT-ONLY** | `generate.py:2003` | `_judge_detail(img_bytes: bytes) -> Any` | **`-> JudgeResult`**. The body is `return await judge.score_feature_articulation(...)`, whose signature is `-> JudgeResult` (`judge.py:280`). It's also passed as `judge_detail: Callable[[bytes], Awaitable[JudgeResult]]` (`render_loop.iter_attempts`, `:169`), so the return is already pinned by the call site. Cleanest of the four. | none |
+
+### Not promoted — protocol-erasure boundaries (KEEP, with reasoning)
+
+These three look promotable but the `Any` is *load-bearing* and the existing comment
+already documents it:
+
+- `generate.py:1944` `result: Any = None` — reassigned across branches to
+  `await main_task` (`GeneratedImage`) **and** `render_loop.conclude(...).image`
+  (typed `Rendered`, `render_loop.py:101`). Downstream it reads `result.mime_type` /
+  `result.model` (`:2160`/`:2173`) — fields that exist on `GeneratedImage` but **not**
+  on the minimal `Rendered` protocol (`render_loop.py:37`: only `jpeg_bytes`). Typing
+  it `GeneratedImage` is unverifiable (one branch is statically `Rendered`); typing it
+  `Rendered` breaks the `.mime_type`/`.model` reads. `Any` is the honest choice. KEEP.
+- `generate.py:1094` `judged_image: Any = judged_result.image` — same erasure, and the
+  code **already carries the comment** "The loop types images as the Rendered protocol;
+  this is the GeneratedImage our render closure returned." Deliberate. KEEP.
+- `generate.py:911/1046/1982` `_render_*(suffix) -> Any` — each returns `GeneratedImage`
+  and is passed as `render: Callable[[str], Awaitable[ImageT: Rendered]]`. `-> GeneratedImage`
+  *would* be stricter-and-correct (GeneratedImage satisfies `Rendered`: has `jpeg_bytes`).
+  Left KEEP/REPORT-adjacent rather than AUTO: it's the same loose-gated file, and the
+  payoff is marginal (the loop's generic `ImageT` already gives the binding its strength —
+  the honest-generic pattern the prior run shipped on `grounding.py`). Could fold into the
+  same REPORT batch if a maintainer touches this block.
+
+### Provider-layer added `Any` — all KEEP (case-(a) boundary, already mypy-strict-green)
+
+| file:line | weak type | why KEEP |
+|---|---|---|
+| `geometry_checks.py:57/114/133/163/183/197` | `list[dict[str, Any]]` / `dict[str, Any]` params | **Validator inputs of UNTRUSTED dicts.** The module docstring: these "NEVER raise" and emit `geo.not_dict` for non-dicts; they exist to validate raw solver/VLM/wire JSON *before* it's trusted. Same doctrine as the prior run's `parse_detections(payload: Any)`/`parse_view(payload: Any)`. Typing them as the `geometry.py` TypedDicts (`ProjectInput`/`ProjectedEntity`/`ObserverPose`/`MapCrop`) would assert validity the function is paid to *check*, and defeat the `isinstance(e, dict)` guards. KEEP — and retyping would **conflict with #4** (forces a wire↔checker coupling the checker deliberately avoids). |
+| `geometry_checks.py:46/54` | `_num(v: Any)`, `_vec2_ok(v: Any)` | Numeric/shape coercers over raw values inside the above validators. Boundary by construction. |
+| `segmenter.py:37/46/68` | `_clamp01(v: Any)`, `_parse_vertices(raw: Any)`, `parse_segments(payload: Any)` | Raw VLM-JSON coercers; **output is already the strong `SegmentEntity` TypedDict** (`segmenter.py:18`). Mirrors the prior run's `detector.parse_detections -> list[Detection]` pattern exactly. KEEP. |
+| `segmenter.py:125`, `judge.py:73` | `messages: list[Any]` | OpenAI chat-messages list (heterogeneous system/user/content-part). The exact pattern doc-06 documented as KEEP in `llm.py`. |
+| `llm.py:145/152` | `_coerce_json_dict(parsed: Any) -> dict[str, Any] \| None` + `cast(dict[str, Any], parsed)` | Decoded-JSON coercer; input is `Any` by definition, output is the JSON dict it validates. Established `llm.py` `_coerce_*`/`_parse_*` family. |
+| `moderation.py:34` | `resp: Any = await client.chat.completions.create(...)` | OpenAI SDK response read structurally (`.choices[0].message.content`) for cross-provider tolerance — doc-06's canonical `response: Any`. |
+| `inpaint.py:38` | `_inpaint_args_for(...) -> dict[str, Any]` | fal request-arg builder (per-model arg shapes). Twin of `image.py`'s `_edit_args_for`, explicitly out-of-scope in doc-06. |
+| `mock.py:91/92/166` | `annotations/tool_calls: list[Any]`, `create(**kwargs: Any) -> _Response` | A mock OpenAI client that *mirrors the SDK's own loose param/return shapes*. Pinning types here would diverge the fake from the real SDK it stands in for. |
+
+### TS source — all KEEP (correct boundary `unknown`)
+
+| file:line | token | why KEEP |
+|---|---|---|
+| `app/api/session/[sessionId]/events/route.ts:33` | `send = (obj: unknown) => …` | SSE serializer; `JSON.stringify`s an arbitrary payload. `unknown` is the correct serialization-boundary type. |
+| `hooks/useSpeedPreset.ts:81` | `function isKnobs(v: unknown): v is LoopKnobs` | A user-defined type guard — `unknown` is the canonical input type for a guard. |
+| `hooks/useSpeedPreset.ts:105` | `const parsed: unknown = JSON.parse(stored)` | Deliberately narrows `JSON.parse`'s `any` to `unknown`, then validates via `isKnobs`. The textbook safe pattern; promoting it would be a regression. |
+
+---
+
+## Green-bar note
+
+No edits made (research-only pass). The 4 REPORT-ONLY annotations are
+behavior-preserving and provably correct from the source types above, but live in
+`generate.py` — which `make eval` *does* mypy-check (`Makefile:40`
+`mypy providers obs.py generate.py`) yet under the loose override
+(`pyproject.toml`: `[generate]` sets `disallow_untyped_defs=false`, and crucially does
+**not** set `warn_return_any`). Global `check_untyped_defs=true` means the loop bodies
+are already inferred correctly today, so these annotations are documentation-grade
+tightening, not bug fixes. Recommend landing them as a single small batch behind one
+`make eval` run if a maintainer is already in that file; not worth a standalone churn PR.

--- a/docs/cleanup/2026-06-13-rerun/07-defensive.md
+++ b/docs/cleanup/2026-06-13-rerun/07-defensive.md
@@ -1,0 +1,117 @@
+# Cleanup #6 (defensive / fail-loud) — delta re-run 2026-06-13
+
+Delta scope: `beedb82..HEAD` (157 commits, ~7.8k TS + ~14k Py — closeup / ladder /
+POV / shared-sessions, PRs #64–#87). Standard = `docs/cleanup/07-defensive.md`
+(prior verdict: **0 removals**, every handler guards a real boundary, fail-loud is
+the house style). Prior reports/KEEPs treated as default.
+
+## Assessment
+
+The discipline held — again. **0 removals, 0 REPORT-ONLY findings, all KEEP.**
+The new code is, if anything, *more* fail-loud than before: the entire new pure-logic
+layer (TS: `edit-mask` / `entity-hit` / `geo-tap` / `scene-closeup` / `waterfall-segments`
+/ `map-labels` / `export-build` / `cost-estimate` and 5 more; Py: `heights.py`,
+`pixel_diff.py`, `geometry_checks.py`, `_common.py`, `geometry_prompt.py`, all of
+`prompt_library/*`) has **zero** try/catch — errors propagate. The new render/edit
+loops (`render_loop.py`, `edit_loop.py`) re-raise `CancelledError`/`BaseException`
+explicitly, propagate attempt-0 render failures, and **log every degrade** with the
+exception type; their keep-best degrade-on-judge-failure path is the loop's documented
+design contract, not a swallow. Every handler I found sits on the same boundary classes
+the prior run KEPT: network/IO (fetch/Mongo/S3/httpx/WebSocket/SSE), untrusted external
+data (VLM/LLM JSON, base64 data URLs, env-var coercion, persisted localStorage), a
+browser/runtime quirk (canvas taint, `video.play()`/`Image.decode()` autoplay, locale
+`Date`), or observability isolation. No new catch in either language returns a
+misleading success value; the error-hiding sweep (catches returning `ok:true`/`true`)
+came back empty.
+
+Only **2** genuinely-new `except` were added to the paid `llm.py` (the rest shifted
+line numbers as functions moved); both are KEEP and report-only by rule anyway. The
+new paid-path modules `judge.py` and `moderation.py` are fail-open-by-design with
+documented rationale + logging — REPORT-ONLY territory, but unambiguously correct.
+
+## Counts
+
+| Bucket | TS | Python | Total |
+|---|---|---|---|
+| New handlers reviewed | ~22 (incl. arrow false-positives discarded) | ~30 | ~50 |
+| AUTO removals | 0 | 0 | **0** |
+| REPORT-ONLY (error-hiding) | 0 | 0 | **0** |
+| KEEP | all | all | **all** |
+
+## Findings — all KEEP
+
+### TypeScript (`apps/web`)
+
+| Sev | Verdict | File:line | Handler | Why it's justified |
+|---|---|---|---|---|
+| — | KEEP | `app/api/gallery/publish/route.ts:26` | body `JSON.parse` → 400 | untrusted request body |
+| — | KEEP | `app/api/gallery/publish/route.ts:65` | `fetch`→Modal `/moderate-text` | documented fail-open (same posture as generate); a moderation-infra hiccup must not block a self-hoster's publish |
+| — | KEEP | `app/api/models/route.ts:22` | `fetch`→Modal `/models` → 502 | network boundary |
+| — | KEEP | `app/api/session/[sessionId]/events/route.ts:36,45,53,90` + `.catch` at 59,63,68 | SSE `controller.enqueue/close`, Mongo change-stream `watchSessionNodes`, `countPresence` | IO boundary; documented soft-degrade to `{type:"unsupported"}` on a standalone Mongo (no replica set); fire-and-forget presence pings |
+| — | KEEP | `app/api/session/[sessionId]/presence/route.ts:29` | body `JSON.parse` → falls to 400 validation | untrusted body |
+| — | KEEP | `hooks/useSharedSession.ts:79` (+`.catch` 56) | `JSON.parse` of an SSE feed frame | untrusted external data; malformed frame skipped |
+| — | KEEP | `hooks/useSpeedPreset.ts:107` | `JSON.parse` of persisted `loopKnobs` localStorage | untrusted/hand-editable persisted state → default |
+| — | KEEP | `hooks/useWorldMode.ts:65,74` | localStorage parse / write | untrusted persisted + private-mode quirk (mirrors prior `useStyleAnchor`) |
+| — | KEEP | `components/PlayPage/SpeedPreset.tsx:63` (`.catch`) | `fetch` `/api/models` | network → `[]` |
+| — | KEEP | `components/PlayPage/GeoEditPanel.tsx:71,86` | network via `onSubmit` (preview/apply) | sets `error` state for the user |
+| — | KEEP | `lib/r2.ts:120,137` | S3 `GetObjectCommand` (`inlineStoredImage`/`getStoredBytes`) | documented best-effort IO; null → caller forwards original URL (the localhost-minio VLM-fetch workaround) |
+| — | KEEP | `lib/image-condition.ts:171` | `cropRegionRect` → `canvas.toDataURL()` | cross-origin canvas-taint browser quirk (the documented region-crop drop) |
+| — | KEEP | `lib/stream-client.ts:140` (+`.catch` 132) | `parseLTXF` of a binary WS frame + MSE append / `video.play()` | external binary data → `onError` (no retry); autoplay quirk |
+| — | KEEP | `hooks/useImageMorph.ts:53` (`.catch(finish)`) | `Image().decode()` | decode-absence quirk; calls the same finish path (no-op, not a swallow) |
+| — | KEEP | `components/atlas-view.tsx:889` (`fmt`) | `new Date(iso).toLocaleString()` | locale/format throw |
+| — | KEEP | `app/play/page.tsx:193,226` (`persistNode`) | `fetch` `/api/nodes` + `JSON.parse` | network → null; caller tolerates a null save (prior pattern) |
+| — | KEEP | `app/play/page.tsx:302` (`extractEntities`) | `fetch` `/api/extract` (Mongo merge) | documented best-effort; merge ran upstream, null → codex refetches |
+| — | KEEP | `app/play/page.tsx:337` | localStorage write (`lastSession`) | private-mode quirk |
+| — | KEEP | `app/play/page.tsx:1338` (`buildMaskPng`) | canvas mask pass → whole-image fallback | canvas-taint browser quirk |
+
+*(Diff-grep also matched `page.tsx:592` and `:1161/1179` — these are arrow-function
+`=>`/`e.preventDefault()` bodies, not catches. All other `page.tsx` catches predate
+`beedb82` and were KEPT in the original run.)*
+
+### Python (`apps/modal-backend`)
+
+| Sev | Verdict | File:line | Handler | Why it's justified |
+|---|---|---|---|---|
+| — | KEEP | `providers/render_loop.py:67,72` | `float`/`int` of `VIEW_LOOP_*` env | env coercion → default (= obs.py:66 posture) |
+| — | KEEP | `providers/render_loop.py:113` (`data_url_bytes`) | `base64.b64decode` of a data URL | untrusted external bytes → None |
+| — | KEEP | `providers/render_loop.py:136-137` (`judge_concurrently`) | re-raises `BaseException` (CancelledError), collects only `Exception` | **fail-loud on cancellation** by design |
+| — | KEEP | `providers/render_loop.py:192` | retry-render exception → log warn + keep-best; attempt-0 PROPAGATES | documented loop contract; logged, not hidden |
+| — | KEEP | `providers/edit_loop.py:57,62` | env coercion | → default |
+| — | KEEP | `providers/edit_loop.py:119` (`inside_crop_bytes`) | PIL decode of result image | untrusted image bytes → full-frame judge (documented) |
+| — | KEEP | `providers/edit_loop.py:178` | retry-render exception | log warn + keep-best (attempt-0 propagates) |
+| — | KEEP | `providers/edit_loop.py:196` | `changed_fraction` pixel-diff failure | log warn + stops loop (documented) |
+| — | KEEP (report-only by rule) | `providers/judge.py:61` (`_parse_judgement`) | `json.loads` of VLM reply | untrusted model output; regex-score fallback is the repair ladder's point |
+| — | KEEP (report-only by rule) | `providers/moderation.py:49` + `contextlib.suppress` 50 | LLM moderation call + the obs `log` inside it | **explicit fail-open** (module docstring); logs the degrade; suppress wraps only the logger |
+| — | KEEP | `providers/segmenter.py:40,87` | `float()` of VLM coord/height | untrusted value → 0.0/None |
+| — | KEEP | `providers/segmenter.py:151` | `json.loads` of VLM reply → `[]` | untrusted output ("tolerant parse… never raises") |
+| — | KEEP | `providers/ratelimit.py:23` | `float(RATE_LIMIT_RPM)` | env coercion → off |
+| — | KEEP | `providers/spend.py:98` | `float(MAX_DAILY_SPEND)` | env coercion → uncapped |
+| — | KEEP (report-only by rule) | `providers/image.py:372` | PROVIDER_FALLBACK loop step | network boundary; records breaker + log warn + tries next; **`raise last_exc`** at L387 when exhausted |
+| — | KEEP (report-only by rule) | `providers/image_edit.py:289` (`_dims_from_data_url`) | `base64.b64decode` | untrusted data URL → None (http URLs use caller dims) |
+| — | KEEP | `providers/model_router.py:83` (`_tier_index`) | `.index()` on unknown tier → -1 | expected-input lookup tolerance |
+| — | KEEP | `providers/view_estimator.py:80,85` | `float()` of VLM pitch/confidence | untrusted value → informative default |
+| — | KEEP | `providers/view_estimator.py:148` (`estimate_view`) | VLM call + `json.loads` → `DEFAULT_VIEW` | network + untrusted output; documented seed-something degrade |
+| — | KEEP | `providers/prompt_library/policy.py:237` | `float()` of VLM `pitch_deg` | untrusted value → default |
+| — | KEEP (report-only by rule) | `providers/llm.py:290` (`_client` startup) | `obs` import + `log` on cold init | **observability must never block client init** (documented; = prior L246 posture) |
+| — | KEEP (report-only by rule) | `providers/llm.py` `_safe_json` (new `except json.JSONDecodeError`) | now routes through `_coerce_json_dict` (list-wrapped reply) | **strengthens** the untrusted-JSON repair ladder |
+| — | KEEP | `scripts/fetch_corpus.py:34` | urllib `HTTPError` 429-retry/backoff | network boundary; **re-raises** non-429 + on final attempt (dev corpus script) |
+| — | KEEP | `scripts/verify-fal-models.py:68` | `urlopen`+`json.loads` per slug | dev-only probe script (not request path); reports + exits non-zero on failures |
+
+`providers/geometry.py` added **no** new `except`. `heights.py`, `pixel_diff.py`,
+`geometry_checks.py`, `_common.py`, `geometry_prompt.py`, `mock.py`, `breaker.py`,
+and all `prompt_library/*` (besides the one VLM-coercion above) carry **zero**
+try/except — pure fail-loud logic. `geometry_checks.py` is the explicit
+"return-issues-NEVER-raise so the caller picks the posture (validators raise,
+runtime logs)" design the brief flags as intended.
+
+## Why nothing was removable (delta summary)
+
+Same conclusion as the prior run, re-verified against the new surface: the REMOVE
+bucket is "wraps OUR OWN deterministic logic and swallows a programming error." After
+reading every new handler, **none** match. The new pure-logic core has no handlers at
+all; the new loops re-raise cancellation and log every degrade; the paid-path catches
+(llm/image/judge/moderation — report-only by the hard rules) each sit on an LLM/fal
+SDK boundary or untrusted-JSON repair and are documented + logged + fail loud at the
+end of the ladder. No AUTO removal qualifies (no existing unit test asserts any of
+these should propagate — the loop tests in fact assert the *degrade* behaviour, e.g.
+`test_render_loop.py` / `test_edit_loop.py`). No error-hiding to hand back to the user.

--- a/docs/cleanup/2026-06-13-rerun/08-comments.md
+++ b/docs/cleanup/2026-06-13-rerun/08-comments.md
@@ -1,0 +1,53 @@
+# Cleanup 8 (delta re-run) — AI-slop / build-history comments
+
+**Scope:** `git diff beedb82..HEAD` over source files only (`apps/web/**/*.{ts,tsx}`,
+`packages/**/*.ts`, `apps/modal-backend/**/*.py`) — the 157 commits / ~7.8k TS +
+~14k Py added since the Jun 9 delta (`beedb82`): closeup / scale-ladder / POV
+surroundings, PRs #64–#87. Standard: original `docs/cleanup/08-comments.md` +
+Jun 9 `00-rerun-2026-06-09.md`. **Comments only; no executable code touched.**
+
+## Assessment
+
+The discipline held completely. The new code carries **zero** in-motion
+narration, PR/audit/phase markers (`FIX A/B/C`, `codex #N`, `(M3)`, `Phase N`),
+`TODO`/`FIXME`/`HACK`/`WIP`, stub bodies, placeholder returns, obvious-restatement
+filler, or hedging slop (`for now`, `temporary`, `ideally we`) in any added
+comment line. Every keyword hit (`used to`, `no longer`, `placeholder`,
+`instead of`) resolved to either a load-bearing WHY (an invariant, or the
+specific visual failure a guard prevents) or an LLM prompt string — both
+explicitly protected by the standard. This delta is, if anything, a model of
+the repo's "explain why" comment culture: the new POV/closeup comments in
+`geo-tap.ts`, the incident-documenting header in `waterfall-segments.ts`, the
+relocation-bug rationale in `location-phrase.ts`, and the `docs/COSTS.md`-mirror
+note in `cost-estimate.ts` are exemplary and stay.
+
+**Net find: 0 edits.** Default-KEEP outcome — no churn to manufacture.
+
+## Findings
+
+| Sev | Action | file:line | Comment | Decision | Reason |
+|-----|--------|-----------|---------|----------|--------|
+| Low | **KEEP** | `apps/web/hooks/useWorldMode.ts:22` | `…world mode is per-session and used to always seed off.` | keep | Explains the deploy-time seeding footgun ("why did consistency regress"); the "used to" contrasts current behaviour against the bug state a reader must understand. Rationale, not changelog. |
+| Low | **KEEP** | `apps/web/app/play/page.tsx:274` (`:515` on disk) | `…exactly the state that used to dead-end at a static "no localized geometry" message.` | keep | Justifies the auto-localize-once effect by naming the dead-end it replaces — load-bearing WHY. |
+| Low | **KEEP** | `apps/web/app/play/page.tsx:709` (`:1473` on disk) | `// re-extraction won't re-add what's no longer drawn.` | keep | States the tombstone invariant for a new reader; present-tense, not history. |
+| Low | **KEEP** | `apps/web/lib/waterfall-segments.ts` header | `Extracted (and fixed) because the inline version mislabeled… (the 184813ms incident).` | keep | The "(and fixed)" / incident reference IS the rationale for why the extracted math differs from the inline version and which regression it prevents. Prior run kept this class of rationale. |
+| Low | **KEEP** | `apps/modal-backend/providers/render_loop.py:122` | `"""Placeholder for a judge axis that isn't applicable this attempt — keeps the gathered result shape positional."""` | keep | `_no_judge` is a real sentinel coroutine (returns `None` to hold a positional slot in `judge_concurrently`), not an unimplemented stub. "Placeholder" names its semantic role. (Also REPORT-ONLY zone.) |
+| Low | **KEEP** | `apps/web/lib/world-geometry.ts:243` | `…a wide building no longer seeds at 6×6, so its map footprint tracks the size it was rendered at.` | keep | **Out of delta scope** — comment pre-dates `beedb82` (already cleaned); not a new-code finding. WHY rationale regardless. |
+
+(Numerous additional `instead of` hits in `geo-tap.ts`, `scene-closeup.ts`,
+`stream-client.ts`, `db.ts`, the API routes, and the Python providers are all
+either WHY-rationale comments or LLM prompt-string content — KEEP, not tabled
+individually.)
+
+## Verification
+
+- Searched added comment lines (`^\+` ∩ `//|#|*`) across the full delta for:
+  in-motion narration (`now we`/`changed to`/`renamed`/`refactored`), markers
+  (`PR #`/`codex #`/`FIX [A-Z0-9]`/`(M\d)`/`Phase \d`/`audit follow`),
+  `TODO`/`FIXME`/`HACK`/`XXX`/`WIP`, self-congratulation, obvious-restatement
+  filler, hedging (`for now`/`temporary`/`ideally we`/`revisit this`), and
+  TS/Py stub bodies (`NotImplementedError`, `=> {}`, `pass # stub`,
+  `return None # placeholder`). **All empty.**
+- The only non-empty keyword classes (`used to` / `no longer` / `placeholder` /
+  `instead of`) were each read in context and resolved to KEEP per the
+  load-bearing / prompt-string carve-outs.


### PR DESCRIPTION
## Summary

Delta cleanup re-run of all 8 concerns over the ~22k new lines since the last cleanup (`beedb82`, Jun 9) — the closeup/ladder/POV-surroundings program (PRs #64–#87), which hadn't been through a cleanup pass. Each concern's standard is its prior `docs/cleanup/0N-*.md` doc; prior KEEP decisions treated as default.

**The discipline held.** The audit found 2 dead symbols, 4 loose annotations, and 1 sibling-loop dedup; everything else KEEP. No TS↔Pydantic contract drift, 0 circular deps, 0 error-hiding, 0 slop comments.

## Changes
- **Remove dead code (#3 unused / #7 legacy):** `cropRegion` (orphaned by the conditioning-crop refactor `6018503`; its CORS/canvas-taint rationale relocated to `cropRegionRect`, 3 stale references re-pointed) + `SessionNodeEvent` (0 refs anywhere).
- **Type generate.py loop plumbing (#5 weak types):** four `list[Any]` / `-> Any` → `list[Attempt]` / `list[EditAttempt]` / `JudgeResult` via `TYPE_CHECKING` imports (lazy at runtime → no Modal cold-start cost).
- **Dedup sibling loops (#1 DRY):** lifted the byte-identical env-float parser to a shared `render_loop._env_float` and imported `_score` rather than redefining it (the loop skeletons stay parallel siblings — different judges/configs).
- **Assessments:** the 8 per-concern reports + `00-summary.md` in `docs/cleanup/2026-06-13-rerun/`.

## Report-only (NOT in this PR — deferred per safe-auto/risky-report)
1. generate.py `result` / `judged_image` stay `Any` (deliberate protocol-erasure across `Rendered`/`GeneratedImage` branches).
2. A few cosmetic intra-web type tidies (e.g. `scene-closeup.ts` `regionBox`).

## Verification
`make eval` green — 610 vitest + pytest (incl. `test_render_loop` + `test_provider_fallback`) + ruff + mypy (`providers obs.py generate.py`) + tsc --noEmit + madge (0 cycles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)