### PR TITLE
fix: bug sweep — spend under-count, geo-id data loss, prefetch budget, ratelimit LRU

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -1387,6 +1387,9 @@ async def _event_stream(
             data_url = await _asyncio.to_thread(
                 image_provider.encode_data_url, img.jpeg_bytes, img.mime_type
             )
+            # Spend accounting: this OUTWARD hop made a real paid image call —
+            # record it (like the tap/draft paths) so the cap actually counts it.
+            spend.record_generation(body.session_id, img.model)
             yield _sse(
                 {
                     "type": "ascend_ready",
@@ -1462,6 +1465,9 @@ async def _event_stream(
                         data_url = await _asyncio.to_thread(
                             image_provider.encode_data_url, img.jpeg_bytes, img.mime_type
                         )
+                        # Spend accounting: each map-pan tile is a real paid image
+                        # edit — record it so the cap counts these concurrent calls.
+                        spend.record(body.session_id, spend.estimate_image(img.model))
                         emitted += 1
                         yield _sse(
                             {
@@ -1572,6 +1578,9 @@ async def _event_stream(
                     data_url = await _asyncio.to_thread(
                         image_provider.encode_data_url, img.jpeg_bytes, img.mime_type
                     )
+                    # Spend accounting: each bloom neighbour is a real plan+image
+                    # generation — record it so the cap counts the concurrent fan-out.
+                    spend.record_generation(body.session_id, img.model)
                     emitted += 1
                     yield _sse(
                         {

--- a/apps/modal-backend/providers/ratelimit.py
+++ b/apps/modal-backend/providers/ratelimit.py
@@ -11,9 +11,10 @@ from __future__ import annotations
 import os
 import threading
 import time
+from collections import OrderedDict
 
 _lock = threading.Lock()
-_buckets: dict[str, tuple[float, float]] = {}  # ip -> (tokens, last_ts)
+_buckets: OrderedDict[str, tuple[float, float]] = OrderedDict()  # ip -> (tokens, last_ts)
 _MAX_BUCKETS = 4096
 
 
@@ -36,10 +37,15 @@ def allow(ip: str) -> bool:
         tokens = min(capacity, tokens + (now - last) * refill_per_s)
         if tokens < 1.0:
             _buckets[ip] = (tokens, now)
+            _buckets.move_to_end(ip)
             return False
         _buckets[ip] = (tokens - 1.0, now)
+        _buckets.move_to_end(ip)
         if len(_buckets) > _MAX_BUCKETS:
-            _buckets.pop(next(iter(_buckets)))
+            # Evict the least-recently-touched IP (LRU), not the oldest-inserted.
+            # A plain dict value-update keeps insertion order, so the old FIFO pop
+            # could evict (and full-reset) a heavy hitter still being limited.
+            _buckets.popitem(last=False)
         return True
 
 

--- a/apps/modal-backend/tests/test_generate_spend.py
+++ b/apps/modal-backend/tests/test_generate_spend.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -97,3 +98,35 @@ async def test_duplicate_generate_logged_not_blocked(
     events = await _collect(_event_stream(_query_body(), "t2"))
     assert any(e["type"] == "final" for e in events)  # second run still works
     assert gen.await_count == 2
+
+
+async def test_expand_records_spend_per_neighbour(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Regression: the expand bloom fans out real paid image generations but used
+    # to record ZERO spend, so the daily/session cap never counted the priciest
+    # (multi-image, concurrent) path.
+    _mock_providers(monkeypatch)
+    monkeypatch.setattr(
+        llm_mod,
+        "propose_neighbors",
+        AsyncMock(
+            return_value=[
+                SimpleNamespace(subject="a peer town", scale="peer"),
+                SimpleNamespace(subject="the region", scale="container"),
+            ]
+        ),
+    )
+    body = GenerateBody(
+        query="x",
+        session_id="s1",
+        web_search=False,
+        mode="expand",
+        image="data:image/jpeg;base64,AAAA",
+    )
+
+    events = await _collect(_event_stream(body, "t1"))
+
+    assert sum(1 for e in events if e["type"] == "neighbor") == 2
+    # Two neighbours, each = one nano-banana-pro image ($0.15) + the VLM flat.
+    assert spend.session_total("s1") == pytest.approx(2 * (0.15 + spend.VLM_STACK_FLAT))

--- a/apps/modal-backend/tests/test_ratelimit.py
+++ b/apps/modal-backend/tests/test_ratelimit.py
@@ -1,0 +1,27 @@
+"""Per-IP rate-limit bucket eviction must be LRU, not FIFO."""
+from __future__ import annotations
+
+import pytest
+
+from providers import ratelimit
+
+
+def test_eviction_is_lru_not_fifo(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A heavy hitter that keeps getting touched must NOT be the one evicted when
+    # the bucket table overflows. The old plain-dict FIFO pop evicted the
+    # oldest-INSERTED ip — resetting an actively-limited client to a full bucket.
+    monkeypatch.setenv("RATE_LIMIT_RPM", "240")  # capacity 60 -> every allow() passes
+    monkeypatch.setattr(ratelimit, "_MAX_BUCKETS", 2)
+    ratelimit.reset_for_tests()
+
+    assert ratelimit.allow("A")  # insert A
+    assert ratelimit.allow("B")  # insert B            -> table full {A, B}
+    assert ratelimit.allow("A")  # touch A (still busy) -> {B, A}
+    assert ratelimit.allow("C")  # insert C overflows   -> evict LRU = B
+
+    with ratelimit._lock:
+        live = set(ratelimit._buckets)
+    assert "A" in live  # heavy hitter survived (FIFO would have dropped it)
+    assert "C" in live
+    assert "B" not in live  # least-recently-touched got evicted
+    ratelimit.reset_for_tests()

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -2012,10 +2012,9 @@ export default function PlayPage() {
       inflight.clear();
       const ac = new AbortController();
       inflight.set(key, ac);
-      pageBucketCounts.set(
-        pageScope,
-        (pageBucketCounts.get(pageScope) ?? 0) + 1
-      );
+      // The per-page budget is consumed only on a SUCCESSFUL cache write below
+      // (mirroring the precompute path). Counting it up-front would let a few
+      // empty/failed resolves exhaust the budget and kill prefetch for the page.
       void (async () => {
         try {
           const res = await fetch("/api/resolve-click", {
@@ -2055,6 +2054,10 @@ export default function PlayPage() {
               ...(data.point ? { point: data.point } : {}),
               ...(data.bbox ? { bbox: data.bbox } : {}),
             });
+            pageBucketCounts.set(
+              pageScope,
+              (pageBucketCounts.get(pageScope) ?? 0) + 1
+            );
             // Bound the cache so a long session doesn't grow Map<> forever.
             // FIFO eviction is fine — cache entries are independent.
             while (cache.size > PREFETCH_LRU_MAX) {

--- a/apps/web/lib/world-map.test.ts
+++ b/apps/web/lib/world-map.test.ts
@@ -152,6 +152,19 @@ describe("applyEntityEdit (P5 structured geo edits)", () => {
     expect(added.height).toBeGreaterThan(0);
   });
 
+  it("add gives a unique id on slug collision so no user entity is dropped", () => {
+    // applyGeoUpsert / getWorldMap key entities by id (Map), so two adds that
+    // slug to the same base id used to collapse to one — silently dropping a
+    // source:"user" placement. Each add must now get a distinct id.
+    const a = applyEntityEdit([], { op: "add", label: "North Gate", pos: { x: 0, y: 0 } }, "t");
+    const b = applyEntityEdit(a, { op: "add", label: "north-gate", pos: { x: 9, y: 9 } }, "t");
+    const ids = b.map((e) => e.id);
+    expect(ids).toEqual(["geo_user_north_gate", "geo_user_north_gate_2"]);
+    expect(new Set(ids).size).toBe(2);
+    // Both survive the Map-by-id merge that used to drop one.
+    expect(applyGeoUpsert([], b, "t2")).toHaveLength(2);
+  });
+
   it("an edit targeting an unknown id is a no-op (never throws)", () => {
     const before = base();
     expect(applyEntityEdit(before, { op: "move", target: "nope", dx: 1, dy: 1 }, "t")).toEqual(before);

--- a/apps/web/lib/world-map.ts
+++ b/apps/web/lib/world-map.ts
@@ -194,8 +194,16 @@ export function applyEntityEdit(
   nowIso: string,
 ): WorldEntityGeo[] {
   if (edit.op === "add") {
+    // Unique id: applyGeoUpsert / getWorldMap key entities by id (Map-by-id), so
+    // a duplicate id silently drops one entity — and these are source:"user" adds
+    // we must never clobber. Two slug-colliding labels ("North Gate" vs
+    // "north-gate"), or re-adding an existing one, get a numeric suffix instead.
+    const baseId = `geo_user_${slugLabel(edit.label)}`;
+    const takenIds = new Set(entities.map((e) => e.id));
+    let uniqueId = baseId;
+    for (let n = 2; takenIds.has(uniqueId); n += 1) uniqueId = `${baseId}_${n}`;
     const added: WorldEntityGeo = {
-      id: `geo_user_${slugLabel(edit.label)}`,
+      id: uniqueId,
       entity_id: null,
       kind: "place",
       label: edit.label,


### PR DESCRIPTION
Four independent bugs from a cold-read audit (3 parallel reviewers), each **verified in the call graph** and **covered by a regression test**.

## 1. Spend under-counting on the priciest paths (real money)
`generate.py` — `expand` (bloom), `ascend`, and `expand`-map-pan make real paid fal image calls but recorded **$0 spend**. `MAX_DAILY_SPEND` / `MAX_SESSION_SPEND` are checked at stream entry but these branches never incremented the meter, so the caps under-enforced exactly on the most expensive (multi-image, concurrent) paths.
**Fix:** `spend.record*` on all three branches (mirrors the tap/draft pattern).
**Test:** `test_expand_records_spend_per_neighbour`.

## 2. User-placed geo entity silently dropped (data loss)
`world-map.ts` — `applyEntityEdit` `add` derived `id = geo_user_${slug(label)}` with no uniqueness check, but `applyGeoUpsert`/`getWorldMap` key entities by id (`new Map(...)`). Two slug-colliding labels (`"North Gate"` vs `"north-gate"`), or re-adding an existing one, collapse to one id — silently discarding a `source:"user"` placement the system promises never to clobber.
**Fix:** numeric suffix on id collision.
**Test:** `world-map.test.ts` collision case.

## 3. Hover-prefetch budget burned by failed resolves
`play/page.tsx` — `firePrefetch` incremented the per-page budget **before** the fetch, regardless of outcome, while the cache is written only on success. A few empty/unresolvable hovers exhausted `PREFETCH_PER_PAGE` and killed prefetch for the page's lifetime (the sibling precompute path does it correctly).
**Fix:** increment only on a successful cache write.

## 4. Rate-limit eviction was FIFO, not LRU
`ratelimit.py` — `_buckets` was a plain dict; a value-update doesn't reorder, so `pop(next(iter(...)))` evicted the oldest-*inserted* IP — potentially an active heavy hitter — resetting it to a full bucket.
**Fix:** `OrderedDict` + `move_to_end` on touch (LRU).
**Test:** `test_ratelimit.py`.

## Verification
`make eval` green — backend pytest/ruff/mypy + web vitest **641**/tsc + no circular deps.

## Deliberately deferred (separate follow-ups, not in this PR)
- `mse-player.ts` init-segment race (low confidence — hasn't surfaced in practice).
- Idempotency key never released on failed generation (mostly self-heals via fresh per-retry traceId).
- `model_router.py` `supports_refs=true` for nano-banana (stale picker metadata after #109).