### PR TITLE
fix(play): tap-hint no longer hides behind the Pin-style / localize buttons

### DIFF
--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -3668,8 +3668,10 @@ export default function PlayPage() {
                 style={editFormStyle}
               />
             ) : (
-              <figcaption className="absolute bottom-0 left-0 right-0 bg-black/50 px-4 py-2 text-sm text-white">
-                {t.tapHint}
+              <figcaption className="pointer-events-none absolute inset-x-0 bottom-3 flex justify-center text-sm text-white">
+                <span className="max-w-[60%] truncate rounded-full bg-black/55 px-3 py-1 backdrop-blur">
+                  {t.tapHint}
+                </span>
               </figcaption>
             )}
           </div>


### PR DESCRIPTION
The "Tap anywhere on the image to explore" hint was a full-width, **left-aligned** bar at `bottom-0`, while the **📌 Pin style** button (`bottom-3 start-3`) and the geo **"localize now"** button (bottom-right) floated on top of it — covering the hint text (only *"…e on the image to explore."* showed).

Fix: center the hint as a self-contained pill at `bottom-3` (same row as the corner buttons, but in the middle where nothing overlaps), `max-w-[60%] truncate`, and `pointer-events-none` so taps on the bottom strip still explore the image. Pre-existing layout bug, not from the recent PRs. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)