### PR TITLE
feat(enter): another-angle azimuth on re-enter (ENTER_AZIMUTH_ROTATE)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,11 @@ FAL_EDIT_TIER=balanced
 # openai/gpt-image-2/edit, fal-ai/nano-banana-2/edit.
 # ENTER_EDIT_REF=true
 # FAL_ENTER_MODEL=fal-ai/nano-banana-pro/edit
+# Another angle on re-enter: when the client sends scene_view.enter_index > 0
+# (a revisit), rotate the scene camera one 90° step so the place is seen from a
+# new side instead of redrawn the same. Default OFF; the first enter is always
+# byte-identical. (Validated: same-place holds 9-10/10 under rotation.)
+# ENTER_AZIMUTH_ROTATE=true
 # The render loop: steep enters (top_down / eye-level) are judged and retried
 # once with the critic's feedback when the projection fails (default ON).
 # Honesty: gpt-image-2 edit attempts ran ~170s each in calibration — a retried

--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -229,6 +229,11 @@ class SceneView(BaseModel):
     scale_tier: str | None = None
     # The deliberate camera for this render (the view grammar). None ⇒ legacy.
     view: ViewSpec | None = None
+    # How many times this place has already been entered (the client's revisit
+    # count). >0 rotates the scene camera to another angle under
+    # ENTER_AZIMUTH_ROTATE; None/0 is byte-identical. Mirrors the optional TS
+    # `enter_index?` (schema-parity gated).
+    enter_index: int | None = None
 
 
 class ProjectedEntity(BaseModel):
@@ -553,6 +558,13 @@ def _view_spec_for(
         f = focus["footprint"]
         if f.get("w") and f.get("d"):
             fp = (float(f["w"]), float(f["d"]))
+    # Another-angle on re-enter (flag-gated OFF): the client's revisit count
+    # rotates a scene enter to a new side. Off ⇒ 0 ⇒ byte-identical.
+    enter_index = (
+        int(sv.enter_index)
+        if sv and sv.enter_index and env_flag("ENTER_AZIMUTH_ROTATE")
+        else 0
+    )
     return cast(
         "dict | None",
         view_policy.default_view(
@@ -568,6 +580,7 @@ def _view_spec_for(
             subject_context=subject_context,
             focus_kind=str(focus.get("kind") or "") if focus else None,
             focus_footprint=fp,
+            enter_index=enter_index,
         ),
     )
 

--- a/apps/modal-backend/providers/prompt_library/policy.py
+++ b/apps/modal-backend/providers/prompt_library/policy.py
@@ -53,6 +53,21 @@ _PERSPECTIVE_SEED_FOOTPRINT = (6.0, 6.0)  # A1: deriveGeo perspective constant �
 _MAP_FRAME_W = 100.0  # MAP_IMAGE_FRAME width (geo-tap.ts)
 _COMPLEX_FRAC, _TINY_FRAC = 0.10, 0.02
 
+# "Another angle" on re-enter: each repeat enter of the same place rotates the
+# scene camera one step, so a revisit is seen from a new side instead of the
+# same view redrawn. 90° → four cardinal views before it wraps.
+_AZIMUTH_STEP_DEG = 90.0
+
+
+def azimuth_for_enter_index(enter_index: int | None) -> float | None:
+    """The scene azimuth for the Nth enter of a place, or None to leave it
+    unstated. The first enter (0/None) keeps today's default facing — no azimuth
+    clause, byte-identical; each subsequent enter rotates one _AZIMUTH_STEP_DEG
+    step (wrapping at 360°), the only signal the 'another angle' feature adds."""
+    if not enter_index or enter_index <= 0:
+        return None
+    return (_AZIMUTH_STEP_DEG * float(enter_index)) % 360.0
+
 
 def _spec(
     projection: str,
@@ -108,12 +123,17 @@ def default_view(
     subject_context: str | None = None,
     focus_kind: str | None = None,
     focus_footprint: tuple[float, float] | None = None,
+    enter_index: int = 0,
 ) -> ViewSpec | None:
     """The deliberate camera for a render, or None (legacy bytes).
 
     enter_as is accepted but no cell branches on it — render_mode already
     encodes the same decision; a second switch for the same fact is how the
-    audit's dead gates were born."""
+    audit's dead gates were born.
+
+    enter_index > 0 rotates a SCENE enter to another angle (the 'another angle'
+    feature); 0 (the default) is byte-identical. Only place_scene consumes it —
+    maps stay north-locked."""
     del enter_as
     rmode = (render_mode or "").strip().lower()
     if rmode == "scale_parent":
@@ -131,6 +151,7 @@ def default_view(
             focus_kind,
             focus_footprint,
             from_closeup=from_closeup,
+            enter_index=enter_index,
         )
     if rmode == "place_closeup":
         # A closeup of something inside a SCENE: the reference pixels dictate
@@ -156,6 +177,39 @@ def default_view(
 
 
 def _scene_view(
+    level: str | None,
+    scale_tier: str | None,
+    place_form: str | None,
+    subject: str | None,
+    subject_context: str | None,
+    focus_kind: str | None,
+    focus_footprint: tuple[float, float] | None,
+    from_closeup: bool = False,
+    enter_index: int = 0,
+) -> ViewSpec | None:
+    """The scene camera, rotated to a new side on re-enter. The projection
+    cascade lives in _scene_base; this wrapper only stamps the 'another angle'
+    azimuth (eye_level + oblique scene specs carry none by default, so a first
+    enter is byte-identical)."""
+    base = _scene_base(
+        level,
+        scale_tier,
+        place_form,
+        subject,
+        subject_context,
+        focus_kind,
+        focus_footprint,
+        from_closeup=from_closeup,
+    )
+    if base is None:
+        return None
+    az = azimuth_for_enter_index(enter_index)
+    if az is not None:
+        base["azimuth_deg"] = az  # fresh dict from _spec each call — safe to stamp
+    return base
+
+
+def _scene_base(
     level: str | None,
     scale_tier: str | None,
     place_form: str | None,

--- a/apps/modal-backend/tests/test_view_policy.py
+++ b/apps/modal-backend/tests/test_view_policy.py
@@ -20,3 +20,72 @@ def test_enter_from_closeup_descends_to_ground_level() -> None:
         place_form="complex",
     )
     assert base is not None and base["projection"] == "oblique"
+
+
+def test_azimuth_for_enter_index_rotates_only_on_revisit() -> None:
+    """The 'another angle' schedule: the first enter (0/None) states no azimuth
+    (byte-identical to today); each re-enter rotates the camera one 90° step,
+    wrapping at four."""
+    from providers.prompt_library import policy
+
+    assert policy.azimuth_for_enter_index(None) is None
+    assert policy.azimuth_for_enter_index(0) is None
+    assert policy.azimuth_for_enter_index(1) == 90.0
+    assert policy.azimuth_for_enter_index(2) == 180.0
+    assert policy.azimuth_for_enter_index(3) == 270.0
+    assert policy.azimuth_for_enter_index(4) == 0.0  # wraps back to north
+
+
+def test_scene_enter_first_view_has_no_azimuth_then_rotates() -> None:
+    """First enter: byte-identical (no azimuth on the scene spec). Re-enter:
+    the same place + projection, rotated to a new side."""
+    from providers.prompt_library import policy
+
+    first = policy.default_view(
+        render_mode="place_scene", world_mode=True, place_form="interior"
+    )
+    assert first is not None and first["projection"] == "eye_level"
+    assert "azimuth_deg" not in first  # unchanged first view
+
+    second = policy.default_view(
+        render_mode="place_scene", world_mode=True, place_form="interior", enter_index=1
+    )
+    assert second is not None and second["projection"] == "eye_level"
+    assert second["azimuth_deg"] == 90.0  # same place, now facing east
+
+
+def test_oblique_establishing_also_rotates_on_revisit() -> None:
+    """Rotation applies to the establishing (aerial) register too — another
+    compass side of the complex, not just interiors."""
+    from providers.prompt_library import policy
+
+    rot = policy.default_view(
+        render_mode="place_scene", world_mode=True, place_form="complex", enter_index=2
+    )
+    assert rot is not None and rot["projection"] == "oblique"
+    assert rot["azimuth_deg"] == 180.0
+
+
+def test_top_down_map_is_north_locked_despite_enter_index() -> None:
+    """Maps are the north-at-top pin — a stray enter_index must never spin a
+    plan map off its locked azimuth 0."""
+    from providers.prompt_library import policy
+
+    m = policy.default_view(
+        render_mode="place_submap", world_mode=True, has_region=False, enter_index=3
+    )
+    assert m is not None and m["projection"] == "top_down"
+    assert m["azimuth_deg"] == 0.0
+
+
+def test_rotated_enter_instruction_states_the_new_facing() -> None:
+    """End-to-end through the prompt builder: the rotated azimuth surfaces as a
+    'facing <compass>' clause (90° → east), no instruction-builder change."""
+    from providers import image_edit
+    from providers.prompt_library import policy
+
+    view = policy.default_view(
+        render_mode="place_scene", world_mode=True, place_form="interior", enter_index=1
+    )
+    text = image_edit.build_enter_instruction("The Hall", ["a long table"], view=view).lower()
+    assert "facing" in text and "east" in text

--- a/apps/web/lib/world-geo-schema.test.ts
+++ b/apps/web/lib/world-geo-schema.test.ts
@@ -54,6 +54,7 @@ const sceneView: SceneView = {
   focus_id: "g1",
   scale_tier: "city",
   view: viewSpec,
+  enter_index: 0,
 };
 const projectedEntity: ProjectedEntity = {
   id: "g1",

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -684,6 +684,10 @@ export interface SceneView {
   // The deliberate camera for this render (the view grammar). Absent/null on
   // legacy nodes â the pre-grammar hardcoded behavior, byte-identical.
   view?: ViewSpec | null;
+  // How many times this place has already been entered (the client's revisit
+  // count). >0 rotates the scene camera to another angle under
+  // ENTER_AZIMUTH_ROTATE; absent/0 is byte-identical.
+  enter_index?: number | null;
 }
 
 // One entity's projected place in a rendered frame (geometry-engine output),

--- a/packages/config/src/world-geo-fixture.json
+++ b/packages/config/src/world-geo-fixture.json
@@ -54,7 +54,8 @@
       "focus_id",
       "scale_tier",
       "view",
-      "closeup"
+      "closeup",
+      "enter_index"
     ],
     "ProjectedEntity": [
       "id",
@@ -182,7 +183,8 @@
         "fov_deg": 90,
         "source": "user"
       },
-      "closeup": false
+      "closeup": false,
+      "enter_index": 0
     },
     "ProjectedEntity": {
       "id": "g1",


### PR DESCRIPTION
## What

Re-entering a place used to redraw the same view. Now — gated behind **`ENTER_AZIMUTH_ROTATE`** (default **OFF**) — each repeat enter rotates the scene camera one 90° step, so a revisited place is seen from a **new side**. The deferred B2 sketch: `enter_index → azimuth_deg`, view-bench gated.

## The seam (why it's small)

Policy's scene specs (`eye_level` / `oblique`) carry **no azimuth** by default, and the prompt builder already renders `azimuth_deg` — "facing east" for eye_level, "from the west" for oblique. So the whole feature is **one pure policy function** — zero instruction-builder change.

- **`policy.azimuth_for_enter_index(i)`** — `None` for the first enter (`0`/`None` → byte-identical), else `(90·i) % 360`. `_scene_view` refactored into `_scene_base` (the projection cascade, untouched) + a thin wrapper that stamps the azimuth. `default_view` gains `enter_index` — only `place_scene` consumes it, so **maps stay north-locked** at azimuth 0.
- **`generate.py`** — `_view_spec_for` reads `scene_view.enter_index`, flag-gated, and threads it. `SceneView` gains `enter_index` (Pydantic + TS interface + `world-geo-fixture` + both parity twins; **P0 green**).
- **`.env.example`** documents the flag.

## Validation

**Free:** 6 policy tests (rotation schedule, first-enter-unchanged, oblique rotates too, maps north-locked, instruction states the new facing) + an instruction-diff proving every index yields a distinct, projection-correct clause; **web tsc + full backend suite + both schema-parity twins green**.

**Paid probe** (one-off, not committed) — re-entering *Stonewatch Castle*:

| enter_index | clause | same_place |
|---|---|---|
| 0 | *(none — unchanged)* | 9/10 |
| 1 (eye_level) | "facing east" | 9/10 |
| 1 (oblique) | "from the west" | 10/10 |

The `enter_index=1` render shows the **same castle / river / town** from a clearly rotated 3/4 angle — rotation gives a new viewpoint while holding identity.

| first enter | re-enter (facing east) |
|---|---|
| head-on, walls + gatehouse straight ahead | same castle from a rotated 3/4 angle — great hall on the left, river curving away, town to the right |

## Follow-up (not in this PR)

The client computing + sending `enter_index` from its revisit count. The backend **honours it today** (flag on + wire field); nothing sends it yet — so this ships dark, validated, ready to wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)