### PR TITLE
fix(image): retry empty OpenRouter image responses instead of erroring

### DIFF
--- a/apps/modal-backend/providers/image.py
+++ b/apps/modal-backend/providers/image.py
@@ -36,6 +36,15 @@ from tenacity import (
 # provider provenance in final.image_model.
 OPENROUTER_IMAGE_PREFIX = "openrouter:"
 
+
+class _EmptyImageResponse(RuntimeError):
+    """An OpenRouter image model answered with no image (empty `images`,
+    `content=None`). Empirically TRANSIENT for riverflow/recraft — a soft refusal
+    or a backend hiccup that clears on a retry — so _is_retryable treats it as
+    retryable. Stays a RuntimeError so the after-3-retries reraise and any
+    RuntimeError-catching caller behave exactly as before."""
+
+
 TIER_MODELS: dict[str, str] = {
     "fast":     "fal-ai/nano-banana",
     "balanced": "fal-ai/nano-banana-pro",
@@ -556,10 +565,11 @@ async def _openrouter_image(
             msg = (resp.model_dump().get("choices") or [{}])[0].get("message") or {}
             images = msg.get("images") or []
             if not images:
-                # Malformed/empty responses fail fast (RuntimeError is not
-                # retryable) — mirrors _first_image on the fal path.
+                # Empty responses are TRANSIENT for these models — retry within
+                # this loop (_EmptyImageResponse is retryable); only the 3rd
+                # empty in a row reraises to the caller's failover / error frame.
                 content = str(msg.get("content"))[:160]
-                raise RuntimeError(
+                raise _EmptyImageResponse(
                     f"openrouter image model returned no image (content={content!r})"
                 )
             url = str((images[0].get("image_url") or {}).get("url") or "")
@@ -589,6 +599,8 @@ def _is_retryable(exc: BaseException) -> bool:
     `openrouter:` image path) likewise wraps transport errors in its own
     types. Falls back to httpx exceptions for the post-fal CDN download path.
     """
+    if isinstance(exc, _EmptyImageResponse):
+        return True  # a no-image response is a transient model hiccup — retry it
     if isinstance(exc, fal_client.FalClientHTTPError):
         code = exc.status_code
         return code == 429 or 500 <= code < 600

--- a/apps/modal-backend/tests/test_image_provider.py
+++ b/apps/modal-backend/tests/test_image_provider.py
@@ -558,3 +558,14 @@ def test_retryable_openai_connection_error() -> None:
     req = httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions")
     err = openai.APIConnectionError(request=req)
     assert image._is_retryable(err) is True
+
+
+def test_retryable_empty_openrouter_image_response() -> None:
+    # An empty image response (riverflow hiccup / soft refusal — the "pro" tier's
+    # `content='None'` error) is TRANSIENT: it must RETRY inside _openrouter_image
+    # rather than fail straight to the user's red banner.
+    exc = image._EmptyImageResponse("returned no image (content='None')")
+    assert image._is_retryable(exc) is True
+    # …but it stays a RuntimeError, so anything catching RuntimeError (and the
+    # after-3-retries reraise) behaves exactly as before.
+    assert isinstance(exc, RuntimeError)


### PR DESCRIPTION
## The bug

The **"pro" image tier** maps to `openrouter:sourceful/riverflow-v2.5-pro`. When riverflow occasionally returns an **empty** response (no `images`, `content=None` — a soft refusal or a transient backend hiccup), `_openrouter_image` raised a plain `RuntimeError` that `_is_retryable` rejected. So:

- the 3× retry loop **did not retry** it (it only catches network transients), and
- `PROVIDER_FALLBACK` is **off by default**, so there was no fallback either.

→ one flaky empty response went straight to the user's red banner: *"openrouter image model returned no image (content='None')"*. (Reported in-app on the pro tier.)

## The fix

Make the empty response a dedicated **`_EmptyImageResponse(RuntimeError)`** that `_is_retryable` treats as **retryable**. The existing 3-attempt exponential-backoff loop now retries it — empties almost always clear on the next attempt. Only the 3rd consecutive empty reraises (to the `PROVIDER_FALLBACK` chain if enabled, else the error frame — same as before). Subclassing `RuntimeError` keeps the after-retries path and any `RuntimeError`-catching caller byte-identical.

## For zero error frames (operator knobs)

- `PROVIDER_FALLBACK=1` → a persistently-failing riverflow falls over to fal `nano-banana-pro` (a degraded page beats a red banner — the intended safety net), or
- `FAL_IMAGE_MODEL_PRO=fal-ai/nano-banana-pro` → pin the pro tier off OpenRouter entirely.

## Test
`_is_retryable(_EmptyImageResponse)` is `True` and it remains a `RuntimeError`. 82 image-provider tests + ruff + mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)