### PR TITLE
fix(image): restore riverflow as the pro tier (undo the #105 quality downgrade)

### DIFF
--- a/apps/modal-backend/providers/image.py
+++ b/apps/modal-backend/providers/image.py
@@ -48,14 +48,15 @@ class _EmptyImageResponse(RuntimeError):
 TIER_MODELS: dict[str, str] = {
     "fast":     "fal-ai/nano-banana",
     "balanced": "fal-ai/nano-banana-pro",
-    # Pro = a RELIABLE fal model. The bakeoff quality winner (riverflow-v2.5-pro,
-    # docs/research/07) is ~150s/gen on OpenRouter and intermittently returns an
-    # empty response (content=None) — a bad production default that broke fresh
-    # pro-tier map gen ("no image" / a 300s proxy-timeout "network error"). Layout
-    # fidelity is saturated across the field, so the marginal quality wasn't worth
-    # the unreliability. Opt back into riverflow (now protected by the fal failover
-    # + SSE heartbeat) with FAL_IMAGE_MODEL_PRO=openrouter:sourceful/riverflow-v2.5-pro.
-    "pro":      "fal-ai/nano-banana-pro",
+    # Pro = the bakeoff QUALITY winner (docs/research/07: "richest detail", held
+    # the medium best — the dense, intricate maps). It's slow (~150-290s) and
+    # occasionally returns an empty response, but it is NOW reliable: a single
+    # slow gen survives the proxy's 300s body timeout via the SSE keepalive
+    # (generate._with_heartbeat), and a true empty FAILS FAST → fal failover
+    # (nano-banana-pro) in seconds (not the 5-min hang #104 caused). Override to a
+    # fast fal model with FAL_IMAGE_MODEL_PRO=fal-ai/nano-banana-pro if you'd rather
+    # trade detail for speed.
+    "pro":      "openrouter:sourceful/riverflow-v2.5-pro",
 }
 TIER_ENV_KEYS: dict[str, str] = {
     "fast":     "FAL_IMAGE_MODEL_FAST",

--- a/apps/modal-backend/tests/test_image_provider.py
+++ b/apps/modal-backend/tests/test_image_provider.py
@@ -54,20 +54,19 @@ def test_resolve_model_legacy_env_falls_through() -> None:
     assert out == image.TIER_MODELS["balanced"]
 
 
-def test_pro_tier_defaults_to_a_reliable_fal_model_not_riverflow() -> None:
-    """The pro tier must default to a fal model — NOT the slow/flaky
-    `openrouter:` riverflow that broke fresh pro-tier map gen. Riverflow stays
-    opt-in via FAL_IMAGE_MODEL_PRO."""
-    resolved = image._resolve_model("pro", None)
-    assert resolved == "fal-ai/nano-banana-pro"
-    assert not resolved.startswith(image.OPENROUTER_IMAGE_PREFIX)
+def test_pro_tier_defaults_to_riverflow_the_quality_winner() -> None:
+    """Pro = riverflow (bakeoff quality winner — the dense, detailed maps). It's
+    slow/occasionally-empty but now reliable via the SSE heartbeat + fail-fast
+    fal failover. Trade detail for speed via FAL_IMAGE_MODEL_PRO."""
+    assert image._resolve_model("pro", None) == "openrouter:sourceful/riverflow-v2.5-pro"
+    assert image.TIER_MODELS["pro"].startswith(image.OPENROUTER_IMAGE_PREFIX)
 
 
-def test_pro_tier_can_opt_back_into_riverflow_via_env(
+def test_pro_tier_can_opt_into_fast_fal_via_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("FAL_IMAGE_MODEL_PRO", "openrouter:sourceful/riverflow-v2.5-pro")
-    assert image._resolve_model("pro", None) == "openrouter:sourceful/riverflow-v2.5-pro"
+    monkeypatch.setenv("FAL_IMAGE_MODEL_PRO", "fal-ai/nano-banana-pro")
+    assert image._resolve_model("pro", None) == "fal-ai/nano-banana-pro"
 
 
 def test_resolve_model_legacy_env_used_for_unset_tier(
@@ -483,10 +482,7 @@ async def test_generate_image_routes_openrouter_prefix_without_fal_key(
         return sentinel
 
     monkeypatch.setattr(image, "_openrouter_image", fake_or)
-    # pro now defaults to fal, so drive the openrouter path via model_override
-    out = await image.generate_image(
-        "a map", "16:9", model_override="openrouter:sourceful/riverflow-v2.5-pro"
-    )
+    out = await image.generate_image("a map", "16:9", tier="pro")  # pro = riverflow
     assert out is sentinel
     assert seen["slug"] == "sourceful/riverflow-v2.5-pro"  # prefix stripped
     assert seen["aspect"] == "16:9"


### PR DESCRIPTION
## Owning it

In #105 I bundled a real reliability fix with a model swap I should never have made: `TIER_MODELS["pro"]` went from `openrouter:sourceful/riverflow-v2.5-pro` → `fal-ai/nano-banana-pro`. The bakeoff (`docs/research/07`) calls riverflow **"richest detail"** and nano-banana-pro **"lower detail"** — same prompt, same params, so the sparse maps were purely the swap.

## Fix

Restore **pro = riverflow** (the dense, detailed maps). Slowness/empties are now handled without sacrificing quality, by #105's machinery:
- `generate._with_heartbeat` — SSE keepalive so a ~290 s riverflow gen survives the 300 s proxy body timeout (no "network error").
- fail-fast `_EmptyImageResponse` + forced fal failover → a true empty degrades to fal in seconds, not a 5-min hang.

`FAL_IMAGE_MODEL_PRO=fal-ai/nano-banana-pro` trades detail for speed. Tests + ruff green; backend container rebuilt + verified in-container (`pro -> riverflow`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)