### PR TITLE
feat(descent): medium-agnostic place_match judge — separate place from medium

### DIFF
--- a/apps/modal-backend/providers/judge.py
+++ b/apps/modal-backend/providers/judge.py
@@ -105,6 +105,39 @@ async def score_style_pair(image_a: bytes, image_b: bytes) -> JudgeResult:
     )
 
 
+async def score_place_match(image_a: bytes, image_b: bytes) -> JudgeResult:
+    """Medium-AGNOSTIC twin of score_style_pair — the descent bench's real-child
+    judge. style_pair conflates two things a cross-medium descent can never win
+    on at once: is it the same PLACE, and is it the same MEDIUM. Descending from
+    an illustrated map into a real photographed church yields a correct
+    illustrated church that style_pair scores ~0 against the photo, sinking
+    style_lift even though region-conditioning carried the place over perfectly.
+    This judge scores ONLY place identity — same structure, layout, key features
+    — and is explicitly told to ignore medium, palette and art style, so descent
+    recon measures place fidelity across illustration->photo golden chains."""
+    system = (
+        "You judge whether two images depict the SAME PLACE — the same physical "
+        "structure, architecture, spatial layout and distinctive features — "
+        "REGARDLESS of how they are rendered. Image 1 is the real reference "
+        "place; image 2 is a candidate. IGNORE the artistic medium entirely: a "
+        "photograph, an illustration, a painting and a 3D render of the SAME "
+        "place must all score high. Ignore palette, lighting, line work and art "
+        "style. Score ONLY place identity. 10 = unmistakably the same place / "
+        "same kind of structured place (same layout, the same key features in "
+        "the same arrangement); 5 = the right KIND of place but a different "
+        "specific one; 0 = an unrelated place."
+        ' Return JSON exactly: {"score": <0-10 number>, "rationale": "<one short sentence>"}.'
+    )
+    user_text = (
+        "Image 1 = the real place. Image 2 = the candidate. Are they the SAME "
+        "place / same structured place — same layout and features — ignoring "
+        "medium, palette and style? Score 0-10."
+    )
+    return await _ask_judge(
+        system, user_text, [_image_block(image_a), _image_block(image_b)]
+    )
+
+
 async def score_entity_consistency(
     entity_name: str, appearance: str, image_a: bytes, image_b: bytes
 ) -> JudgeResult:

--- a/apps/modal-backend/tests/descent_bench/runner.py
+++ b/apps/modal-backend/tests/descent_bench/runner.py
@@ -5,14 +5,16 @@ a place ENTITY in a parent map), crop the parent map at that place and generate 
 "enter" view two ways:
   with   — region-conditioned on the cropped parent place (the product descent)
   without— a plain fresh generation (baseline)
-then JUDGE both against the REAL child photo (style match) and the cropped region
-(continuity). The headline metric is style_lift = how much region-conditioning
-moves the descent TOWARD the real place. Reuses the continuity bench's region
-crop + enter generation.
+then JUDGE both against the REAL child photo and the cropped region (continuity).
+The headline metric is place_lift = how much region-conditioning moves the
+descent TOWARD the real PLACE, scored medium-AGNOSTICALLY (score_place_match) so
+an illustration->photo chain isn't penalised for the medium gap it can't close.
+style_lift (score_style_pair, medium-sensitive) is kept as a secondary signal.
+Reuses the continuity bench's region crop + enter generation.
 
 Dry by default (resolve chains + cost preview, $0):
     .venv/bin/python -m tests.descent_bench.runner
-Live (DESCENT_BENCH_RUN=1, ~$0.30/chain — 2 image gens + 3 judges):
+Live (DESCENT_BENCH_RUN=1, ~$0.31/chain — 2 image gens + 5 judges):
     make eval-descent
 Needs `make corpus-fetch` (parent + child images) and VERIFIED parent descriptions.
 """
@@ -81,6 +83,12 @@ async def _score_chain(chain: dict[str, Any], aspect: str) -> dict[str, Any]:
     (art / f"descent-{chain['child_id']}-without.jpg").write_bytes(without_img)
     real_with = await judge.score_style_pair(child_bytes, with_img)
     real_without = await judge.score_style_pair(child_bytes, without_img)
+    # medium-AGNOSTIC place judge: style_pair sinks a CORRECT illustrated descent
+    # of a photographed place to ~0 purely on the medium gap. place_match scores
+    # same-place-ignoring-medium, so place_lift measures what the descent is
+    # actually for — carrying the real place over — across illustration->photo.
+    place_with = await judge.score_place_match(child_bytes, with_img)
+    place_without = await judge.score_place_match(child_bytes, without_img)
     continuity = await judge.score_continuation(region, with_img)
     return {
         "child_id": chain["child_id"],
@@ -89,19 +97,33 @@ async def _score_chain(chain: dict[str, Any], aspect: str) -> dict[str, Any]:
         "real_style_with": round(real_with.score, 2),
         "real_style_without": round(real_without.score, 2),
         "style_lift": round(real_with.score - real_without.score, 2),
+        "place_match_with": round(place_with.score, 2),
+        "place_match_without": round(place_without.score, 2),
+        "place_lift": round(place_with.score - place_without.score, 2),
         "continuity_with": round(continuity.score, 2),
-        "rationale": real_with.rationale,
+        "rationale": place_with.rationale,
+    }
+
+
+def _aggregate(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Roll rows up into the report. The HEADLINE is mean_place_lift (medium-
+    agnostic); mean_style_lift is kept as a secondary medium-transfer signal so
+    the committed baseline stays comparable."""
+    def _mean(key: str) -> float:
+        vals = [r[key] for r in rows]
+        return round(sum(vals) / len(vals), 3) if vals else 0.0
+
+    return {
+        "run_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "chains": rows,
+        "mean_place_lift": _mean("place_lift"),
+        "mean_style_lift": _mean("style_lift"),
     }
 
 
 async def _run(chains: list[dict[str, Any]]) -> dict[str, Any]:
     rows = [await _score_chain(c, "16:9") for c in chains]
-    lifts = [r["style_lift"] for r in rows]
-    return {
-        "run_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-        "chains": rows,
-        "mean_style_lift": round(sum(lifts) / len(lifts), 3) if lifts else 0.0,
-    }
+    return _aggregate(rows)
 
 
 def main() -> int:
@@ -115,19 +137,23 @@ def main() -> int:
               "verified parent map entity)")
         return 0
     if os.environ.get("DESCENT_BENCH_RUN") != "1":
-        cost = len(chains) * (2 * _GEN_USD + 3 * _JUDGE_USD)
-        print(f"\nDRY RUN — would spend ~${cost:.2f} ({len(chains)} chain(s) x 2 gens + 3 judges).")
+        cost = len(chains) * (2 * _GEN_USD + 5 * _JUDGE_USD)
+        print(f"\nDRY RUN — would spend ~${cost:.2f} ({len(chains)} chain(s) x 2 gens + 5 judges).")
         print("Set DESCENT_BENCH_RUN=1 to execute.")
         return 0
     report = asyncio.run(_run(chains))
     _REPORT.parent.mkdir(parents=True, exist_ok=True)
     _REPORT.write_text(json.dumps(report, indent=2) + "\n")
-    print(f"\nmean style_lift: {report['mean_style_lift']:+.3f} over {len(report['chains'])} chain(s)")
+    print(
+        f"\nmean place_lift: {report['mean_place_lift']:+.3f}  "
+        f"(style_lift: {report['mean_style_lift']:+.3f}) over "
+        f"{len(report['chains'])} chain(s)"
+    )
     for r in report["chains"]:
         print(
-            f"  {r['place']:<16} real-style with={r['real_style_with']} "
-            f"without={r['real_style_without']} (lift {r['style_lift']:+}) "
-            f"continuity={r['continuity_with']}"
+            f"  {r['place']:<16} place with={r['place_match_with']} "
+            f"without={r['place_match_without']} (lift {r['place_lift']:+}) | "
+            f"style-lift {r['style_lift']:+} continuity={r['continuity_with']}"
         )
     return 0
 

--- a/apps/modal-backend/tests/descent_bench/test_descent.py
+++ b/apps/modal-backend/tests/descent_bench/test_descent.py
@@ -1,0 +1,27 @@
+"""Descent-bench aggregation (free): the report rolls up BOTH the
+medium-confounded style_lift AND the medium-agnostic place_lift, so an
+illustration->photo chain is no longer judged solely on a medium gap it can
+never close."""
+from __future__ import annotations
+
+import pytest
+
+from tests.descent_bench.runner import _aggregate
+
+
+def _row(style_lift: float, place_lift: float) -> dict:
+    return {"child_id": "c", "style_lift": style_lift, "place_lift": place_lift}
+
+
+def test_aggregate_means_both_lifts() -> None:
+    report = _aggregate([_row(-7.0, 4.0), _row(1.0, 2.0)])
+    assert report["mean_style_lift"] == pytest.approx(-3.0)
+    assert report["mean_place_lift"] == pytest.approx(3.0)
+    assert report["chains"] == [_row(-7.0, 4.0), _row(1.0, 2.0)]
+
+
+def test_aggregate_empty_is_zero() -> None:
+    report = _aggregate([])
+    assert report["mean_style_lift"] == 0.0
+    assert report["mean_place_lift"] == 0.0
+    assert report["chains"] == []

--- a/apps/modal-backend/tests/test_judge_place_match.py
+++ b/apps/modal-backend/tests/test_judge_place_match.py
@@ -1,0 +1,51 @@
+"""score_place_match — the medium-AGNOSTIC place judge.
+
+The descent bench compares a generated descent against the REAL child photo.
+score_style_pair is medium-confounded: an illustrated descent of a real church
+(correct place) scores LOW against a photo purely because illustration != photo.
+score_place_match asks the opposite question — SAME place/structure, IGNORE the
+medium — so descent recon can measure place fidelity across illustration->photo
+chains. This test pins the prompt's medium-agnostic contract + image order
+without spending a VLM call (the _ask_judge boundary is stubbed)."""
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+import pytest
+
+from providers import judge
+from providers.judge import JudgeResult
+
+
+@pytest.mark.asyncio
+async def test_score_place_match_is_medium_agnostic_and_passes_both_images(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    async def fake_ask(system: str, user_text: str, image_blocks: list[dict[str, object]]):
+        captured["system"] = system
+        captured["user_text"] = user_text
+        captured["blocks"] = image_blocks
+        return JudgeResult(7.0, "same nave", "raw")
+
+    monkeypatch.setattr(judge, "_ask_judge", fake_ask)
+
+    result = await judge.score_place_match(b"REAL-CHILD", b"GENERATED-DESCENT")
+
+    assert result.score == 7.0
+    prompt = (captured["system"] + " " + captured["user_text"]).lower()
+    # the whole point: explicitly discount medium so a correct illustrated
+    # descent of a photographed place is not punished for being an illustration
+    assert "ignore" in prompt
+    assert any(w in prompt for w in ("medium", "photo", "illustration"))
+    assert any(w in prompt for w in ("place", "structure", "layout"))
+
+    # both images travel, real child FIRST then the candidate descent SECOND
+    blocks = captured["blocks"]
+    assert len(blocks) == 2
+    a64 = base64.b64encode(b"REAL-CHILD").decode("ascii")
+    b64 = base64.b64encode(b"GENERATED-DESCENT").decode("ascii")
+    assert a64 in blocks[0]["image_url"]["url"]
+    assert b64 in blocks[1]["image_url"]["url"]


### PR DESCRIPTION
## What

Descent recon (`tests/descent_bench`) judged its generated descent against the **real child photo** with `score_style_pair`, which conflates two things a cross-medium golden chain can never win at once: *is it the same **place***, and *is it the same **medium***.

The one golden chain — illustrated manor map → `"Church"` → real **Chester Cathedral nave** photo — exposes the confound exactly: the region-conditioned descent is a faithful small stone chapel (continuity **9/10**) but scores `style_lift −7` **purely** for rendering as an illustration instead of a photo.

## Change

- **`providers/judge.py`** — new `score_place_match(image_a, image_b)`: a medium-**agnostic** twin of `score_style_pair`. Scores **only place identity** (same structure / layout / features); explicitly told to ignore medium, palette and art style.
- **`tests/descent_bench/runner.py`** — wire it in. `place_lift` is now the **headline**; `style_lift` stays as a secondary medium-transfer signal (keeps the committed baseline comparable). Extracted `_aggregate()` so the rollup is unit-testable.
- TDD: `tests/test_judge_place_match.py` (medium-agnostic prompt contract + image order, `_ask_judge` stubbed — $0) and `tests/descent_bench/test_descent.py` (`_aggregate` means both lifts).

## Live validation (1 chain, ~$0.30)

| metric | with-region | without | lift |
|---|---|---|---|
| **place_match** (new, medium-agnostic) | 4.0 | 4.0 | **+0.0** |
| style_pair (old, medium-sensitive) | 1.0 | 8.0 | −7.0 |
| continuity_with | — | — | **9.0** |

Judge rationale: *"both depict a church with pews and stone arches, but scale/layout differ"* — never faults the medium.

**Honest reading:** `style_lift −7` is confirmed a **pure medium artifact** (faithful chapel, penalized only for being illustrated). `place_lift 0` is correct — the parent's *generic* church icon encodes no Chester-*specific* identity to transfer, so neither descent reproduces the cathedral. The real descent-quality signal on this chain is `continuity_with = 9.0`.

**Follow-up (not blocking):** golden chains need parent specificity that actually matches the child — a concrete quality criterion for the *more-chains* backlog item.

## Test
`pytest tests/test_judge_place_match.py tests/descent_bench/test_descent.py tests/recon_bench/test_recon.py` → 13 passed. Descent dry-run + report verified; no schema change (P0 parity untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)