### PR TITLE
feat(on-ramp): tighten first-run docs and optional coach hint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,10 +4,11 @@
 # QUICK START (local docker stack): copy this file to `.env`, fill in the two
 # keys below, then `make demo` (or `docker compose up --build`). Everything
 # else — Mongo, blob storage (Minio), URLs — is wired to local containers with
-# working defaults; you don't need to touch it. For a no-cloud LLM too, run
-# `make demo-local` (adds Ollama; then only FAL_KEY is needed). The detailed
-# reference further down is for the non-Docker / hosted (Modal + R2) path —
-# copy those into apps/web/.env.local and apps/modal-backend/.env as needed.
+# working defaults; you don't need to touch it. See docs/DOCKER.md for the
+# full walkthrough. For a no-cloud LLM too, run `make demo-local` (adds Ollama;
+# then only FAL_KEY is needed). The detailed reference further down is for the
+# non-Docker / hosted (Modal + R2) path — copy those into apps/web/.env.local
+# and apps/modal-backend/.env as needed.
 # ------------------------------------------------------------------
 
 # --- Modal backend ---
@@ -110,6 +111,9 @@ MONGODB_DB=openflipbook
 # Modal URLs — printed after `modal deploy`
 MODAL_API_URL=
 NEXT_PUBLIC_LTX_WS_URL=
+
+# Optional: pre-first-page coach hint on /play (build-time; rebuild web after change).
+# NEXT_PUBLIC_ON_RAMP_COACH=true
 
 # --- Optional: Sentry observability ---
 # Leave blank to disable. SDKs are no-op when DSN is unset.

--- a/README.md
+++ b/README.md
@@ -17,14 +17,12 @@ Sped up 4×: landing → `"how does a steam engine work"` deeplink → two click
 
 ## Why this exists
 
-[flipbook.page](https://flipbook.page) is fun but closed. I wanted to see if the same paradigm — one image per page, tap to explore — could live on a stack you actually own: your fal key, your OpenRouter key, your R2, your Mongo, your Modal. Turns out yes. Same loop, different stack, MIT.
-
-It's also a nice excuse to swap pieces around. The image model, the planner, the click-resolving VLM, the video backend — all behind small interfaces in `apps/modal-backend/providers/`. Trade nano-banana for Flux, Qwen-VL for Gemini, LTX-2 for Wan; nothing else has to change.
+[flipbook.page](https://flipbook.page) is fun but closed. I wanted the same loop — one image per page, tap to explore — on a stack I actually own: my keys, my storage, my backend. This is that, MIT-licensed, with every piece swappable behind small provider interfaces in `apps/modal-backend/providers/`.
 
 ## TL;DR
 
-- **One image per page**, rendered by [`fal-ai/nano-banana`](https://fal.ai/models/fal-ai/nano-banana) (Gemini 2.5 Flash Image). Text inside the page is pixels, not DOM.
-- **Click → next page.** [`qwen/qwen-2.5-vl-72b-instruct`](https://openrouter.ai/qwen/qwen-2.5-vl-72b-instruct) via OpenRouter resolves the clicked region to a phrase; [`qwen/qwen-2.5-72b-instruct:online`](https://openrouter.ai/qwen/qwen-2.5-72b-instruct) plans the page with web-search grounding.
+- **One image per page**, rendered by fal (default balanced tier: [`nano-banana-pro`](https://fal.ai/models/fal-ai/nano-banana-pro)). Text inside the page is pixels, not DOM.
+- **Click → next page.** [`google/gemini-3-flash-preview`](https://openrouter.ai/google/gemini-3-flash-preview) via OpenRouter resolves the clicked region to a phrase; the same model family plans the page with web-search grounding.
 - **Seed from your own image.** Upload / drag-and-drop works as a starting point.
 - **Optional animation toggle.**
   - Default: one-shot 5s MP4 from `fal-ai/ltx-video/image-to-video`. Cheap (~$0.02/clip), no GPU on your side.
@@ -45,15 +43,15 @@ It's also a nice excuse to swap pieces around. The image model, the planner, the
              │                                           │ tap on a region
              ▼                                           ▼
     ┌───────────────────┐   plan page    ┌──────────────────────────┐
-    │  OpenRouter Qwen  │ ─────────────▶ │  fal-ai/nano-banana       │
-    │  (text + :online) │                │  renders labelled image   │
+    │  OpenRouter Gemini │ ─────────────▶ │  fal nano-banana-pro      │
+    │  3 Flash (+ search)│                │  renders labelled image   │
     └───────────────────┘                └──────────────┬───────────┘
              ▲                                          │
              │  subject phrase                          │
              │                                          ▼
     ┌────────┴──────────┐    click +    ┌──────────────────────────┐
-    │ OpenRouter Qwen 2.5 VL  image ◀── │ next page conditioning    │
-    └───────────────────┘               └──────────────────────────┘
+    │ OpenRouter Gemini 3  image ◀── │ next page conditioning    │
+    │ Flash (VLM)          │               └──────────────────────────┘
                                                        │
                                                        ▼
                                ┌────────────────────────────────────┐
@@ -70,33 +68,36 @@ It's also a nice excuse to swap pieces around. The image model, the planner, the
 
 ## Quickstart
 
+The fastest path — Docker, local Mongo + blob storage, cloud AI (two keys):
+
 ```bash
 git clone https://github.com/eren23/openflipbook
 cd openflipbook
 
-# Prereqs
-brew install pnpm modal-cli uv      # or your equivalents
-docker --version                    # for docker compose path
-
-# Python backend deps
-cd apps/modal-backend
-uv venv --python 3.12 --seed && source .venv/bin/activate
-uv pip install -r requirements.txt
-cp .env.example .env                # fill FAL_KEY + OPENROUTER_API_KEY
-cd ../..
-
-# Web env
-cp .env.example apps/web/.env.local
-# fill: MONGODB_URI, MONGODB_DB, R2_*, MODAL_API_URL (=http://backend:8787 if using compose)
-
-# Dev loop
-docker compose up -d --build        # one-command E2E: mongo + backend + web
-open http://localhost:3000/play
+cp .env.example .env          # fill FAL_KEY + OPENROUTER_API_KEY
+make demo                     # → http://localhost:3000/play
 ```
 
-Open `/status` in the browser for a live env check with green/red badges per missing variable.
+That's it. Mongo, Minio, backend, and web all come up wired together. Open [`/status`](http://localhost:3000/status) for a live env check. Full compose reference: [`docs/DOCKER.md`](docs/DOCKER.md).
 
-## What you need
+**Images-only cloud:** `make demo-local` runs the planner + click VLM on local Ollama — only `FAL_KEY` needed (first run pulls multi-GB models; CPU-slow).
+
+**Without Docker:** see [`docs/LOCAL_DEV.md`](docs/LOCAL_DEV.md).
+
+### Hosted setup (Modal + R2)
+
+If you want to deploy the backend to Modal and store blobs on Cloudflare R2 instead of the local stack, you'll also need Mongo/R2 credentials and a Modal token. Walkthrough: [`docs/BYO-KEYS.md`](docs/BYO-KEYS.md).
+
+## What you need (local demo)
+
+| Service | Used for | Variable |
+|---|---|---|
+| [fal](https://fal.ai/dashboard/keys) | image gen + optional animate | `FAL_KEY` |
+| [OpenRouter](https://openrouter.ai/keys) | planning + click VLM + web search | `OPENROUTER_API_KEY` |
+
+Mongo + blob storage run locally in Docker — no cloud accounts required for `make demo`.
+
+## What you need (hosted)
 
 | Service | Used for | Variable |
 |---|---|---|

--- a/apps/modal-backend/.env.example
+++ b/apps/modal-backend/.env.example
@@ -41,7 +41,18 @@ OPENROUTER_ENABLE_WEB_SEARCH=true
 # custom = any OpenAI-images-compatible base URL:
 # IMAGE_PROVIDER=custom
 # IMAGE_BASE_URL=http://localhost:8080/v1
-FAL_IMAGE_MODEL=fal-ai/nano-banana
+
+# --- Image generation tier (fast | balanced | pro) ---
+# Per-request override available in body.image_tier from the frontend.
+FAL_IMAGE_TIER=balanced
+# Per-tier slug overrides (optional — leave UNSET to track the code defaults:
+# fast=fal-ai/nano-banana, balanced=fal-ai/nano-banana-pro,
+# pro=openrouter:sourceful/riverflow-v2.5-pro). Pinning the base nano-banana
+# model here overrides balanced tier and garbles map labels — don't.
+# FAL_IMAGE_MODEL_FAST=fal-ai/nano-banana
+# FAL_IMAGE_MODEL_BALANCED=fal-ai/nano-banana-pro
+# FAL_IMAGE_MODEL_PRO=fal-ai/bytedance/seedream/v4/text-to-image
+
 FAL_ANIMATE_MODEL=fal-ai/ltx-video/image-to-video
 
 # Per-tier video model overrides (defaults in providers/video.py).

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -17,8 +17,10 @@ ENV NEXT_TELEMETRY_DISABLED=1
 # world mode OFF while local dev (.env.local) had it on.
 ARG NEXT_PUBLIC_WORLD_MODE
 ARG NEXT_PUBLIC_DOM_LABELS
+ARG NEXT_PUBLIC_ON_RAMP_COACH
 ENV NEXT_PUBLIC_WORLD_MODE=$NEXT_PUBLIC_WORLD_MODE \
-    NEXT_PUBLIC_DOM_LABELS=$NEXT_PUBLIC_DOM_LABELS
+    NEXT_PUBLIC_DOM_LABELS=$NEXT_PUBLIC_DOM_LABELS \
+    NEXT_PUBLIC_ON_RAMP_COACH=$NEXT_PUBLIC_ON_RAMP_COACH
 COPY --from=deps /repo/node_modules ./node_modules
 COPY --from=deps /repo/apps/web/node_modules ./apps/web/node_modules
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json tsconfig.base.json ./

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -138,6 +138,10 @@ const EDIT_REGION_ENABLED = ["1", "true", "yes"].includes(
 const WORLD_TAP_DEGRADE_ENABLED = !["0", "false", "no"].includes(
   (process.env.NEXT_PUBLIC_WORLD_TAP_DEGRADE ?? "").toLowerCase()
 );
+// On-ramp coach: pre-first-page hint + existing post-first-page chip (default OFF).
+const ON_RAMP_COACH_ENABLED = ["1", "true", "yes"].includes(
+  (process.env.NEXT_PUBLIC_ON_RAMP_COACH ?? "").toLowerCase(),
+);
 
 interface Page {
   nodeId: string | null;
@@ -3617,12 +3621,20 @@ export default function PlayPage() {
       {/* Hide the coach while the Around tray is open — both are pinned to
           bottom-centre, so they'd overlap; mid-bloom the hint is noise anyway.
           It returns when the tray is closed. */}
-      {phase === "ready" && !helpOpen && !bloom && history.items.length <= 1 && (
-        <FirstRunCoach
-          onShowHelp={() => setHelpOpen(true)}
-          worldHint={worldEnabled}
-        />
-      )}
+      {!helpOpen &&
+        !bloom &&
+        ((ON_RAMP_COACH_ENABLED &&
+          history.items.length === 0 &&
+          phase !== "generating") ||
+          (phase === "ready" && history.items.length <= 1)) && (
+          <FirstRunCoach
+            onShowHelp={() => setHelpOpen(true)}
+            worldHint={worldEnabled}
+            variant={
+              ON_RAMP_COACH_ENABLED && history.items.length === 0 ? "pre" : "post"
+            }
+          />
+        )}
 
       {scrubberOpen && page?.imageDataUrl && history.trail.length > 1 && (
         <TimeScrubber

--- a/apps/web/components/PlayPage/FirstRunCoach.test.tsx
+++ b/apps/web/components/PlayPage/FirstRunCoach.test.tsx
@@ -17,6 +17,15 @@ describe("FirstRunCoach", () => {
     expect(screen.getByText("E")).toBeTruthy(); // the Around hotkey is surfaced
   });
 
+  it("pre variant nudges a first query before any page exists", () => {
+    render(<FirstRunCoach onShowHelp={() => {}} variant="pre" />);
+    const text = document.body.textContent ?? "";
+    expect(/ask anything above/i.test(text)).toBe(true);
+    expect(/first page/i.test(text)).toBe(true);
+    expect(/tap anywhere/i.test(text)).toBe(true);
+    expect(/around/i.test(text)).toBe(false);
+  });
+
   it("opens help from the ? button", () => {
     const onShowHelp = vi.fn();
     render(<FirstRunCoach onShowHelp={onShowHelp} />);

--- a/apps/web/components/PlayPage/FirstRunCoach.tsx
+++ b/apps/web/components/PlayPage/FirstRunCoach.tsx
@@ -2,20 +2,28 @@
 
 import { BloomGlyph } from "./BloomGlyph";
 
+export type FirstRunCoachVariant = "pre" | "post";
+
 interface Props {
   onShowHelp: () => void;
   /** World mode is on → also teach the enter affordance (the pulsing rings). */
   worldHint?: boolean;
+  /** Pre-first-page hint vs post-first-page tap/around pairing. Default post. */
+  variant?: FirstRunCoachVariant;
 }
 
 /**
- * Persistent bottom-of-page hint chip. Its job is to teach the two generative
- * moves as a *pair* — tap a region to go IN (depth), or bloom the world AROUND
- * the page (breadth, the `E` / Around action). Without this pairing, "what does
- * Expand do" was a mystery. Stays out of the visual centre — the rendered
- * illustration is what matters.
+ * Persistent bottom-of-page hint chip. Pre variant nudges a first query; post
+ * variant teaches the two generative moves as a *pair* — tap a region to go IN
+ * (depth), or bloom the world AROUND the page (breadth, the `E` / Around
+ * action). Stays out of the visual centre — the rendered illustration is what
+ * matters.
  */
-export function FirstRunCoach({ onShowHelp, worldHint = false }: Props) {
+export function FirstRunCoach({
+  onShowHelp,
+  worldHint = false,
+  variant = "post",
+}: Props) {
   return (
     <div
       role="status"
@@ -23,39 +31,53 @@ export function FirstRunCoach({ onShowHelp, worldHint = false }: Props) {
       className="pointer-events-none fixed inset-x-0 bottom-6 z-40 flex justify-center px-4"
     >
       <div className="pointer-events-auto flex max-w-[92vw] flex-wrap items-center justify-center gap-2.5 rounded-full border border-[var(--color-edge)] bg-[var(--color-canvas)]/95 px-4 py-2 text-sm shadow-lg backdrop-blur">
-        {/* The two moves, side by side, so the in/around duality is obvious. */}
-        <span className="whitespace-nowrap opacity-80">Tap to go in</span>
-        <span className="opacity-40">·</span>
-        {worldHint && (
+        {variant === "pre" ? (
           <>
-            <span className="flex items-center gap-1.5 whitespace-nowrap opacity-80">
-              <span className="inline-block h-2.5 w-2.5 rounded-full border-2 border-emerald-600/70" />
-              rings = enterable places
+            <span className="whitespace-nowrap opacity-80">
+              Ask anything above — I&apos;ll draw the first page
             </span>
             <span className="opacity-40">·</span>
+            <span className="whitespace-nowrap opacity-80">
+              then tap anywhere to go deeper
+            </span>
+          </>
+        ) : (
+          <>
+            {/* The two moves, side by side, so the in/around duality is obvious. */}
+            <span className="whitespace-nowrap opacity-80">Tap to go in</span>
+            <span className="opacity-40">·</span>
+            {worldHint && (
+              <>
+                <span className="flex items-center gap-1.5 whitespace-nowrap opacity-80">
+                  <span className="inline-block h-2.5 w-2.5 rounded-full border-2 border-emerald-600/70" />
+                  rings = enterable places
+                </span>
+                <span className="opacity-40">·</span>
+              </>
+            )}
+            <span className="flex items-center gap-1.5 whitespace-nowrap opacity-80">
+              <BloomGlyph className="h-3.5 w-3.5 text-teal-600" />
+              around
+              <kbd className="rounded border border-[var(--color-edge)] px-1 font-mono text-[10px]">
+                E
+              </kbd>
+            </span>
+            <span className="opacity-40">·</span>
+            <button
+              type="button"
+              aria-label="shortcuts"
+              onClick={onShowHelp}
+              className="rounded-full border border-[var(--color-edge)] px-2 py-0.5 font-mono text-xs hover:bg-[var(--color-ink)]/10"
+              title="Show all shortcuts"
+            >
+              ?
+            </button>
+            <span className="whitespace-nowrap opacity-80">shortcuts</span>
+            <span className="opacity-40">·</span>
+            <span className="font-mono text-xs opacity-80">T</span>
+            <span className="opacity-80">scrubber</span>
           </>
         )}
-        <span className="flex items-center gap-1.5 whitespace-nowrap opacity-80">
-          <BloomGlyph className="h-3.5 w-3.5 text-teal-600" />
-          around
-          <kbd className="rounded border border-[var(--color-edge)] px-1 font-mono text-[10px]">
-            E
-          </kbd>
-        </span>
-        <span className="opacity-40">·</span>
-        <button
-          type="button"
-          aria-label="shortcuts"
-          onClick={onShowHelp}
-          className="rounded-full border border-[var(--color-edge)] px-2 py-0.5 font-mono text-xs hover:bg-[var(--color-ink)]/10"
-          title="Show all shortcuts"
-        >
-          ?
-        </button>
-        <span className="whitespace-nowrap opacity-80">shortcuts</span>
-        <span className="opacity-40">·</span>
-        <span className="font-mono text-xs opacity-80">T</span>
-        <span className="opacity-80">scrubber</span>
       </div>
     </div>
   );

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,6 +143,7 @@ services:
       args:
         NEXT_PUBLIC_WORLD_MODE: ${NEXT_PUBLIC_WORLD_MODE:-${WORLD_MODE:-false}}
         NEXT_PUBLIC_DOM_LABELS: ${NEXT_PUBLIC_DOM_LABELS:-${WORLD_MODE:-false}}
+        NEXT_PUBLIC_ON_RAMP_COACH: ${NEXT_PUBLIC_ON_RAMP_COACH:-false}
     container_name: openflipbook-web
     restart: unless-stopped
     # Same posture as the backend: the root .env (single-file demo) carries

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,7 +61,7 @@ the orchestrator (`page.tsx`) is the only place that composes them.
 - `useImageMorph` — `morphFx` state + the `Image().decode()` pre-flip effect. Caller is responsible for setting morphFx when a click fires; the hook handles `wait → reveal`.
 - `usePrefetchCache` — refs + `bucketKey` (3% grid → ~1100 cells/page) + `clearTimer` + `reset`. Owns the storage shape; the orchestrator still owns the precompute / hover-debounce effects (those need `page`, `phase`, `generate` from the orchestrator).
 - `useKeyboardShortcuts` — global keydown listener with one bool `anyOverlayOpen` and a flat handler interface. Modifier rule (skip on Cmd/Ctrl/Alt) keeps DevTools/copy/paste reachable.
-- `useFirstRunCoach` — single-shot "have we shown the coach?" flag in localStorage.
+- `FirstRunCoach` visibility — orchestrator-gated in `page.tsx` (shown until the first tap-child; optional pre-gen hint when `NEXT_PUBLIC_ON_RAMP_COACH` is on).
 
 ### `apps/web/components/PlayPage/`
 

--- a/docs/BYO-KEYS.md
+++ b/docs/BYO-KEYS.md
@@ -1,11 +1,23 @@
 # BYO Keys — running Endless Canvas yourself
 
-> Just want to try it locally? Skip all of this — `cp .env.example .env`, add a
-> `FAL_KEY` (+ `OPENROUTER_API_KEY`), and `make demo`. The Docker stack runs
-> Mongo + blob storage locally so you don't provision R2/Mongo/Modal. See
-> [DOCKER.md](./DOCKER.md). This page is the hosted-production path.
+## Local first (recommended)
 
-Endless Canvas has no hosted backend. To actually generate pages you need to provide:
+Three steps to a first generated page — no Modal, no R2, no hosted Mongo:
+
+```bash
+cp .env.example .env          # fill FAL_KEY + OPENROUTER_API_KEY
+make demo                     # → http://localhost:3000/play
+```
+
+The Docker stack runs Mongo + Minio locally and wires everything for you. Only the AI calls go to the cloud (OpenRouter + fal). See [`DOCKER.md`](./DOCKER.md) for the full compose reference.
+
+Want the LLM local too? `make demo-local` — only `FAL_KEY` needed (Ollama handles planner + click VLM; first run pulls multi-GB models).
+
+---
+
+## Hosted production path
+
+Endless Canvas has no hosted backend. To deploy to Modal + R2 yourself you need to provide:
 
 1. **OpenRouter API key** — planning + VLM click interpretation + web search.
 2. **fal API key** — image generation (nano-banana).


### PR DESCRIPTION
## Summary

- Lead README and BYO-KEYS with the two-key `make demo` path; split hosted (Modal + R2) setup into its own section
- Unpin `FAL_IMAGE_MODEL` in the backend `.env.example` so balanced tier defaults aren't overridden
- Add optional pre-first-page coach behind `NEXT_PUBLIC_ON_RAMP_COACH` (build-time, default off — existing click flow unchanged when off)

## Test plan

- [x] `make eval`
- [ ] `cp .env.example .env`, fill keys, `make demo` → first page at `/play`
- [ ] Flag off: coach only after first page (same as before)
- [ ] `NEXT_PUBLIC_ON_RAMP_COACH=true make demo` → pre-coach before first gen, post-coach after, gone after first tap-child


Made with [Cursor](https://cursor.com)