### PR TITLE
test(play): lock the tap-hint anti-overlap fix (unit + e2e)

### DIFF
--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -61,6 +61,7 @@ import { useTraceEmitter } from "@/hooks/useTraceEmitter";
 import { QueryToolbar } from "@/components/PlayPage/QueryToolbar";
 import { StyleGallery } from "@/components/PlayPage/StyleGallery";
 import { FirstRunCoach } from "@/components/PlayPage/FirstRunCoach";
+import { TapHint } from "@/components/PlayPage/TapHint";
 import { BloomGlyph } from "@/components/PlayPage/BloomGlyph";
 import { MorphImagePair } from "@/components/PlayPage/MorphImagePair";
 import { StrokeOverlay } from "@/components/PlayPage/StrokeOverlay";
@@ -3668,11 +3669,7 @@ export default function PlayPage() {
                 style={editFormStyle}
               />
             ) : (
-              <figcaption className="pointer-events-none absolute inset-x-0 bottom-3 flex justify-center text-sm text-white">
-                <span className="max-w-[60%] truncate rounded-full bg-black/55 px-3 py-1 backdrop-blur">
-                  {t.tapHint}
-                </span>
-              </figcaption>
+              <TapHint text={t.tapHint} />
             )}
           </div>
         </figure>

--- a/apps/web/components/PlayPage/TapHint.test.tsx
+++ b/apps/web/components/PlayPage/TapHint.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { TapHint } from "./TapHint";
+
+/**
+ * The tap-hint used to be a full-width, left-aligned bar that the bottom-corner
+ * buttons (📌 Pin style / "localize now") sat on top of, hiding the text. These
+ * pin the three properties of the fix so it can't silently regress.
+ */
+describe("TapHint", () => {
+  it("renders the hint copy", () => {
+    render(<TapHint text="Tap anywhere on the image to explore." />);
+    expect(screen.getByText(/tap anywhere on the image to explore/i)).toBeTruthy();
+  });
+
+  it("does not capture pointer events — a tap on the bottom strip still explores", () => {
+    const { container } = render(<TapHint text="x" />);
+    const cap = container.querySelector("figcaption");
+    expect(cap?.className).toContain("pointer-events-none");
+  });
+
+  it("is centered so it clears the bottom-corner buttons", () => {
+    const { container } = render(<TapHint text="x" />);
+    expect(container.querySelector("figcaption")?.className).toContain("justify-center");
+  });
+
+  it("wraps the copy in a readable, truncating pill (its own background, capped width)", () => {
+    const { container } = render(<TapHint text="x" />);
+    const pill = container.querySelector("figcaption > span");
+    expect(pill?.className).toContain("truncate");
+    expect(pill?.className).toMatch(/bg-black\/\d+/); // own backdrop so it's legible over any art
+    expect(pill?.className).toMatch(/max-w-/); // doesn't stretch into the corners
+  });
+});

--- a/apps/web/components/PlayPage/TapHint.tsx
+++ b/apps/web/components/PlayPage/TapHint.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+interface Props {
+  /** The localised hint copy (i18n `tapHint`). */
+  text: string;
+}
+
+/**
+ * The "Tap anywhere on the image to explore" hint. A CENTERED, self-contained
+ * pill at the bottom of the image — three properties matter and are pinned by
+ * TapHint.test.tsx:
+ *  - `pointer-events-none` so a tap on the bottom strip still explores the image
+ *    instead of dying on the caption,
+ *  - `justify-center` so it sits in the middle, clear of the bottom-corner
+ *    buttons (📌 Pin style on the left, "localize now" on the right) that used to
+ *    cover the old full-width left-aligned bar,
+ *  - a truncating pill with its own background so it stays readable over any art.
+ */
+export function TapHint({ text }: Props) {
+  return (
+    <figcaption className="pointer-events-none absolute inset-x-0 bottom-3 flex justify-center text-sm text-white">
+      <span className="max-w-[60%] truncate rounded-full bg-black/55 px-3 py-1 backdrop-blur">
+        {text}
+      </span>
+    </figcaption>
+  );
+}

--- a/apps/web/e2e/bottom-ui.spec.ts
+++ b/apps/web/e2e/bottom-ui.spec.ts
@@ -1,0 +1,43 @@
+import { type Locator, expect, test } from "@playwright/test";
+
+import { waitForStableImage } from "./helpers";
+
+type Box = { x: number; y: number; width: number; height: number };
+
+function overlaps(a: Box, b: Box): boolean {
+  return !(
+    a.x + a.width <= b.x ||
+    b.x + b.width <= a.x ||
+    a.y + a.height <= b.y ||
+    b.y + b.height <= a.y
+  );
+}
+
+async function box(loc: Locator): Promise<Box> {
+  const b = await loc.boundingBox();
+  expect(b, "element must have a bounding box").not.toBeNull();
+  return b!;
+}
+
+// Regression guard for the tap-hint hiding behind the bottom-corner buttons.
+// The hint used to be a full-width left-aligned bar that "📌 Pin style" (and the
+// geo "localize now" button) sat on top of. It is now a centered pill — assert
+// it shares the row with those buttons but never overlaps them.
+test("tap-hint pill stays clear of the bottom-corner buttons", async ({ page }) => {
+  await page.goto("/play?q=" + encodeURIComponent("a quiet harbour at dawn"));
+  await waitForStableImage(page);
+
+  const hint = page.getByText(/tap anywhere on the image to explore/i);
+  const pin = page.getByRole("button", { name: /^Pin style$/ });
+
+  await expect(hint).toBeVisible();
+  await expect(pin).toBeVisible();
+
+  const hintBox = await box(hint);
+  const pinBox = await box(pin);
+
+  expect(
+    overlaps(hintBox, pinBox),
+    "the tap-hint must not overlap the Pin-style button",
+  ).toBe(false);
+});


### PR DESCRIPTION
Regression guards for the bottom tap-hint hiding behind the corner buttons (fixed in #107).

- Extracts the hint into a `<TapHint>` component — **rendered output is byte-identical** to the inline #107 figcaption, so the deployed fix is unchanged; this just makes it testable.
- **`TapHint.test.tsx`** (vitest): pins the three properties of the fix — `pointer-events-none` (a bottom-strip tap still explores), `justify-center` (clears the corner buttons), and a truncating pill with its own background (readable, capped width).
- **`e2e/bottom-ui.spec.ts`** (Playwright): generates a page and asserts the tap-hint pill's bounding box does **not** intersect the "Pin style" button's — the actual overlap the fix addresses. Runs in CI's `e2e-mock` (can't run against the live riverflow stack — its ~290 s gen exceeds the 240 s e2e timeout).

Unit 4/4 · full web suite **640 green** · tsc clean · e2e spec discovered. No container rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)