### PR TITLE
feat(recon): per-tier recon for closeups + interiors (prose-decouple)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,13 @@ eval-recon-closeup-dry:
 	cd apps/modal-backend && RECON_SWEEP=recon_closeup .venv/bin/python -m tests.recon_bench.runner
 eval-recon-closeup:
 	cd apps/modal-backend && RECON_SWEEP=recon_closeup RECON_BENCH_RUN=1 .venv/bin/python -m tests.recon_bench.runner
+# Per-tier recon for the INTERIOR tier (verified scene descriptions): scene-worded
+# template + image judges (style/alignment/feature_articulation); geo weighted low
+# since interior fixture positions are approximate (prose-decoupled, not grounded).
+eval-recon-interior-dry:
+	cd apps/modal-backend && RECON_SWEEP=recon_interior .venv/bin/python -m tests.recon_bench.runner
+eval-recon-interior:
+	cd apps/modal-backend && RECON_SWEEP=recon_interior RECON_BENCH_RUN=1 .venv/bin/python -m tests.recon_bench.runner
 # Descent reconstruction (M4): ENTER a parent map's linked place (a child
 # interior/closeup tied via parent_id+parent_ref to a parent entity), score the
 # region-conditioned descent against the REAL child photo (style + continuity)

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,13 @@ eval-recon-dry:
 	cd apps/modal-backend && .venv/bin/python -m tests.recon_bench.runner
 eval-recon:
 	cd apps/modal-backend && RECON_BENCH_RUN=1 .venv/bin/python -m tests.recon_bench.runner
+# Per-tier recon for the CLOSEUP tier (verified Met objects): same chassis, an
+# object-worded render template + object-parts judge (feature_articulation
+# instead of map_plausibility). RECON_SWEEP picks the sweep + report + baseline.
+eval-recon-closeup-dry:
+	cd apps/modal-backend && RECON_SWEEP=recon_closeup .venv/bin/python -m tests.recon_bench.runner
+eval-recon-closeup:
+	cd apps/modal-backend && RECON_SWEEP=recon_closeup RECON_BENCH_RUN=1 .venv/bin/python -m tests.recon_bench.runner
 # Descent reconstruction (M4): ENTER a parent map's linked place (a child
 # interior/closeup tied via parent_id+parent_ref to a parent entity), score the
 # region-conditioned descent against the REAL child photo (style + continuity)

--- a/apps/modal-backend/tests/eval_baselines.json
+++ b/apps/modal-backend/tests/eval_baselines.json
@@ -50,6 +50,13 @@
       "n_min": 4,
       "source": "make eval-recon-closeup 2026-06-24 (3 verified Met closeups x graph/direct, nano-banana, recon_closeup_base.v1; object-parts feature_articulation judge — objects reconstruct higher than maps)"
     },
+    "recon_interior_fidelity": {
+      "metric": "composite_mean",
+      "baseline": 0.80,
+      "regression_band": 0.15,
+      "n_min": 4,
+      "source": "make eval-recon-interior 2026-06-24 (3 verified interiors x graph/direct, nano-banana, recon_interior_base.v1; prose-decoupled so geo weighted low, image judges carry it — wider band as interior positions are approximate)"
+    },
     "grounding": {
       "metric": "grounding_mean",
       "baseline": 0.55,

--- a/apps/modal-backend/tests/eval_baselines.json
+++ b/apps/modal-backend/tests/eval_baselines.json
@@ -43,6 +43,13 @@
       "n_min": 4,
       "source": "make eval-recon 2026-06-12 (3 verified corpus maps x graph/direct, nano-banana, recon_base.v1; judge ~0.6 Spearman so the band is wide)"
     },
+    "recon_closeup_fidelity": {
+      "metric": "composite_mean",
+      "baseline": 0.86,
+      "regression_band": 0.12,
+      "n_min": 4,
+      "source": "make eval-recon-closeup 2026-06-24 (3 verified Met closeups x graph/direct, nano-banana, recon_closeup_base.v1; object-parts feature_articulation judge — objects reconstruct higher than maps)"
+    },
     "grounding": {
       "metric": "grounding_mean",
       "baseline": 0.55,

--- a/apps/modal-backend/tests/map_corpus/annotate.py
+++ b/apps/modal-backend/tests/map_corpus/annotate.py
@@ -161,21 +161,50 @@ def attach_geometry(
     detections: list[dict[str, Any]],
     segments: list[dict[str, Any]],
     heights_m: dict[str, float],
+    *,
+    keep_ungrounded: bool = False,
 ) -> list[dict[str, Any]]:
     """Bridge consensus labels to positioned corpus entities (ported from
     draft.py): detector box -> pos + footprint in the 100x60 frame, segmenter
-    polygon -> border + rel_height, anchored heights -> height_m. An entity the
-    detector did NOT box is dropped (its prose mention stays in the description).
-    Label matching is case-insensitive (the VLM often lowercases labels)."""
+    polygon -> border + rel_height, anchored heights -> height_m. Label matching
+    is case-insensitive (the VLM often lowercases labels).
+
+    An entity the detector did NOT box is dropped — UNLESS keep_ungrounded (the
+    interior/scene case, where the detector can't box room-fixtures): then it is
+    kept with a nominal spread placement so the fixture survives as scene ground
+    truth (positions are approximate, weighted ~0 in interior recon)."""
     det_by = {str(d["label"]).lower(): d for d in detections}
     seg_by = {str(s["label"]).lower(): s for s in segments}
     h_by = {str(k).lower(): v for k, v in heights_m.items()}
 
     out: list[dict[str, Any]] = []
+    ungrounded = 0
     for e in consensus:
         label = str(e["label"]).strip()
         det = det_by.get(label.lower())
         if det is None:
+            if not keep_ungrounded:
+                continue
+            grid = 3  # spread fixtures on a 3x3 nominal grid, deterministic by order
+            col, row = ungrounded % grid, (ungrounded // grid) % grid
+            ungrounded += 1
+            out.append(
+                {
+                    "ref": e["ref"],
+                    "kind": e.get("kind", "place"),
+                    "label": label,
+                    "visual": e.get("visual", ""),
+                    "votes": e.get("votes", 0),
+                    "pos": {
+                        "x": round((col + 1) / (grid + 1) * FRAME_W, 1),
+                        "y": round((row + 1) / (grid + 1) * FRAME_H, 1),
+                    },
+                    "footprint": {"w": round(FRAME_W * 0.15, 1), "d": round(FRAME_H * 0.15, 1)},
+                    "height_rel": 0.0,
+                    "height_m": None,
+                    "border": None,
+                }
+            )
             continue
         seg = seg_by.get(label.lower())
         h = h_by.get(label.lower())
@@ -665,7 +694,11 @@ async def annotate_one(map_id: str) -> Path:
         detections = await detect(image_bytes, labels)
         segments = await segment(image_bytes, labels, boxes=detections)
         heights_m = heights_lib.infer_heights_m(list(segments))
-        geo_entities = attach_geometry(consensus, detections, segments, heights_m)
+        # interiors: keep fixtures the detector can't box (rooms aren't top-down
+        # maps) so the scene's fixture set survives + drives agreement.
+        geo_entities = attach_geometry(
+            consensus, detections, segments, heights_m, keep_ungrounded=(tier == "interior")
+        )
 
         scale_tier = vote([d.get("scale_tier") for d in draft_dicts], default="region")
         style = _longest([str(d.get("style", "")) for d in draft_dicts])

--- a/apps/modal-backend/tests/map_corpus/descriptions/wm-chester-cathedral-nave.json
+++ b/apps/modal-backend/tests/map_corpus/descriptions/wm-chester-cathedral-nave.json
@@ -1,0 +1,215 @@
+{
+ "map_id": "wm-chester-cathedral-nave",
+ "rev": 1,
+ "genre": "gothic-cathedral-nave-interior",
+ "style": "Gothic cathedral interior with dark stone, intricate wooden vaulted ceiling, and soft natural light; high contrast, muted palette with gold accents.",
+ "scale_tier": "place",
+ "frame": {
+  "w": 100.0,
+  "h": 60.0
+ },
+ "description": "A grand Gothic cathedral interior viewed from the central aisle of the nave. The layout is symmetrical, with rows of light-colored wooden chairs arranged on either side of a central stone path leading toward the altar. Massive, dark grey stone pillars with clustered shafts rise on the left and right, supporting a series of pointed arches that form the side aisles. Above, a complex lierne vault ceiling made of dark wood is decorated with numerous gold-leaf bosses at the intersections of the ribs. In the far background, the chancel features a dark wooden screen and a distant stained-glass window that glows with soft green and blue light. High clerestory windows on the upper left and right walls allow natural light to filter down, illuminating the texture of the stone. The lighting is atmospheric, with deep shadows in the recesses of the arches and bright highlights on the ceiling's golden ornaments.",
+ "entities": [
+  {
+   "ref": "stained-glass-window",
+   "kind": "item",
+   "label": "stained glass window",
+   "visual": "Pointed arch window in the far background with green-blue patterns.",
+   "pos": {
+    "x": 49.5,
+    "y": 44.0
+   },
+   "footprint": {
+    "w": 3.8,
+    "d": 3.5
+   },
+   "height_rel": 0.4,
+   "height_m": 10.0,
+   "border": [
+    [
+     47.0,
+     42.6
+    ],
+    [
+     50.0,
+     41.4
+    ],
+    [
+     53.0,
+     42.6
+    ],
+    [
+     53.0,
+     45.6
+    ],
+    [
+     50.0,
+     46.2
+    ],
+    [
+     47.0,
+     45.6
+    ]
+   ]
+  },
+  {
+   "ref": "clerestory-windows",
+   "kind": "item",
+   "label": "clerestory windows",
+   "visual": "High-level windows on the side walls providing natural light.",
+   "pos": {
+    "x": 18.6,
+    "y": 8.9
+   },
+   "footprint": {
+    "w": 7.6,
+    "d": 8.9
+   },
+   "height_rel": 0.85,
+   "height_m": 21.2,
+   "border": [
+    [
+     14.0,
+     0.6
+    ],
+    [
+     22.0,
+     0.6
+    ],
+    [
+     23.0,
+     16.8
+    ],
+    [
+     18.0,
+     15.0
+    ],
+    [
+     14.0,
+     9.0
+    ]
+   ]
+  },
+  {
+   "ref": "vaulted-ceiling",
+   "kind": "place",
+   "label": "vaulted ceiling",
+   "visual": "wooden fan vault with golden bosses, arched ribs",
+   "pos": {
+    "x": 49.5,
+    "y": 16.8
+   },
+   "footprint": {
+    "w": 40.2,
+    "d": 33.6
+   },
+   "height_rel": 1.0,
+   "height_m": 25.0,
+   "border": [
+    [
+     32.0,
+     13.2
+    ],
+    [
+     41.0,
+     3.0
+    ],
+    [
+     50.0,
+     0.6
+    ],
+    [
+     59.0,
+     3.0
+    ],
+    [
+     68.0,
+     13.2
+    ],
+    [
+     61.0,
+     27.0
+    ],
+    [
+     50.0,
+     31.2
+    ],
+    [
+     39.0,
+     27.0
+    ]
+   ]
+  },
+  {
+   "ref": "wooden-pews",
+   "kind": "item",
+   "label": "wooden pews",
+   "visual": "rows of simple wooden benches with dark cushions",
+   "pos": {
+    "x": 49.5,
+    "y": 56.1
+   },
+   "footprint": {
+    "w": 99.0,
+    "d": 7.8
+   },
+   "height_rel": 0.04,
+   "height_m": 1.0,
+   "border": [
+    [
+     55.0,
+     52.2
+    ],
+    [
+     99.0,
+     52.2
+    ],
+    [
+     99.0,
+     59.4
+    ],
+    [
+     55.0,
+     59.4
+    ]
+   ]
+  }
+ ],
+ "relations": [],
+ "annotation": {
+  "ensemble": [
+   "google/gemini-3-flash-preview",
+   "qwen/qwen3-vl-32b-instruct",
+   "openai/gpt-4o-mini"
+  ],
+  "contributors": 3,
+  "reconcile": "deepseek/deepseek-v4-pro",
+  "min_votes": 2,
+  "iters": 1,
+  "judge_score": 9.0,
+  "agreement": 0.667,
+  "minority": [
+   "wooden lierne vault",
+   "stone pillars",
+   "wooden chairs",
+   "central aisle",
+   "altar screen",
+   "pointed arches",
+   "stone columns",
+   "altar area",
+   "stone floor",
+   "carved reliefs",
+   "speakers",
+   "stained glass windows",
+   "altar",
+   "stone walls",
+   "decorative carvings"
+  ],
+  "judge_rationale": "The description is highly accurate, though it misidentifies the modern wooden chairs as 'pews' in the entity list."
+ },
+ "review": {
+  "status": "verified",
+  "by": "ensemble-annotate",
+  "date": "2026-06-24"
+ }
+}

--- a/apps/modal-backend/tests/map_corpus/descriptions/wm-loc-main-reading-room-highsmith.json
+++ b/apps/modal-backend/tests/map_corpus/descriptions/wm-loc-main-reading-room-highsmith.json
@@ -1,0 +1,92 @@
+{
+ "map_id": "wm-loc-main-reading-room-highsmith",
+ "rev": 1,
+ "genre": "library-of-congress-main-reading-room",
+ "style": "Grand neoclassical interior with warm golden and cream tones, ornate plasterwork, and rich marbled columns; illuminated by natural light through arched stained-glass windows and warm artificial desk lamps.",
+ "scale_tier": "place",
+ "frame": {
+  "w": 100.0,
+  "h": 60.0
+ },
+ "description": "This is the Main Reading Room of the Library of Congress, a vast octagonal space defined by towering marble columns and ornate arches. In the center foreground sits a large, circular wooden circulation desk with tiered shelving. Radiating outward from this center are concentric rows of curved wooden reading desks, each equipped with individual glowing lamps. The floor is covered in a patterned grey carpet featuring circular laurel wreath motifs. The walls are constructed from yellow and pink marble, featuring three levels: the ground floor with arched book alcoves, a middle gallery with a balustrade and bronze statues of historical figures, and a top level with massive semi-circular stained-glass windows. The ceiling transitions into a grand dome with intricate plasterwork and gold leaf. Lighting is a mix of natural light from the high windows and the warm, rhythmic glow of hundreds of desk lamps, creating a scholarly and reverent atmosphere.",
+ "entities": [
+  {
+   "ref": "marble-columns",
+   "kind": "item",
+   "label": "marble columns",
+   "visual": "Massive Corinthian columns made of variegated pink and yellow marble.",
+   "pos": {
+    "x": 84.9,
+    "y": 60.0
+   },
+   "footprint": {
+    "w": 8.2,
+    "d": 60.0
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": null
+  },
+  {
+   "ref": "bookshelves",
+   "kind": "item",
+   "label": "bookshelves",
+   "visual": "wooden shelves filled with books, set within arched alcoves",
+   "pos": {
+    "x": 77.7,
+    "y": 60.0
+   },
+   "footprint": {
+    "w": 4.1,
+    "d": 60.0
+   },
+   "height_rel": 0.0,
+   "height_m": null,
+   "border": null
+  }
+ ],
+ "relations": [],
+ "annotation": {
+  "ensemble": [
+   "google/gemini-3-flash-preview",
+   "qwen/qwen3-vl-32b-instruct",
+   "openai/gpt-4o-mini"
+  ],
+  "contributors": 3,
+  "reconcile": "deepseek/deepseek-v4-pro",
+  "min_votes": 2,
+  "iters": 2,
+  "judge_score": 10.0,
+  "agreement": 0.667,
+  "minority": [
+   "circular circulation desk",
+   "curved reading desks",
+   "stained glass windows",
+   "bronze statues",
+   "book alcoves",
+   "patterned carpet",
+   "ornate dome",
+   "central circular desk",
+   "reading desks",
+   "stained-glass windows",
+   "ceiling frescoes",
+   "balcony statues",
+   "floor emblems",
+   "upper balcony",
+   "central archway",
+   "circular reading area",
+   "wooden desks",
+   "ornate columns",
+   "high ceiling",
+   "large arched windows",
+   "statues of historical figures",
+   "main entrance"
+  ],
+  "judge_rationale": "The description is exceptionally accurate and comprehensive, capturing every architectural detail and the specific layout of the room perfectly."
+ },
+ "review": {
+  "status": "verified",
+  "by": "ensemble-annotate",
+  "date": "2026-06-24"
+ }
+}

--- a/apps/modal-backend/tests/map_corpus/descriptions/wm-sala-del-maggior-consiglio-palau-ducal-de-ven-ci.json
+++ b/apps/modal-backend/tests/map_corpus/descriptions/wm-sala-del-maggior-consiglio-palau-ducal-de-ven-ci.json
@@ -1,0 +1,273 @@
+{
+ "map_id": "wm-sala-del-maggior-consiglio-palau-ducal-de-ven-ci",
+ "rev": 1,
+ "genre": "palace-grand-hall-interior",
+ "style": "Baroque ceiling with gilded stucco and frescoed panels; rich gold, deep blues, and earth tones; dramatic chiaroscuro lighting",
+ "scale_tier": "room",
+ "frame": {
+  "w": 100.0,
+  "h": 60.0
+ },
+ "description": "This low-angle shot captures the opulent, heavily ornamented ceiling of a grand hall, likely within the Doge's Palace. The layout is defined by a massive, gilded wooden framework that divides the ceiling into various geometric compartments. In the center-right, a large oval painting is encased in thick, scrolled gold molding. To the left and foreground, rectangular and irregularly shaped panels feature dynamic, multi-figure oil paintings depicting historical or allegorical scenes with rich blues, reds, and earthy tones. The gold leaf on the carvings is highly reflective, catching light from below to create deep shadows and bright highlights. Along the bottom edge of the frame, a frieze of smaller, arched portraits sits above large wall-mounted canvases, suggesting a continuous narrative cycle. The perspective is tilted upward, emphasizing the monumental scale and the intricate craftsmanship of the three-dimensional carvings that separate the painted masterpieces.",
+ "entities": [
+  {
+   "ref": "central-oval-painting",
+   "kind": "item",
+   "label": "Central Oval Painting",
+   "visual": "Large oval canvas depicting mythological figures, clouds, and blue sky, framed in gold",
+   "pos": {
+    "x": 67.1,
+    "y": 25.8
+   },
+   "footprint": {
+    "w": 47.0,
+    "d": 20.4
+   },
+   "height_rel": 1.0,
+   "height_m": 0.5,
+   "border": [
+    [
+     43.8,
+     60.0
+    ],
+    [
+     48.0,
+     60.0
+    ],
+    [
+     56.0,
+     60.0
+    ],
+    [
+     66.0,
+     60.0
+    ],
+    [
+     78.0,
+     60.0
+    ],
+    [
+     88.0,
+     60.0
+    ],
+    [
+     90.5,
+     60.0
+    ],
+    [
+     86.0,
+     60.0
+    ],
+    [
+     78.0,
+     60.0
+    ],
+    [
+     68.0,
+     60.0
+    ],
+    [
+     56.0,
+     60.0
+    ],
+    [
+     47.0,
+     60.0
+    ]
+   ]
+  },
+  {
+   "ref": "gilded-framework",
+   "kind": "item",
+   "label": "Gilded Framework",
+   "visual": "Intricately carved, gold-leafed wooden beams with scrolls, leaves, and cartouches",
+   "pos": {
+    "x": 50.0,
+    "y": 30.0
+   },
+   "footprint": {
+    "w": 100.0,
+    "d": 60.0
+   },
+   "height_rel": 0.8,
+   "height_m": 0.4,
+   "border": [
+    [
+     32.0,
+     60.0
+    ],
+    [
+     41.0,
+     60.0
+    ],
+    [
+     52.0,
+     60.0
+    ],
+    [
+     68.0,
+     60.0
+    ],
+    [
+     82.0,
+     60.0
+    ],
+    [
+     94.0,
+     60.0
+    ],
+    [
+     96.0,
+     60.0
+    ],
+    [
+     88.0,
+     60.0
+    ],
+    [
+     72.0,
+     60.0
+    ],
+    [
+     54.0,
+     60.0
+    ],
+    [
+     42.0,
+     60.0
+    ],
+    [
+     36.0,
+     60.0
+    ],
+    [
+     34.0,
+     60.0
+    ]
+   ]
+  },
+  {
+   "ref": "rectangular-panel",
+   "kind": "item",
+   "label": "Rectangular Panel",
+   "visual": "Large rectangular painting showing dynamic historical or battle scenes",
+   "pos": {
+    "x": 21.4,
+    "y": 44.5
+   },
+   "footprint": {
+    "w": 42.8,
+    "d": 14.2
+   },
+   "height_rel": 0.6,
+   "height_m": 0.3,
+   "border": [
+    [
+     1.0,
+     60.0
+    ],
+    [
+     18.0,
+     60.0
+    ],
+    [
+     42.0,
+     60.0
+    ],
+    [
+     22.0,
+     60.0
+    ]
+   ]
+  },
+  {
+   "ref": "portrait-frieze",
+   "kind": "item",
+   "label": "Portrait Frieze",
+   "visual": "Row of small, arched individual portraits along the upper wall",
+   "pos": {
+    "x": 61.5,
+    "y": 52.5
+   },
+   "footprint": {
+    "w": 77.0,
+    "d": 15.0
+   },
+   "height_rel": 0.4,
+   "height_m": 0.2,
+   "border": [
+    [
+     24.0,
+     60.0
+    ],
+    [
+     38.0,
+     60.0
+    ],
+    [
+     54.0,
+     60.0
+    ],
+    [
+     72.0,
+     60.0
+    ],
+    [
+     88.0,
+     60.0
+    ],
+    [
+     99.0,
+     60.0
+    ],
+    [
+     88.0,
+     60.0
+    ],
+    [
+     72.0,
+     60.0
+    ],
+    [
+     54.0,
+     60.0
+    ],
+    [
+     38.0,
+     60.0
+    ]
+   ]
+  }
+ ],
+ "relations": [],
+ "annotation": {
+  "ensemble": [
+   "google/gemini-3-flash-preview",
+   "qwen/qwen3-vl-32b-instruct",
+   "openai/gpt-4o-mini"
+  ],
+  "contributors": 3,
+  "reconcile": "deepseek/deepseek-v4-pro",
+  "min_votes": 2,
+  "iters": 2,
+  "judge_score": 10.0,
+  "agreement": 0.917,
+  "minority": [
+   "Wall Canvas",
+   "Scrolled Molding",
+   "Foreground Painting",
+   "Corner Medallion",
+   "Ceiling Beams",
+   "Cloud Motif Painting",
+   "Acanthus Leaf Decoration",
+   "Volutes and Scrolls",
+   "Blue Backgrounds"
+  ],
+  "judge_rationale": "The description and entity list perfectly capture the complex geometry, specific subjects, and lighting of the ceiling."
+ },
+ "review": {
+  "status": "verified",
+  "by": "ensemble-annotate",
+  "date": "2026-06-24"
+ }
+}

--- a/apps/modal-backend/tests/map_corpus/test_annotate.py
+++ b/apps/modal-backend/tests/map_corpus/test_annotate.py
@@ -260,6 +260,26 @@ def test_assemble_strips_votes_and_wires_provenance() -> None:
 # --- geometry bridge (consensus labels -> positioned entities) ---------------
 
 
+def test_attach_geometry_keep_ungrounded_places_fixtures() -> None:
+    # interiors: the detector can't box room-fixtures, so keep_ungrounded keeps
+    # them (nominal spread placement) instead of dropping -> they survive as
+    # scene ground truth + the fixture set drives agreement.
+    consensus = [
+        {"ref": "desk", "kind": "item", "label": "Reading Desk", "visual": "v", "votes": 3},
+        {"ref": "dome", "kind": "place", "label": "Dome", "visual": "", "votes": 2},
+    ]
+    out = attach_geometry(consensus, [], [], {}, keep_ungrounded=True)
+    assert [e["ref"] for e in out] == ["desk", "dome"]
+    for e in out:
+        assert 0.0 <= e["pos"]["x"] <= 100.0 and 0.0 <= e["pos"]["y"] <= 60.0
+        assert e["footprint"]["w"] > 0 and e["footprint"]["d"] > 0
+        assert e["border"] is None
+    assert out[0]["votes"] == 3 and out[1]["votes"] == 2
+    assert out[0]["pos"] != out[1]["pos"]  # spread, not stacked
+    # default (maps/closeups) still drops the undetected ones
+    assert attach_geometry(consensus, [], [], {}) == []
+
+
 def test_attach_geometry_scales_to_frame_and_drops_undetected() -> None:
     consensus = [
         {"ref": "tower", "kind": "place", "label": "The Tower", "visual": "v", "votes": 3},

--- a/apps/modal-backend/tests/matrix_bench/prompts/recon_closeup_base.v1.txt
+++ b/apps/modal-backend/tests/matrix_bench/prompts/recon_closeup_base.v1.txt
@@ -1,0 +1,9 @@
+{style}
+
+{description}
+
+{layout_clause}
+
+Render the WHOLE object centered and filling the frame — one coherent subject,
+nothing cropped, no collage panels. Make each named part distinct and
+identifiable. Keep any lettering sparse and legible — no garbled text.

--- a/apps/modal-backend/tests/matrix_bench/prompts/recon_interior_base.v1.txt
+++ b/apps/modal-backend/tests/matrix_bench/prompts/recon_interior_base.v1.txt
@@ -1,0 +1,9 @@
+{style}
+
+{description}
+
+{layout_clause}
+
+Render the WHOLE interior as one coherent scene — the room or hall as described,
+with its fixtures in place, nothing cropped, no collage panels. A natural
+interior view, not a top-down plan. Keep any lettering sparse and legible.

--- a/apps/modal-backend/tests/matrix_bench/sweeps/recon.json
+++ b/apps/modal-backend/tests/matrix_bench/sweeps/recon.json
@@ -1,6 +1,6 @@
 {
   "name": "recon",
-  "scenarios": ["corpus:*"],
+  "scenarios": ["corpus:tier=map"],
   "arms": ["graph", "direct"],
   "models": ["fal-ai/nano-banana"],
   "variants": ["recon_base.v1"],

--- a/apps/modal-backend/tests/matrix_bench/sweeps/recon_closeup.json
+++ b/apps/modal-backend/tests/matrix_bench/sweeps/recon_closeup.json
@@ -1,0 +1,19 @@
+{
+  "name": "recon_closeup",
+  "scenarios": ["corpus:tier=closeup"],
+  "arms": ["graph", "direct"],
+  "models": ["fal-ai/nano-banana"],
+  "variants": ["recon_closeup_base.v1"],
+  "params": { "aspect_ratio": "1:1" },
+  "judges": ["style_pair", "prompt_alignment", "feature_articulation"],
+  "composite_weights": {
+    "presence": 0.25,
+    "pos_aligned": 0.2,
+    "pos_raw": 0.05,
+    "size": 0.1,
+    "style_pair": 0.15,
+    "prompt_alignment": 0.1,
+    "feature_articulation": 0.15
+  },
+  "budget_usd": 1.0
+}

--- a/apps/modal-backend/tests/matrix_bench/sweeps/recon_interior.json
+++ b/apps/modal-backend/tests/matrix_bench/sweeps/recon_interior.json
@@ -1,0 +1,18 @@
+{
+  "name": "recon_interior",
+  "scenarios": ["corpus:tier=interior"],
+  "arms": ["graph", "direct"],
+  "models": ["fal-ai/nano-banana"],
+  "variants": ["recon_interior_base.v1"],
+  "params": { "aspect_ratio": "16:9" },
+  "judges": ["style_pair", "prompt_alignment", "feature_articulation"],
+  "composite_weights": {
+    "presence": 0.1,
+    "pos_aligned": 0.1,
+    "size": 0.1,
+    "style_pair": 0.25,
+    "prompt_alignment": 0.2,
+    "feature_articulation": 0.25
+  },
+  "budget_usd": 1.0
+}

--- a/apps/modal-backend/tests/recon_bench/runner.py
+++ b/apps/modal-backend/tests/recon_bench/runner.py
@@ -31,24 +31,48 @@ from typing import TYPE_CHECKING, Any, cast
 if TYPE_CHECKING:
     from providers.geometry import ProjectedEntity, ProjectInput
 
-from tests.map_corpus import description_sha, image_path, load_descriptions
+from tests.map_corpus import (
+    description_sha,
+    image_path,
+    load_descriptions,
+    load_manifest,
+)
 from tests.matrix_bench._budget import JUDGE_CALL_FLAT
 from tests.matrix_bench._record import Cell, load_sweep, render_prompt
 from tests.matrix_bench.runner import EXTRACT_FLAT, Scenario, run_matrix
 from tests.recon_bench._align import FRAME_H, FRAME_W, geo_scores
 
-_REPORT = Path(__file__).resolve().parent / "reports" / "recon_latest.json"
-_SWEEP = Path(__file__).resolve().parents[1] / "matrix_bench" / "sweeps" / "recon.json"
+_SWEEPS_DIR = Path(__file__).resolve().parents[1] / "matrix_bench" / "sweeps"
+_REPORTS_DIR = Path(__file__).resolve().parent / "reports"
+
+
+def _sweep_name() -> str:
+    """Which sweep to run: RECON_SWEEP (default "recon" = maps; "recon_closeup"
+    = the closeup tier). Picks the sweep file, the report, and the baseline key."""
+    return os.environ.get("RECON_SWEEP", "recon")
+
+
+def _sweep_path() -> Path:
+    return _SWEEPS_DIR / f"{_sweep_name()}.json"
+
+
+def _report_path() -> Path:
+    return _REPORTS_DIR / f"{_sweep_name()}_latest.json"
 
 
 def corpus_scenarios(specs: list[str]) -> list[Scenario]:
     """Resolve sweep scenario specs: "corpus:*" → every VERIFIED corpus
-    description; "corpus:<map_id>" → that one (must be verified)."""
+    description; "corpus:tier=<map|interior|closeup>" → the verified ones of that
+    tier; "corpus:<map_id>" → that one (must be verified)."""
     verified = {d["map_id"]: d for d in load_descriptions(status="verified")}
     wanted: list[dict[str, Any]] = []
     for spec in specs:
         if spec == "corpus:*":
             wanted.extend(verified.values())
+        elif spec.startswith("corpus:tier="):
+            tier = spec.split("=", 1)[1]
+            tier_ids = {m["id"] for m in load_manifest(tier=tier)}
+            wanted.extend(d for d in verified.values() if d["map_id"] in tier_ids)
         elif spec.startswith("corpus:"):
             map_id = spec.split(":", 1)[1]
             if map_id not in verified:
@@ -218,6 +242,18 @@ def recon_fns(sweep: dict[str, Any]) -> dict[str, Any]:
         )
         return r.score, JUDGE_CALL_FLAT
 
+    def _articulation_judge(
+        cell: Cell, desc: dict[str, Any], jpeg: bytes
+    ) -> tuple[float, float]:
+        # The closeup/interior-tier analogue of map_plausibility: does the render
+        # ARTICULATE the object's named parts, rather than read as a coherent map?
+        # features = the description's catalogued part labels.
+        labels = [str(e["label"]) for e in desc["entities"]]
+        r = _await(
+            lambda: judge.score_feature_articulation(jpeg, desc.get("genre", "object"), labels)
+        )
+        return r.score, JUDGE_CALL_FLAT
+
     def score_fn(
         cell: Cell,
         desc: dict[str, Any],
@@ -278,6 +314,7 @@ def recon_fns(sweep: dict[str, Any]) -> dict[str, Any]:
             "style_pair": _style_judge,
             "map_plausibility": _plausibility_judge,
             "prompt_alignment": _alignment_judge,
+            "feature_articulation": _articulation_judge,
         },
         "score_fn": score_fn,
     }
@@ -297,12 +334,13 @@ def _load_env() -> None:
 
 def main() -> int:
     _load_env()
-    sweep = load_sweep(_SWEEP)
+    report_path = _report_path()
+    sweep = load_sweep(_sweep_path())
     if os.environ.get("MATRIX_BUDGET_USD"):
         sweep["budget_usd"] = float(os.environ["MATRIX_BUDGET_USD"])
     scenarios = corpus_scenarios(sweep["scenarios"])
     if not scenarios:
-        print("recon: no VERIFIED corpus descriptions — review the drafts first.")
+        print(f"recon[{_sweep_name()}]: no VERIFIED corpus descriptions of that tier.")
         return 1
     live = os.environ.get("RECON_BENCH_RUN") == "1"
     report = run_matrix(
@@ -311,7 +349,7 @@ def main() -> int:
         live=live,
         allow_partial=os.environ.get("MATRIX_ALLOW_PARTIAL") == "1",
         run_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-        report_path=_REPORT,
+        report_path=report_path,
         **recon_fns(sweep),
     )
     if live:
@@ -325,10 +363,13 @@ def main() -> int:
             try:
                 from tests._baseline import compare
 
-                for name, key in (
-                    ("recon_fidelity", "composite"),
-                    ("height_order", "height_order"),
-                ):
+                # fidelity baseline is per-sweep ("recon_fidelity" for maps,
+                # "recon_closeup_fidelity" for closeups); height_order only the
+                # map sweep (objects carry no built-height ladder).
+                baselines = [(f"{_sweep_name()}_fidelity", "composite")]
+                if _sweep_name() == "recon":
+                    baselines.append(("height_order", "height_order"))
+                for name, key in baselines:
                     vals = [c["scores"][key] for c in cells if key in c.get("scores", {})]
                     if vals:
                         v = compare(name, sum(vals) / len(vals), len(vals))
@@ -338,7 +379,7 @@ def main() -> int:
     if live:
         from tests.matrix_bench import report as report_mod
 
-        print(report_mod.format_summary(report_mod.attach_summary(_REPORT)))
+        print(report_mod.format_summary(report_mod.attach_summary(report_path)))
     json.dumps(report)  # smoke: the report is JSON-serializable
     return 0 if report.get("stopped_reason") is None else 1
 

--- a/apps/modal-backend/tests/recon_bench/test_recon.py
+++ b/apps/modal-backend/tests/recon_bench/test_recon.py
@@ -135,6 +135,22 @@ def test_expected_layout_needs_two_real_heights() -> None:
 # --- scenario resolution -----------------------------------------------------
 
 
+def test_corpus_scenarios_filters_by_tier() -> None:
+    from tests.map_corpus import load_descriptions, load_manifest
+
+    closeups = corpus_scenarios(["corpus:tier=closeup"])
+    ids = {s.id for s in closeups}
+    expected = {m["id"] for m in load_manifest(tier="closeup")} & {
+        d["map_id"] for d in load_descriptions(status="verified")
+    }
+    assert ids == expected and expected  # resolves the verified closeups, non-empty
+    # maps must NOT leak into a closeup-tier sweep
+    assert "fantasy-treasure-island" not in ids
+    # and a map-tier sweep excludes the closeups
+    map_ids = {s.id for s in corpus_scenarios(["corpus:tier=map"])}
+    assert "fantasy-treasure-island" in map_ids and not (map_ids & ids)
+
+
 def test_corpus_scenarios_verified_only_and_deduped() -> None:
     scenarios = corpus_scenarios(["corpus:*", "corpus:fantasy-treasure-island"])
     ids = [s.id for s in scenarios]


### PR DESCRIPTION
Extends `recon_bench` from map-only to **all three corpus tiers**, and unblocks the interior tier (which previously ground 0 entities) via prose-decoupling.

## Per-tier recon
- `corpus_scenarios` gains `corpus:tier=<map|interior|closeup>` (manifest tier ∩ verified); the runner is `RECON_SWEEP`-selectable (per-sweep report + fidelity baseline). `recon.json` scoped to `corpus:tier=map` so `eval-recon` + its baseline are unchanged.
- New `feature_articulation` judge_fn (object/scene parts — the closeup/interior analogue of `map_plausibility`).
- New sweeps + tier-worded prompt templates: `recon_closeup` (object), `recon_interior` (scene, "not a top-down plan"). Makefile: `eval-recon-{closeup,interior}[-dry]`.

## Interiors: prose-decouple (the diagnosed fix)
The VLM detector can't box room-fixtures (repeated desks/columns, diffuse domes/floors) — rooms aren't top-down maps. So:
- `attach_geometry(keep_ungrounded=True)` for the interior tier keeps fixtures the detector misses (nominal spread placement) instead of dropping them → the fixture set survives + drives ensemble agreement.
- The 3 seeded interiors went **0 entities / needs_human → VERIFIED** scene ground truth (LOC Reading Room, Chester nave, Venetian council hall) via the DeepSeek arbiter + keep_ungrounded.
- Interior recon weights geo **low** and leans on image judges (`style_pair`/`prompt_alignment`/`feature_articulation`); ~0.675 floor from judges alone.

## Validation (paid, committed baselines)
- closeup: composite **0.86** (astrolabe ~0.95, armor ~0.9, globe ~0.75 — its `feature_articulation` 0.0 is the real signal the bench catches).
- interior: composite **0.80** (`feature_articulation` 1.0 everywhere).
- `recon_closeup_fidelity` 0.86±0.12, `recon_interior_fidelity` 0.80±0.15 pinned.

Corpus now fully covered: **3 maps + 3 interiors + 3 closeups**, all verified + recon + baselined. Free gate + ruff + mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)