### PR TITLE
feat(live): wire SAM3 border polygons + box refinement into the live path

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -314,6 +314,13 @@ def _segment_borders_on() -> bool:
     return env_flag("WORLD_SEGMENT_BORDERS")
 
 
+def _grounding_sam3_on() -> bool:
+    """Tighten the grounding loop's detector boxes to SAM3 mask bboxes
+    (GROUNDING_SAM3). Pairs with SEGMENTER_PROVIDER=sam3_fal; off → box-level
+    grounding (current behaviour)."""
+    return env_flag("GROUNDING_SAM3")
+
+
 def _geometric_world_on() -> bool:
     """Master gate for the geometric world (GEOMETRIC_WORLD). Off → the geo
     endpoints (e.g. /edit-entities) are disabled and behave as if absent."""
@@ -653,6 +660,22 @@ async def _run_grounding(
 
     async def _verify(img: Any) -> Any:
         observed = await detector.detect(img.jpeg_bytes, labels)
+        if _grounding_sam3_on():
+            try:
+                from providers.segmenter import refine_detections_with_masks, segment
+
+                segs = await segment(
+                    img.jpeg_bytes, labels, boxes=cast("list[dict[str, Any]]", observed)
+                )
+                observed = cast(
+                    "list[Detection]",
+                    refine_detections_with_masks(
+                        cast("list[dict[str, Any]]", observed),
+                        cast("list[dict[str, Any]]", segs),
+                    ),
+                )
+            except Exception:  # best-effort: a SAM3 failure keeps the detector boxes
+                pass
         return grounding.diff(expected, observed)
 
     async def _repair(img: Any, report: Any) -> Any | None:

--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -307,6 +307,13 @@ def _world_mode_on(requested: bool) -> bool:
     return bool(requested) and env_flag("WORLD_MODE")
 
 
+def _segment_borders_on() -> bool:
+    """Fill per-node SAM3 border polygons during extraction (WORLD_SEGMENT_BORDERS).
+    Pairs with SEGMENTER_PROVIDER=sam3_fal to get pixel-accurate outlines in the
+    live overlay; off → only the detector box is known (current behaviour)."""
+    return env_flag("WORLD_SEGMENT_BORDERS")
+
+
 def _geometric_world_on() -> bool:
     """Master gate for the geometric world (GEOMETRIC_WORLD). Off → the geo
     endpoints (e.g. /edit-entities) are disabled and behave as if absent."""
@@ -2621,6 +2628,46 @@ async def extract_entities_endpoint(req: Request, body: ExtractEntitiesBody):
                     box = _match(u.match_name)
                     if box:
                         u.bbox = box
+
+                # SAM3 outline pass (best-effort, flag-gated): one segment call
+                # box-prompted with the detector boxes -> a tight border polygon
+                # per entity for the overlay. A failure leaves boxes intact.
+                if _segment_borders_on():
+                    try:
+                        from providers.segmenter import segment as _segment
+
+                        segs = await _segment(
+                            geo_img_bytes,
+                            labels,
+                            boxes=cast("list[dict[str, Any]]", dets),
+                        )
+                        seg_by = {
+                            str(s.get("label", "")).lower().strip(): s for s in segs
+                        }
+
+                        def _border(name: str) -> list[list[float]] | None:
+                            key = name.lower().strip()
+                            s = seg_by.get(key) or next(
+                                (v for k, v in seg_by.items() if k and (k in key or key in k)),
+                                None,
+                            )
+                            poly = s.get("polygon") if s else None
+                            return poly if poly and len(poly) >= 3 else None
+
+                        for e in need_added:
+                            b = _border(e.name)
+                            if b:
+                                e.border = b
+                        for u in need_updated:
+                            b = _border(u.match_name)
+                            if b:
+                                u.border = b
+                    except Exception as exc:  # outlines are optional
+                        log(
+                            "info",
+                            "extract.segment_failed",
+                            error=f"{type(exc).__name__}: {exc}",
+                        )
             log(
                 "info",
                 "extract.localized",
@@ -2660,6 +2707,7 @@ async def extract_entities_endpoint(req: Request, body: ExtractEntitiesBody):
             "state": e.state,
             "confidence": e.confidence,
             "bbox": e.bbox,
+            "border": e.border,
         }
 
     return JSONResponse(
@@ -2672,6 +2720,7 @@ async def extract_entities_endpoint(req: Request, body: ExtractEntitiesBody):
                         "changes": u.changes,
                         "confidence": u.confidence,
                         "bbox": u.bbox,
+                        "border": u.border,
                     }
                     for u in result.updated
                 ],

--- a/apps/modal-backend/providers/llm.py
+++ b/apps/modal-backend/providers/llm.py
@@ -177,6 +177,10 @@ class ExtractedEntity:
     state: dict[str, str | int | float | bool]
     confidence: float
     bbox: dict[str, float] | None = None
+    # Per-node SAM3 border polygon (normalized 0..1 image space, 3..24 verts).
+    # The VLM doesn't emit this; the extract endpoint's segmenter fills it behind
+    # WORLD_SEGMENT_BORDERS so the overlay can draw a tight outline, not just a box.
+    border: list[list[float]] | None = None
 
 
 @dataclass
@@ -188,6 +192,7 @@ class EntityUpdate:
     # extract endpoint's detector fills it so recurring entities keep a
     # per-node bbox for geometry + the overlay.
     bbox: dict[str, float] | None = None
+    border: list[list[float]] | None = None  # SAM3 polygon, same shape as above
 
 
 @dataclass

--- a/apps/modal-backend/providers/segmenter.py
+++ b/apps/modal-backend/providers/segmenter.py
@@ -75,6 +75,40 @@ def detector_box_to_sam_box(det: dict[str, Any], img_w: int, img_h: int) -> dict
     return {"x_min": x_min, "y_min": y_min, "x_max": x_max, "y_max": y_max}
 
 
+def box_from_polygon(polygon: list[list[float]]) -> dict[str, float]:
+    """A polygon's centre-based bounding box {x_pct,y_pct,w_pct,h_pct} (the
+    Detection shape) — the mask's tight extent."""
+    xs = [p[0] for p in polygon]
+    ys = [p[1] for p in polygon]
+    x1, x2, y1, y2 = min(xs), max(xs), min(ys), max(ys)
+    return {
+        "x_pct": (x1 + x2) / 2.0,
+        "y_pct": (y1 + y2) / 2.0,
+        "w_pct": x2 - x1,
+        "h_pct": y2 - y1,
+    }
+
+
+def refine_detections_with_masks(
+    detections: list[dict[str, Any]], segments: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Tighten each detector box to its SAM3 mask's bounding box (label-matched,
+    case-insensitive), keeping the detection's label + score. A detection with no
+    matching mask is passed through unchanged — so this only ever sharpens the
+    grounding loop's observed boxes, never drops one."""
+    seg_by = {str(s.get("label", "")).lower(): s for s in segments}
+    out: list[dict[str, Any]] = []
+    for d in detections:
+        seg = seg_by.get(str(d.get("label", "")).lower())
+        poly = seg.get("polygon") if seg else None
+        if poly and len(poly) >= MIN_VERTICES:
+            box = box_from_polygon(poly)
+            out.append({"label": d.get("label", ""), "score": d.get("score", 1.0), **box})
+        else:
+            out.append(d)
+    return out
+
+
 def polygon_from_mask(
     mask_img: Any, n_vertices: int = 20, thresh: int = 127, max_dim: int = 256
 ) -> list[list[float]]:

--- a/apps/modal-backend/tests/test_segmenter.py
+++ b/apps/modal-backend/tests/test_segmenter.py
@@ -7,9 +7,11 @@ import pytest
 
 from providers.segmenter import (
     MAX_VERTICES,
+    box_from_polygon,
     detector_box_to_sam_box,
     parse_segments,
     polygon_from_mask,
+    refine_detections_with_masks,
     segmenter_provider,
 )
 
@@ -128,6 +130,30 @@ def test_detector_box_to_sam_box_centre_to_pixel_corners() -> None:
         {"x_pct": 0.5, "y_pct": 0.5, "w_pct": 0.2, "h_pct": 0.1}, 1000, 600
     )
     assert b == {"x_min": 400, "y_min": 270, "x_max": 600, "y_max": 330}
+
+
+def test_box_from_polygon_is_the_centre_based_bbox() -> None:
+    b = box_from_polygon([[0.2, 0.3], [0.6, 0.3], [0.5, 0.7]])
+    assert b["x_pct"] == pytest.approx(0.4) and b["y_pct"] == pytest.approx(0.5)
+    assert b["w_pct"] == pytest.approx(0.4) and b["h_pct"] == pytest.approx(0.4)
+
+
+def test_refine_detections_tightens_to_mask_bbox() -> None:
+    dets = [
+        {"label": "tower", "x_pct": 0.5, "y_pct": 0.5, "w_pct": 0.3, "h_pct": 0.3, "score": 0.9},
+        {"label": "lake", "x_pct": 0.2, "y_pct": 0.8, "w_pct": 0.1, "h_pct": 0.1, "score": 0.5},
+    ]
+    segs = [
+        {"label": "tower", "polygon": [[0.4, 0.4], [0.6, 0.4], [0.5, 0.6]],
+         "rel_height": 0.0, "est_height_m": None, "score": 1.0}
+    ]
+    out = refine_detections_with_masks(dets, segs)
+    by = {d["label"]: d for d in out}
+    # tower box tightened to the mask bbox; label + detection score preserved
+    assert by["tower"]["w_pct"] == pytest.approx(0.2) and by["tower"]["h_pct"] == pytest.approx(0.2)
+    assert by["tower"]["x_pct"] == pytest.approx(0.5) and by["tower"]["score"] == 0.9
+    # no matching mask -> unchanged
+    assert by["lake"]["w_pct"] == 0.1
 
 
 def test_detector_box_clamps_to_image_bounds() -> None:

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,5 +1,11 @@
 FROM node:22-alpine AS base
-RUN corepack enable && corepack prepare pnpm@9.15.9 --activate
+# node:22-alpine ships an old corepack whose registry fetch fails the pnpm
+# signature/integrity check ("Internal Error ... fetchUrlStream"). Upgrade
+# corepack first so `prepare` can download pnpm. Direct npm install of pnpm as a
+# belt-and-suspenders fallback if corepack still can't activate.
+RUN npm install -g corepack@latest \
+ && (corepack enable && corepack prepare pnpm@9.15.9 --activate \
+     || npm install -g pnpm@9.15.9)
 ENV CI=1
 
 FROM base AS deps

--- a/apps/web/components/PlayPage/GeometryOverlay.tsx
+++ b/apps/web/components/PlayPage/GeometryOverlay.tsx
@@ -7,7 +7,10 @@ import type { Entity } from "@openflipbook/config";
 import { useContainRect } from "@/hooks/useContainRect";
 
 interface Props {
-  entities: Pick<Entity, "id" | "name" | "kind" | "appearance_bboxes">[];
+  entities: Pick<
+    Entity,
+    "id" | "name" | "kind" | "appearance_bboxes" | "appearance_borders"
+  >[];
   nodeId: string;
   /** The rendered <img>; lets the overlay track the object-contain content rect
    *  so boxes land on the image, not the letterboxed wrapper. */
@@ -61,6 +64,18 @@ export default function GeometryOverlay({
     if (bb.w_pct * bb.h_pct > 0.6) return [];
     return [{ e, bb }];
   });
+  // SAM3 outlines for this node (WORLD_SEGMENT_BORDERS): a tight polygon per
+  // entity, normalized 0..1 image space — same scoping + centroid-in-frame
+  // sanity as the boxes. Drawn over the box, so the box still carries the label.
+  const borders = entities.flatMap((e) => {
+    if (allowedEntityIds && !allowedEntityIds.has(e.id)) return [];
+    const poly = e.appearance_borders?.[nodeId];
+    if (!poly || poly.length < 3) return [];
+    const cx = poly.reduce((s, p) => s + p[0], 0) / poly.length;
+    const cy = poly.reduce((s, p) => s + p[1], 0) / poly.length;
+    if (cx < 0 || cx > 1 || cy < 0 || cy > 1) return [];
+    return [{ e, poly }];
+  });
   // Map an image-space (0..1) bbox onto the element. With a measured content
   // rect we land on the letterboxed image (px); otherwise fall back to
   // wrapper-relative % (exact when the image fills the box, e.g. 16:9-in-16:9).
@@ -85,6 +100,38 @@ export default function GeometryOverlay({
         };
   return (
     <div className="pointer-events-none absolute inset-0" data-testid="geometry-overlay">
+      {borders.map(({ e, poly }) => {
+        const color = KIND_COLOR[e.kind] ?? "#64748b";
+        // SVG box = the measured content rect (px); viewBox 0..1 lets the
+        // normalized polygon map straight in. No content rect ⇒ wrapper-relative
+        // (exact when the image fills the box), matching the box `place` fallback.
+        const style: CSSProperties = content
+          ? {
+              left: `${content.offsetX}px`,
+              top: `${content.offsetY}px`,
+              width: `${content.width}px`,
+              height: `${content.height}px`,
+            }
+          : { inset: 0 };
+        return (
+          <svg
+            key={`border-${e.id}`}
+            data-testid="geo-border"
+            className="absolute"
+            style={style}
+            viewBox="0 0 1 1"
+            preserveAspectRatio="none"
+          >
+            <polygon
+              points={poly.map(([x, y]) => `${x},${y}`).join(" ")}
+              fill={`${color}22`}
+              stroke={color}
+              strokeWidth={2}
+              vectorEffect="non-scaling-stroke"
+            />
+          </svg>
+        );
+      })}
       {boxes.map(({ e, bb }) => {
         const color = KIND_COLOR[e.kind] ?? "#64748b";
         return (
@@ -107,7 +154,7 @@ export default function GeometryOverlay({
           </div>
         );
       })}
-      {boxes.length === 0 && (
+      {boxes.length === 0 && borders.length === 0 && (
         // bottom-RIGHT: bottom-left is the Pin-style chip's spot (the audit's
         // overlap bug). pointer-events-auto only here — boxes stay transparent.
         <div className="pointer-events-auto absolute bottom-1 right-1 rounded bg-black/60 px-1.5 py-0.5 text-[10px] text-white">

--- a/apps/web/lib/world.test.ts
+++ b/apps/web/lib/world.test.ts
@@ -256,6 +256,27 @@ describe("mergeIntoEntities", () => {
     });
   });
 
+  it("captures the SAM3 border from an added entity into appearance_borders", () => {
+    const out = __test.mergeIntoEntities([], "node-1", {
+      ...emptyResult(),
+      added: [
+        makeAdded({
+          border: [
+            [0.1, 0.2],
+            [0.5, 0.2],
+            [0.3, 0.6],
+          ],
+        }),
+      ],
+    });
+    const e = out.entities[0]!;
+    expect(e.appearance_borders?.["node-1"]).toEqual([
+      [0.1, 0.2],
+      [0.5, 0.2],
+      [0.3, 0.6],
+    ]);
+  });
+
   it("merges bbox from a re-added existing entity under the new node id", () => {
     const seed = __test.makeEntity({
       id: "e1",

--- a/apps/web/lib/world.ts
+++ b/apps/web/lib/world.ts
@@ -80,6 +80,9 @@ interface EntityDoc {
   // Sparse map node_id → bbox. Pre-Phase-4 docs have no entries; the
   // hover-chip overlay falls back to no-render in that case.
   appearance_bboxes: Record<string, EntityBBox>;
+  // Sparse map node_id → SAM3 border polygon ([x,y] pairs, 0..1 image space).
+  // Populated behind WORLD_SEGMENT_BORDERS; absent on older/box-only docs.
+  appearance_borders?: Record<string, [number, number][]>;
   pinned_by_user: boolean;
   confidence: number;
   updated_at: Date;
@@ -117,6 +120,7 @@ function entityToWire(doc: EntityDoc): Entity {
     last_seen_node_id: doc.last_seen_node_id,
     appears_on_node_ids: doc.appears_on_node_ids,
     appearance_bboxes: doc.appearance_bboxes ?? {},
+    appearance_borders: doc.appearance_borders ?? {},
     pinned_by_user: doc.pinned_by_user,
     confidence: doc.confidence,
     updated_at: doc.updated_at.toISOString(),
@@ -313,6 +317,7 @@ function cloneEntity(e: EntityDoc): EntityDoc {
     state: { ...e.state },
     appears_on_node_ids: e.appears_on_node_ids.slice(),
     appearance_bboxes: { ...(e.appearance_bboxes ?? {}) },
+    appearance_borders: { ...(e.appearance_borders ?? {}) },
   };
 }
 
@@ -418,6 +423,7 @@ function applyExtractionToEntities(
       last_seen_node_id: nodeId,
       appears_on_node_ids: [nodeId],
       appearance_bboxes: a.bbox ? { [nodeId]: a.bbox } : {},
+      appearance_borders: a.border ? { [nodeId]: a.border } : {},
       pinned_by_user: false,
       confidence: a.confidence,
       updated_at: now,
@@ -479,6 +485,12 @@ function applyUpdate(
     target.appearance_bboxes = {
       ...target.appearance_bboxes,
       [nodeId]: update.bbox,
+    };
+  }
+  if (update.border) {
+    target.appearance_borders = {
+      ...(target.appearance_borders ?? {}),
+      [nodeId]: update.border,
     };
   }
   target.last_seen_node_id = nodeId;
@@ -585,6 +597,12 @@ function reconcileAddedIntoExisting(
     target.appearance_bboxes = {
       ...target.appearance_bboxes,
       [nodeId]: added.bbox,
+    };
+  }
+  if (added.border) {
+    target.appearance_borders = {
+      ...(target.appearance_borders ?? {}),
+      [nodeId]: added.border,
     };
   }
   target.last_seen_node_id = nodeId;

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -541,6 +541,10 @@ export interface Entity {
   // tile. Older entities (pre-bbox extraction) simply have no entries
   // here and fall back to no-chip rendering.
   appearance_bboxes: Record<string, EntityBBox>;
+  // Sparse map of node_id → SAM3 border polygon ([x,y] pairs, normalized 0..1
+  // image space). Populated by extraction behind WORLD_SEGMENT_BORDERS; the geo
+  // overlay draws a tight outline when present, else falls back to the bbox.
+  appearance_borders?: Record<string, [number, number][]>;
   // User-pinned entries are never auto-deleted or auto-merged. Extractor
   // suggestions targeting a user-renamed entity get reconciled by alias.
   pinned_by_user: boolean;
@@ -741,6 +745,9 @@ export interface ExtractedEntity {
   // Optional bounding box in 0..1 normalized image coords for in-image
   // hover chips. Omitted when the extractor can't localize the entity.
   bbox?: { x_pct: number; y_pct: number; w_pct: number; h_pct: number } | null;
+  // SAM3 border polygon ([x,y] pairs, 0..1 image space) when the extractor
+  // segmented the entity (WORLD_SEGMENT_BORDERS). Omitted otherwise.
+  border?: [number, number][] | null;
 }
 
 export interface EntityUpdate {
@@ -752,6 +759,7 @@ export interface EntityUpdate {
   // keeps an appearance_bbox per node â without it, geometry/overlay drop the
   // entity on every re-appearance. Omitted when localization fails.
   bbox?: { x_pct: number; y_pct: number; w_pct: number; h_pct: number } | null;
+  border?: [number, number][] | null;  // SAM3 polygon, same shape as ExtractedEntity
 }
 
 export interface EntityExtractionResult {


### PR DESCRIPTION
## What

Completes the SAM3 live-wiring so M2's pixel-accurate segmentation actually reaches the app. Three feature increments plus one infra fix — all new behaviour is **flag-gated off by default**.

### `WORLD_SEGMENT_BORDERS` — border polygons end-to-end
- **Extraction (1/3):** after the detector box pass, run one box-prompted `segment()` call (routes to SAM3 via `SEGMENTER_PROVIDER=sam3_fal`) and attach a per-node border polygon (normalized 0..1) to each entity. Best-effort: a segment failure leaves boxes intact.
- **Persist + render (2-3/3):** `Entity.appearance_borders` + `border` wire fields carry the polygon through `world.ts` (entityToWire / cloneEntity / 3 merge sites) to `GeometryOverlay`, which draws a non-scaling SVG `<polygon>` per entity over the box. Falls back to box-only when off / no border.

### `GROUNDING_SAM3` — tighter grounding boxes
- In `_verify`, tighten each detected box to its SAM3 mask bbox before the layout diff → sharper IoU + centroid, more accurate presence/position scoring and repair target. Best-effort: SAM3 failure keeps detector boxes.

### Infra fix (not gated)
- `apps/web/Dockerfile`: upgrade corepack before `pnpm prepare` (node:22-alpine ships an old corepack whose registry fetch fails the pnpm integrity check, breaking the web image build / `make demo`), with a `pnpm@9.15.9` fallback. Pre-existing bug, independent of the SAM3 wiring.

## Test
- `segmenter.py`: `box_from_polygon` + `refine_detections_with_masks` covered by `test_segmenter.py` (pure functions).
- `world.ts`: vitest for the border merge/clone paths.
- Gates green: tsc + 613 vitest + circular + mypy + ruff + python free gate.

## Risk
Low — every new code path is behind `WORLD_SEGMENT_BORDERS` / `GROUNDING_SAM3` (both default off); overlay behaviour is unchanged when off. Only the Dockerfile corepack fix is always-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)