### PR TITLE
feat(corpus): evolvable reference-corpus pipeline (M1–M4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,10 @@ apps/modal-backend/tests/**/cache/
 # Ground-truth corpus images (fetched by scripts/fetch_corpus.py; text-only
 # descriptions + the sha-pinned manifest are what git tracks).
 apps/modal-backend/tests/map_corpus/images/
+# Generated annotation artifacts: ensemble candidates awaiting human promotion
+# and the in->out overlay renders. Not source of truth; regenerated on demand.
+apps/modal-backend/tests/map_corpus/descriptions/candidates/
+apps/modal-backend/tests/map_corpus/overlays/
 
 # Ladder proof runs (e2e artifacts: images + manifests + reports).
 ladder-proof-runs/

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,9 @@ corpus-draft:
 # Ensemble annotate (the evolvable upgrade to corpus-draft): fan the describe
 # call over N VLMs, reconcile deterministically, judge, refine once on a low
 # score, and AUTO-PROMOTE to review.status=verified when the judge AND ensemble
-# agreement both clear their gates (else needs_human). PAID (~$0.03-0.10/map).
+# agreement both clear their gates (else needs_human). Non-destructive: a
+# verified description is preserved; output lands in descriptions/candidates/
+# unless CORPUS_ANNOTATE_FORCE=1. PAID (~$0.03-0.10/map).
 # Preview the ensemble + gates with no flag; CORPUS_ANNOTATE_RUN=1 to spend.
 #   make corpus-annotate-preview
 #   make corpus-annotate id=fantasy-treasure-island   (or id=all)

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,14 @@ corpus-annotate-preview:
 	cd apps/modal-backend && .venv/bin/python -m tests.map_corpus.annotate $(or $(id),all)
 corpus-annotate:
 	cd apps/modal-backend && CORPUS_ANNOTATE_RUN=1 .venv/bin/python -m tests.map_corpus.annotate $(or $(id),all)
+# Visual in->out: draw a description's entities (detector boxes + segmenter
+# borders + labels) back onto its source map. FREE (no API). Verified by
+# default; add cand=1 to render the ensemble candidate instead. Writes
+# tests/map_corpus/overlays/<id>.<source>.png.
+#   make corpus-overlay id=fantasy-treasure-island
+#   make corpus-overlay id=fantasy-treasure-island cand=1
+corpus-overlay:
+	cd apps/modal-backend && .venv/bin/python -m tests.map_corpus.overlay $(or $(id),fantasy-treasure-island) $(if $(cand),--candidate,)
 # Reconstruction bench: regenerate each VERIFIED corpus map from its authored
 # description (graph = product planning path, direct = ground-truth layout),
 # extract + score vs ground truth + VLM judges. Rides the matrix chassis:

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,21 @@ corpus-fetch:
 	cd apps/modal-backend && .venv/bin/python scripts/fetch_corpus.py --pin
 corpus-draft:
 	cd apps/modal-backend && CORPUS_DRAFT_RUN=1 .venv/bin/python -m tests.map_corpus.draft $(or $(id),all)
+# Ensemble annotate (the evolvable upgrade to corpus-draft): fan the describe
+# call over N VLMs, reconcile deterministically, judge, refine once on a low
+# score, and AUTO-PROMOTE to review.status=verified when the judge AND ensemble
+# agreement both clear their gates (else needs_human). PAID (~$0.03-0.10/map).
+# Preview the ensemble + gates with no flag; CORPUS_ANNOTATE_RUN=1 to spend.
+#   make corpus-annotate-preview
+#   make corpus-annotate id=fantasy-treasure-island   (or id=all)
+# Knobs (env): CORPUS_ANNOTATE_MODELS=google/gemini-3-pro-preview,anthropic/claude-sonnet-4-6,qwen/qwen3-vl-235b-a22b-instruct
+#   (middle-ground ensemble — avoid Opus, the describe cost driver; unset = single cheap VLM)
+#   CORPUS_JUDGE_THRESHOLD (7.0)  CORPUS_AGREEMENT_THRESHOLD (0.6)
+#   CORPUS_ANNOTATE_MAX_ITERS (2)  CORPUS_MIN_VOTES (majority)
+corpus-annotate-preview:
+	cd apps/modal-backend && .venv/bin/python -m tests.map_corpus.annotate $(or $(id),all)
+corpus-annotate:
+	cd apps/modal-backend && CORPUS_ANNOTATE_RUN=1 .venv/bin/python -m tests.map_corpus.annotate $(or $(id),all)
 # Reconstruction bench: regenerate each VERIFIED corpus map from its authored
 # description (graph = product planning path, direct = ground-truth layout),
 # extract + score vs ground truth + VLM judges. Rides the matrix chassis:

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,15 @@ eval-recon-dry:
 	cd apps/modal-backend && .venv/bin/python -m tests.recon_bench.runner
 eval-recon:
 	cd apps/modal-backend && RECON_BENCH_RUN=1 .venv/bin/python -m tests.recon_bench.runner
+# Descent reconstruction (M4): ENTER a parent map's linked place (a child
+# interior/closeup tied via parent_id+parent_ref to a parent entity), score the
+# region-conditioned descent against the REAL child photo (style + continuity)
+# vs a fresh baseline. Dry (resolve chains + cost, $0): make eval-descent-dry
+# Live (DESCENT_BENCH_RUN=1, ~$0.30/chain): make eval-descent
+eval-descent-dry:
+	cd apps/modal-backend && .venv/bin/python -m tests.descent_bench.runner
+eval-descent:
+	cd apps/modal-backend && DESCENT_BENCH_RUN=1 .venv/bin/python -m tests.descent_bench.runner
 eval-repair:
 	cd apps/modal-backend && .venv/bin/python -m pytest -m repair -q
 eval-edit:

--- a/apps/modal-backend/providers/judge.py
+++ b/apps/modal-backend/providers/judge.py
@@ -277,6 +277,34 @@ async def score_view_conformance(image: bytes, projection: str) -> JudgeResult:
     return await _ask_judge(system, user_text, [_image_block(image)])
 
 
+async def score_annotation(
+    image: bytes, description: str, labels: list[str]
+) -> JudgeResult:
+    """Annotation-quality judge — drives the corpus ensemble-annotate auto-promote
+    gate (tests/map_corpus/annotate.py). Given the image, the prose meant to let a
+    painter redraw it, and the catalogued entity labels, score how COMPLETE and
+    ACCURATE the annotation is. The rationale is fed back into the refine pass, so
+    it must name what is missing or wrong."""
+    named = ", ".join(label.strip() for label in labels if label and label.strip())[:400]
+    system = (
+        "You are a strict annotation-quality judge for a ground-truth map/scene "
+        "corpus. You are given an image, a prose description meant to let a painter "
+        "redraw it, and the list of entities that were catalogued. Score 0-10 how "
+        "COMPLETE and ACCURATE the annotation is: every prominent feature named and "
+        "correctly placed in the prose, no invented features absent from the image, "
+        "no major visible feature missed. 10 = a faithful, complete annotation; 5 = "
+        "roughly right but missing or misdescribing notable features; 0 = wrong or "
+        "badly incomplete. Judge fidelity to the image only — ignore art quality."
+        ' Return JSON exactly: {"score": <0-10 number>, "rationale": "<one short '
+        'sentence naming what is missing or wrong>"}.'
+    )
+    user_text = (
+        f"Catalogued entities: {named or '(none)'}.\n\nDescription:\n{description[:1200]}\n\n"
+        "Score the annotation's completeness and accuracy against the image (0-10)."
+    )
+    return await _ask_judge(system, user_text, [_image_block(image)])
+
+
 async def score_feature_articulation(
     image: bytes, place_label: str, features: list[str]
 ) -> JudgeResult:

--- a/apps/modal-backend/providers/segmenter.py
+++ b/apps/modal-backend/providers/segmenter.py
@@ -1,16 +1,29 @@
-"""VLM polygon segmentation + relative heights (B2 segmenter).
+"""Polygon segmentation + relative heights (B2 segmenter), pluggable backend.
 
-Same shape as detector.py, one level richer: instead of a box per label, the
-VLM traces each visible target's BORDER as a closed polygon and ranks its
-apparent built height. Polygons are normalized 0..1 image coords, 3..24
-vertices; rel_height is 0..1 of the tallest visible target; est_height_m is
-the VLM's own absolute guess (anchoring happens in providers/heights.py, not
-here). Tolerant parse: a malformed entry is dropped, never raises.
+Each label gets a BORDER polygon (normalized 0..1, 3..24 vertices) + a height
+ranking, the shape detector.py emits one level richer. `segment()` routes on
+SEGMENTER_PROVIDER:
+
+  vlm (default)  — Gemini traces the borders and guesses built heights in ONE
+                   call; cheap, but the polygons can be loose/hallucinated.
+  sam3_fal       — fal-ai/sam-3 returns a pixel-accurate mask per label
+                   (promptable-concept, one call each); the mask is traced to the
+                   same polygon shape (polygon_from_mask). Tighter borders for
+                   grounding/IoU; rel_height becomes a geometric proxy (mask bbox
+                   height) and est_height_m is left to the VLM/authored path.
+
+The return type (SegmentEntity) is identical across providers, so draft.py,
+annotate.py and recon_bench are untouched — flip SEGMENTER_PROVIDER and the same
+pipeline grounds on SAM3 instead. Tolerant parse throughout: a malformed entry is
+dropped, never raises.
 """
 from __future__ import annotations
 
+import asyncio
 import base64
+import io
 import json
+import math
 import os
 from typing import Any, TypedDict
 
@@ -32,6 +45,75 @@ def _segmenter_model() -> str:
         "WORLD_BENCH_JUDGE_MODEL",
         os.environ.get("OPENROUTER_VLM_MODEL", "google/gemini-3-flash-preview"),
     )
+
+
+def segmenter_provider() -> str:
+    """Which segmenter backs segment(): "vlm" (Gemini polygon trace, default —
+    nothing changes unless opted in) or "sam3_fal" (pixel-accurate masks from
+    fal-ai/sam-3, traced to the same polygon shape). An unknown value falls back
+    to "vlm" so a typo can never silently disable segmentation."""
+    v = os.environ.get("SEGMENTER_PROVIDER", "vlm").strip().lower()
+    return v if v in {"vlm", "sam3_fal"} else "vlm"
+
+
+def _sam_model() -> str:
+    return os.environ.get("FAL_SAM_MODEL", "fal-ai/sam-3/image")
+
+
+def polygon_from_mask(
+    mask_img: Any, n_vertices: int = 20, thresh: int = 127, max_dim: int = 256
+) -> list[list[float]]:
+    """Trace a binary mask's outline as a normalized polygon (0..1 image coords),
+    pure PIL — no cv2/numpy. Radial method: from the foreground centroid, cast
+    `n_vertices` rays and take the farthest foreground pixel along each. Exact for
+    star-convex blobs (mountains, islands, buildings — the corpus's targets) and a
+    graceful approximation otherwise; the SAM3 mask + box stay the source of truth
+    for tight IoU. Returns [] for an empty mask. Output matches SegmentEntity's
+    polygon: <=MAX_VERTICES vertices, clockwise-ish by ray order."""
+    g = mask_img.convert("L")
+    w0, h0 = g.size
+    scale = min(1.0, max_dim / max(w0, h0)) if max(w0, h0) else 1.0
+    if scale < 1.0:
+        g = g.resize((max(1, int(w0 * scale)), max(1, int(h0 * scale))))
+    w, h = g.size
+    px = g.load()
+    fg = [[bool(px[x, y] > thresh) for x in range(w)] for y in range(h)]
+    pts = [(x, y) for y in range(h) for x in range(w) if fg[y][x]]
+    if not pts:
+        return []
+
+    cx = sum(p[0] for p in pts) / len(pts)
+    cy = sum(p[1] for p in pts) / len(pts)
+    # if the centroid sits in a hole (crescent/donut), snap to the nearest fg pixel
+    if not fg[min(h - 1, max(0, int(cy)))][min(w - 1, max(0, int(cx)))]:
+        ox, oy = min(pts, key=lambda p: (p[0] - cx) ** 2 + (p[1] - cy) ** 2)
+        cx, cy = float(ox), float(oy)
+
+    max_r = math.hypot(w, h)
+    verts: list[list[float]] = []
+    for i in range(max(3, n_vertices)):
+        ang = 2.0 * math.pi * i / max(3, n_vertices)
+        dx, dy = math.cos(ang), math.sin(ang)
+        last: tuple[int, int] | None = None
+        r = 0.0
+        while r <= max_r:
+            x, y = round(cx + dx * r), round(cy + dy * r)
+            if 0 <= x < w and 0 <= y < h and fg[y][x]:
+                last = (x, y)
+                r += 1.0
+            else:
+                break
+        if last is not None:
+            verts.append([round(last[0] / w, 4), round(last[1] / h, 4)])
+
+    # drop consecutive duplicates + a closing vertex equal to the first
+    out: list[list[float]] = []
+    for v in verts:
+        if not out or out[-1] != v:
+            out.append(v)
+    if len(out) > 1 and out[0] == out[-1]:
+        out.pop()
+    return out[:MAX_VERTICES] if len(out) >= MIN_VERTICES else []
 
 
 def _clamp01(v: Any) -> float:
@@ -101,9 +183,84 @@ def parse_segments(payload: Any) -> list[SegmentEntity]:
 
 
 async def segment(image_bytes: bytes, labels: list[str]) -> list[SegmentEntity]:
-    """Segment the given labels in the image: one closed border polygon +
-    height ranking per label actually present (the VLM is told NOT to invent
-    absent labels). One call covers all labels."""
+    """Segment the given labels: one closed border polygon + height ranking per
+    label actually present. Routes on SEGMENTER_PROVIDER (default "vlm"); the
+    return shape is identical across providers so draft/annotate/recon are
+    untouched."""
+    if segmenter_provider() == "sam3_fal":
+        return await _segment_sam3(image_bytes, labels)
+    return await _segment_vlm(image_bytes, labels)
+
+
+async def _segment_sam3(image_bytes: bytes, labels: list[str]) -> list[SegmentEntity]:
+    """Pixel-accurate segmentation via fal-ai/sam-3 (one promptable-concept call
+    per label). The SAM3 mask PNG is traced to the SegmentEntity polygon shape;
+    rel_height is the mask's normalized bbox height ranked against the tallest
+    label (a geometric proxy — SAM3 doesn't estimate built height, so
+    est_height_m stays None and the VLM/authored path keeps that job). A label
+    SAM3 can't find is omitted (no mask returned), same contract as the VLM path."""
+    from PIL import Image
+
+    from providers.image import _fal_subscribe, _fetch_url_bytes
+
+    data_uri = f"data:image/jpeg;base64,{base64.b64encode(image_bytes).decode('ascii')}"
+    model = _sam_model()
+
+    async def one(label: str) -> tuple[SegmentEntity, float] | None:
+        try:
+            result = await _fal_subscribe(
+                model,
+                {
+                    "image_url": data_uri,
+                    "prompt": label,
+                    "apply_mask": False,
+                    "include_boxes": True,
+                    "include_scores": True,
+                    "max_masks": 1,
+                },
+            )
+        except Exception:
+            return None
+        masks = result.get("masks") or []
+        if not masks:
+            return None  # SAM3 found no instance of this concept
+        url = masks[0].get("url") if isinstance(masks[0], dict) else None
+        if not url:
+            return None
+        try:
+            mask_bytes, _ = await _fetch_url_bytes(url)
+            polygon = polygon_from_mask(Image.open(io.BytesIO(mask_bytes)))
+        except Exception:
+            return None
+        if len(polygon) < MIN_VERTICES:
+            return None
+        boxes = result.get("boxes") or []
+        scores = result.get("scores") or []
+        box_h = float(boxes[0][3]) if boxes and len(boxes[0]) >= 4 else 0.0
+        score = _clamp01(scores[0]) if scores else 1.0
+        seg: SegmentEntity = {
+            "label": label,
+            "polygon": polygon,
+            "rel_height": 0.0,  # filled below, once we know the tallest
+            "est_height_m": None,
+            "score": score,
+        }
+        return seg, box_h
+
+    results = [r for r in await asyncio.gather(*[one(label) for label in labels]) if r]
+    if not results:
+        return []
+    tallest = max((box_h for _, box_h in results), default=0.0)
+    out: list[SegmentEntity] = []
+    for seg, box_h in results:
+        seg["rel_height"] = _clamp01(box_h / tallest) if tallest > 0 else 0.0
+        out.append(seg)
+    return out
+
+
+async def _segment_vlm(image_bytes: bytes, labels: list[str]) -> list[SegmentEntity]:
+    """The VLM polygon tracer (Gemini): one call covers all labels; the VLM is
+    told NOT to invent absent labels."""
     from providers import llm
 
     b64 = base64.b64encode(image_bytes).decode("ascii")

--- a/apps/modal-backend/providers/segmenter.py
+++ b/apps/modal-backend/providers/segmenter.py
@@ -60,6 +60,21 @@ def _sam_model() -> str:
     return os.environ.get("FAL_SAM_MODEL", "fal-ai/sam-3/image")
 
 
+def detector_box_to_sam_box(det: dict[str, Any], img_w: int, img_h: int) -> dict[str, int]:
+    """Convert a detector box (centre-based, normalized 0..1: x_pct, y_pct,
+    w_pct, h_pct) into a SAM3 box_prompt (pixel corners {x_min,y_min,x_max,
+    y_max}, clamped to the image). SAM3 can't ground a proper-noun label like
+    "Spyglass Hill" from text, but the VLM detector localizes it — so we hand
+    SAM3 the box and let it refine the pixel mask."""
+    x, y = float(det.get("x_pct", 0.5)), float(det.get("y_pct", 0.5))
+    w, h = float(det.get("w_pct", 0.0)), float(det.get("h_pct", 0.0))
+    x_min = min(max(0, round((x - w / 2) * img_w)), img_w)
+    y_min = min(max(0, round((y - h / 2) * img_h)), img_h)
+    x_max = min(max(0, round((x + w / 2) * img_w)), img_w)
+    y_max = min(max(0, round((y + h / 2) * img_h)), img_h)
+    return {"x_min": x_min, "y_min": y_min, "x_max": x_max, "y_max": y_max}
+
+
 def polygon_from_mask(
     mask_img: Any, n_vertices: int = 20, thresh: int = 127, max_dim: int = 256
 ) -> list[list[float]]:
@@ -182,43 +197,58 @@ def parse_segments(payload: Any) -> list[SegmentEntity]:
     return out
 
 
-async def segment(image_bytes: bytes, labels: list[str]) -> list[SegmentEntity]:
+async def segment(
+    image_bytes: bytes,
+    labels: list[str],
+    boxes: list[dict[str, Any]] | None = None,
+) -> list[SegmentEntity]:
     """Segment the given labels: one closed border polygon + height ranking per
     label actually present. Routes on SEGMENTER_PROVIDER (default "vlm"); the
     return shape is identical across providers so draft/annotate/recon are
-    untouched."""
+    untouched. `boxes` (the detector's output for these labels) is used only by
+    the SAM3 path — proper-noun labels don't ground from text, so the detector's
+    box localizes the concept and SAM3 refines the mask; the VLM path ignores it."""
     if segmenter_provider() == "sam3_fal":
-        return await _segment_sam3(image_bytes, labels)
+        return await _segment_sam3(image_bytes, labels, boxes)
     return await _segment_vlm(image_bytes, labels)
 
 
-async def _segment_sam3(image_bytes: bytes, labels: list[str]) -> list[SegmentEntity]:
-    """Pixel-accurate segmentation via fal-ai/sam-3 (one promptable-concept call
-    per label). The SAM3 mask PNG is traced to the SegmentEntity polygon shape;
+async def _segment_sam3(
+    image_bytes: bytes,
+    labels: list[str],
+    boxes: list[dict[str, Any]] | None,
+) -> list[SegmentEntity]:
+    """Pixel-accurate segmentation via fal-ai/sam-3, one call per label. Each
+    label is BOX-PROMPTED with its detector box (proper-noun text prompts return
+    nothing; a box scores reliably), falling back to a text prompt when no box is
+    available. The SAM3 mask PNG is traced to the SegmentEntity polygon shape;
     rel_height is the mask's normalized bbox height ranked against the tallest
     label (a geometric proxy — SAM3 doesn't estimate built height, so
     est_height_m stays None and the VLM/authored path keeps that job). A label
-    SAM3 can't find is omitted (no mask returned), same contract as the VLM path."""
+    SAM3 can't ground is omitted, same contract as the VLM path."""
     from PIL import Image
 
     from providers.image import _fal_subscribe, _fetch_url_bytes
 
     data_uri = f"data:image/jpeg;base64,{base64.b64encode(image_bytes).decode('ascii')}"
     model = _sam_model()
+    img_w, img_h = Image.open(io.BytesIO(image_bytes)).size
+    box_by = {str(b.get("label", "")).lower(): b for b in (boxes or [])}
 
     async def one(label: str) -> tuple[SegmentEntity, float] | None:
+        arguments: dict[str, Any] = {
+            "image_url": data_uri,
+            "prompt": label,
+            "apply_mask": False,
+            "include_boxes": True,
+            "include_scores": True,
+            "max_masks": 1,
+        }
+        det = box_by.get(label.lower())
+        if det is not None:
+            arguments["box_prompts"] = [detector_box_to_sam_box(det, img_w, img_h)]
         try:
-            result = await _fal_subscribe(
-                model,
-                {
-                    "image_url": data_uri,
-                    "prompt": label,
-                    "apply_mask": False,
-                    "include_boxes": True,
-                    "include_scores": True,
-                    "max_masks": 1,
-                },
-            )
+            result = await _fal_subscribe(model, arguments)
         except Exception:
             return None
         masks = result.get("masks") or []

--- a/apps/modal-backend/tests/descent_bench/__init__.py
+++ b/apps/modal-backend/tests/descent_bench/__init__.py
@@ -1,0 +1,3 @@
+"""Descent reconstruction bench: does ENTERING a parent map's place reproduce the
+REAL child (interior/closeup)? Reuses the continuity bench's region crop + enter
+generation, but scores against the linked real photo, not just self-consistency."""

--- a/apps/modal-backend/tests/descent_bench/runner.py
+++ b/apps/modal-backend/tests/descent_bench/runner.py
@@ -1,0 +1,128 @@
+"""Descent reconstruction bench — the M4 payoff.
+
+For each golden chain (a child interior/closeup linked via parent_id+parent_ref to
+a place ENTITY in a parent map), crop the parent map at that place and generate an
+"enter" view two ways:
+  with   — region-conditioned on the cropped parent place (the product descent)
+  without— a plain fresh generation (baseline)
+then JUDGE both against the REAL child photo (style match) and the cropped region
+(continuity). The headline metric is style_lift = how much region-conditioning
+moves the descent TOWARD the real place. Reuses the continuity bench's region
+crop + enter generation.
+
+Dry by default (resolve chains + cost preview, $0):
+    .venv/bin/python -m tests.descent_bench.runner
+Live (DESCENT_BENCH_RUN=1, ~$0.30/chain — 2 image gens + 3 judges):
+    make eval-descent
+Needs `make corpus-fetch` (parent + child images) and VERIFIED parent descriptions.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from tests.map_corpus import image_path, load_descriptions, load_manifest
+from tests.map_corpus.chains import descent_chains
+
+_REPORT = Path(__file__).resolve().parent / "reports" / "descent_latest.json"
+_GEN_USD = 0.15  # one balanced image
+_JUDGE_USD = 0.001
+
+
+def _load_env() -> None:
+    env = Path(__file__).resolve().parents[2] / ".env"
+    if env.exists():
+        for line in env.read_text().splitlines():
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                k, _, v = line.partition("=")
+                os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+    os.environ.setdefault("CONTINUITY_BENCH_JUDGE_MODEL", "google/gemini-3-flash-preview")
+
+
+def _model() -> str:
+    # force the balanced model (the .env may pin plain nano-banana — memory
+    # project_fal_model_pin — which garbles; nano-banana-pro is the real balanced)
+    return os.environ.get("FAL_IMAGE_MODEL_BALANCED", "fal-ai/nano-banana-pro")
+
+
+def resolve_chains() -> list[dict[str, Any]]:
+    descs = {d["map_id"]: d for d in load_descriptions(status="verified")}
+    return descent_chains(load_manifest(), descs)
+
+
+async def _score_chain(chain: dict[str, Any], aspect: str) -> dict[str, Any]:
+    from providers import image as image_provider
+    from providers import judge
+    from tests.continuity_bench.coherence_runner import _enter, _region_crop
+
+    parent_bytes = image_path(chain["parent_id"]).read_bytes()
+    child_bytes = image_path(chain["child_id"]).read_bytes()
+    region = _region_crop(parent_bytes, chain["anchor"])
+    region_url = image_provider.encode_data_url(region)
+    label = chain["label"]
+    base = f"A closer, interior view of {label}, a place within the parent map."
+    preamble = image_provider.conditioning_preamble(["region"], "place_scene")
+    model = _model()
+
+    with_img = await _enter(f"{preamble}\n\n{base}", aspect, model, region_url)
+    without_img = await _enter(base, aspect, model, None)
+    real_with = await judge.score_style_pair(child_bytes, with_img)
+    real_without = await judge.score_style_pair(child_bytes, without_img)
+    continuity = await judge.score_continuation(region, with_img)
+    return {
+        "child_id": chain["child_id"],
+        "parent_id": chain["parent_id"],
+        "place": label,
+        "real_style_with": round(real_with.score, 2),
+        "real_style_without": round(real_without.score, 2),
+        "style_lift": round(real_with.score - real_without.score, 2),
+        "continuity_with": round(continuity.score, 2),
+        "rationale": real_with.rationale,
+    }
+
+
+async def _run(chains: list[dict[str, Any]]) -> dict[str, Any]:
+    rows = [await _score_chain(c, "16:9") for c in chains]
+    lifts = [r["style_lift"] for r in rows]
+    return {
+        "run_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "chains": rows,
+        "mean_style_lift": round(sum(lifts) / len(lifts), 3) if lifts else 0.0,
+    }
+
+
+def main() -> int:
+    _load_env()
+    chains = resolve_chains()
+    print(f"descent: {len(chains)} golden chain(s) resolved")
+    for c in chains:
+        print(f"  {c['parent_id']} :: {c['label']!r} -> {c['child_id']}")
+    if not chains:
+        print("  (none — link a child manifest row with parent_id + parent_ref to a "
+              "verified parent map entity)")
+        return 0
+    if os.environ.get("DESCENT_BENCH_RUN") != "1":
+        cost = len(chains) * (2 * _GEN_USD + 3 * _JUDGE_USD)
+        print(f"\nDRY RUN — would spend ~${cost:.2f} ({len(chains)} chain(s) x 2 gens + 3 judges).")
+        print("Set DESCENT_BENCH_RUN=1 to execute.")
+        return 0
+    report = asyncio.run(_run(chains))
+    _REPORT.parent.mkdir(parents=True, exist_ok=True)
+    _REPORT.write_text(json.dumps(report, indent=2) + "\n")
+    print(f"\nmean style_lift: {report['mean_style_lift']:+.3f} over {len(report['chains'])} chain(s)")
+    for r in report["chains"]:
+        print(
+            f"  {r['place']:<16} real-style with={r['real_style_with']} "
+            f"without={r['real_style_without']} (lift {r['style_lift']:+}) "
+            f"continuity={r['continuity_with']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/modal-backend/tests/descent_bench/runner.py
+++ b/apps/modal-backend/tests/descent_bench/runner.py
@@ -71,6 +71,14 @@ async def _score_chain(chain: dict[str, Any], aspect: str) -> dict[str, Any]:
 
     with_img = await _enter(f"{preamble}\n\n{base}", aspect, model, region_url)
     without_img = await _enter(base, aspect, model, None)
+    # save artifacts for visual inspection (overlays/ is gitignored)
+    from tests.map_corpus import ROOT
+
+    art = ROOT / "overlays"
+    art.mkdir(parents=True, exist_ok=True)
+    (art / f"descent-{chain['child_id']}-region.jpg").write_bytes(region)
+    (art / f"descent-{chain['child_id']}-with.jpg").write_bytes(with_img)
+    (art / f"descent-{chain['child_id']}-without.jpg").write_bytes(without_img)
     real_with = await judge.score_style_pair(child_bytes, with_img)
     real_without = await judge.score_style_pair(child_bytes, without_img)
     continuity = await judge.score_continuation(region, with_img)

--- a/apps/modal-backend/tests/map_corpus/__init__.py
+++ b/apps/modal-backend/tests/map_corpus/__init__.py
@@ -20,8 +20,13 @@ FRAME_W = 100.0
 FRAME_H = 60.0
 
 
-def load_manifest() -> list[dict[str, Any]]:
-    return json.loads(MANIFEST.read_text())["maps"]
+def load_manifest(tier: str | None = None) -> list[dict[str, Any]]:
+    """Corpus source rows. Each row carries a `tier` (map | interior | closeup);
+    rows authored before tiers existed default to "map". Pass `tier` to filter."""
+    rows = json.loads(MANIFEST.read_text())["maps"]
+    for r in rows:
+        r.setdefault("tier", "map")
+    return [r for r in rows if r.get("tier") == tier] if tier is not None else rows
 
 
 def image_path(map_id: str) -> Path:

--- a/apps/modal-backend/tests/map_corpus/annotate.py
+++ b/apps/modal-backend/tests/map_corpus/annotate.py
@@ -290,20 +290,58 @@ def assemble_description(
 # refine once on a low score. Verified by dry-run, not unit tests (same split as
 # draft.py / recon_bench).
 
+# The describe prompt is tier-specific (a map is annotated cartographically; an
+# interior as a scene; a closeup as an object) but the RETURN SHAPE is identical
+# across tiers — same style/scale_tier/description/entities/relations — so the
+# reconcile, geometry and recon machinery is unchanged. describe_system(tier)
+# picks the variant; an unknown tier falls back to the map prompt.
+_ENTITY_TAIL = (
+    "entities: [6-10 of the most prominent {what}: {{ref: <kebab-slug>, kind: "
+    'one of ["place","item","creature","person"], label: <its name>, visual: '
+    "<=12 words}}], relations: [4-8 spatial relations between entity LABELS (use "
+    "the exact label strings, not slugs): {{subject: <label>, relation: one of "
+    '["near","behind","in_front_of","left_of","right_of","inside","on_top_of",'
+    '"facing"], object: <label>}}]}}.'
+)
+
 _DESCRIBE_SYSTEM = (
     "You are a careful cartographic annotator. Given a map image, return ONE "
     "JSON object: {style: <art medium + palette, <=25 words>, scale_tier: one "
     'of ["region","city","district","place"], description: <a precise 120-200 '
     "word prose description of the WHOLE map a painter could redraw it from — "
     "name the major features, their relative positions (north/south/etc), "
-    "relative sizes and heights>, entities: [6-10 of the most prominent named "
-    "features: {ref: <kebab-slug>, kind: one of "
-    '["place","item","creature","person"], label: <the feature\'s name>, '
-    "visual: <=12 words}], relations: [4-8 spatial relations between entity "
-    "LABELS (use the exact label strings, not slugs): {subject: <label>, "
-    'relation: one of ["near","behind","in_front_of","left_of","right_of",'
-    '"inside","on_top_of","facing"], object: <label>}]}.'
+    "relative sizes and heights>, " + _ENTITY_TAIL.format(what="named features")
 )
+
+_INTERIOR_SYSTEM = (
+    "You are a careful interior-scene annotator. Given a photo of the INSIDE of "
+    "a place (a room, hall, or building interior), return ONE JSON object: "
+    "{style: <medium + palette / photo look, <=25 words>, scale_tier: one of "
+    '["place","room"], description: <a precise 120-200 word description of the '
+    "space a set designer could rebuild it from — the layout, major furniture "
+    "and fixtures, where each sits (left/right/back/foreground), the lighting>, "
+    + _ENTITY_TAIL.format(what="objects and fixtures in the room")
+)
+
+_CLOSEUP_SYSTEM = (
+    "You are a careful object annotator. Given a CLOSEUP photo of a single "
+    "object or artifact, return ONE JSON object: {style: <medium + palette / "
+    'photo look, <=25 words>, scale_tier: one of ["room","object"], '
+    "description: <a precise 120-200 word description a sculptor/maker could "
+    "reproduce it from — its overall form, materials, parts and their "
+    "arrangement, surface detail>, "
+    + _ENTITY_TAIL.format(what="distinct parts or details of the object")
+)
+
+
+def describe_system(tier: str) -> str:
+    """The describe-prompt for a corpus tier (map | interior | closeup); an
+    unknown tier falls back to the cartographic (map) prompt."""
+    if tier == "interior":
+        return _INTERIOR_SYSTEM
+    if tier == "closeup":
+        return _CLOSEUP_SYSTEM
+    return _DESCRIBE_SYSTEM
 
 _ANNOTATION_SCHEMA: dict[str, Any] = {
     "type": "object",
@@ -416,13 +454,15 @@ def _next_rev(map_id: str) -> int:
     return 1
 
 
-async def _describe(model: str, image_bytes: bytes, feedback: str = "") -> dict[str, Any]:
-    """One VLM's structured annotation of the map. `feedback` (a judge rationale)
-    is fed back on a refine pass."""
+async def _describe(
+    model: str, image_bytes: bytes, system: str, feedback: str = ""
+) -> dict[str, Any]:
+    """One VLM's structured annotation under the tier-specific `system` prompt.
+    `feedback` (a judge rationale) is fed back on a refine pass."""
     from providers import llm
 
     b64 = base64.b64encode(image_bytes).decode("ascii")
-    user_text = "Describe this map." + (
+    user_text = "Describe this image precisely." + (
         f"\n\nA reviewer flagged the previous annotation: {feedback} Re-describe "
         "carefully — fix those issues and name any prominent feature that was missed."
         if feedback
@@ -431,7 +471,7 @@ async def _describe(model: str, image_bytes: bytes, feedback: str = "") -> dict[
     return await llm._complete_json(
         model=model,
         messages=[
-            {"role": "system", "content": _DESCRIBE_SYSTEM},
+            {"role": "system", "content": system},
             {
                 "role": "user",
                 "content": [
@@ -459,7 +499,10 @@ async def annotate_one(map_id: str) -> Path:
     from providers.detector import detect
     from providers.segmenter import segment
 
-    genre = next((m["genre"] for m in load_manifest() if m["id"] == map_id), "")
+    row = next((m for m in load_manifest() if m["id"] == map_id), {})
+    genre = str(row.get("genre", ""))
+    tier = str(row.get("tier", "map"))
+    system = describe_system(tier)
     img = image_path(map_id)
     if not img.exists():
         raise SystemExit(f"{img} missing — run `make corpus-fetch` first")
@@ -472,7 +515,7 @@ async def annotate_one(map_id: str) -> Path:
     best: dict[str, Any] | None = None
     for attempt in range(_max_iters()):
         results = await asyncio.gather(
-            *[_describe(m, image_bytes, feedback) for m in models],
+            *[_describe(m, image_bytes, system, feedback) for m in models],
             return_exceptions=True,
         )
         # Instrument the fan-out boundary: a dropped/failed model must be visible,

--- a/apps/modal-backend/tests/map_corpus/annotate.py
+++ b/apps/modal-backend/tests/map_corpus/annotate.py
@@ -11,6 +11,10 @@ judge AND the ensemble agreement both clear their thresholds the description is
 auto-promoted to review.status="verified"; otherwise it lands as "needs_human"
 with the disagreements attached, so a person reviews the exception, not every map.
 
+Non-destructive by default: a committed human-`verified` description is never
+silently overwritten — a fresh annotation lands in `descriptions/candidates/<id>.json`
+(invisible to recon) for review, unless CORPUS_ANNOTATE_FORCE=1.
+
 The reconcile / agreement / promote core is pure and gated by test_annotate.py;
 the paid fan-out + judge loop is the thin async wrapper at the bottom.
 """
@@ -230,6 +234,18 @@ def decide_status(
     return "needs_human"
 
 
+def output_name(map_id: str, existing_status: str | None, *, force: bool) -> str:
+    """Where to write the annotation (relative to DESCRIPTIONS), non-destructive
+    by default: a committed human-verified description is NEVER silently
+    overwritten — the fresh annotation lands as `candidates/<id>.json` (a subdir
+    invisible to load_descriptions/recon) so a person promotes it on review.
+    Anything else (no prior file, a draft, a prior auto-run) writes canonically.
+    force=True (CORPUS_ANNOTATE_FORCE) overrides the guard."""
+    if existing_status == "verified" and not force:
+        return f"candidates/{map_id}.json"
+    return f"{map_id}.json"
+
+
 def assemble_description(
     *,
     map_id: str,
@@ -360,6 +376,22 @@ def _longest(strings: list[str]) -> str:
     and prose from the ensemble's drafts."""
     cleaned = [s.strip() for s in strings if isinstance(s, str) and s.strip()]
     return max(cleaned, key=len) if cleaned else ""
+
+
+def _force_overwrite() -> bool:
+    return os.environ.get("CORPUS_ANNOTATE_FORCE", "").strip().lower() in {"1", "true", "yes"}
+
+
+def _existing_status(map_id: str) -> str | None:
+    """review.status of the committed description for this map, or None if there
+    is no canonical file yet."""
+    path = DESCRIPTIONS / f"{map_id}.json"
+    if not path.exists():
+        return None
+    try:
+        return str(json.loads(path.read_text()).get("review", {}).get("status")) or None
+    except Exception:
+        return None
 
 
 def _next_rev(map_id: str) -> int:
@@ -508,14 +540,20 @@ async def annotate_one(map_id: str) -> Path:
         by="ensemble-annotate",
         date=time.strftime("%Y-%m-%d", time.gmtime()),
     )
-    DESCRIPTIONS.mkdir(parents=True, exist_ok=True)
-    out = DESCRIPTIONS / f"{map_id}.json"
+    rel = output_name(map_id, _existing_status(map_id), force=_force_overwrite())
+    out = DESCRIPTIONS / rel
+    out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(json.dumps(desc, indent=1) + "\n")
     print(
         f"  {map_id}: {best['status']} "
         f"(judge {annotation['judge_score']}, agreement {annotation['agreement']}, "
-        f"{len(best['geo_entities'])} entities, {best['iters']} iter) -> {out.name}"
+        f"{len(best['geo_entities'])} entities, {best['iters']} iter) -> {rel}"
     )
+    if rel.startswith("candidates/"):
+        print(
+            "  (verified original preserved — wrote a CANDIDATE; review it, then move "
+            "it into descriptions/ to promote, or set CORPUS_ANNOTATE_FORCE=1 to overwrite)"
+        )
     return out
 
 
@@ -551,6 +589,10 @@ def main() -> int:
         print(
             f"  gates: judge>={_judge_threshold()} AND agreement>="
             f"{_agreement_threshold()} -> auto-verified, else needs_human"
+        )
+        print(
+            "  non-destructive: a verified description is preserved; output lands in "
+            "descriptions/candidates/ unless CORPUS_ANNOTATE_FORCE=1"
         )
         return 0
     _load_env()

--- a/apps/modal-backend/tests/map_corpus/annotate.py
+++ b/apps/modal-backend/tests/map_corpus/annotate.py
@@ -352,11 +352,21 @@ def _ensemble_models() -> list[str]:
     return [llm._vlm_model()]
 
 
-def _min_votes(n_models: int) -> int:
-    override = os.environ.get("CORPUS_MIN_VOTES")
-    if override:
-        return max(1, int(override))
-    return 1 if n_models <= 1 else n_models // 2 + 1  # simple majority
+def default_min_votes(n_effective: int, override: int | None) -> int:
+    """How many DISTINCT models must name an entity for it to reach consensus.
+    Default 1 (union — recall-first; corroboration is expressed by the agreement
+    score + the detector/judge/human gates, not by dropping singletons). An
+    explicit CORPUS_MIN_VOTES is honoured but CLAMPED to the models that actually
+    contributed, so a strict policy + a dropped model can never force-empty the
+    consensus (the 0-entity collapse this guard exists to prevent)."""
+    if override is not None:
+        return max(1, min(override, max(1, n_effective)))
+    return 1
+
+
+def _min_votes_override() -> int | None:
+    raw = os.environ.get("CORPUS_MIN_VOTES", "").strip()
+    return int(raw) if raw else None
 
 
 def _judge_threshold() -> float:
@@ -457,19 +467,29 @@ async def annotate_one(map_id: str) -> Path:
 
     models = _ensemble_models()
     n = len(models)
-    min_votes = _min_votes(n)
 
     feedback = ""
     best: dict[str, Any] | None = None
     for attempt in range(_max_iters()):
-        drafts = await asyncio.gather(
+        results = await asyncio.gather(
             *[_describe(m, image_bytes, feedback) for m in models],
             return_exceptions=True,
         )
-        draft_dicts = [d for d in drafts if isinstance(d, dict) and d.get("entities")]
+        # Instrument the fan-out boundary: a dropped/failed model must be visible,
+        # never silently swallowed (that masked a degraded ensemble as "disagreement").
+        draft_dicts: list[dict[str, Any]] = []
+        for model, r in zip(models, results, strict=True):
+            if isinstance(r, Exception):
+                print(f"    {model}: ERROR {type(r).__name__}: {str(r)[:140]}")
+            elif isinstance(r, dict) and r.get("entities"):
+                print(f"    {model}: {len(r['entities'])} entities")
+                draft_dicts.append(r)
+            else:
+                print(f"    {model}: no entities returned")
         if not draft_dicts:
             raise SystemExit(f"{map_id}: every ensemble describe call failed/empty")
 
+        min_votes = default_min_votes(len(draft_dicts), _min_votes_override())
         consensus, minority = merge_entities(
             [d.get("entities", []) for d in draft_dicts], min_votes=min_votes
         )
@@ -507,6 +527,8 @@ async def annotate_one(map_id: str) -> Path:
             "rationale": jr.rationale,
             "status": status,
             "iters": attempt + 1,
+            "contributors": len(draft_dicts),
+            "min_votes": min_votes,
         }
         if best is None or cand["judge_score"] > best["judge_score"]:
             best = cand
@@ -517,8 +539,9 @@ async def annotate_one(map_id: str) -> Path:
     assert best is not None
     annotation = {
         "ensemble": models,
+        "contributors": best["contributors"],
         "reconcile": "deterministic-merge",
-        "min_votes": min_votes,
+        "min_votes": best["min_votes"],
         "iters": best["iters"],
         "judge_score": round(float(best["judge_score"]), 2),
         "agreement": round(float(best["agreement"]), 3),

--- a/apps/modal-backend/tests/map_corpus/annotate.py
+++ b/apps/modal-backend/tests/map_corpus/annotate.py
@@ -234,13 +234,19 @@ def decide_status(
     return "needs_human"
 
 
-def output_name(map_id: str, existing_status: str | None, *, force: bool) -> str:
+def output_name(
+    map_id: str, existing_status: str | None, status: str, *, force: bool
+) -> str:
     """Where to write the annotation (relative to DESCRIPTIONS), non-destructive
-    by default: a committed human-verified description is NEVER silently
-    overwritten — the fresh annotation lands as `candidates/<id>.json` (a subdir
-    invisible to load_descriptions/recon) so a person promotes it on review.
-    Anything else (no prior file, a draft, a prior auto-run) writes canonically.
-    force=True (CORPUS_ANNOTATE_FORCE) overrides the guard."""
+    by default. A fresh annotation lands as `candidates/<id>.json` (a subdir
+    invisible to load_descriptions / recon / the integrity gate) when either: the
+    run did NOT auto-verify (a `needs_human` verdict is not reviewed ground
+    truth), or a committed human-`verified` description already exists (never
+    silently clobbered). An auto-`verified` result with nothing to protect is
+    promoted to `<id>.json`. force=True (CORPUS_ANNOTATE_FORCE) overrides the
+    clobber guard."""
+    if status != "verified":
+        return f"candidates/{map_id}.json"
     if existing_status == "verified" and not force:
         return f"candidates/{map_id}.json"
     return f"{map_id}.json"
@@ -606,7 +612,9 @@ async def annotate_one(map_id: str) -> Path:
         by="ensemble-annotate",
         date=time.strftime("%Y-%m-%d", time.gmtime()),
     )
-    rel = output_name(map_id, _existing_status(map_id), force=_force_overwrite())
+    rel = output_name(
+        map_id, _existing_status(map_id), best["status"], force=_force_overwrite()
+    )
     out = DESCRIPTIONS / rel
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(json.dumps(desc, indent=1) + "\n")
@@ -616,9 +624,14 @@ async def annotate_one(map_id: str) -> Path:
         f"{len(best['geo_entities'])} entities, {best['iters']} iter) -> {rel}"
     )
     if rel.startswith("candidates/"):
+        why = (
+            "verdict is needs_human"
+            if best["status"] != "verified"
+            else "a verified original is preserved"
+        )
         print(
-            "  (verified original preserved — wrote a CANDIDATE; review it, then move "
-            "it into descriptions/ to promote, or set CORPUS_ANNOTATE_FORCE=1 to overwrite)"
+            f"  (wrote a CANDIDATE — {why}; review it, then move it into descriptions/ "
+            "to promote)"
         )
     return out
 

--- a/apps/modal-backend/tests/map_corpus/annotate.py
+++ b/apps/modal-backend/tests/map_corpus/annotate.py
@@ -495,7 +495,7 @@ async def annotate_one(map_id: str) -> Path:
         )
         labels = [e["label"] for e in consensus]
         detections = await detect(image_bytes, labels)
-        segments = await segment(image_bytes, labels)
+        segments = await segment(image_bytes, labels, boxes=detections)
         heights_m = heights_lib.infer_heights_m(list(segments))
         geo_entities = attach_geometry(consensus, detections, segments, heights_m)
 

--- a/apps/modal-backend/tests/map_corpus/annotate.py
+++ b/apps/modal-backend/tests/map_corpus/annotate.py
@@ -1,0 +1,562 @@
+"""Ensemble corpus annotation — the evolvable upgrade to draft.py.
+
+draft.py asks ONE VLM to describe a map, then a human verifies it. This module
+fans the describe call out over N VLMs (CORPUS_ANNOTATE_MODELS, e.g. a Claude
+slug + Gemini + a Qwen-VL — all through the one OpenRouter client), then
+RECONCILES their entity lists into a single consensus deterministically (no
+extra paid arbiter call — the merge is pure code, cacheable and testable). An
+annotation-quality judge scores the consensus against the image; a low score
+triggers one targeted re-describe (the judge's rationale fed back). When the
+judge AND the ensemble agreement both clear their thresholds the description is
+auto-promoted to review.status="verified"; otherwise it lands as "needs_human"
+with the disagreements attached, so a person reviews the exception, not every map.
+
+The reconcile / agreement / promote core is pure and gated by test_annotate.py;
+the paid fan-out + judge loop is the thin async wrapper at the bottom.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import re
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from tests.map_corpus import (
+    DESCRIPTIONS,
+    FRAME_H,
+    FRAME_W,
+    image_path,
+    load_manifest,
+)
+
+_ARTICLE_RE = re.compile(r"^(the|a|an)\s+")
+_EDGE_PUNCT_RE = re.compile(r"^[^a-z0-9]+|[^a-z0-9]+$")
+_WS_RE = re.compile(r"\s+")
+
+
+def norm_label(s: str) -> str:
+    """Canonical key for cross-model entity matching: lowercase, collapse
+    internal whitespace, strip edge punctuation, drop a single leading article
+    so "The Tower" matches "Tower"."""
+    t = _WS_RE.sub(" ", str(s).strip().lower())
+    t = _EDGE_PUNCT_RE.sub("", t)
+    t = _ARTICLE_RE.sub("", t)
+    return t.strip()
+
+
+def slug(s: str) -> str:
+    """Kebab-case ref slug (same convention as draft._slug)."""
+    return re.sub(r"[^a-z0-9]+", "-", str(s).lower()).strip("-") or "x"
+
+
+def _mode_first_seen(items: list[str]) -> str:
+    """Most common item; ties broken by first appearance (deterministic)."""
+    if not items:
+        return ""
+    counts = Counter(items)
+    best = max(counts.values())
+    for it in items:
+        if counts[it] == best:
+            return it
+    return items[0]
+
+
+def merge_entities(
+    drafts: list[list[dict[str, Any]]], *, min_votes: int
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Reconcile N per-model entity lists into one consensus. Entities are
+    matched across models by norm_label; an entity reaching >= min_votes
+    DISTINCT models (a model naming it twice is one vote) is consensus, the
+    rest are minority (disagreements). Per consensus entity: canonical label =
+    most-frequent surface form (tie -> first-seen), kind = majority vote, visual
+    = the richest (longest) non-empty description, votes = distinct model count."""
+    order: list[str] = []
+    info: dict[str, dict[str, Any]] = {}
+    for di, draft in enumerate(drafts):
+        if not isinstance(draft, list):
+            continue
+        for e in draft:
+            if not isinstance(e, dict):
+                continue
+            label = str(e.get("label", "")).strip()
+            if not label:
+                continue
+            key = norm_label(label)
+            if not key:
+                continue
+            if key not in info:
+                info[key] = {"voters": set(), "labels": [], "kinds": [], "visuals": []}
+                order.append(key)
+            rec = info[key]
+            rec["voters"].add(di)
+            rec["labels"].append(label)
+            rec["kinds"].append(str(e.get("kind", "")).strip() or "place")
+            visual = str(e.get("visual", "")).strip()
+            if visual:
+                rec["visuals"].append(visual)
+
+    consensus: list[dict[str, Any]] = []
+    minority: list[dict[str, Any]] = []
+    for key in order:
+        rec = info[key]
+        votes = len(rec["voters"])
+        label = _mode_first_seen(rec["labels"])
+        ent = {
+            "ref": slug(label),
+            "kind": _mode_first_seen(rec["kinds"]) or "place",
+            "label": label,
+            "visual": max(rec["visuals"], key=len) if rec["visuals"] else "",
+            "votes": votes,
+        }
+        (consensus if votes >= min_votes else minority).append(ent)
+    return consensus, minority
+
+
+def merge_relations(
+    relation_lists: list[list[dict[str, Any]]], label_to_ref: dict[str, str]
+) -> list[dict[str, Any]]:
+    """Reconcile per-model relation lists. Endpoints are entity LABELS (the
+    describe prompt asks for labels, not slugs); each is normalised and resolved
+    against label_to_ref (norm_label -> consensus ref). A relation survives only
+    when BOTH endpoints resolve to distinct consensus entities. Deduped, first-
+    seen order preserved."""
+    out: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for rels in relation_lists:
+        if not isinstance(rels, list):
+            continue
+        for r in rels:
+            if not isinstance(r, dict):
+                continue
+            subj = label_to_ref.get(norm_label(str(r.get("subject", ""))))
+            obj = label_to_ref.get(norm_label(str(r.get("object", ""))))
+            rel = str(r.get("relation", "")).strip() or "near"
+            if not subj or not obj or subj == obj:
+                continue
+            key = (subj, rel, obj)
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append({"subject": subj, "relation": rel, "object": obj})
+    return out
+
+
+def attach_geometry(
+    consensus: list[dict[str, Any]],
+    detections: list[dict[str, Any]],
+    segments: list[dict[str, Any]],
+    heights_m: dict[str, float],
+) -> list[dict[str, Any]]:
+    """Bridge consensus labels to positioned corpus entities (ported from
+    draft.py): detector box -> pos + footprint in the 100x60 frame, segmenter
+    polygon -> border + rel_height, anchored heights -> height_m. An entity the
+    detector did NOT box is dropped (its prose mention stays in the description).
+    Label matching is case-insensitive (the VLM often lowercases labels)."""
+    det_by = {str(d["label"]).lower(): d for d in detections}
+    seg_by = {str(s["label"]).lower(): s for s in segments}
+    h_by = {str(k).lower(): v for k, v in heights_m.items()}
+
+    out: list[dict[str, Any]] = []
+    for e in consensus:
+        label = str(e["label"]).strip()
+        det = det_by.get(label.lower())
+        if det is None:
+            continue
+        seg = seg_by.get(label.lower())
+        h = h_by.get(label.lower())
+        out.append(
+            {
+                "ref": e["ref"],
+                "kind": e.get("kind", "place"),
+                "label": label,
+                "visual": e.get("visual", ""),
+                "votes": e.get("votes", 0),
+                "pos": {
+                    "x": round(det["x_pct"] * FRAME_W, 1),
+                    "y": round(det["y_pct"] * FRAME_H, 1),
+                },
+                "footprint": {
+                    "w": round(max(det["w_pct"] * FRAME_W, 0.5), 1),
+                    "d": round(max(det["h_pct"] * FRAME_H, 0.5), 1),
+                },
+                "height_rel": seg["rel_height"] if seg else 0.0,
+                "height_m": (round(h, 1) or None) if h else None,
+                "border": (
+                    [[round(x * FRAME_W, 1), round(y * FRAME_H, 1)] for x, y in seg["polygon"]]
+                    if seg
+                    else None
+                ),
+            }
+        )
+    return out
+
+
+def vote(values: list[Any], *, default: Any = None) -> Any:
+    """Majority vote over scalar values (scale_tier, kind …); ties broken by
+    first-seen, empty -> default."""
+    vals = [v for v in values if v is not None]
+    if not vals:
+        return default
+    return _mode_first_seen(vals)
+
+
+def agreement_score(consensus: list[dict[str, Any]], n_models: int) -> float:
+    """Ensemble agreement: mean vote-fraction (votes / n_models) over the
+    consensus entities. 1.0 = every kept entity was unanimous. 0.0 if there are
+    no consensus entities or no models."""
+    if not consensus or n_models <= 0:
+        return 0.0
+    return sum(min(int(e["votes"]), n_models) / n_models for e in consensus) / len(consensus)
+
+
+def decide_status(
+    judge_score: float,
+    agreement: float,
+    *,
+    judge_threshold: float,
+    agreement_threshold: float,
+) -> str:
+    """Auto-promote gate: "verified" iff the annotation-quality judge AND the
+    ensemble agreement both clear their thresholds (inclusive), else
+    "needs_human"."""
+    if judge_score >= judge_threshold and agreement >= agreement_threshold:
+        return "verified"
+    return "needs_human"
+
+
+def assemble_description(
+    *,
+    map_id: str,
+    genre: str,
+    style: str,
+    scale_tier: str,
+    description: str,
+    frame: dict[str, float],
+    entities: list[dict[str, Any]],
+    relations: list[dict[str, Any]],
+    rev: int,
+    annotation: dict[str, Any],
+    status: str,
+    by: str = "",
+    date: str = "",
+) -> dict[str, Any]:
+    """Build the canonical corpus description artifact. Ensemble provenance lands
+    in an `annotation` block; the per-entity `votes` count is dropped so the
+    `entities` records stay the exact shape recon_bench consumes. Inputs are not
+    mutated (a fresh dict per entity)."""
+    clean_entities = [{k: v for k, v in e.items() if k != "votes"} for e in entities]
+    return {
+        "map_id": map_id,
+        "rev": rev,
+        "genre": genre,
+        "style": style,
+        "scale_tier": scale_tier,
+        "frame": dict(frame),
+        "description": description,
+        "entities": clean_entities,
+        "relations": list(relations),
+        "annotation": dict(annotation),
+        "review": {"status": status, "by": by, "date": date},
+    }
+
+
+# --- paid pipeline: the async fan-out + judge->refine loop --------------------
+#
+# Everything above is pure and gated by test_annotate.py. Below is the thin glue
+# that actually spends tokens: fan a describe call over the ensemble, reconcile
+# (pure), ground positions with the detector + segmenter, judge the result, and
+# refine once on a low score. Verified by dry-run, not unit tests (same split as
+# draft.py / recon_bench).
+
+_DESCRIBE_SYSTEM = (
+    "You are a careful cartographic annotator. Given a map image, return ONE "
+    "JSON object: {style: <art medium + palette, <=25 words>, scale_tier: one "
+    'of ["region","city","district","place"], description: <a precise 120-200 '
+    "word prose description of the WHOLE map a painter could redraw it from — "
+    "name the major features, their relative positions (north/south/etc), "
+    "relative sizes and heights>, entities: [6-10 of the most prominent named "
+    "features: {ref: <kebab-slug>, kind: one of "
+    '["place","item","creature","person"], label: <the feature\'s name>, '
+    "visual: <=12 words}], relations: [4-8 spatial relations between entity "
+    "LABELS (use the exact label strings, not slugs): {subject: <label>, "
+    'relation: one of ["near","behind","in_front_of","left_of","right_of",'
+    '"inside","on_top_of","facing"], object: <label>}]}.'
+)
+
+_ANNOTATION_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "style": {"type": "string"},
+        "scale_tier": {"type": "string"},
+        "description": {"type": "string"},
+        "entities": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "ref": {"type": "string"},
+                    "kind": {"type": "string"},
+                    "label": {"type": "string"},
+                    "visual": {"type": "string"},
+                },
+            },
+        },
+        "relations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "subject": {"type": "string"},
+                    "relation": {"type": "string"},
+                    "object": {"type": "string"},
+                },
+            },
+        },
+    },
+    "required": ["entities"],
+}
+
+
+def _ensemble_models() -> list[str]:
+    """The describe ensemble (comma-separated CORPUS_ANNOTATE_MODELS, e.g. a
+    Claude slug + Gemini + a Qwen-VL). Falls back to the single shared VLM so an
+    unconfigured run behaves like draft.py."""
+    raw = os.environ.get("CORPUS_ANNOTATE_MODELS", "").strip()
+    models = [m.strip() for m in raw.split(",") if m.strip()]
+    if models:
+        return models
+    from providers import llm
+
+    return [llm._vlm_model()]
+
+
+def _min_votes(n_models: int) -> int:
+    override = os.environ.get("CORPUS_MIN_VOTES")
+    if override:
+        return max(1, int(override))
+    return 1 if n_models <= 1 else n_models // 2 + 1  # simple majority
+
+
+def _judge_threshold() -> float:
+    return float(os.environ.get("CORPUS_JUDGE_THRESHOLD", "7.0"))
+
+
+def _agreement_threshold() -> float:
+    return float(os.environ.get("CORPUS_AGREEMENT_THRESHOLD", "0.6"))
+
+
+def _max_iters() -> int:
+    return max(1, int(os.environ.get("CORPUS_ANNOTATE_MAX_ITERS", "2")))
+
+
+def _longest(strings: list[str]) -> str:
+    """The richest (longest) non-empty string — used to pick the consensus style
+    and prose from the ensemble's drafts."""
+    cleaned = [s.strip() for s in strings if isinstance(s, str) and s.strip()]
+    return max(cleaned, key=len) if cleaned else ""
+
+
+def _next_rev(map_id: str) -> int:
+    """One past the committed description's rev (so a re-annotate re-bills its
+    recon cells), or 1 for a new map."""
+    path = DESCRIPTIONS / f"{map_id}.json"
+    if path.exists():
+        try:
+            return int(json.loads(path.read_text()).get("rev", 0)) + 1
+        except Exception:
+            return 1
+    return 1
+
+
+async def _describe(model: str, image_bytes: bytes, feedback: str = "") -> dict[str, Any]:
+    """One VLM's structured annotation of the map. `feedback` (a judge rationale)
+    is fed back on a refine pass."""
+    from providers import llm
+
+    b64 = base64.b64encode(image_bytes).decode("ascii")
+    user_text = "Describe this map." + (
+        f"\n\nA reviewer flagged the previous annotation: {feedback} Re-describe "
+        "carefully — fix those issues and name any prominent feature that was missed."
+        if feedback
+        else ""
+    )
+    return await llm._complete_json(
+        model=model,
+        messages=[
+            {"role": "system", "content": _DESCRIBE_SYSTEM},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": user_text},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/jpeg;base64,{b64}", "detail": "high"},
+                    },
+                ],
+            },
+        ],
+        schema=_ANNOTATION_SCHEMA,
+        schema_name="corpus_annotation",
+        temperature=0.0,
+        max_tokens=1600,
+    )
+
+
+async def annotate_one(map_id: str) -> Path:
+    """Ensemble-annotate one corpus map: fan out -> reconcile -> ground -> judge
+    -> refine, then write descriptions/<id>.json with provenance + an auto-
+    promote verdict (verified | needs_human)."""
+    from providers import heights as heights_lib
+    from providers import judge
+    from providers.detector import detect
+    from providers.segmenter import segment
+
+    genre = next((m["genre"] for m in load_manifest() if m["id"] == map_id), "")
+    img = image_path(map_id)
+    if not img.exists():
+        raise SystemExit(f"{img} missing — run `make corpus-fetch` first")
+    image_bytes = img.read_bytes()
+
+    models = _ensemble_models()
+    n = len(models)
+    min_votes = _min_votes(n)
+
+    feedback = ""
+    best: dict[str, Any] | None = None
+    for attempt in range(_max_iters()):
+        drafts = await asyncio.gather(
+            *[_describe(m, image_bytes, feedback) for m in models],
+            return_exceptions=True,
+        )
+        draft_dicts = [d for d in drafts if isinstance(d, dict) and d.get("entities")]
+        if not draft_dicts:
+            raise SystemExit(f"{map_id}: every ensemble describe call failed/empty")
+
+        consensus, minority = merge_entities(
+            [d.get("entities", []) for d in draft_dicts], min_votes=min_votes
+        )
+        labels = [e["label"] for e in consensus]
+        detections = await detect(image_bytes, labels)
+        segments = await segment(image_bytes, labels)
+        heights_m = heights_lib.infer_heights_m(list(segments))
+        geo_entities = attach_geometry(consensus, detections, segments, heights_m)
+
+        scale_tier = vote([d.get("scale_tier") for d in draft_dicts], default="region")
+        style = _longest([str(d.get("style", "")) for d in draft_dicts])
+        description = _longest([str(d.get("description", "")) for d in draft_dicts])
+        label_to_ref = {norm_label(e["label"]): e["ref"] for e in geo_entities}
+        relations = merge_relations(
+            [d.get("relations", []) for d in draft_dicts], label_to_ref
+        )
+        agreement = agreement_score(geo_entities, n)
+
+        jr = await judge.score_annotation(image_bytes, description, labels)
+        status = decide_status(
+            jr.score,
+            agreement,
+            judge_threshold=_judge_threshold(),
+            agreement_threshold=_agreement_threshold(),
+        )
+        cand = {
+            "geo_entities": geo_entities,
+            "minority": minority,
+            "scale_tier": scale_tier,
+            "style": style,
+            "description": description,
+            "relations": relations,
+            "agreement": agreement,
+            "judge_score": jr.score,
+            "rationale": jr.rationale,
+            "status": status,
+            "iters": attempt + 1,
+        }
+        if best is None or cand["judge_score"] > best["judge_score"]:
+            best = cand
+        if status == "verified":
+            break
+        feedback = jr.rationale
+
+    assert best is not None
+    annotation = {
+        "ensemble": models,
+        "reconcile": "deterministic-merge",
+        "min_votes": min_votes,
+        "iters": best["iters"],
+        "judge_score": round(float(best["judge_score"]), 2),
+        "agreement": round(float(best["agreement"]), 3),
+        "minority": [m["label"] for m in best["minority"]],
+        "judge_rationale": best["rationale"],
+    }
+    desc = assemble_description(
+        map_id=map_id,
+        genre=genre,
+        style=best["style"],
+        scale_tier=best["scale_tier"],
+        description=best["description"],
+        frame={"w": FRAME_W, "h": FRAME_H},
+        entities=best["geo_entities"],
+        relations=best["relations"],
+        rev=_next_rev(map_id),
+        annotation=annotation,
+        status=best["status"],
+        by="ensemble-annotate",
+        date=time.strftime("%Y-%m-%d", time.gmtime()),
+    )
+    DESCRIPTIONS.mkdir(parents=True, exist_ok=True)
+    out = DESCRIPTIONS / f"{map_id}.json"
+    out.write_text(json.dumps(desc, indent=1) + "\n")
+    print(
+        f"  {map_id}: {best['status']} "
+        f"(judge {annotation['judge_score']}, agreement {annotation['agreement']}, "
+        f"{len(best['geo_entities'])} entities, {best['iters']} iter) -> {out.name}"
+    )
+    return out
+
+
+def _load_env() -> None:
+    env_path = Path(__file__).resolve().parents[2] / ".env"
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+    os.environ.setdefault("WORLD_BENCH_JUDGE_MODEL", "google/gemini-3-flash-preview")
+
+
+async def _run(target: str) -> int:
+    ids = [m["id"] for m in load_manifest()] if target == "all" else [target]
+    for map_id in ids:
+        print(f"annotating {map_id} ...")
+        await annotate_one(map_id)
+    return 0
+
+
+def main() -> int:
+    if os.environ.get("CORPUS_ANNOTATE_RUN") != "1":
+        models = _ensemble_models()
+        print(
+            "corpus-annotate: PAID (ensemble describe + detector + segmenter + "
+            "judge per map, ~$0.03-0.10/map depending on ensemble size). "
+            "Set CORPUS_ANNOTATE_RUN=1 to run."
+        )
+        print(f"  ensemble ({len(models)}): {', '.join(models)}")
+        print(
+            f"  gates: judge>={_judge_threshold()} AND agreement>="
+            f"{_agreement_threshold()} -> auto-verified, else needs_human"
+        )
+        return 0
+    _load_env()
+    target = sys.argv[1] if len(sys.argv) > 1 else "all"
+    return asyncio.run(_run(target))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/modal-backend/tests/map_corpus/annotate.py
+++ b/apps/modal-backend/tests/map_corpus/annotate.py
@@ -123,13 +123,16 @@ def merge_entities(
 
 
 def merge_relations(
-    relation_lists: list[list[dict[str, Any]]], label_to_ref: dict[str, str]
+    relation_lists: list[list[dict[str, Any]]],
+    label_to_ref: dict[str, str],
+    allowed: set[str] | None = None,
 ) -> list[dict[str, Any]]:
     """Reconcile per-model relation lists. Endpoints are entity LABELS (the
     describe prompt asks for labels, not slugs); each is normalised and resolved
     against label_to_ref (norm_label -> consensus ref). A relation survives only
-    when BOTH endpoints resolve to distinct consensus entities. Deduped, first-
-    seen order preserved."""
+    when BOTH endpoints resolve to distinct consensus entities AND its type is in
+    `allowed` (when given — keeps a model's invented relation like "attached_to"
+    out of the corpus vocabulary). Deduped, first-seen order preserved."""
     out: list[dict[str, Any]] = []
     seen: set[tuple[str, str, str]] = set()
     for rels in relation_lists:
@@ -142,6 +145,8 @@ def merge_relations(
             obj = label_to_ref.get(norm_label(str(r.get("object", ""))))
             rel = str(r.get("relation", "")).strip() or "near"
             if not subj or not obj or subj == obj:
+                continue
+            if allowed is not None and rel not in allowed:
                 continue
             key = (subj, rel, obj)
             if key in seen:
@@ -425,6 +430,13 @@ def _max_iters() -> int:
     return max(1, int(os.environ.get("CORPUS_ANNOTATE_MAX_ITERS", "2")))
 
 
+def _plan_relations() -> set[str]:
+    """The corpus relation vocabulary (the same set the integrity gate enforces)."""
+    from providers.llm import _PLAN_RELATIONS
+
+    return set(_PLAN_RELATIONS)
+
+
 def _longest(strings: list[str]) -> str:
     """The richest (longest) non-empty string — used to pick the consensus style
     and prose from the ensemble's drafts."""
@@ -553,7 +565,9 @@ async def annotate_one(map_id: str) -> Path:
         description = _longest([str(d.get("description", "")) for d in draft_dicts])
         label_to_ref = {norm_label(e["label"]): e["ref"] for e in geo_entities}
         relations = merge_relations(
-            [d.get("relations", []) for d in draft_dicts], label_to_ref
+            [d.get("relations", []) for d in draft_dicts],
+            label_to_ref,
+            allowed=set(_plan_relations()),
         )
         agreement = agreement_score(geo_entities, n)
 

--- a/apps/modal-backend/tests/map_corpus/annotate.py
+++ b/apps/modal-backend/tests/map_corpus/annotate.py
@@ -206,6 +206,44 @@ def attach_geometry(
     return out
 
 
+def parse_arbiter_consensus(
+    payload: Any, n_models: int
+) -> list[dict[str, Any]]:
+    """Coerce an LLM arbiter's reconciled reply into consensus entities. The
+    arbiter has already MERGED synonyms across the model drafts and counted how
+    many models referred to each (counting synonyms as one) — we just validate:
+    drop blanks, clamp votes to 1..n_models, slug the ref, dedup by norm_label
+    (first wins). Tolerant: junk -> []."""
+    if isinstance(payload, dict):
+        payload = payload.get("entities") or payload.get("added") or []
+    if not isinstance(payload, list):
+        return []
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for e in payload:
+        if not isinstance(e, dict):
+            continue
+        label = str(e.get("label", "")).strip()
+        key = norm_label(label)
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        try:
+            votes = int(e.get("votes", 1))
+        except (TypeError, ValueError):
+            votes = 1
+        out.append(
+            {
+                "ref": slug(label),
+                "kind": str(e.get("kind", "")).strip() or "place",
+                "label": label,
+                "visual": str(e.get("visual", "")).strip(),
+                "votes": max(1, min(votes, max(1, n_models))),
+            }
+        )
+    return out
+
+
 def vote(values: list[Any], *, default: Any = None) -> Any:
     """Majority vote over scalar values (scale_tier, kind …); ties broken by
     first-seen, empty -> default."""
@@ -418,6 +456,27 @@ def _min_votes_override() -> int | None:
     return int(raw) if raw else None
 
 
+def _arbiter_model() -> str | None:
+    """Optional LLM (text) arbiter that reconciles the model drafts SEMANTICALLY —
+    merging synonymous part/fixture names the deterministic exact-label merge
+    keeps apart (the non-map thinness fix). Unset -> deterministic merge. A strong
+    cheap reasoner like deepseek/deepseek-v4-pro fits (text-only, no image)."""
+    return os.environ.get("CORPUS_ARBITER_MODEL", "").strip() or None
+
+
+_ARBITER_SYSTEM = (
+    "You reconcile entity lists from several annotators of the SAME image into ONE "
+    "consensus list. The annotators each listed the prominent features/parts but "
+    "often use DIFFERENT WORDS for the same thing (e.g. 'rete' vs 'openwork star "
+    "disc'; 'pew' vs 'bench'). MERGE synonyms into a single entity. For each "
+    "consensus entity return: label (the clearest canonical name), kind (one of "
+    "place|item|creature|person), visual (the richest <=12-word description), votes "
+    "(how many of the N annotators referred to it, counting synonyms as the same — "
+    'an integer from 1 to N). Return JSON exactly: {"entities":[{"label":..,'
+    '"kind":..,"visual":..,"votes":..}]}.'
+)
+
+
 def _judge_threshold() -> float:
     return float(os.environ.get("CORPUS_JUDGE_THRESHOLD", "7.0"))
 
@@ -508,6 +567,48 @@ async def _describe(
     )
 
 
+async def arbiter_reconcile(
+    drafts: list[dict[str, Any]], *, model: str, min_votes: int, n_models: int
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Semantic reconcile via a text LLM: feed the annotators' entity lists, get
+    back one synonym-merged consensus with vote counts. Returns (consensus,
+    minority) split on min_votes, same shape as merge_entities. Falls back to the
+    deterministic merge if the arbiter returns nothing usable."""
+    from providers import llm
+
+    blocks = []
+    for i, d in enumerate(drafts):
+        ents = d.get("entities", []) or []
+        lines = "; ".join(
+            f"{str(e.get('label', '')).strip()} ({str(e.get('visual', '')).strip()})"
+            for e in ents
+            if isinstance(e, dict) and str(e.get("label", "")).strip()
+        )
+        blocks.append(f"Annotator {i + 1}: {lines}")
+    user_text = (
+        f"There are N={n_models} annotators. Merge their entity lists into one "
+        "consensus (synonyms = one entity, with a votes count 1..N):\n\n"
+        + "\n".join(blocks)
+    )
+    parsed = await llm._complete_json(
+        model=model,
+        messages=[
+            {"role": "system", "content": _ARBITER_SYSTEM},
+            {"role": "user", "content": user_text},
+        ],
+        schema=None,
+        schema_name="arbiter_consensus",
+        temperature=0.0,
+        max_tokens=1200,
+    )
+    entities = parse_arbiter_consensus(parsed, n_models)
+    if not entities:  # arbiter failed -> deterministic fallback (never lose the run)
+        return merge_entities([d.get("entities", []) for d in drafts], min_votes=min_votes)
+    consensus = [e for e in entities if e["votes"] >= min_votes]
+    minority = [e for e in entities if e["votes"] < min_votes]
+    return consensus, minority
+
+
 async def annotate_one(map_id: str) -> Path:
     """Ensemble-annotate one corpus map: fan out -> reconcile -> ground -> judge
     -> refine, then write descriptions/<id>.json with provenance + an auto-
@@ -551,9 +652,15 @@ async def annotate_one(map_id: str) -> Path:
             raise SystemExit(f"{map_id}: every ensemble describe call failed/empty")
 
         min_votes = default_min_votes(len(draft_dicts), _min_votes_override())
-        consensus, minority = merge_entities(
-            [d.get("entities", []) for d in draft_dicts], min_votes=min_votes
-        )
+        arbiter = _arbiter_model()
+        if arbiter:
+            consensus, minority = await arbiter_reconcile(
+                draft_dicts, model=arbiter, min_votes=min_votes, n_models=len(draft_dicts)
+            )
+        else:
+            consensus, minority = merge_entities(
+                [d.get("entities", []) for d in draft_dicts], min_votes=min_votes
+            )
         labels = [e["label"] for e in consensus]
         detections = await detect(image_bytes, labels)
         segments = await segment(image_bytes, labels, boxes=detections)
@@ -592,6 +699,7 @@ async def annotate_one(map_id: str) -> Path:
             "iters": attempt + 1,
             "contributors": len(draft_dicts),
             "min_votes": min_votes,
+            "reconcile": arbiter or "deterministic-merge",
         }
         if best is None or cand["judge_score"] > best["judge_score"]:
             best = cand
@@ -603,7 +711,7 @@ async def annotate_one(map_id: str) -> Path:
     annotation = {
         "ensemble": models,
         "contributors": best["contributors"],
-        "reconcile": "deterministic-merge",
+        "reconcile": best["reconcile"],
         "min_votes": best["min_votes"],
         "iters": best["iters"],
         "judge_score": round(float(best["judge_score"]), 2),

--- a/apps/modal-backend/tests/map_corpus/chains.py
+++ b/apps/modal-backend/tests/map_corpus/chains.py
@@ -1,0 +1,52 @@
+"""Descent chains: link a child reference (an interior/closeup manifest row) to a
+place ENTITY in a parent map, so the descent bench can crop the parent at that
+spot, generate an "enter" view, and score it against the REAL child image.
+
+The link lives on the child's MANIFEST row (parent_id + parent_ref) — the child
+needs no description of its own; its ground truth is the photo. The parent must
+have a (verified) corpus description so parent_ref resolves to a position.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def parent_anchor(parent_desc: dict[str, Any], parent_ref: str) -> dict[str, Any] | None:
+    """The parent entity named by `parent_ref`, as a 'place' dict
+    {label, pos:{x,y}} for the region crop — or None if the ref isn't present."""
+    for e in parent_desc.get("entities", []):
+        if e.get("ref") == parent_ref and isinstance(e.get("pos"), dict):
+            return {"label": str(e.get("label") or parent_ref), "pos": e["pos"]}
+    return None
+
+
+def descent_chains(
+    manifest_rows: list[dict[str, Any]], descs_by_id: dict[str, dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Resolve every child row whose parent_id has a description AND whose
+    parent_ref names a real entity in it. A row missing the link, or pointing at
+    an unknown parent / entity, is skipped."""
+    by_id = {m["id"]: m for m in manifest_rows}
+    out: list[dict[str, Any]] = []
+    for row in manifest_rows:
+        pid, pref = row.get("parent_id"), row.get("parent_ref")
+        if not pid or not pref:
+            continue
+        parent_desc = descs_by_id.get(pid)
+        parent_row = by_id.get(pid)
+        if not parent_desc or not parent_row:
+            continue
+        anchor = parent_anchor(parent_desc, str(pref))
+        if not anchor:
+            continue
+        out.append(
+            {
+                "child_id": row["id"],
+                "child_filename": row["filename"],
+                "parent_id": pid,
+                "parent_filename": parent_row["filename"],
+                "label": anchor["label"],
+                "anchor": anchor,
+            }
+        )
+    return out

--- a/apps/modal-backend/tests/map_corpus/descriptions/met-193606-celestial-globe-with-clockwork.json
+++ b/apps/modal-backend/tests/map_corpus/descriptions/met-193606-celestial-globe-with-clockwork.json
@@ -1,0 +1,195 @@
+{
+ "map_id": "met-193606-celestial-globe-with-clockwork",
+ "rev": 1,
+ "genre": "horology",
+ "style": "Studio product photography of a Renaissance-era scientific instrument, featuring polished silver and gilded brass against a neutral gray background.",
+ "scale_tier": "object",
+ "frame": {
+  "w": 100.0,
+  "h": 60.0
+ },
+ "description": "This ornate celestial globe clock is a masterpiece of Renaissance metalwork, standing on a base featuring a silver Pegasus. The central component is a large, polished silver sphere engraved with intricate celestial maps, including constellations and stars. This globe is encased within a gilded brass framework consisting of a vertical meridian ring and a horizontal horizon ring, both inscribed with degrees and astronomical data. At the top of the globe, a small silver clock face with Roman numerals and a single hand is mounted. The entire assembly is supported by a finely sculpted silver Pegasus with gilded wings, depicted in a dynamic galloping pose. The Pegasus stands upon a gilded, oval-shaped base with a stepped, architectural rim. The contrast between the cool, reflective silver of the globe and horse and the warm, matte gold of the rings and wings creates a luxurious aesthetic. The craftsmanship is highly detailed, from the individual feathers on the wings to the precise engravings on the celestial sphere.",
+ "entities": [
+  {
+   "ref": "celestial-globe",
+   "kind": "item",
+   "label": "celestial globe",
+   "visual": "Polished silver sphere engraved with constellations and astronomical lines.",
+   "pos": {
+    "x": 49.8,
+    "y": 25.1
+   },
+   "footprint": {
+    "w": 40.2,
+    "d": 19.7
+   },
+   "height_rel": 0.6,
+   "height_m": 0.1,
+   "border": [
+    [
+     30.8,
+     60.0
+    ],
+    [
+     35.5,
+     60.0
+    ],
+    [
+     44.5,
+     60.0
+    ],
+    [
+     55.5,
+     60.0
+    ],
+    [
+     64.5,
+     60.0
+    ],
+    [
+     69.2,
+     60.0
+    ],
+    [
+     64.5,
+     60.0
+    ],
+    [
+     55.5,
+     60.0
+    ],
+    [
+     44.5,
+     60.0
+    ],
+    [
+     35.5,
+     60.0
+    ]
+   ]
+  },
+  {
+   "ref": "meridian-ring",
+   "kind": "item",
+   "label": "Meridian Ring",
+   "visual": "gilded brass ring encircling the globe vertically with engraved markings",
+   "pos": {
+    "x": 49.4,
+    "y": 24.7
+   },
+   "footprint": {
+    "w": 41.2,
+    "d": 23.5
+   },
+   "height_rel": 0.8,
+   "height_m": 0.2,
+   "border": [
+    [
+     48.5,
+     60.0
+    ],
+    [
+     51.5,
+     60.0
+    ],
+    [
+     61.5,
+     60.0
+    ],
+    [
+     67.5,
+     60.0
+    ],
+    [
+     69.5,
+     60.0
+    ],
+    [
+     67.5,
+     60.0
+    ],
+    [
+     61.5,
+     60.0
+    ],
+    [
+     51.5,
+     60.0
+    ],
+    [
+     48.5,
+     60.0
+    ],
+    [
+     38.5,
+     60.0
+    ],
+    [
+     32.5,
+     60.0
+    ],
+    [
+     30.5,
+     60.0
+    ],
+    [
+     32.5,
+     60.0
+    ],
+    [
+     38.5,
+     60.0
+    ]
+   ]
+  }
+ ],
+ "relations": [
+  {
+   "subject": "celestial-globe",
+   "relation": "inside",
+   "object": "meridian-ring"
+  },
+  {
+   "subject": "meridian-ring",
+   "relation": "on_top_of",
+   "object": "celestial-globe"
+  }
+ ],
+ "annotation": {
+  "ensemble": [
+   "google/gemini-3-flash-preview",
+   "qwen/qwen3-vl-32b-instruct",
+   "openai/gpt-4o-mini"
+  ],
+  "contributors": 3,
+  "reconcile": "deepseek/deepseek-v4-pro",
+  "min_votes": 2,
+  "iters": 1,
+  "judge_score": 9.0,
+  "agreement": 0.833,
+  "minority": [
+   "Silver Pegasus",
+   "Gilded Wings",
+   "Horizon Ring",
+   "Clock Dial",
+   "Gilded Base",
+   "equatorial ring",
+   "clock face",
+   "Pegasus figure",
+   "winged wings",
+   "oval base",
+   "rocky outcrop",
+   "winged horse",
+   "golden frame",
+   "navigation dial",
+   "circular base",
+   "horse legs"
+  ],
+  "judge_rationale": "The description is highly accurate and detailed, though it describes the base as solid/oval when it is actually an open ring."
+ },
+ "review": {
+  "status": "verified",
+  "by": "ensemble-annotate",
+  "date": "2026-06-18"
+ }
+}

--- a/apps/modal-backend/tests/map_corpus/descriptions/met-894753-armor-i-gusoku-i-with-box.json
+++ b/apps/modal-backend/tests/map_corpus/descriptions/met-894753-armor-i-gusoku-i-with-box.json
@@ -1,0 +1,341 @@
+{
+ "map_id": "met-894753-armor-i-gusoku-i-with-box",
+ "rev": 1,
+ "genre": "armor",
+ "style": "Studio photograph of a Japanese samurai armor, featuring dark lacquered metal, deep teal and gold lamellar plates, and ornate silk textiles; neutral gray background, even lighting.",
+ "scale_tier": "object",
+ "frame": {
+  "w": 100.0,
+  "h": 60.0
+ },
+ "description": "A complete set of Japanese samurai armor (gusoku) featuring a dark, lacquered aesthetic with intricate textile accents. The helmet (kabuto) is a high-domed, black lacquered bowl with large, rounded side flaps (fukigaeshi) and a prominent crest. Below the helmet is a black lacquered face mask (menpo) with a thick, tan braided cord tied at the chin. The torso is protected by a breastplate (dou) composed of horizontal, dark teal-laced scales, accented by orange silk tassels and gold-toned hardware. Large shoulder guards (sode) match the breastplate's construction. The lower half consists of a multi-layered skirt (kusazuri) of similar scale-work, draped over a pale green and gold patterned silk undergarment. The forearms are encased in brown lacquered bracers (kote) with gold floral motifs, while the lower legs are protected by matching greaves (suneate) featuring yellow-dotted knee guards and green silk ties. The entire ensemble is meticulously assembled with silk cords and leather straps.",
+ "entities": [
+  {
+   "ref": "kabuto-helmet",
+   "kind": "item",
+   "label": "Kabuto Helmet",
+   "visual": "High-domed black lacquered iron helmet with wide horn-like crest and face guard",
+   "pos": {
+    "x": 48.0,
+    "y": 8.9
+   },
+   "footprint": {
+    "w": 33.6,
+    "d": 7.4
+   },
+   "height_rel": 0.2,
+   "height_m": 0.3,
+   "border": [
+    [
+     41.5,
+     5.1
+    ],
+    [
+     51.0,
+     5.1
+    ],
+    [
+     58.0,
+     8.1
+    ],
+    [
+     65.0,
+     10.5
+    ],
+    [
+     55.0,
+     12.6
+    ],
+    [
+     55.0,
+     15.6
+    ],
+    [
+     45.0,
+     15.6
+    ],
+    [
+     45.0,
+     12.6
+    ],
+    [
+     35.0,
+     10.5
+    ],
+    [
+     42.0,
+     8.1
+    ]
+   ]
+  },
+  {
+   "ref": "menpo-mask",
+   "kind": "item",
+   "label": "Menpo Mask",
+   "visual": "Black lacquered facial armor with fierce expression and thick beige braided cord",
+   "pos": {
+    "x": 48.0,
+    "y": 12.9
+   },
+   "footprint": {
+    "w": 12.0,
+    "d": 3.6
+   },
+   "height_rel": 0.08,
+   "height_m": 0.1,
+   "border": [
+    [
+     46.0,
+     10.8
+    ],
+    [
+     54.0,
+     10.8
+    ],
+    [
+     54.0,
+     14.4
+    ],
+    [
+     50.0,
+     15.6
+    ],
+    [
+     46.0,
+     14.4
+    ]
+   ]
+  },
+  {
+   "ref": "dou-breastplate",
+   "kind": "item",
+   "label": "Dou Breastplate",
+   "visual": "Dark teal-laced horizontal scale chest armor with gold rings and orange silk tassels",
+   "pos": {
+    "x": 49.0,
+    "y": 23.1
+   },
+   "footprint": {
+    "w": 22.0,
+    "d": 10.8
+   },
+   "height_rel": 0.25,
+   "height_m": 0.4,
+   "border": [
+    [
+     40.0,
+     18.6
+    ],
+    [
+     60.0,
+     18.6
+    ],
+    [
+     61.0,
+     29.4
+    ],
+    [
+     50.0,
+     30.6
+    ],
+    [
+     39.0,
+     29.4
+    ]
+   ]
+  },
+  {
+   "ref": "sode-shoulder-guards",
+   "kind": "item",
+   "label": "Sode Shoulder Guards",
+   "visual": "Large rectangular layered dark teal-laced scale plates over fabric on shoulders",
+   "pos": {
+    "x": 33.0,
+    "y": 20.4
+   },
+   "footprint": {
+    "w": 13.0,
+    "d": 9.0
+   },
+   "height_rel": 0.18,
+   "height_m": 0.3,
+   "border": [
+    [
+     31.0,
+     15.0
+    ],
+    [
+     39.0,
+     16.2
+    ],
+    [
+     38.0,
+     24.6
+    ],
+    [
+     27.0,
+     24.6
+    ],
+    [
+     27.0,
+     18.0
+    ]
+   ]
+  },
+  {
+   "ref": "kote-bracers",
+   "kind": "item",
+   "label": "Kote Bracers",
+   "visual": "Brown lacquered forearm guards with gold floral patterns and green silk wrappings",
+   "pos": {
+    "x": 33.5,
+    "y": 30.6
+   },
+   "footprint": {
+    "w": 12.0,
+    "d": 8.4
+   },
+   "height_rel": 0.15,
+   "height_m": 0.3,
+   "border": [
+    [
+     28.0,
+     27.0
+    ],
+    [
+     39.0,
+     27.0
+    ],
+    [
+     40.0,
+     34.8
+    ],
+    [
+     33.0,
+     34.8
+    ]
+   ]
+  },
+  {
+   "ref": "kusazuri-skirt",
+   "kind": "item",
+   "label": "Kusazuri Skirt",
+   "visual": "Hanging panels of dark teal scales over green patterned fabric protecting lower torso and thighs",
+   "pos": {
+    "x": 49.5,
+    "y": 41.4
+   },
+   "footprint": {
+    "w": 64.0,
+    "d": 19.2
+   },
+   "height_rel": 0.35,
+   "height_m": 0.6,
+   "border": [
+    [
+     23.0,
+     33.0
+    ],
+    [
+     77.0,
+     33.0
+    ],
+    [
+     82.0,
+     51.0
+    ],
+    [
+     50.0,
+     51.6
+    ],
+    [
+     18.0,
+     51.0
+    ]
+   ]
+  },
+  {
+   "ref": "suneate-greaves",
+   "kind": "item",
+   "label": "Suneate Greaves",
+   "visual": "Brown lacquered shin guards with gold patterns and yellow-dotted knee protectors",
+   "pos": {
+    "x": 49.5,
+    "y": 50.4
+   },
+   "footprint": {
+    "w": 21.0,
+    "d": 13.2
+   },
+   "height_rel": 0.22,
+   "height_m": 0.4,
+   "border": [
+    [
+     39.0,
+     43.8
+    ],
+    [
+     60.0,
+     43.8
+    ],
+    [
+     59.0,
+     57.0
+    ],
+    [
+     40.0,
+     57.0
+    ]
+   ]
+  }
+ ],
+ "relations": [
+  {
+   "subject": "kabuto-helmet",
+   "relation": "on_top_of",
+   "object": "menpo-mask"
+  },
+  {
+   "subject": "menpo-mask",
+   "relation": "in_front_of",
+   "object": "dou-breastplate"
+  },
+  {
+   "subject": "sode-shoulder-guards",
+   "relation": "near",
+   "object": "dou-breastplate"
+  },
+  {
+   "subject": "suneate-greaves",
+   "relation": "near",
+   "object": "kusazuri-skirt"
+  },
+  {
+   "subject": "kote-bracers",
+   "relation": "left_of",
+   "object": "dou-breastplate"
+  }
+ ],
+ "annotation": {
+  "ensemble": [
+   "google/gemini-3-flash-preview",
+   "qwen/qwen3-vl-32b-instruct",
+   "openai/gpt-4o-mini"
+  ],
+  "contributors": 3,
+  "reconcile": "deepseek/deepseek-v4-pro",
+  "min_votes": 2,
+  "iters": 1,
+  "judge_score": 10.0,
+  "agreement": 1.0,
+  "minority": [
+   "Silk Undergarment"
+  ],
+  "judge_rationale": "The description is exceptionally accurate and detailed, correctly identifying colors, textures, and specific components of the armor."
+ },
+ "review": {
+  "status": "verified",
+  "by": "ensemble-annotate",
+  "date": "2026-06-18"
+ }
+}

--- a/apps/modal-backend/tests/map_corpus/descriptions/met-923639-astrolabe.json
+++ b/apps/modal-backend/tests/map_corpus/descriptions/met-923639-astrolabe.json
@@ -1,0 +1,288 @@
+{
+ "map_id": "met-923639-astrolabe",
+ "rev": 1,
+ "genre": "metalwork-copper-alloy",
+ "style": "Antique brass astrolabe, engraved with celestial and zodiacal markings, warm golden tone, high-contrast etched details, studio lighting on neutral gray background.",
+ "scale_tier": "object",
+ "frame": {
+  "w": 100.0,
+  "h": 60.0
+ },
+ "description": "This 16th-century brass astrolabe is a complex astronomical instrument composed of several layered components. The base is the 'mater', a thick circular plate with a raised outer rim or 'limb' engraved with a 360-degree scale. At the top, a decorative 'throne' featuring three floral rosettes supports a suspension ring. Inside the mater sits a removable 'tympan' plate engraved with a stereographic projection of the celestial sphere, including a grid of altitude and azimuth lines. Overlying this is the 'rete', an intricate, openwork brass frame with flame-like pointers indicating the positions of fixed stars and an eccentric circle representing the ecliptic, marked with zodiac signs. A straight, rotating 'rule' or index arm is pinned to the center, spanning the diameter of the instrument. The entire surface is densely engraved with Latin inscriptions, including star names like 'SPICA' and 'COR LE', and zodiacal divisions. The brass has a soft, aged patina with minor surface scratches and oxidation consistent with historical use.",
+ "entities": [
+  {
+   "ref": "mater",
+   "kind": "item",
+   "label": "mater",
+   "visual": "The thick, circular brass base plate with a raised outer rim.",
+   "pos": {
+    "x": 49.0,
+    "y": 35.3
+   },
+   "footprint": {
+    "w": 55.0,
+    "d": 30.7
+   },
+   "height_rel": 0.3,
+   "height_m": null,
+   "border": [
+    [
+     49.0,
+     20.1
+    ],
+    [
+     65.0,
+     22.2
+    ],
+    [
+     75.0,
+     28.8
+    ],
+    [
+     76.0,
+     39.0
+    ],
+    [
+     68.0,
+     47.4
+    ],
+    [
+     50.0,
+     50.4
+    ],
+    [
+     32.0,
+     47.4
+    ],
+    [
+     24.0,
+     39.0
+    ],
+    [
+     25.0,
+     28.8
+    ],
+    [
+     35.0,
+     22.2
+    ]
+   ]
+  },
+  {
+   "ref": "rete",
+   "kind": "item",
+   "label": "rete",
+   "visual": "Openwork brass cutout frame with star pointers and an ecliptic circle.",
+   "pos": {
+    "x": 49.0,
+    "y": 35.3
+   },
+   "footprint": {
+    "w": 45.0,
+    "d": 25.1
+   },
+   "height_rel": 0.15,
+   "height_m": null,
+   "border": [
+    [
+     49.0,
+     22.8
+    ],
+    [
+     58.0,
+     24.6
+    ],
+    [
+     65.0,
+     30.0
+    ],
+    [
+     65.0,
+     37.2
+    ],
+    [
+     58.0,
+     42.6
+    ],
+    [
+     49.0,
+     44.4
+    ],
+    [
+     40.0,
+     42.6
+    ],
+    [
+     33.0,
+     37.2
+    ],
+    [
+     33.0,
+     30.0
+    ],
+    [
+     40.0,
+     24.6
+    ]
+   ]
+  },
+  {
+   "ref": "rule",
+   "kind": "item",
+   "label": "rule",
+   "visual": "A straight, rotating brass index arm pinned at the center.",
+   "pos": {
+    "x": 49.0,
+    "y": 35.3
+   },
+   "footprint": {
+    "w": 50.2,
+    "d": 12.7
+   },
+   "height_rel": 0.1,
+   "height_m": null,
+   "border": [
+    [
+     24.0,
+     28.2
+    ],
+    [
+     45.0,
+     33.6
+    ],
+    [
+     74.0,
+     40.8
+    ],
+    [
+     73.0,
+     42.0
+    ],
+    [
+     45.0,
+     34.8
+    ],
+    [
+     23.0,
+     29.4
+    ]
+   ]
+  },
+  {
+   "ref": "throne",
+   "kind": "item",
+   "label": "throne",
+   "visual": "Ornate floral-carved bracket at the top connecting to the ring.",
+   "pos": {
+    "x": 49.5,
+    "y": 14.4
+   },
+   "footprint": {
+    "w": 13.0,
+    "d": 11.6
+   },
+   "height_rel": 1.0,
+   "height_m": null,
+   "border": [
+    [
+     43.1,
+     18.3
+    ],
+    [
+     46.5,
+     16.5
+    ],
+    [
+     50.1,
+     15.6
+    ],
+    [
+     53.8,
+     16.5
+    ],
+    [
+     56.9,
+     18.3
+    ],
+    [
+     56.0,
+     20.1
+    ],
+    [
+     53.0,
+     20.4
+    ],
+    [
+     47.0,
+     20.4
+    ],
+    [
+     44.0,
+     20.1
+    ]
+   ]
+  }
+ ],
+ "relations": [
+  {
+   "subject": "rule",
+   "relation": "on_top_of",
+   "object": "rete"
+  },
+  {
+   "subject": "throne",
+   "relation": "on_top_of",
+   "object": "mater"
+  },
+  {
+   "subject": "throne",
+   "relation": "on_top_of",
+   "object": "rete"
+  },
+  {
+   "subject": "rete",
+   "relation": "on_top_of",
+   "object": "mater"
+  },
+  {
+   "subject": "rule",
+   "relation": "on_top_of",
+   "object": "mater"
+  }
+ ],
+ "annotation": {
+  "ensemble": [
+   "google/gemini-3-flash-preview",
+   "qwen/qwen3-vl-32b-instruct",
+   "openai/gpt-4o-mini"
+  ],
+  "contributors": 3,
+  "reconcile": "deepseek/deepseek-v4-pro",
+  "min_votes": 2,
+  "iters": 2,
+  "judge_score": 10.0,
+  "agreement": 1.0,
+  "minority": [
+   "suspension ring",
+   "tympan",
+   "limb",
+   "central pin",
+   "suspension-ring",
+   "zodiac-signs",
+   "celestial-grid",
+   "pivot-point",
+   "bottom-ornament",
+   "degree-scale",
+   "ring",
+   "inscriptions",
+   "pivot",
+   "surface"
+  ],
+  "judge_rationale": "The description is exceptionally accurate and detailed, correctly identifying all technical components and specific inscriptions visible in the image."
+ },
+ "review": {
+  "status": "verified",
+  "by": "ensemble-annotate",
+  "date": "2026-06-18"
+ }
+}

--- a/apps/modal-backend/tests/map_corpus/draft.py
+++ b/apps/modal-backend/tests/map_corpus/draft.py
@@ -107,8 +107,9 @@ async def draft_one(map_id: str) -> Path:
     ]
     labels = [str(e["label"]).strip() for e in raw_entities]
 
-    detections = {d["label"].lower(): d for d in await detect(image_bytes, labels)}
-    segments = await segment(image_bytes, labels)
+    detection_list = await detect(image_bytes, labels)
+    detections = {d["label"].lower(): d for d in detection_list}
+    segments = await segment(image_bytes, labels, boxes=detection_list)
     seg_by_label = {s["label"].lower(): s for s in segments}
     heights_m = heights.infer_heights_m(list(segments))
 

--- a/apps/modal-backend/tests/map_corpus/manifest.json
+++ b/apps/modal-backend/tests/map_corpus/manifest.json
@@ -56,7 +56,7 @@
       "source_url": "https://images.metmuseum.org/CRDImages/cl/original/DP-41678-001.jpg",
       "license_note": "CC0 (The Met Open Access)",
       "attribution": "\"Astrolabe\", The Metropolitan Museum of Art, CC0",
-      "filename": "met-923639.jpg",
+      "filename": "met-923639-astrolabe.jpg",
       "sha256": "6e34ec6199e09a41152a17986a395e820711b2f22206477c09e2a2592123dd2d"
     },
     {
@@ -66,7 +66,7 @@
       "source_url": "https://images.metmuseum.org/CRDImages/es/original/DP231286.jpg",
       "license_note": "CC0 (The Met Open Access)",
       "attribution": "\"Celestial globe with clockwork\", The Metropolitan Museum of Art, CC0",
-      "filename": "met-193606.jpg",
+      "filename": "met-193606-celestial-globe-with-clockwork.jpg",
       "sha256": "428c9fab5f028e57baee7f215611593da2e87f9b2dc0b1913f59a5e53daec855"
     },
     {
@@ -76,7 +76,7 @@
       "source_url": "https://images.metmuseum.org/CRDImages/aa/original/LC-TR_360_4a_l_2022-020-2-Edit.jpg",
       "license_note": "CC0 (The Met Open Access)",
       "attribution": "\"Armor (<i>Gusoku</i>) with Box\", The Metropolitan Museum of Art, CC0",
-      "filename": "met-894753.jpg",
+      "filename": "met-894753-armor-i-gusoku-i-with-box.jpg",
       "sha256": "22b2b0f249801225893a6872481f9b9d91c9ce65e02589e2fbee983aa552a163"
     },
     {

--- a/apps/modal-backend/tests/map_corpus/manifest.json
+++ b/apps/modal-backend/tests/map_corpus/manifest.json
@@ -48,6 +48,36 @@
       "license_note": "Public domain (medieval manor plan via Wikimedia Commons)",
       "sha256": "7d7fcdf1d38ca5a55d592986f370681aa4111021f7574690f71791bb5888c00e",
       "filename": "village-medieval-manor.jpg"
+    },
+    {
+      "id": "met-923639-astrolabe",
+      "tier": "closeup",
+      "genre": "metalwork-copper-alloy",
+      "source_url": "https://images.metmuseum.org/CRDImages/cl/original/DP-41678-001.jpg",
+      "license_note": "CC0 (The Met Open Access)",
+      "attribution": "\"Astrolabe\", The Metropolitan Museum of Art, CC0",
+      "filename": "met-923639.jpg",
+      "sha256": "6e34ec6199e09a41152a17986a395e820711b2f22206477c09e2a2592123dd2d"
+    },
+    {
+      "id": "met-193606-celestial-globe-with-clockwork",
+      "tier": "closeup",
+      "genre": "horology",
+      "source_url": "https://images.metmuseum.org/CRDImages/es/original/DP231286.jpg",
+      "license_note": "CC0 (The Met Open Access)",
+      "attribution": "\"Celestial globe with clockwork\", The Metropolitan Museum of Art, CC0",
+      "filename": "met-193606.jpg",
+      "sha256": "428c9fab5f028e57baee7f215611593da2e87f9b2dc0b1913f59a5e53daec855"
+    },
+    {
+      "id": "met-894753-armor-i-gusoku-i-with-box",
+      "tier": "closeup",
+      "genre": "armor",
+      "source_url": "https://images.metmuseum.org/CRDImages/aa/original/LC-TR_360_4a_l_2022-020-2-Edit.jpg",
+      "license_note": "CC0 (The Met Open Access)",
+      "attribution": "\"Armor (<i>Gusoku</i>) with Box\", The Metropolitan Museum of Art, CC0",
+      "filename": "met-894753.jpg",
+      "sha256": "22b2b0f249801225893a6872481f9b9d91c9ce65e02589e2fbee983aa552a163"
     }
   ]
 }

--- a/apps/modal-backend/tests/map_corpus/manifest.json
+++ b/apps/modal-backend/tests/map_corpus/manifest.json
@@ -97,7 +97,9 @@
       "license_note": "CC0 (via Wikimedia Commons)",
       "attribution": "Michael D Beckwith, via Wikimedia Commons, CC0",
       "sha256": "8199a6cdde9dd5ab3b2a1f102c86c25bce772b86e4412f5877df5ca79d0207d9",
-      "filename": "wm-chester-cathedral-nave.jpg"
+      "filename": "wm-chester-cathedral-nave.jpg",
+      "parent_id": "village-medieval-manor",
+      "parent_ref": "church"
     },
     {
       "id": "wm-sala-del-maggior-consiglio-palau-ducal-de-ven-ci",

--- a/apps/modal-backend/tests/map_corpus/manifest.json
+++ b/apps/modal-backend/tests/map_corpus/manifest.json
@@ -78,6 +78,36 @@
       "attribution": "\"Armor (<i>Gusoku</i>) with Box\", The Metropolitan Museum of Art, CC0",
       "filename": "met-894753.jpg",
       "sha256": "22b2b0f249801225893a6872481f9b9d91c9ce65e02589e2fbee983aa552a163"
+    },
+    {
+      "id": "wm-loc-main-reading-room-highsmith",
+      "tier": "interior",
+      "genre": "library-of-congress-main-reading-room",
+      "source_url": "https://commons.wikimedia.org/wiki/Special:FilePath/LOC%20Main%20Reading%20Room%20Highsmith.jpg?width=1600",
+      "license_note": "Public domain (via Wikimedia Commons)",
+      "attribution": "Carol M. Highsmith, via Wikimedia Commons, Public domain",
+      "sha256": "581e3bf552198e1a285ef0c0ab2a6a8d443223827e0ceb550cd2cd32aa6afb2a",
+      "filename": "wm-loc-main-reading-room-highsmith.jpg"
+    },
+    {
+      "id": "wm-chester-cathedral-nave",
+      "tier": "interior",
+      "genre": "gothic-cathedral-nave-interior",
+      "source_url": "https://commons.wikimedia.org/wiki/Special:FilePath/Chester%20Cathedral%20Nave.jpg?width=1600",
+      "license_note": "CC0 (via Wikimedia Commons)",
+      "attribution": "Michael D Beckwith, via Wikimedia Commons, CC0",
+      "sha256": "8199a6cdde9dd5ab3b2a1f102c86c25bce772b86e4412f5877df5ca79d0207d9",
+      "filename": "wm-chester-cathedral-nave.jpg"
+    },
+    {
+      "id": "wm-sala-del-maggior-consiglio-palau-ducal-de-ven-ci",
+      "tier": "interior",
+      "genre": "palace-grand-hall-interior",
+      "source_url": "https://commons.wikimedia.org/wiki/Special:FilePath/Sala%20del%20Maggior%20Consiglio%20-%20Palau%20Ducal%20de%20Ven%C3%A8cia.JPG?width=1600",
+      "license_note": "CC BY-SA 3.0 (via Wikimedia Commons)",
+      "attribution": "Joanbanjo, via Wikimedia Commons, CC BY-SA 3.0",
+      "sha256": "12f7f44988fc21a2168ea5406db32edb63ac731c446d711d216bb577873d71ec",
+      "filename": "wm-sala-del-maggior-consiglio-palau-ducal-de-ven-ci.jpg"
     }
   ]
 }

--- a/apps/modal-backend/tests/map_corpus/overlay.py
+++ b/apps/modal-backend/tests/map_corpus/overlay.py
@@ -1,0 +1,133 @@
+"""Render an annotation back onto its source map — the visual in->out check.
+
+Given a corpus description (verified or a candidate from annotate.py) and the
+map image it was made from, draw each entity's detector box, segmenter border
+and centroid + label onto the image, so a reviewer can SEE what the pipeline
+extracted (and where the VLM segmenter's borders go wrong — the M2/SAM3 case).
+
+    .venv/bin/python -m tests.map_corpus.overlay <map-id>              # verified
+    .venv/bin/python -m tests.map_corpus.overlay <map-id> --candidate  # candidate
+or: make corpus-overlay id=<map-id>
+
+Writes tests/map_corpus/overlays/<id>.<source>.png (free, no API calls).
+"""
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from tests.map_corpus import DESCRIPTIONS, ROOT, image_path
+
+OVERLAYS = ROOT / "overlays"
+
+
+def frame_to_px(
+    x: float, y: float, frame_w: float, frame_h: float, img_w: int, img_h: int
+) -> tuple[int, int]:
+    """Map a point in the corpus frame (0..frame_w, 0..frame_h; origin top-left)
+    to image pixels (rounded). This is the transform the whole overlay rides on."""
+    return (round(x / frame_w * img_w), round(y / frame_h * img_h))
+
+
+def render_overlay(image_bytes: bytes, desc: dict[str, Any]) -> bytes:
+    """Draw the description's entities over the image; return PNG bytes."""
+    from PIL import Image, ImageColor, ImageDraw, ImageFont
+
+    img = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+    w, h = img.size
+    fw = float(desc.get("frame", {}).get("w", 100.0))
+    fh = float(desc.get("frame", {}).get("h", 60.0))
+    draw = ImageDraw.Draw(img, "RGBA")
+    try:
+        font = ImageFont.load_default(size=max(13, w // 60))
+    except TypeError:  # very old Pillow without the size kwarg
+        font = ImageFont.load_default()
+
+    box_c = ImageColor.getrgb("#00e5ff")  # detector footprint
+    border_c = ImageColor.getrgb("#ffd400")  # segmenter polygon
+    dot_c = ImageColor.getrgb("#ff2d55")  # centroid
+
+    for e in desc.get("entities", []):
+        pos = e["pos"]
+        fp = e.get("footprint", {"w": 2.0, "d": 2.0})
+        cx, cy = frame_to_px(pos["x"], pos["y"], fw, fh, w, h)
+        # detector footprint box (pos is the centre)
+        x0, y0 = frame_to_px(pos["x"] - fp["w"] / 2, pos["y"] - fp["d"] / 2, fw, fh, w, h)
+        x1, y1 = frame_to_px(pos["x"] + fp["w"] / 2, pos["y"] + fp["d"] / 2, fw, fh, w, h)
+        draw.rectangle([x0, y0, x1, y1], outline=(*box_c, 230), width=2)
+        # segmenter border polygon (this is where loose VLM traces show up)
+        border = e.get("border")
+        if border and len(border) >= 3:
+            pts = [frame_to_px(vx, vy, fw, fh, w, h) for vx, vy in border]
+            draw.line([*pts, pts[0]], fill=(*border_c, 230), width=2)
+        # centroid + label
+        draw.ellipse([cx - 4, cy - 4, cx + 4, cy + 4], fill=(*dot_c, 255))
+        label = str(e.get("label", ""))
+        tb = draw.textbbox((0, 0), label, font=font)
+        tw, th = tb[2] - tb[0], tb[3] - tb[1]
+        ly = max(0, cy - th - 6)
+        draw.rectangle([cx + 6, ly, cx + 10 + tw, ly + th + 4], fill=(0, 0, 0, 170))
+        draw.text((cx + 8, ly + 2), label, fill=(255, 255, 255, 255), font=font)
+
+    # header strip: source + entity count + verdict
+    status = desc.get("review", {}).get("status", "?")
+    ann = desc.get("annotation", {})
+    head = (
+        f"{desc.get('map_id', '')}  |  {len(desc.get('entities', []))} entities  |  "
+        f"status={status}"
+        + (
+            f"  |  judge={ann.get('judge_score')} agree={ann.get('agreement')}"
+            f" contrib={ann.get('contributors')}"
+            if ann
+            else ""
+        )
+    )
+    draw.rectangle([0, 0, w, 22], fill=(0, 0, 0, 180))
+    draw.text((6, 4), head, fill=(255, 255, 255, 255), font=font)
+
+    out = io.BytesIO()
+    img.save(out, format="PNG")
+    return out.getvalue()
+
+
+def _load_desc(map_id: str, candidate: bool) -> tuple[dict[str, Any], str]:
+    path = (
+        DESCRIPTIONS / "candidates" / f"{map_id}.json"
+        if candidate
+        else DESCRIPTIONS / f"{map_id}.json"
+    )
+    if not path.exists():
+        raise SystemExit(f"{path} not found")
+    return json.loads(path.read_text()), ("candidate" if candidate else "verified")
+
+
+def overlay_one(map_id: str, candidate: bool = False) -> Path:
+    desc, source = _load_desc(map_id, candidate)
+    img = image_path(map_id)
+    if not img.exists():
+        raise SystemExit(f"{img} missing — run `make corpus-fetch` first")
+    png = render_overlay(img.read_bytes(), desc)
+    OVERLAYS.mkdir(parents=True, exist_ok=True)
+    out = OVERLAYS / f"{map_id}.{source}.png"
+    out.write_bytes(png)
+    print(f"  wrote {out.relative_to(ROOT.parent.parent)} ({len(desc.get('entities', []))} entities)")
+    return out
+
+
+def main() -> int:
+    args = [a for a in sys.argv[1:] if a]
+    candidate = "--candidate" in args
+    ids = [a for a in args if not a.startswith("--")]
+    if not ids:
+        print("usage: python -m tests.map_corpus.overlay <map-id> [--candidate]")
+        return 1
+    for map_id in ids:
+        overlay_one(map_id, candidate=candidate)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/modal-backend/tests/map_corpus/sources/__init__.py
+++ b/apps/modal-backend/tests/map_corpus/sources/__init__.py
@@ -1,0 +1,4 @@
+"""Source adapters that FIND free-to-use reference imagery online and emit corpus
+manifest rows (id, tier, source_url, license_note, attribution, filename). They
+only add rows; `make corpus-fetch` then downloads + sha-pins the binaries, exactly
+as for the hand-seeded maps."""

--- a/apps/modal-backend/tests/map_corpus/sources/met.py
+++ b/apps/modal-backend/tests/map_corpus/sources/met.py
@@ -1,0 +1,108 @@
+"""The Metropolitan Museum of Art Open Access adapter — CC0 object photography,
+ideal for the `closeup` tier. Keyless REST API (collectionapi.metmuseum.org):
+search?q=<query> -> objectIDs, objects/<id> -> the object (isPublicDomain +
+primaryImage + title + classification). The pure object->row mapping is gated by
+test_sources_met.py; the live search is a free (no-key, no-spend) CLI.
+
+    .venv/bin/python -m tests.map_corpus.sources.met "ceramic vase" --limit 8
+    .venv/bin/python -m tests.map_corpus.sources.met "ceramic vase" --append   # add to manifest
+
+Rows are added WITHOUT a sha256; `make corpus-fetch` pins them on first download.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+import urllib.parse
+import urllib.request
+from typing import Any
+
+from tests.map_corpus import MANIFEST
+
+_BASE = "https://collectionapi.metmuseum.org/public/collection/v1"
+
+
+def _slug(s: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", str(s).lower()).strip("-") or "x"
+
+
+def met_object_to_row(obj: dict[str, Any], tier: str = "closeup") -> dict[str, Any] | None:
+    """Map a Met object to a corpus manifest row, or None if it isn't CC0 / has
+    no image. genre falls back classification -> department -> "object"."""
+    if not obj.get("isPublicDomain"):
+        return None
+    image = str(obj.get("primaryImage") or "").strip()
+    if not image:
+        return None
+    oid = obj.get("objectID")
+    title = str(obj.get("title") or "untitled").strip()
+    genre = _slug(str(obj.get("classification") or obj.get("department") or "object"))
+    return {
+        "id": f"met-{oid}-{_slug(title)}"[:60],
+        "tier": tier,
+        "genre": genre,
+        "source_url": image,
+        "license_note": "CC0 (The Met Open Access)",
+        "attribution": f'"{title}", The Metropolitan Museum of Art, CC0',
+        "filename": f"met-{oid}.jpg",
+    }
+
+
+def _get_json(url: str) -> Any:
+    req = urllib.request.Request(url, headers={"User-Agent": "openflipbook-corpus/1.0"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def find_rows(query: str, limit: int = 8, tier: str = "closeup") -> list[dict[str, Any]]:
+    """Live (free) search: walk Met search results until `limit` CC0 rows are
+    collected. Network — only the CLI calls this."""
+    search = _get_json(f"{_BASE}/search?hasImages=true&q={urllib.parse.quote(query)}")
+    ids = search.get("objectIDs") or []
+    rows: list[dict[str, Any]] = []
+    for oid in ids:
+        if len(rows) >= limit:
+            break
+        try:
+            row = met_object_to_row(_get_json(f"{_BASE}/objects/{oid}"), tier=tier)
+        except Exception:
+            continue
+        if row:
+            rows.append(row)
+    return rows
+
+
+def _append_to_manifest(rows: list[dict[str, Any]]) -> int:
+    data = json.loads(MANIFEST.read_text())
+    have = {m["id"] for m in data["maps"]}
+    added = [r for r in rows if r["id"] not in have]
+    data["maps"].extend(added)
+    MANIFEST.write_text(json.dumps(data, indent=2) + "\n")
+    return len(added)
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    if not args:
+        print('usage: python -m tests.map_corpus.sources.met "<query>" [--limit N] [--tier T] [--append]')
+        return 1
+    append = "--append" in args
+    tier = "closeup"
+    limit = 8
+    if "--tier" in args:
+        tier = args[args.index("--tier") + 1]
+    if "--limit" in args:
+        limit = int(args[args.index("--limit") + 1])
+    query = next(a for a in args if not a.startswith("--") and not a.isdigit())
+    rows = find_rows(query, limit=limit, tier=tier)
+    print(json.dumps(rows, indent=2))
+    print(f"\n{len(rows)} CC0 candidate(s) for {query!r} (tier={tier})")
+    if append:
+        n = _append_to_manifest(rows)
+        print(f"appended {n} new row(s) to manifest.json — run `make corpus-fetch` to pin")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/modal-backend/tests/map_corpus/sources/met.py
+++ b/apps/modal-backend/tests/map_corpus/sources/met.py
@@ -38,15 +38,16 @@ def met_object_to_row(obj: dict[str, Any], tier: str = "closeup") -> dict[str, A
     oid = obj.get("objectID")
     title = str(obj.get("title") or "untitled").strip()
     genre = _slug(str(obj.get("classification") or obj.get("department") or "object"))
+    row_id = f"met-{oid}-{_slug(title)}"[:60]
     return {
-        "id": f"met-{oid}-{_slug(title)}"[:60],
+        "id": row_id,
         "tier": tier,
         "genre": genre,
         "source_url": image,
         "license_note": "CC0 (The Met Open Access)",
         "attribution": f'"{title}", The Metropolitan Museum of Art, CC0',
         "sha256": None,  # pinned by scripts/fetch_corpus.py --pin on first fetch
-        "filename": f"met-{oid}.jpg",
+        "filename": f"{row_id}.jpg",  # corpus invariant: filename starts with id
     }
 
 

--- a/apps/modal-backend/tests/map_corpus/sources/met.py
+++ b/apps/modal-backend/tests/map_corpus/sources/met.py
@@ -45,6 +45,7 @@ def met_object_to_row(obj: dict[str, Any], tier: str = "closeup") -> dict[str, A
         "source_url": image,
         "license_note": "CC0 (The Met Open Access)",
         "attribution": f'"{title}", The Metropolitan Museum of Art, CC0',
+        "sha256": None,  # pinned by scripts/fetch_corpus.py --pin on first fetch
         "filename": f"met-{oid}.jpg",
     }
 

--- a/apps/modal-backend/tests/map_corpus/sources/wikimedia.py
+++ b/apps/modal-backend/tests/map_corpus/sources/wikimedia.py
@@ -1,0 +1,143 @@
+"""Wikimedia Commons adapter — PD / CC0 / CC-BY raster photos, ideal for the
+`interior` tier ("inside places"). Keyless MediaWiki API: a generator=search over
+the File namespace returns pages with imageinfo + extmetadata (license + artist).
+The pure page->row mapping is gated by test_sources_wikimedia.py; the live search
+is a free (no-key, no-spend) CLI. source_url uses the same stable Special:FilePath
+?width=1600 form as the hand-seeded maps.
+
+    .venv/bin/python -m tests.map_corpus.sources.wikimedia "cathedral interior" --limit 6
+    .venv/bin/python -m tests.map_corpus.sources.wikimedia "library reading room" --append
+
+Rows are added WITHOUT a sha256; `make corpus-fetch` pins them on first download.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+import urllib.parse
+import urllib.request
+from typing import Any
+
+from tests.map_corpus import MANIFEST
+
+_API = "https://commons.wikimedia.org/w/api.php"
+_RASTER = {"image/jpeg", "image/png"}
+
+
+def _slug(s: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", str(s).lower()).strip("-") or "x"
+
+
+def _strip_html(s: str) -> str:
+    return re.sub(r"\s+", " ", re.sub(r"<[^>]+>", "", str(s))).strip()
+
+
+def _is_free(code: str, short: str) -> bool:
+    code = code.lower().strip()
+    return (
+        code in {"cc0", "pd"}
+        or code.startswith("cc-by")
+        or "public domain" in short.lower()
+    )
+
+
+def commons_page_to_row(
+    page: dict[str, Any], tier: str = "interior", genre: str = "interior"
+) -> dict[str, Any] | None:
+    """Map a Commons API page to a corpus manifest row, or None if it isn't a
+    free-licensed raster image."""
+    infos = page.get("imageinfo") or []
+    if not infos:
+        return None
+    ii = infos[0]
+    if str(ii.get("mime", "")).lower() not in _RASTER:
+        return None
+    ext = ii.get("extmetadata") or {}
+    code = str((ext.get("License") or {}).get("value") or "")
+    short = str((ext.get("LicenseShortName") or {}).get("value") or "")
+    if not _is_free(code, short):
+        return None
+
+    title = str(page.get("title", "")).split(":", 1)[-1].strip()  # drop "File:"
+    if not title:
+        return None
+    stem, _, ext_name = title.rpartition(".")
+    suffix = ext_name.lower() if ext_name.lower() in {"jpg", "jpeg", "png"} else "jpg"
+    slug = _slug(stem or title)[:48]
+    artist = _strip_html(str((ext.get("Artist") or {}).get("value") or "")) or "Wikimedia Commons"
+    return {
+        "id": f"wm-{slug}"[:60],
+        "tier": tier,
+        "genre": _slug(genre),
+        "source_url": (
+            f"https://commons.wikimedia.org/wiki/Special:FilePath/"
+            f"{urllib.parse.quote(title)}?width=1600"
+        ),
+        "license_note": f"{short or code} (via Wikimedia Commons)",
+        "attribution": f"{artist}, via Wikimedia Commons, {short or code}",
+        "sha256": None,
+        "filename": f"wm-{slug}.{suffix}",
+    }
+
+
+def _get_json(url: str) -> Any:
+    req = urllib.request.Request(url, headers={"User-Agent": "openflipbook-corpus/1.0"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def find_rows(query: str, limit: int = 6, tier: str = "interior") -> list[dict[str, Any]]:
+    """Live (free) Commons search over the File namespace -> free-licensed rows."""
+    params = {
+        "action": "query",
+        "format": "json",
+        "generator": "search",
+        "gsrsearch": query,
+        "gsrnamespace": "6",  # File:
+        "gsrlimit": str(max(limit * 3, limit)),  # over-fetch; many will be non-free
+        "prop": "imageinfo",
+        "iiprop": "url|mime|extmetadata",
+    }
+    data = _get_json(f"{_API}?{urllib.parse.urlencode(params)}")
+    pages = ((data.get("query") or {}).get("pages") or {}).values()
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for page in pages:
+        if len(rows) >= limit:
+            break
+        row = commons_page_to_row(page, tier=tier, genre=_slug(query))
+        if row and row["id"] not in seen:
+            seen.add(row["id"])
+            rows.append(row)
+    return rows
+
+
+def _append_to_manifest(rows: list[dict[str, Any]]) -> int:
+    data = json.loads(MANIFEST.read_text())
+    have = {m["id"] for m in data["maps"]}
+    added = [r for r in rows if r["id"] not in have]
+    data["maps"].extend(added)
+    MANIFEST.write_text(json.dumps(data, indent=2) + "\n")
+    return len(added)
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    if not args:
+        print('usage: python -m tests.map_corpus.sources.wikimedia "<query>" [--limit N] [--tier T] [--append]')
+        return 1
+    append = "--append" in args
+    tier = args[args.index("--tier") + 1] if "--tier" in args else "interior"
+    limit = int(args[args.index("--limit") + 1]) if "--limit" in args else 6
+    query = next(a for a in args if not a.startswith("--") and not a.isdigit())
+    rows = find_rows(query, limit=limit, tier=tier)
+    print(json.dumps(rows, indent=2))
+    print(f"\n{len(rows)} free-licensed candidate(s) for {query!r} (tier={tier})")
+    if append:
+        print(f"appended {_append_to_manifest(rows)} new row(s) — run `make corpus-fetch` to pin")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/modal-backend/tests/map_corpus/test_annotate.py
+++ b/apps/modal-backend/tests/map_corpus/test_annotate.py
@@ -9,12 +9,14 @@ from __future__ import annotations
 
 import pytest
 
+from tests.map_corpus import load_manifest
 from tests.map_corpus.annotate import (
     agreement_score,
     assemble_description,
     attach_geometry,
     decide_status,
     default_min_votes,
+    describe_system,
     merge_entities,
     merge_relations,
     norm_label,
@@ -97,6 +99,23 @@ def test_vote_majority_and_tiebreak_and_default() -> None:
 
 
 # --- agreement metric --------------------------------------------------------
+
+
+def test_load_manifest_defaults_tier_to_map_and_filters() -> None:
+    rows = load_manifest()
+    assert rows and all(r.get("tier") == "map" for r in rows)  # existing rows -> map
+    assert load_manifest(tier="map") == rows
+    assert load_manifest(tier="interior") == []
+
+
+def test_describe_system_is_tier_specific() -> None:
+    m = describe_system("map").lower()
+    i = describe_system("interior").lower()
+    c = describe_system("closeup").lower()
+    assert "cartograph" in m
+    assert "interior" in i or "room" in i
+    assert "object" in c or "close" in c
+    assert describe_system("unknown") == describe_system("map")  # safe default
 
 
 def test_default_min_votes_is_lenient_and_clamped_to_contributors() -> None:

--- a/apps/modal-backend/tests/map_corpus/test_annotate.py
+++ b/apps/modal-backend/tests/map_corpus/test_annotate.py
@@ -103,9 +103,14 @@ def test_vote_majority_and_tiebreak_and_default() -> None:
 
 def test_load_manifest_defaults_tier_to_map_and_filters() -> None:
     rows = load_manifest()
-    assert rows and all(r.get("tier") == "map" for r in rows)  # existing rows -> map
-    assert load_manifest(tier="map") == rows
-    assert load_manifest(tier="interior") == []
+    assert all(r.get("tier") in {"map", "interior", "closeup"} for r in rows)
+    maps = load_manifest(tier="map")
+    assert maps and all(r["tier"] == "map" for r in maps)
+    # the hand-seeded maps carry no explicit tier -> default to "map"
+    assert any(r["id"] == "fantasy-treasure-island" for r in maps)
+    # tier filtering partitions the manifest
+    parts = sum(len(load_manifest(tier=t)) for t in ("map", "interior", "closeup"))
+    assert parts == len(rows)
 
 
 def test_describe_system_is_tier_specific() -> None:

--- a/apps/modal-backend/tests/map_corpus/test_annotate.py
+++ b/apps/modal-backend/tests/map_corpus/test_annotate.py
@@ -158,16 +158,18 @@ def test_decide_status_requires_both_gates() -> None:
 # --- non-destructive output routing ------------------------------------------
 
 
-def test_output_name_protects_verified_unless_forced() -> None:
-    # a brand-new map or a prior auto-run draft is written canonically
-    assert output_name("m", None, force=False) == "m.json"
-    assert output_name("m", "vlm_draft", force=False) == "m.json"
-    assert output_name("m", "needs_human", force=False) == "m.json"
-    # a committed human-verified description is NEVER silently clobbered — the
-    # annotation lands as a candidate (a sibling subdir invisible to recon)
-    assert output_name("m", "verified", force=False) == "candidates/m.json"
+def test_output_name_routes_by_verdict_and_protects_verified() -> None:
+    # an auto-VERIFIED result with nothing to clobber is promoted canonically
+    assert output_name("m", None, "verified", force=False) == "m.json"
+    # a prior draft may be overwritten by an auto-verified result
+    assert output_name("m", "vlm_draft", "verified", force=False) == "m.json"
+    # a NON-verified verdict is never written to the reviewed-ground-truth dir —
+    # it lands as a candidate (subdir invisible to recon + the integrity gate)
+    assert output_name("m", None, "needs_human", force=False) == "candidates/m.json"
+    # a committed human-verified description is never silently clobbered...
+    assert output_name("m", "verified", "verified", force=False) == "candidates/m.json"
     # ...unless the operator forces it
-    assert output_name("m", "verified", force=True) == "m.json"
+    assert output_name("m", "verified", "verified", force=True) == "m.json"
 
 
 # --- relation reconcile ------------------------------------------------------

--- a/apps/modal-backend/tests/map_corpus/test_annotate.py
+++ b/apps/modal-backend/tests/map_corpus/test_annotate.py
@@ -21,6 +21,7 @@ from tests.map_corpus.annotate import (
     merge_relations,
     norm_label,
     output_name,
+    parse_arbiter_consensus,
     slug,
     vote,
 )
@@ -81,6 +82,27 @@ def test_merge_keeps_majority_and_flags_minority() -> None:
     # Random Rock: only 1 model -> minority, not consensus
     assert "random-rock" not in by
     assert [m["label"] for m in minority] == ["Random Rock"]
+
+
+def test_parse_arbiter_consensus_merges_synonyms_clamps_votes_dedups() -> None:
+    # the LLM arbiter returns one consensus list with synonym-corrected votes
+    payload = {
+        "entities": [
+            {"label": "Rete", "kind": "item", "visual": "openwork star disc", "votes": 3},
+            {"label": "rete", "kind": "item", "visual": "", "votes": 1},  # dup norm -> dropped
+            {"label": "Mater", "kind": "item", "visual": "base plate", "votes": 9},  # clamp to n
+            {"label": "  ", "votes": 2},  # blank -> dropped
+        ]
+    }
+    out = parse_arbiter_consensus(payload, n_models=3)
+    by = {e["ref"]: e for e in out}
+    assert set(by) == {"rete", "mater"}
+    assert by["rete"]["votes"] == 3 and by["rete"]["kind"] == "item"
+    assert by["rete"]["label"] == "Rete" and by["rete"]["visual"] == "openwork star disc"
+    assert by["mater"]["votes"] == 3  # 9 clamped to n_models
+    # tolerant: junk shapes yield []
+    assert parse_arbiter_consensus(None, 3) == []
+    assert parse_arbiter_consensus({"nope": 1}, 3) == []
 
 
 def test_merge_min_votes_one_keeps_everything() -> None:

--- a/apps/modal-backend/tests/map_corpus/test_annotate.py
+++ b/apps/modal-backend/tests/map_corpus/test_annotate.py
@@ -191,6 +191,20 @@ def test_merge_relations_keeps_consensus_endpoints_and_dedupes() -> None:
     assert rels == [{"subject": "spyglass-hill", "relation": "near", "object": "skeleton-island"}]
 
 
+def test_merge_relations_enforces_allowed_vocabulary() -> None:
+    label_to_ref = {"a": "a", "b": "b"}
+    lists = [
+        [
+            {"subject": "a", "relation": "near", "object": "b"},
+            {"subject": "a", "relation": "attached_to", "object": "b"},  # not in vocab
+        ]
+    ]
+    rels = merge_relations(lists, label_to_ref, allowed={"near", "inside"})
+    assert rels == [{"subject": "a", "relation": "near", "object": "b"}]
+    # no allowed set -> keep all (back-compat)
+    assert len(merge_relations(lists, label_to_ref)) == 2
+
+
 # --- artifact assembly + provenance ------------------------------------------
 
 

--- a/apps/modal-backend/tests/map_corpus/test_annotate.py
+++ b/apps/modal-backend/tests/map_corpus/test_annotate.py
@@ -1,0 +1,194 @@
+"""Ensemble-annotation gate (free): the deterministic reconcile + promote core.
+
+The paid pipeline (tests/map_corpus/annotate.py) fans a describe call out over N
+VLMs, then reconciles their entity lists into one consensus WITHOUT another paid
+call — that reconcile, the agreement metric and the auto-promote decision are
+pure functions and live or die here.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tests.map_corpus.annotate import (
+    agreement_score,
+    assemble_description,
+    attach_geometry,
+    decide_status,
+    merge_entities,
+    merge_relations,
+    norm_label,
+    slug,
+    vote,
+)
+
+# --- label normalisation -----------------------------------------------------
+
+
+def test_norm_label_canonicalises_for_matching() -> None:
+    assert norm_label("Spyglass Hill") == norm_label("spyglass  hill")
+    # a single leading article is dropped so "The Tower" matches "Tower"
+    assert norm_label("The Tower") == norm_label("Tower")
+    # surrounding punctuation/whitespace stripped, internal kept
+    assert norm_label("  Skeleton Island! ") == "skeleton island"
+
+
+def test_slug_is_kebab() -> None:
+    assert slug("Ben Gunn's cave") == "ben-gunn-s-cave"
+    assert slug("") == "x"
+
+
+# --- entity reconcile (the arbiter) ------------------------------------------
+
+
+def _drafts() -> list[list[dict]]:
+    return [
+        [
+            {"ref": "spyglass", "kind": "place", "label": "Spyglass Hill", "visual": "a peak"},
+            {"ref": "skeleton", "kind": "place", "label": "Skeleton Island", "visual": ""},
+            # same model names spyglass twice — must still count as ONE vote
+            {"ref": "spyglass2", "kind": "place", "label": "spyglass hill", "visual": ""},
+        ],
+        [
+            {"ref": "sg", "kind": "place", "label": "The Spyglass Hill", "visual": "tall snowy mountain peak"},
+            {"ref": "sk", "kind": "item", "label": "Skeleton Island", "visual": "rocky islet"},
+        ],
+        [
+            {"ref": "sg", "kind": "place", "label": "Spyglass Hill", "visual": ""},
+            {"ref": "rr", "kind": "place", "label": "Random Rock", "visual": "a lone boulder"},
+        ],
+    ]
+
+
+def test_merge_keeps_majority_and_flags_minority() -> None:
+    consensus, minority = merge_entities(_drafts(), min_votes=2)
+    by = {e["ref"]: e for e in consensus}
+
+    # Spyglass Hill: named by all 3 models (the dup in model 0 is ONE vote)
+    assert by["spyglass-hill"]["votes"] == 3
+    # canonical label = most-frequent surface form, tie broken by first-seen
+    assert by["spyglass-hill"]["label"] == "Spyglass Hill"
+    # richest (longest) visual wins
+    assert by["spyglass-hill"]["visual"] == "tall snowy mountain peak"
+
+    # Skeleton Island: 2 votes, kind tie (place vs item) -> first-seen "place"
+    assert by["skeleton-island"]["votes"] == 2
+    assert by["skeleton-island"]["kind"] == "place"
+
+    # Random Rock: only 1 model -> minority, not consensus
+    assert "random-rock" not in by
+    assert [m["label"] for m in minority] == ["Random Rock"]
+
+
+def test_merge_min_votes_one_keeps_everything() -> None:
+    consensus, minority = merge_entities(_drafts(), min_votes=1)
+    assert minority == []
+    assert {e["ref"] for e in consensus} == {"spyglass-hill", "skeleton-island", "random-rock"}
+
+
+# --- scalar vote -------------------------------------------------------------
+
+
+def test_vote_majority_and_tiebreak_and_default() -> None:
+    assert vote(["place", "place", "item"]) == "place"
+    assert vote(["region", "city"]) == "region"  # tie -> first-seen
+    assert vote([], default="region") == "region"
+
+
+# --- agreement metric --------------------------------------------------------
+
+
+def test_agreement_is_mean_vote_fraction() -> None:
+    consensus = [{"votes": 3}, {"votes": 2}]
+    assert agreement_score(consensus, n_models=3) == pytest.approx((1.0 + 2 / 3) / 2)
+    assert agreement_score([], n_models=3) == 0.0
+    assert agreement_score(consensus, n_models=0) == 0.0
+
+
+# --- auto-promote decision ---------------------------------------------------
+
+
+def test_decide_status_requires_both_gates() -> None:
+    ok = dict(judge_threshold=7.0, agreement_threshold=0.6)
+    assert decide_status(9.0, 0.9, **ok) == "verified"
+    assert decide_status(7.0, 0.6, **ok) == "verified"  # boundary inclusive
+    assert decide_status(5.0, 0.9, **ok) == "needs_human"  # judge too low
+    assert decide_status(9.0, 0.4, **ok) == "needs_human"  # agreement too low
+
+
+# --- relation reconcile ------------------------------------------------------
+
+
+def test_merge_relations_keeps_consensus_endpoints_and_dedupes() -> None:
+    label_to_ref = {"spyglass hill": "spyglass-hill", "skeleton island": "skeleton-island"}
+    lists = [
+        [
+            {"subject": "Spyglass Hill", "relation": "near", "object": "Skeleton Island"},
+            {"subject": "Spyglass Hill", "relation": "near", "object": "Random Rock"},  # endpoint not consensus
+        ],
+        [
+            {"subject": "The Spyglass Hill", "relation": "near", "object": "Skeleton Island"},  # dup after norm
+            {"subject": "Skeleton Island", "relation": "near", "object": "Skeleton Island"},  # self -> drop
+        ],
+    ]
+    rels = merge_relations(lists, label_to_ref)
+    assert rels == [{"subject": "spyglass-hill", "relation": "near", "object": "skeleton-island"}]
+
+
+# --- artifact assembly + provenance ------------------------------------------
+
+
+def test_assemble_strips_votes_and_wires_provenance() -> None:
+    entities = [
+        {
+            "ref": "a", "kind": "place", "label": "A", "visual": "",
+            "pos": {"x": 1.0, "y": 2.0}, "footprint": {"w": 1.0, "d": 1.0},
+            "height_rel": 0.0, "height_m": None, "border": None, "votes": 3,
+        }
+    ]
+    annotation = {
+        "ensemble": ["anthropic/claude", "google/gemini"], "iters": 2,
+        "judge_score": 8.0, "agreement": 0.9, "minority": ["Random Rock"],
+    }
+    d = assemble_description(
+        map_id="m", genre="fantasy", style="ink", scale_tier="region",
+        description="a place", frame={"w": 100.0, "h": 60.0},
+        entities=entities, relations=[], rev=2, annotation=annotation, status="verified",
+    )
+    assert d["map_id"] == "m" and d["rev"] == 2
+    assert d["review"]["status"] == "verified"
+    # the corpus entity schema stays clean — votes live in provenance, not the entity
+    assert "votes" not in d["entities"][0]
+    assert d["annotation"]["judge_score"] == 8.0
+    assert d["annotation"]["minority"] == ["Random Rock"]
+    # the input list isn't mutated as a side effect
+    assert "votes" in entities[0]
+
+
+# --- geometry bridge (consensus labels -> positioned entities) ---------------
+
+
+def test_attach_geometry_scales_to_frame_and_drops_undetected() -> None:
+    consensus = [
+        {"ref": "tower", "kind": "place", "label": "The Tower", "visual": "v", "votes": 3},
+        {"ref": "ghost", "kind": "place", "label": "Ghost", "visual": "", "votes": 2},
+    ]
+    detections = [
+        {"label": "the tower", "x_pct": 0.5, "y_pct": 0.2, "w_pct": 0.1, "h_pct": 0.05, "score": 1.0},
+    ]
+    segments = [
+        {"label": "the tower", "polygon": [[0.4, 0.1], [0.6, 0.1], [0.5, 0.3]],
+         "rel_height": 0.8, "est_height_m": 30.0, "score": 1.0},
+    ]
+    heights_m = {"the tower": 30.0}  # segmenter labels come back lowercased
+
+    out = attach_geometry(consensus, detections, segments, heights_m)
+
+    # "Ghost" had no detection box -> dropped (matches draft.py's contract)
+    assert [e["ref"] for e in out] == ["tower"]
+    e = out[0]
+    assert e["label"] == "The Tower" and e["kind"] == "place" and e["votes"] == 3
+    assert e["pos"] == {"x": 50.0, "y": 12.0}  # 0.5*100, 0.2*60
+    assert e["footprint"] == {"w": 10.0, "d": 3.0}
+    assert e["height_rel"] == 0.8
+    assert e["height_m"] == 30.0
+    assert e["border"] == [[40.0, 6.0], [60.0, 6.0], [50.0, 18.0]]

--- a/apps/modal-backend/tests/map_corpus/test_annotate.py
+++ b/apps/modal-backend/tests/map_corpus/test_annotate.py
@@ -14,6 +14,7 @@ from tests.map_corpus.annotate import (
     assemble_description,
     attach_geometry,
     decide_status,
+    default_min_votes,
     merge_entities,
     merge_relations,
     norm_label,
@@ -96,6 +97,20 @@ def test_vote_majority_and_tiebreak_and_default() -> None:
 
 
 # --- agreement metric --------------------------------------------------------
+
+
+def test_default_min_votes_is_lenient_and_clamped_to_contributors() -> None:
+    # regression: a 2-model ensemble must NOT require unanimity (the bug that
+    # dropped every entity to minority and produced a 0-entity annotation)
+    assert default_min_votes(2, None) == 1
+    assert default_min_votes(1, None) == 1
+    # an explicit majority policy is honoured...
+    assert default_min_votes(3, 2) == 2
+    # ...but never exceeds the models that actually contributed, so a strict
+    # policy + a dropped model can never force-empty the consensus
+    assert default_min_votes(2, 3) == 2
+    assert default_min_votes(1, 2) == 1
+    assert default_min_votes(5, 0) == 1  # floor of 1
 
 
 def test_agreement_is_mean_vote_fraction() -> None:

--- a/apps/modal-backend/tests/map_corpus/test_annotate.py
+++ b/apps/modal-backend/tests/map_corpus/test_annotate.py
@@ -17,6 +17,7 @@ from tests.map_corpus.annotate import (
     merge_entities,
     merge_relations,
     norm_label,
+    output_name,
     slug,
     vote,
 )
@@ -113,6 +114,21 @@ def test_decide_status_requires_both_gates() -> None:
     assert decide_status(7.0, 0.6, **ok) == "verified"  # boundary inclusive
     assert decide_status(5.0, 0.9, **ok) == "needs_human"  # judge too low
     assert decide_status(9.0, 0.4, **ok) == "needs_human"  # agreement too low
+
+
+# --- non-destructive output routing ------------------------------------------
+
+
+def test_output_name_protects_verified_unless_forced() -> None:
+    # a brand-new map or a prior auto-run draft is written canonically
+    assert output_name("m", None, force=False) == "m.json"
+    assert output_name("m", "vlm_draft", force=False) == "m.json"
+    assert output_name("m", "needs_human", force=False) == "m.json"
+    # a committed human-verified description is NEVER silently clobbered — the
+    # annotation lands as a candidate (a sibling subdir invisible to recon)
+    assert output_name("m", "verified", force=False) == "candidates/m.json"
+    # ...unless the operator forces it
+    assert output_name("m", "verified", force=True) == "m.json"
 
 
 # --- relation reconcile ------------------------------------------------------

--- a/apps/modal-backend/tests/map_corpus/test_chains.py
+++ b/apps/modal-backend/tests/map_corpus/test_chains.py
@@ -1,0 +1,45 @@
+"""Descent-chain resolution gate (free): a child manifest row's parent_id +
+parent_ref resolves to an anchor point in the parent map's description, so the
+descent bench knows WHERE in the parent to enter."""
+from __future__ import annotations
+
+from tests.map_corpus.chains import descent_chains, parent_anchor
+
+
+def _parent() -> dict:
+    return {
+        "map_id": "manor",
+        "entities": [
+            {"ref": "church", "label": "Church", "pos": {"x": 52.1, "y": 35.5}},
+            {"ref": "mill", "label": "Mill", "pos": {"x": 57.4, "y": 40.3}},
+        ],
+    }
+
+
+def test_parent_anchor_finds_entity_pos() -> None:
+    a = parent_anchor(_parent(), "church")
+    assert a == {"label": "Church", "pos": {"x": 52.1, "y": 35.5}}
+    assert parent_anchor(_parent(), "missing") is None
+
+
+def test_descent_chains_resolves_linked_rows_only() -> None:
+    manifest = [
+        {"id": "manor", "filename": "manor.jpg", "tier": "map"},
+        {
+            "id": "chester-nave", "filename": "chester-nave.jpg", "tier": "interior",
+            "parent_id": "manor", "parent_ref": "church",
+        },
+        {"id": "lone-interior", "filename": "lone.jpg", "tier": "interior"},  # no link
+        {
+            "id": "dangling", "filename": "d.jpg", "tier": "interior",
+            "parent_id": "manor", "parent_ref": "nonexistent",  # ref not in parent
+        },
+    ]
+    chains = descent_chains(manifest, {"manor": _parent()})
+    assert len(chains) == 1
+    c = chains[0]
+    assert c["child_id"] == "chester-nave" and c["parent_id"] == "manor"
+    assert c["child_filename"] == "chester-nave.jpg"
+    assert c["parent_filename"] == "manor.jpg"
+    assert c["label"] == "Church"
+    assert c["anchor"]["pos"] == {"x": 52.1, "y": 35.5}

--- a/apps/modal-backend/tests/map_corpus/test_overlay.py
+++ b/apps/modal-backend/tests/map_corpus/test_overlay.py
@@ -1,0 +1,15 @@
+"""Overlay gate (free): the frame->pixel transform that lands the annotation on
+the source image. The drawing itself is verified by eye (it's a viz tool); this
+pins the coordinate math so an overlay can't silently drift off the image."""
+from __future__ import annotations
+
+from tests.map_corpus.overlay import frame_to_px
+
+
+def test_frame_to_px_maps_corners_and_center() -> None:
+    # frame is 100x60 (the corpus convention); image any size
+    assert frame_to_px(0, 0, 100, 60, 1000, 600) == (0, 0)
+    assert frame_to_px(100, 60, 100, 60, 1000, 600) == (1000, 600)
+    assert frame_to_px(50, 30, 100, 60, 800, 480) == (400, 240)
+    # rounds to the nearest pixel
+    assert frame_to_px(48, 13.1, 100, 60, 480, 355) == (230, 78)

--- a/apps/modal-backend/tests/map_corpus/test_sources_met.py
+++ b/apps/modal-backend/tests/map_corpus/test_sources_met.py
@@ -24,7 +24,7 @@ def test_met_object_to_row_emits_a_cc0_closeup_row() -> None:
     assert row["tier"] == "closeup"
     assert row["genre"] == "ceramics"
     assert row["source_url"].endswith(".jpg")
-    assert row["filename"] == "met-45734.jpg"
+    assert row["filename"] == row["id"] + ".jpg"  # corpus invariant: filename starts with id
     assert "CC0" in row["license_note"]
     assert "Metropolitan" in row["attribution"] and "Standing Vase" in row["attribution"]
 

--- a/apps/modal-backend/tests/map_corpus/test_sources_met.py
+++ b/apps/modal-backend/tests/map_corpus/test_sources_met.py
@@ -1,0 +1,42 @@
+"""Met source-adapter gate (free): the pure Met-object -> manifest-row mapping
+that keeps only CC0 objects with an image and stamps license + attribution."""
+from __future__ import annotations
+
+from tests.map_corpus.sources.met import met_object_to_row
+
+
+def _obj(**over: object) -> dict[str, object]:
+    o: dict[str, object] = {
+        "objectID": 45734,
+        "isPublicDomain": True,
+        "primaryImage": "https://images.metmuseum.org/CRDImages/as/original/DP251139.jpg",
+        "title": "Standing Vase",
+        "classification": "Ceramics",
+    }
+    o.update(over)
+    return o
+
+
+def test_met_object_to_row_emits_a_cc0_closeup_row() -> None:
+    row = met_object_to_row(_obj())
+    assert row is not None
+    assert row["id"].startswith("met-45734")
+    assert row["tier"] == "closeup"
+    assert row["genre"] == "ceramics"
+    assert row["source_url"].endswith(".jpg")
+    assert row["filename"] == "met-45734.jpg"
+    assert "CC0" in row["license_note"]
+    assert "Metropolitan" in row["attribution"] and "Standing Vase" in row["attribution"]
+
+
+def test_met_object_to_row_drops_non_public_domain_or_imageless() -> None:
+    assert met_object_to_row(_obj(isPublicDomain=False)) is None
+    assert met_object_to_row(_obj(primaryImage="")) is None
+    assert met_object_to_row({"objectID": 1}) is None
+
+
+def test_met_object_to_row_tier_override_and_genre_fallback() -> None:
+    row = met_object_to_row(_obj(classification="", department="European Paintings"), tier="interior")
+    assert row is not None
+    assert row["tier"] == "interior"
+    assert row["genre"] == "european-paintings"

--- a/apps/modal-backend/tests/map_corpus/test_sources_wikimedia.py
+++ b/apps/modal-backend/tests/map_corpus/test_sources_wikimedia.py
@@ -1,0 +1,63 @@
+"""Wikimedia Commons source-adapter gate (free): the pure page -> manifest-row
+mapping that keeps only free-licensed raster images, builds a stable
+Special:FilePath URL, and stamps attribution + license."""
+from __future__ import annotations
+
+from tests.map_corpus.sources.wikimedia import commons_page_to_row
+
+
+def _page(**over: object) -> dict[str, object]:
+    p: dict[str, object] = {
+        "title": "File:Trinity College Library Dublin.jpg",
+        "imageinfo": [
+            {
+                "url": "https://upload.wikimedia.org/wikipedia/commons/x/xx/Trinity.jpg",
+                "mime": "image/jpeg",
+                "extmetadata": {
+                    "License": {"value": "cc-by-sa-4.0"},
+                    "LicenseShortName": {"value": "CC BY-SA 4.0"},
+                    "Artist": {"value": "<a href='/wiki/User:Foo'>Jane Doe</a>"},
+                },
+            }
+        ],
+    }
+    p.update(over)
+    return p
+
+
+def test_commons_page_to_row_free_license() -> None:
+    row = commons_page_to_row(_page(), genre="library")
+    assert row is not None
+    assert row["tier"] == "interior"
+    assert row["genre"] == "library"
+    assert row["id"].startswith("wm-")
+    assert "Special:FilePath" in row["source_url"] and "width=1600" in row["source_url"]
+    assert "Trinity%20College%20Library%20Dublin.jpg" in row["source_url"]
+    assert row["filename"].endswith(".jpg") and row["sha256"] is None
+    # attribution has the (HTML-stripped) artist + the license short name
+    assert "Jane Doe" in row["attribution"] and "CC BY-SA 4.0" in row["attribution"]
+
+
+def test_commons_page_to_row_accepts_cc0_and_public_domain() -> None:
+    for code, short in [("cc0", "CC0"), ("pd", "Public domain")]:
+        p = _page()
+        p["imageinfo"][0]["extmetadata"] = {  # type: ignore[index]
+            "License": {"value": code},
+            "LicenseShortName": {"value": short},
+        }
+        assert commons_page_to_row(p) is not None
+
+
+def test_commons_page_to_row_rejects_nonfree_and_nonraster() -> None:
+    nonfree = _page()
+    nonfree["imageinfo"][0]["extmetadata"] = {  # type: ignore[index]
+        "License": {"value": "fair use"},
+        "LicenseShortName": {"value": "Fair use"},
+    }
+    assert commons_page_to_row(nonfree) is None
+
+    pdf = _page()
+    pdf["imageinfo"][0]["mime"] = "application/pdf"  # type: ignore[index]
+    assert commons_page_to_row(pdf) is None
+
+    assert commons_page_to_row({"title": "File:x.jpg"}) is None

--- a/apps/modal-backend/tests/recon_bench/runner.py
+++ b/apps/modal-backend/tests/recon_bench/runner.py
@@ -181,7 +181,7 @@ def recon_fns(sweep: dict[str, Any]) -> dict[str, Any]:
     ) -> tuple[dict[str, Any], float]:
         labels = [e["label"] for e in desc["entities"]]
         detections = _await(lambda: detect(jpeg, labels))
-        segments = _await(lambda: segment(jpeg, labels))
+        segments = _await(lambda: segment(jpeg, labels, boxes=detections))
         inferred = heights_lib.infer_heights_m(list(segments))
         return (
             {

--- a/apps/modal-backend/tests/test_segmenter.py
+++ b/apps/modal-backend/tests/test_segmenter.py
@@ -7,6 +7,7 @@ import pytest
 
 from providers.segmenter import (
     MAX_VERTICES,
+    detector_box_to_sam_box,
     parse_segments,
     polygon_from_mask,
     segmenter_provider,
@@ -119,3 +120,20 @@ def test_polygon_from_empty_mask_is_empty() -> None:
     from PIL import Image
 
     assert polygon_from_mask(Image.new("L", (50, 50), 0)) == []
+
+
+def test_detector_box_to_sam_box_centre_to_pixel_corners() -> None:
+    # detector boxes are centre-based normalized; SAM3 box_prompts are pixel corners
+    b = detector_box_to_sam_box(
+        {"x_pct": 0.5, "y_pct": 0.5, "w_pct": 0.2, "h_pct": 0.1}, 1000, 600
+    )
+    assert b == {"x_min": 400, "y_min": 270, "x_max": 600, "y_max": 330}
+
+
+def test_detector_box_clamps_to_image_bounds() -> None:
+    # a box hanging off the top-left edge is clamped, never negative
+    b = detector_box_to_sam_box(
+        {"x_pct": 0.05, "y_pct": 0.02, "w_pct": 0.2, "h_pct": 0.1}, 1000, 600
+    )
+    assert b["x_min"] == 0 and b["y_min"] == 0
+    assert b["x_max"] == 150 and b["y_max"] == 42

--- a/apps/modal-backend/tests/test_segmenter.py
+++ b/apps/modal-backend/tests/test_segmenter.py
@@ -3,7 +3,14 @@ and deduped, height fields coerced — the tolerant-parse contract that lets
 the VLM reply be sloppy without ever raising."""
 from __future__ import annotations
 
-from providers.segmenter import MAX_VERTICES, parse_segments
+import pytest
+
+from providers.segmenter import (
+    MAX_VERTICES,
+    parse_segments,
+    polygon_from_mask,
+    segmenter_provider,
+)
 
 
 def _seg(**over: object) -> dict[str, object]:
@@ -77,3 +84,38 @@ def test_height_fields_coerced() -> None:
     assert by["a"]["rel_height"] == 1.0 and by["a"]["est_height_m"] is None
     assert by["b"]["rel_height"] == 0.0 and by["b"]["est_height_m"] is None
     assert by["c"]["rel_height"] == 0.5 and by["c"]["est_height_m"] == 12.5
+
+
+# --- SAM3 provider dispatch + pure mask->polygon ----------------------------
+
+
+def test_segmenter_provider_defaults_to_vlm(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SEGMENTER_PROVIDER", raising=False)
+    assert segmenter_provider() == "vlm"
+    monkeypatch.setenv("SEGMENTER_PROVIDER", "SAM3_FAL")  # case-insensitive
+    assert segmenter_provider() == "sam3_fal"
+    monkeypatch.setenv("SEGMENTER_PROVIDER", "nonsense")  # unknown -> safe default
+    assert segmenter_provider() == "vlm"
+
+
+def test_polygon_from_mask_bounds_the_blob() -> None:
+    from PIL import Image, ImageDraw
+
+    img = Image.new("L", (200, 120), 0)
+    ImageDraw.Draw(img).ellipse([40, 30, 160, 90], fill=255)  # bbox (0.2,0.25)-(0.8,0.75)
+
+    poly = polygon_from_mask(img, n_vertices=20)
+
+    assert 3 <= len(poly) <= MAX_VERTICES
+    xs = [p[0] for p in poly]
+    ys = [p[1] for p in poly]
+    assert all(0.0 <= v <= 1.0 for v in xs + ys)
+    # the radial polygon's bbox approximates the white ellipse's bbox
+    assert abs(min(xs) - 0.2) < 0.08 and abs(max(xs) - 0.8) < 0.08
+    assert abs(min(ys) - 0.25) < 0.08 and abs(max(ys) - 0.75) < 0.08
+
+
+def test_polygon_from_empty_mask_is_empty() -> None:
+    from PIL import Image
+
+    assert polygon_from_mask(Image.new("L", (50, 50), 0)) == []


### PR DESCRIPTION
Evolvable reference-corpus pipeline: **source → ensemble-annotate → SAM3-ground → reconstruct**. Evolves `tests/map_corpus/` from a single-Gemini `draft.py` + human-verify into a multi-model, tiered, SAM3-grounded corpus with descent reconstruction. 14 commits; M1–M4 stacked (can split at merge). Every free gate (`pytest -m "not paid"` + ruff + mypy) green throughout.

## M1 — Ensemble annotation engine
`tests/map_corpus/annotate.py`: fan a describe call over N VLMs (`CORPUS_ANNOTATE_MODELS`, incl. a Claude/Qwen/GPT slug via OpenRouter) → **deterministic reconcile in pure code** (arbiter is not a paid call) → ground positions (detector + segmenter + heights) → `judge.score_annotation` → refine once on a low score → `decide_status` auto-promotes on **judge AND ensemble-agreement** gates.
- **Non-destructive**: a verified description is never silently clobbered; non-verified verdicts route to `descriptions/candidates/` (invisible to recon + the integrity gate). `CORPUS_ANNOTATE_FORCE=1` overrides.
- **Robust**: `min_votes` clamps to actual contributors (a 404'd model can't collapse the result); the fan-out logs each model's outcome; agreement ÷ configured size so a dropout → `needs_human`.

## M2 — SAM3 segmenter (pixel-accurate borders)
`providers/segmenter.py` routes on `SEGMENTER_PROVIDER` (default `vlm` → no-op; `sam3_fal` → fal-ai/sam-3). Pure PIL `polygon_from_mask` (no cv2/numpy) → same `SegmentEntity` shape, so draft/annotate/recon ground on SAM3 by flipping one env. **Box-prompted** (proper-noun text prompts return 0 masks; the detector's box scores 0.86–0.95) — validated end-to-end.

## M3 — Tiers + "find online" adapters
`load_manifest(tier=…)` (map|interior|closeup); annotate is tier-aware (`describe_system()` — cartographic / interior-scene / object-parts, same return shape). Two **keyless, free** adapters under `tests/map_corpus/sources/`: **met.py** (Met CC0 → closeups) + **wikimedia.py** (Commons PD/CC0/CC-BY → interiors). Corpus seeded + sha-pinned: **6 maps, 3 interiors, 3 closeups**.

## M4 — Descent reconstruction
`chains.py` links a child to a parent-map place entity (`parent_id`+`parent_ref`); `tests/descent_bench/runner.py` crops the parent at that place → generates the region-conditioned "enter" view vs a fresh baseline → judges both against the **real child** (style) + region (continuity). `make eval-descent`. Live-validated on `manor::church → Chester nave`: a correct illustrated church (continuity 9.0).

## Tooling
`overlay.py` (`make corpus-overlay`) draws an annotation back onto its source map; preview/dry-run on every paid step; full TDD suite on the pure cores.

## Honest open items (surfaced, not hidden)
- **Rich non-map grounding** — interiors/closeups annotate *thin* (different part-vocabularies + a detector tuned for map-places). Needs synonym-aware reconcile + a parts/fixtures detector.
- **Medium-agnostic descent judge** — `style_pair` is confounded when a chain crosses media (illustrated map → photo child).
- **A 2nd working vision slug** for auto-`verified` corroboration (`gemini-3-pro-preview` 404s; `gemini-3-flash` + `qwen3-vl-32b` + `gpt-4o-mini` works).
- Per-tier recon, Smithsonian adapter, more golden chains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)