### PR TITLE
perf(image): drop the inert fal ref-upload on the fresh-gen path

### DIFF
--- a/apps/modal-backend/providers/image.py
+++ b/apps/modal-backend/providers/image.py
@@ -147,20 +147,20 @@ def _args_for(
             "prompt": prompt,
             "image_size": SEEDREAM_SIZE_MAP.get(aspect_ratio, "landscape_16_9"),
         }
-    # nano-banana + nano-banana-pro accept aspect_ratio directly, plus an optional
-    # `image_urls` list. NOTE (verified via scripts/verify-fal-models.py): NO image
-    # model in use accepts `negative_prompt` (nano-banana, nano-banana-pro and
-    # flux-pro/kontext all omit it) — so we never send one; the MEDIUM LOCK in the
-    # prompt text is the model-agnostic style guard. And the text-to-image nano
-    # endpoints accept `image_urls` but IGNORE it — an empirical test (a photoreal
-    # prompt + an engraving ref came back still-photoreal) confirms fresh-gen image
-    # conditioning is a no-op here; refs only bite on the edit/continue endpoints
-    # (nano-banana/edit takes image_urls, kontext a singular image_url). We still
-    # pass them (harmless, future-proof), but the prompt TEXT does the real work.
-    args: dict[str, Any] = {"prompt": prompt, "aspect_ratio": aspect_ratio}
-    if reference_urls and "nano-banana" in model:
-        args["image_urls"] = reference_urls
-    return args
+    # nano-banana + nano-banana-pro accept aspect_ratio directly. NOTE (verified
+    # via scripts/verify-fal-models.py): NO image model in use accepts
+    # `negative_prompt` (nano-banana, nano-banana-pro and flux-pro/kontext all
+    # omit it) — so we never send one; the MEDIUM LOCK in the prompt text is the
+    # model-agnostic style guard. The text-to-image nano endpoints DO accept
+    # `image_urls`, but they IGNORE it — an empirical test (a photoreal prompt +
+    # an engraving ref came back still-photoreal) proved fresh-gen image
+    # conditioning is a no-op. So fresh-gen never sends image_urls (and never
+    # uploads refs — see _generate_with_slug); `reference_urls` is kept on the
+    # signature for parity with callers but is unused here. Real reference
+    # conditioning lives only on the edit/continue endpoints in image_edit.py
+    # (nano-banana/edit takes image_urls, kontext a singular image_url); on this
+    # path the prompt TEXT does all the work.
+    return {"prompt": prompt, "aspect_ratio": aspect_ratio}
 
 
 def conditioning_preamble(roles: list[str], mode: str) -> str:
@@ -306,23 +306,21 @@ async def _generate_with_slug(
         return generated
 
     _ensure_fal_key()
-    # Reference conditioning: upload each data URL to fal storage (queue
-    # endpoints choke on multi-MB inline data URLs) and pass them as image_urls.
-    # Only nano-banana accepts refs; other fal models stay text-only.
-    fal_refs: list[str] | None = None
-    if reference_urls and "nano-banana" in model:
-        from ._common import to_fal_url
-
-        fal_refs = [await to_fal_url(u) for u in reference_urls]
+    # Fresh-gen is text-to-image only: the nano text-to-image endpoints accept
+    # `image_urls` but IGNORE it (empirically verified — see _args_for), so we
+    # neither upload the refs to fal storage nor pass them. `reference_urls` is
+    # still accepted (callers thread it through generate_image) but is a no-op
+    # here; genuine reference conditioning lives on the edit/continue endpoints
+    # in image_edit.py. The prompt TEXT carries style/continuity on this path.
     async with span(
         "image.generate",
         model=model,
         prompt_len=len(prompt),
         provider="fal",
-        refs=len(fal_refs or []),
+        refs=0,
     ) as ctx:
         result = await _fal_subscribe(
-            model, _args_for(model, prompt, aspect_ratio, fal_refs)
+            model, _args_for(model, prompt, aspect_ratio)
         )
         image_info = _first_image(result)
         jpeg_bytes, mime = await _fetch_image_bytes(image_info)

--- a/apps/modal-backend/tests/test_image_provider.py
+++ b/apps/modal-backend/tests/test_image_provider.py
@@ -97,11 +97,12 @@ def test_args_for_nano_banana_passes_aspect() -> None:
 # --- image conditioning (multi-reference) -----------------------------------
 
 
-def test_args_for_nano_banana_includes_reference_urls() -> None:
+def test_args_for_nano_banana_ignores_reference_urls() -> None:
+    # Fresh-gen is a no-op for refs: the nano text-to-image endpoint ignores
+    # image_urls, so _args_for must never emit it (see image.py comment).
     args = image._args_for("fal-ai/nano-banana-pro", "p", "16:9", ["u1", "u2"])
-    assert args["prompt"] == "p"
-    assert args["aspect_ratio"] == "16:9"
-    assert args["image_urls"] == ["u1", "u2"]
+    assert args == {"prompt": "p", "aspect_ratio": "16:9"}
+    assert "image_urls" not in args
 
 
 def test_args_for_seedream_ignores_reference_urls() -> None:
@@ -120,13 +121,17 @@ def test_args_for_nano_banana_empty_refs_unchanged() -> None:
     }
 
 
-async def test_generate_image_uploads_and_passes_reference_urls(
+async def test_generate_image_ignores_reference_urls_on_fresh_gen(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Fresh-gen no longer uploads refs to fal nor passes image_urls (the nano
+    # text-to-image endpoint ignores them). Refs supplied -> still text-only.
     monkeypatch.setenv("FAL_KEY", "fk")
     captured: dict = {}
+    uploaded: list[str] = []
 
     async def fake_to_fal(data_url: str) -> str:
+        uploaded.append(data_url)
         return f"fal://{data_url[-1]}"
 
     async def fake_sub(model: str, args: dict) -> dict:
@@ -144,8 +149,8 @@ async def test_generate_image_uploads_and_passes_reference_urls(
         "a cat", "16:9", reference_urls=["data:a", "data:b"]
     )
     assert out.jpeg_bytes == b"jpeg"
-    # Data URLs uploaded to fal storage, the resulting URLs passed as image_urls.
-    assert captured["args"]["image_urls"] == ["fal://a", "fal://b"]
+    assert uploaded == []  # no wasted fal upload on fresh-gen
+    assert "image_urls" not in captured["args"]
 
 
 def test_conditioning_preamble_orders_signals_for_tap() -> None:


### PR DESCRIPTION
## What
The nano-banana(-pro) text-to-image endpoints accept `image_urls` but IGNORE them (verified no-op) — real reference conditioning lives only on the edit/continue endpoints in `image_edit.py`. `_generate_with_slug` was uploading reference images to fal storage and passing `image_urls` for nothing: one wasted fal upload per fresh page.

## Change
Stop uploading + passing refs on the **fresh-gen path only** (`providers/image.py`). Edit/continue/inpaint untouched. Comments + tests updated to lock the no-op.

## Verification
`make eval` green (backend pytest/ruff/mypy + web vitest 640 tests/tsc + no circular deps). Independent review confirmed `_generate_with_slug` is fresh-gen-only and no reachable model honors `image_urls` on text-to-image.

## Follow-up (separate)
`model_router.py:152-154` still advertises `supports_refs=true` for nano-banana to the frontend picker — now factually wrong (picker metadata only, no routing impact).