### PR TITLE
feat: add Requesty as an OpenAI-compatible LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,13 +39,19 @@ OPENROUTER_ENABLE_WEB_SEARCH=true
 # OpenRouter defaults above unchanged. Set it to run the planner + click VLM on
 # a direct vendor API or any OpenAI-compatible local server (Ollama/LM Studio/
 # vLLM). Web search is OpenRouter-only and is skipped on other providers.
-#   openrouter (default) | openai | anthropic | google | custom
+#   openrouter (default) | requesty | openai | anthropic | google | custom
 # LLM_PROVIDER=custom
 # LLM_BASE_URL=http://localhost:11434/v1   # required for `custom` (Ollama shown)
 # LLM_API_KEY=                              # blank is fine for keyless local servers
 # LLM_VLM_MODEL=qwen2.5vl
 # LLM_TEXT_MODEL=qwen2.5
 # LLM_STRUCTURED_OUTPUT=auto                # auto | json_object | tool | prompt
+# Requesty (OpenRouter-shaped aggregator; uses REQUESTY_API_KEY, provider/model
+# slugs). Key: https://app.requesty.ai/api-keys
+# LLM_PROVIDER=requesty
+# REQUESTY_API_KEY=
+# LLM_VLM_MODEL=openai/gpt-4o
+# LLM_TEXT_MODEL=openai/gpt-4o-mini
 
 # Swap the image backend off fal (advanced). Leave IMAGE_PROVIDER unset to keep
 # fal + its quality tiers. `openai` / `custom` use the OpenAI Images API shape;

--- a/apps/modal-backend/.env.example
+++ b/apps/modal-backend/.env.example
@@ -21,11 +21,17 @@ OPENROUTER_ENABLE_WEB_SEARCH=true
 # Leave LLM_PROVIDER unset to keep OpenRouter byte-for-byte. Set it to point the
 # planner + click VLM at a direct vendor API or any OpenAI-compatible local
 # server (Ollama / LM Studio / vLLM) — every target speaks the OpenAI wire format.
-#   openrouter (default) | openai | anthropic | google | custom
+#   openrouter (default) | requesty | openai | anthropic | google | custom
 # LLM_PROVIDER=openai
 # LLM_API_KEY=
 # LLM_VLM_MODEL=gpt-4o
 # LLM_TEXT_MODEL=gpt-4o-mini
+# Requesty is an OpenRouter-shaped aggregator (same provider/model slugs); it
+# uses its own key instead of LLM_API_KEY. Get one at https://app.requesty.ai/api-keys
+# LLM_PROVIDER=requesty
+# REQUESTY_API_KEY=
+# LLM_VLM_MODEL=openai/gpt-4o
+# LLM_TEXT_MODEL=openai/gpt-4o-mini
 # `custom` = any OpenAI-compatible base URL (Ollama shown; no key needed locally):
 # LLM_PROVIDER=custom
 # LLM_BASE_URL=http://localhost:11434/v1

--- a/apps/modal-backend/obs.py
+++ b/apps/modal-backend/obs.py
@@ -413,6 +413,17 @@ async def status_payload(service: str) -> dict[str, Any]:
         _check_provider("fal", "https://fal.run/health"),
         _check_provider("openrouter", "https://openrouter.ai/api/v1/models"),
     )
+    providers: dict[str, bool] = {
+        "fal": fal_ok,
+        "openrouter": openrouter_ok,
+    }
+    # Requesty is an optional OpenRouter-shaped LLM provider; only probe (and
+    # surface) it when it's the configured provider, so the default payload is
+    # unchanged for the OpenRouter path.
+    if (os.environ.get("LLM_PROVIDER", "").strip().lower()) == "requesty":
+        providers["requesty"] = await _check_provider(
+            "requesty", "https://router.requesty.ai/v1/models"
+        )
     return {
         "ok": True,
         "service": service,
@@ -420,8 +431,5 @@ async def status_payload(service: str) -> dict[str, Any]:
         "uptime_s": round(time.time() - _started_at, 1),
         "in_flight": _in_flight,
         "last_error_ts": _last_error_ts,
-        "providers": {
-            "fal": fal_ok,
-            "openrouter": openrouter_ok,
-        },
+        "providers": providers,
     }

--- a/apps/modal-backend/providers/llm/__init__.py
+++ b/apps/modal-backend/providers/llm/__init__.py
@@ -42,6 +42,7 @@ from .client import (
     DEFAULT_VLM_MODEL,
     ENTITY_KINDS,
     OPENROUTER_BASE_URL,
+    REQUESTY_BASE_URL,
     SCALE_KINDS,
     _cache_enabled,
     _choice_content,

--- a/apps/modal-backend/providers/llm/client.py
+++ b/apps/modal-backend/providers/llm/client.py
@@ -31,6 +31,7 @@ from _env import env_flag
 from providers import llm as _llm
 
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+REQUESTY_BASE_URL = "https://router.requesty.ai/v1"
 DEFAULT_VLM_MODEL = "google/gemini-3.7-flash"
 DEFAULT_TEXT_MODEL = "google/gemini-3.7-flash"
 
@@ -42,6 +43,7 @@ DEFAULT_TEXT_MODEL = "google/gemini-3.7-flash"
 # OpenAI-compatibility endpoints so the single AsyncOpenAI code path is reused.
 _LLM_BASE_URLS = {
     "openrouter": OPENROUTER_BASE_URL,
+    "requesty": REQUESTY_BASE_URL,
     "openai": "https://api.openai.com/v1",
     "anthropic": "https://api.anthropic.com/v1",
     "google": "https://generativelanguage.googleapis.com/v1beta/openai/",
@@ -97,6 +99,21 @@ def _resolve_provider() -> tuple[str, str, str, dict[str, str]]:
             "X-Title": "Endless Canvas",
         }
         return provider, base_override or OPENROUTER_BASE_URL, api_key, headers
+    if provider == "requesty":
+        # Requesty is an OpenRouter-shaped aggregator: same provider/model slug
+        # naming and the same optional HTTP-Referer / X-Title attribution
+        # headers, on its own base URL + key. Mirror the openrouter branch so
+        # the default OpenRouter path is untouched.
+        api_key = os.environ.get("REQUESTY_API_KEY")
+        if not api_key:
+            raise RuntimeError("REQUESTY_API_KEY is not set")
+        headers = {
+            "HTTP-Referer": os.environ.get(
+                "REQUESTY_REFERER", "https://github.com/eren23/openflipbook"
+            ),
+            "X-Title": "Endless Canvas",
+        }
+        return provider, base_override or REQUESTY_BASE_URL, api_key, headers
     base_url = base_override or _LLM_BASE_URLS.get(provider, "")
     if not base_url:
         raise RuntimeError(
@@ -288,6 +305,9 @@ def _resolve_structured_tier(provider: str, model: str) -> str:
         # All three honour json_object on their OpenAI-compatible endpoints.
         return "json_object"
     if provider == "openrouter":
+        return "json_object" if _supports_structured_output(model) else "prompt"
+    if provider == "requesty":
+        # Same OpenRouter-shaped slug family routing.
         return "json_object" if _supports_structured_output(model) else "prompt"
     # custom / unknown (local OpenAI-compatible servers): decide by family.
     if any(fam in m for fam in _STRUCTURED_OUTPUT_FAMILIES):

--- a/apps/modal-backend/tests/test_llm_provider.py
+++ b/apps/modal-backend/tests/test_llm_provider.py
@@ -506,6 +506,47 @@ def test_maybe_response_format_omitted_for_unsupported_model() -> None:
     assert out == {}
 
 
+# ---------- provider resolution (requesty mirrors openrouter) ------------
+
+
+def test_resolve_provider_requesty_uses_own_key_and_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Requesty is OpenRouter-shaped: its own key + base URL, plus the same
+    # HTTP-Referer / X-Title attribution headers as the openrouter branch.
+    monkeypatch.setenv("LLM_PROVIDER", "requesty")
+    monkeypatch.setenv("REQUESTY_API_KEY", "rq-test-key")
+    monkeypatch.delenv("LLM_BASE_URL", raising=False)
+    provider, base_url, api_key, headers = llm._resolve_provider()
+    assert provider == "requesty"
+    assert base_url == llm.REQUESTY_BASE_URL == "https://router.requesty.ai/v1"
+    assert api_key == "rq-test-key"
+    assert headers["X-Title"] == "Endless Canvas"
+    assert "HTTP-Referer" in headers
+
+
+def test_resolve_provider_requesty_requires_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "requesty")
+    monkeypatch.delenv("REQUESTY_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="REQUESTY_API_KEY"):
+        llm._resolve_provider()
+
+
+def test_resolve_structured_tier_requesty_matches_openrouter() -> None:
+    # Same provider/model slug routing as openrouter: known-good family →
+    # json_object, everything else → prompt.
+    assert (
+        llm._resolve_structured_tier("requesty", "openai/gpt-4o-mini")
+        == "json_object"
+    )
+    assert (
+        llm._resolve_structured_tier("requesty", "mistralai/mistral-large")
+        == "prompt"
+    )
+
+
 def test_extraction_prompt_lists_canonical_state_keys() -> None:
     # Phase 7a/7c — the prompt nudges the VLM toward canonical keys so the
     # web-side allow-list doesn't have to silently drop everything.

--- a/apps/web/app/status/page.tsx
+++ b/apps/web/app/status/page.tsx
@@ -17,7 +17,7 @@ interface BackendStatus {
   uptime_s?: number;
   in_flight?: number;
   last_error_ts?: number | null;
-  providers?: { fal?: boolean; openrouter?: boolean };
+  providers?: { fal?: boolean; openrouter?: boolean; requesty?: boolean };
   error?: string;
 }
 
@@ -163,6 +163,20 @@ export default async function StatusPage() {
               {backend.providers?.openrouter ? "ok" : "down"}
             </span>
           </li>
+          {backend.providers?.requesty !== undefined && (
+            <li>
+              requesty:{" "}
+              <span
+                className={
+                  backend.providers?.requesty
+                    ? "text-green-700"
+                    : "text-amber-700"
+                }
+              >
+                {backend.providers?.requesty ? "ok" : "down"}
+              </span>
+            </li>
+          )}
           <li>uptime: {backend.uptime_s ?? "—"}s</li>
           <li>in-flight: {backend.in_flight ?? 0}</li>
           <li className="col-span-2 opacity-70">

--- a/docs/BYO-KEYS.md
+++ b/docs/BYO-KEYS.md
@@ -113,6 +113,7 @@ the base URL and the key:
 | `LLM_PROVIDER` | Base URL | Models to set |
 |---|---|---|
 | `openrouter` (default) | OpenRouter | `OPENROUTER_VLM_MODEL` / `OPENROUTER_TEXT_MODEL` |
+| `requesty` | Requesty (OpenRouter-shaped aggregator) | `REQUESTY_API_KEY`, `LLM_VLM_MODEL=openai/gpt-4o`, `LLM_TEXT_MODEL=openai/gpt-4o-mini` |
 | `openai` | `api.openai.com` | `LLM_VLM_MODEL=gpt-4o`, `LLM_TEXT_MODEL=gpt-4o-mini` |
 | `google` | Gemini OpenAI-compat | `LLM_VLM_MODEL=gemini-2.5-flash` |
 | `anthropic` | Anthropic OpenAI-compat | `LLM_VLM_MODEL=claude-3.5-sonnet` (runs at the `json_object` tier) |


### PR DESCRIPTION
## Add Requesty as an OpenAI-compatible LLM provider

Adds `requesty` as a selectable `LLM_PROVIDER`, mirroring the existing OpenRouter wiring. Requesty (`https://router.requesty.ai/v1`) is an OpenRouter-shaped aggregator: it speaks the OpenAI wire protocol, uses the same `provider/model` slug naming (e.g. `openai/gpt-4o-mini`), and accepts the same optional `HTTP-Referer` / `X-Title` attribution headers. Because of that, this reuses the single `AsyncOpenAI` code path, no new client, no new behavior surface.

Default behavior is unchanged: leave `LLM_PROVIDER` unset and the OpenRouter path is byte-for-byte identical.

### Files changed
- `apps/modal-backend/providers/llm.py`: `REQUESTY_BASE_URL` constant; `requesty` entry in `_LLM_BASE_URLS`; a dedicated `_resolve_provider` branch using `REQUESTY_API_KEY` + the attribution headers (mirrors the `openrouter` branch); `requesty` added to the structured-output tier ladder (same provider/model slug routing as OpenRouter).
- `apps/modal-backend/obs.py`: `status_payload` probes `router.requesty.ai/v1/models` only when `LLM_PROVIDER=requesty`, so the default `/status` payload is unchanged for OpenRouter users.
- `apps/web/app/status/page.tsx`: conditional `requesty` health row (only renders when the backend reports it).
- `.env.example` and `apps/modal-backend/.env.example`, document `LLM_PROVIDER=requesty` + `REQUESTY_API_KEY`.
- `docs/BYO-KEYS.md`: provider table row for Requesty.
- `apps/modal-backend/tests/test_llm_provider.py`: tests for requesty key/base-URL resolution, the missing-key error, and the structured-output tier.

### Live test
Verified against the live API before opening this PR:
- `POST https://router.requesty.ai/v1/chat/completions` with `model: openai/gpt-4o-mini` and the same `HTTP-Referer`/`X-Title` headers the code sends → HTTP 200, real completion returned (`gpt-4o-mini-2024-07-18`).
- `GET https://router.requesty.ai/v1/models` (the health-check endpoint) → HTTP 200.

Edited Python files pass `py_compile`.

---
I work at Requesty. This mirrors the existing OpenRouter wiring. Happy to adjust or close it if it's not a fit.

