### PR TITLE
feat(corpus): Smithsonian Open Access source adapter (CC0 closeups)

### DIFF
--- a/apps/modal-backend/tests/map_corpus/sources/smithsonian.py
+++ b/apps/modal-backend/tests/map_corpus/sources/smithsonian.py
@@ -1,0 +1,164 @@
+"""Smithsonian Open Access adapter — CC0 object photography (and some interiors /
+maps) across 19 units, ideal for the `closeup` tier alongside the Met. The v1.0
+Open Access API (api.si.edu) needs an api.data.gov key; the pure record->row
+mapping is gated by test_sources_smithsonian.py, the live search is a free CLI.
+
+    export SMITHSONIAN_API_KEY=...        # from https://api.data.gov/signup/ (DEMO_KEY works, low limits)
+    .venv/bin/python -m tests.map_corpus.sources.smithsonian "pocket watch" --limit 8
+    .venv/bin/python -m tests.map_corpus.sources.smithsonian "telescope" --append   # add to manifest
+
+Rows are added WITHOUT a sha256; `make corpus-fetch` pins them on first download.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.parse
+import urllib.request
+from typing import Any
+
+from tests.map_corpus import MANIFEST
+
+_BASE = "https://api.si.edu/openaccess/api/v1.0"
+
+
+def _slug(s: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", str(s).lower()).strip("-") or "x"
+
+
+def _is_cc0(media_item: dict[str, Any], dnr: dict[str, Any]) -> bool:
+    """CC0 can be stamped per-media (usage.access) or only at the record level
+    (metadata_usage.access). Prefer the media's own grant, fall back to the
+    record's."""
+    media_access = (media_item.get("usage") or {}).get("access")
+    if media_access:
+        return str(media_access).upper() == "CC0"
+    return str((dnr.get("metadata_usage") or {}).get("access") or "").upper() == "CC0"
+
+
+def _image_url(media_item: dict[str, Any]) -> str | None:
+    """The canonical full image: the media's `content` URL when it's an http link,
+    else a IIIF/deliveryService URL built from its `idsId`."""
+    content = str(media_item.get("content") or "").strip()
+    if content.startswith("http"):
+        return content
+    ids = str(media_item.get("idsId") or "").strip()
+    if ids:
+        return f"https://ids.si.edu/ids/deliveryService?id={urllib.parse.quote(ids)}&max=1600"
+    return None
+
+
+def smithsonian_record_to_row(
+    record: dict[str, Any], tier: str = "closeup", genre: str | None = None
+) -> dict[str, Any] | None:
+    """Map a Smithsonian Open Access record to a corpus manifest row, or None if
+    it has no CC0 image. genre: explicit arg > indexedStructured.object_type >
+    "object"."""
+    content = record.get("content") or {}
+    dnr = content.get("descriptiveNonRepeating") or {}
+    media_list = ((dnr.get("online_media") or {}).get("media")) or []
+
+    image: str | None = None
+    for m in media_list:
+        if str(m.get("type", "")).lower() != "images":
+            continue
+        url = _image_url(m)
+        if url and _is_cc0(m, dnr):
+            image = url
+            break
+    if not image:
+        return None
+
+    title = str((dnr.get("title") or {}).get("content") or record.get("title") or "untitled").strip()
+    unit = str(dnr.get("unit_code") or record.get("unitCode") or "Smithsonian").strip()
+    object_type = (content.get("indexedStructured") or {}).get("object_type") or []
+    genre_label = genre or (object_type[0] if object_type else None) or "object"
+    row_id = f"si-{_slug(record.get('id') or title)}"[:60]
+    record_link = str(dnr.get("record_link") or "").strip()
+    attribution = f'"{title}", {unit}, Smithsonian Open Access, CC0'
+    if record_link:
+        attribution += f" — {record_link}"
+    return {
+        "id": row_id,
+        "tier": tier,
+        "genre": _slug(genre_label),
+        "source_url": image,
+        "license_note": "CC0 (Smithsonian Open Access)",
+        "attribution": attribution,
+        "sha256": None,  # pinned by scripts/fetch_corpus.py on first fetch
+        "filename": f"{row_id}.jpg",  # corpus invariant: filename starts with id
+    }
+
+
+def _api_key() -> str:
+    return (
+        os.environ.get("SMITHSONIAN_API_KEY")
+        or os.environ.get("DATA_GOV_API_KEY")
+        or "DEMO_KEY"
+    )
+
+
+def _get_json(url: str) -> Any:
+    req = urllib.request.Request(url, headers={"User-Agent": "openflipbook-corpus/1.0"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def find_rows(query: str, limit: int = 8, tier: str = "closeup") -> list[dict[str, Any]]:
+    """Live (free) Open Access search narrowed to image records; CC0 is enforced
+    in the mapping, so we over-fetch and filter. Network — only the CLI calls
+    this."""
+    params = {
+        "api_key": _api_key(),
+        "q": f'{query} AND online_media_type:"Images"',
+        "rows": str(max(limit * 4, limit)),
+    }
+    data = _get_json(f"{_BASE}/search?{urllib.parse.urlencode(params)}")
+    records = ((data.get("response") or {}).get("rows")) or []
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for rec in records:
+        if len(rows) >= limit:
+            break
+        try:
+            row = smithsonian_record_to_row(rec, tier=tier)
+        except Exception:
+            continue
+        if row and row["id"] not in seen:
+            seen.add(row["id"])
+            rows.append(row)
+    return rows
+
+
+def _append_to_manifest(rows: list[dict[str, Any]]) -> int:
+    data = json.loads(MANIFEST.read_text())
+    have = {m["id"] for m in data["maps"]}
+    added = [r for r in rows if r["id"] not in have]
+    data["maps"].extend(added)
+    MANIFEST.write_text(json.dumps(data, indent=2) + "\n")
+    return len(added)
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    if not args:
+        print('usage: python -m tests.map_corpus.sources.smithsonian "<query>" [--limit N] [--tier T] [--append]')
+        return 1
+    append = "--append" in args
+    tier = args[args.index("--tier") + 1] if "--tier" in args else "closeup"
+    limit = int(args[args.index("--limit") + 1]) if "--limit" in args else 8
+    query = next(a for a in args if not a.startswith("--") and not a.isdigit())
+    if _api_key() == "DEMO_KEY":
+        print("note: using DEMO_KEY (low rate limit) — set SMITHSONIAN_API_KEY for real runs.")
+    rows = find_rows(query, limit=limit, tier=tier)
+    print(json.dumps(rows, indent=2))
+    print(f"\n{len(rows)} CC0 candidate(s) for {query!r} (tier={tier})")
+    if append:
+        print(f"appended {_append_to_manifest(rows)} new row(s) — run `make corpus-fetch` to pin")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/modal-backend/tests/map_corpus/test_sources_smithsonian.py
+++ b/apps/modal-backend/tests/map_corpus/test_sources_smithsonian.py
@@ -1,0 +1,98 @@
+"""Smithsonian Open Access adapter gate (free): the pure record -> manifest-row
+mapping that keeps only CC0 image records and stamps license + attribution.
+Smithsonian's strength is CC0 object photography, so it defaults to the closeup
+tier (complementing the Met adapter with natural-history / technology breadth)."""
+from __future__ import annotations
+
+from typing import Any
+
+from tests.map_corpus.sources.smithsonian import smithsonian_record_to_row
+
+_IMG = "https://ids.si.edu/ids/deliveryService?id=NMAH-AHB2019q012345"
+
+
+def _record(
+    *,
+    media_access: str | None = "CC0",
+    meta_access: str | None = "CC0",
+    content: str | None = _IMG,
+    ids_id: str | None = "NMAH-AHB2019q012345",
+    media_type: str = "Images",
+    with_media: bool = True,
+    object_type: tuple[str, ...] = ("Watches",),
+    title: str = "Pocket Watch",
+) -> dict[str, Any]:
+    media: list[dict[str, Any]] = []
+    if with_media:
+        m: dict[str, Any] = {"type": media_type, "thumbnail": _IMG + "&max=150"}
+        if content is not None:
+            m["content"] = content
+        if ids_id is not None:
+            m["idsId"] = ids_id
+        if media_access is not None:
+            m["usage"] = {"access": media_access}
+        media = [m]
+    dnr: dict[str, Any] = {
+        "title": {"label": "Title", "content": title},
+        "unit_code": "NMAH",
+        "record_link": "https://americanhistory.si.edu/collections/object/nmah_1234567",
+        "online_media": {"mediaCount": len(media), "media": media},
+    }
+    if meta_access is not None:
+        dnr["metadata_usage"] = {"access": meta_access}
+    return {
+        "id": "edanmdm-nmah_1234567",
+        "title": title,
+        "unitCode": "NMAH",
+        "content": {
+            "descriptiveNonRepeating": dnr,
+            "indexedStructured": {"object_type": list(object_type)},
+        },
+    }
+
+
+def test_smithsonian_record_to_row_emits_a_cc0_closeup_row() -> None:
+    row = smithsonian_record_to_row(_record())
+    assert row is not None
+    assert row["id"].startswith("si-")
+    assert row["tier"] == "closeup"
+    assert row["genre"] == "watches"  # from indexedStructured.object_type
+    assert row["source_url"] == _IMG
+    assert row["filename"] == row["id"] + ".jpg"  # corpus invariant: filename starts with id
+    assert "CC0" in row["license_note"] and "Smithsonian" in row["license_note"]
+    assert "Pocket Watch" in row["attribution"] and "NMAH" in row["attribution"]
+    assert row["sha256"] is None  # pinned by make corpus-fetch on first download
+
+
+def test_smithsonian_record_to_row_drops_non_cc0_or_imageless() -> None:
+    # neither the media nor the metadata grants CC0
+    assert smithsonian_record_to_row(_record(media_access="Not CC0", meta_access=None)) is None
+    # no media at all
+    assert smithsonian_record_to_row(_record(with_media=False)) is None
+    # the only media is not an image
+    assert smithsonian_record_to_row(_record(media_type="Documents")) is None
+    # no resolvable image URL (no content, no idsId)
+    assert smithsonian_record_to_row(_record(content=None, ids_id=None)) is None
+
+
+def test_smithsonian_record_to_row_cc0_via_metadata_when_media_usage_absent() -> None:
+    # many records carry CC0 only at the metadata level, not per-media
+    row = smithsonian_record_to_row(_record(media_access=None, meta_access="CC0"))
+    assert row is not None and "CC0" in row["license_note"]
+
+
+def test_smithsonian_record_to_row_builds_iiif_url_from_idsid_when_no_content() -> None:
+    row = smithsonian_record_to_row(_record(content=None, ids_id="NMAH-XYZ-9"))
+    assert row is not None
+    assert "ids.si.edu" in row["source_url"] and "NMAH-XYZ-9" in row["source_url"]
+
+
+def test_smithsonian_record_to_row_tier_override_and_genre_fallback() -> None:
+    # explicit genre wins; explicit tier overrides
+    row = smithsonian_record_to_row(_record(object_type=()), tier="interior", genre="period room")
+    assert row is not None
+    assert row["tier"] == "interior"
+    assert row["genre"] == "period-room"
+    # with no object_type and no explicit genre, falls back to a generic label
+    bare = smithsonian_record_to_row(_record(object_type=()))
+    assert bare is not None and bare["genre"] == "object"


### PR DESCRIPTION
## What

The corpus expansion's first item — a **third CC0 source adapter** alongside Met + Wikimedia. Smithsonian Open Access adds natural-history / technology / design-museum breadth to the **closeup** tier.

Same shape as the existing adapters: a **pure** `smithsonian_record_to_row` mapping (gated by tests) + a free live-search CLI. Rows land without a `sha256`; `make corpus-fetch` pins them on first download.

```bash
export SMITHSONIAN_API_KEY=...   # api.data.gov key; DEMO_KEY works at a low rate limit
python -m tests.map_corpus.sources.smithsonian "vase" --limit 8 [--append]
```

## Mapping rules

- **CC0 only** — honoured whether stamped per-media (`usage.access`) or only at the record level (`metadata_usage.access`).
- **Image URL** — the media's `content` link, or a IIIF/deliveryService URL built from its `idsId`.
- **genre** — explicit arg > `indexedStructured.object_type` > `"object"`.
- **id** `si-<slug>`, **filename** `<id>.jpg` (the corpus filename-starts-with-id invariant).

## Live findings (probed against the real v1.0 API, baked into the design)

- The **search** response carries `online_media` **inline** for image-rich records — no per-id `/content` hydration needed (unlike the Met's two-step).
- The v1.0 API needs an **api.data.gov key** (`SMITHSONIAN_API_KEY` / `DATA_GOV_API_KEY`; `DEMO_KEY` works at a low limit — the CLI says so).
- `online_media_type:"Images"` over-matches catalog records with no downloadable media, so CC0+image is **enforced in the mapping** and `find_rows` over-fetches ×4 and filters.

## Validation

- **5 unit tests** (CC0 per-media + per-metadata, imageless/non-image drops, IIIF-from-idsId fallback, tier override + genre fallback) · ruff + mypy clean · full `map_corpus` suite green.
- **End-to-end**: `"vase"` → CC0 candidate rows whose `source_url` returns a real `image/jpeg` (850 KB, JPEG magic) — ready for `corpus-fetch`.

No rows appended to the manifest (the adapter is the deliverable; rows are added on demand via `--append`, matching Met/Wikimedia).

🤖 Generated with [Claude Code](https://claude.com/claude-code)