### PR TITLE
fix: follow-ups — stale supports_refs metadata, idempotency-key release, MSE init race

### DIFF
--- a/apps/modal-backend/providers/model_router.py
+++ b/apps/modal-backend/providers/model_router.py
@@ -149,9 +149,12 @@ class ModelCaps:
 
 
 CAPABILITIES: tuple[tuple[str, ModelCaps], ...] = (
-    ("fal-ai/nano-banana-pro", ModelCaps("nano-banana-pro", True, True, True, 0.15, 25)),
-    ("fal-ai/nano-banana-2", ModelCaps("nano-banana-2", True, True, True, 0.08, 18)),
-    ("fal-ai/nano-banana", ModelCaps("nano-banana", True, True, False, 0.039, 10)),
+    # nano-banana text-to-image ACCEPTS but IGNORES image_urls on fresh gen
+    # (verified no-op; PR #109 removed the inert ref-upload) -> supports_refs=False.
+    # Real reference conditioning lives only on the /edit + continue endpoints.
+    ("fal-ai/nano-banana-pro", ModelCaps("nano-banana-pro", True, False, True, 0.15, 25)),
+    ("fal-ai/nano-banana-2", ModelCaps("nano-banana-2", True, False, True, 0.08, 18)),
+    ("fal-ai/nano-banana", ModelCaps("nano-banana", True, False, False, 0.039, 10)),
     ("fal-ai/flux-pro/kontext", ModelCaps("flux kontext", True, False, True, 0.04, 20)),
     ("fal-ai/flux-pro/v1/fill", ModelCaps("flux fill (inpaint)", True, False, True, 0.10, 25)),
     ("fal-ai/bria", ModelCaps("bria expand", True, False, True, 0.04, 15)),

--- a/apps/modal-backend/tests/test_model_router.py
+++ b/apps/modal-backend/tests/test_model_router.py
@@ -107,3 +107,12 @@ def test_select_enter_model_routes_steep_to_gpt(monkeypatch: pytest.MonkeyPatch)
     assert model_router.select_enter_model(None) == model_router.resolve_model("enter_scene")
     monkeypatch.setenv("FAL_ENTER_MODEL_STEEP", "fal-ai/custom/steep")
     assert model_router.select_enter_model("eye_level") == "fal-ai/custom/steep"
+
+
+def test_nano_text_to_image_does_not_support_refs() -> None:
+    # Fresh-gen nano endpoints accept-but-ignore image_urls (PR #109); the
+    # registry must report that so the picker never promises ref conditioning.
+    caps = {r["slug"]: r for r in model_router.registry()}
+    for slug in ("fal-ai/nano-banana", "fal-ai/nano-banana-2", "fal-ai/nano-banana-pro"):
+        assert caps[slug]["supports_refs"] is False, slug
+        assert caps[slug]["supports_edit"] is True, slug  # /edit variant unaffected

--- a/apps/web/app/api/generate-page/route.ts
+++ b/apps/web/app/api/generate-page/route.ts
@@ -6,7 +6,10 @@ import { resolveEntitiesForPrompt } from "@/lib/world";
 import { getWorldMap } from "@/lib/world-map";
 import { modalAuthHeaders, modalUrl as joinModalUrl } from "@/lib/modal";
 import { verifyOwnerReadonly } from "@/lib/session-owner";
-import { claimIdempotencyKey } from "@/lib/idempotency";
+import {
+  claimIdempotencyKey,
+  releaseIdempotencyKey,
+} from "@/lib/idempotency";
 import {
   estimateGenerationCost,
   recordSpend,
@@ -60,140 +63,153 @@ export async function POST(req: Request) {
     if (!auth.ok) return auth.res;
   }
   // Idempotency: refuse a re-sent generation (same key) BEFORE any paid work, so
-  // a retry / double-submit / proxy replay can't re-run the model stack.
+  // a retry / double-submit / proxy replay can't re-run the model stack. The key
+  // is RELEASED on every non-success exit below (spend cap, upstream failure, a
+  // thrown error) so a failed generation can be retried — only completed work
+  // keeps the trace id reserved.
   const idemKey = req.headers.get("idempotency-key");
-  if (idemKey && (await claimIdempotencyKey(`gen:${idemKey}`)) === "duplicate") {
+  const genKey = idemKey ? `gen:${idemKey}` : null;
+  if (genKey && (await claimIdempotencyKey(genKey)) === "duplicate") {
     return NextResponse.json(
       { error: "duplicate request (idempotency-key already used)" },
       { status: 409 },
     );
   }
-  if (guardBody?.session_id) {
-    // Durable global + per-session spend cap (Mongo-backed; shared across
-    // replicas and restart-proof — the backend meter is only per-container).
-    const reason = await spendOverCap(guardBody.session_id);
-    if (reason) {
-      return NextResponse.json(
-        {
-          error: `spend cap reached — ${reason}. Raise/unset MAX_DAILY_SPEND / MAX_SESSION_SPEND.`,
-        },
-        { status: 429 },
-      );
-    }
-    await recordSpend(guardBody.session_id, estimateGenerationCost(guardBody));
-  }
+  let keepClaim = false;
   try {
-    const parsed = JSON.parse(rawText) as GenerateRequestBody;
-    let mutated = false;
-    // A reopened node's page image arrives as its STORE URL; on the docker
-    // stack that's a localhost minio URL the VLM providers refuse to fetch.
-    // Inline our own stored bytes to a data URL (best-effort; see
-    // inlineStoredImage).
-    if (parsed?.image && !parsed.image.startsWith("data:")) {
-      const inlined = await inlineStoredImage(parsed.image);
-      if (inlined) {
-        parsed.image = inlined;
-        mutated = true;
+    if (guardBody?.session_id) {
+      // Durable global + per-session spend cap (Mongo-backed; shared across
+      // replicas and restart-proof — the backend meter is only per-container).
+      const reason = await spendOverCap(guardBody.session_id);
+      if (reason) {
+        return NextResponse.json(
+          {
+            error: `spend cap reached — ${reason}. Raise/unset MAX_DAILY_SPEND / MAX_SESSION_SPEND.`,
+          },
+          { status: 429 },
+        );
       }
+      await recordSpend(guardBody.session_id, estimateGenerationCost(guardBody));
     }
-    // The conditioning stack (style/parent/region refs) has the same problem:
-    // a reopened session's refs arrive as STORE URLs — on the docker stack
-    // that's a localhost minio URL fal's servers can't fetch, and the whole
-    // edit fails with invalid_request. Inline each (best-effort, per entry;
-    // a foreign/public URL passes through unchanged).
-    if (parsed?.condition_image_urls?.length) {
-      const refs = parsed.condition_image_urls;
-      const inlinedRefs = await Promise.all(
-        refs.map(async (u) =>
-          u && !u.startsWith("data:") ? ((await inlineStoredImage(u)) ?? u) : u,
-        ),
-      );
-      if (inlinedRefs.some((u, i) => u !== refs[i])) {
-        parsed.condition_image_urls = inlinedRefs;
-        mutated = true;
-      }
-    }
-    if (parsed && parsed.session_id && parsed.query && !parsed.world_context) {
-      const world_context = await resolveEntitiesForPrompt({
-        sessionId: parsed.session_id,
-        query: parsed.query,
-        parentTitle: parsed.parent_title ?? null,
-        parentQuery: parsed.parent_query ?? null,
-        parentNodeId: parsed.current_node_id || null,
-      });
-      if (world_context.length > 0) {
-        // FIX C: join geometric size (footprint/height) from the session's
-        // world_map so the planner can keep recurring entities at a consistent
-        // relative scale across pages. Best-effort — a missing/empty map just
-        // omits sizes and the planner behaves exactly as before.
-        try {
-          const geo = await getWorldMap(parsed.session_id);
-          const sizeById = new Map(
-            geo.entities
-              .filter((g) => g.entity_id)
-              .map((g) => [
-                g.entity_id as string,
-                { footprint: g.footprint, height: g.height },
-              ])
-          );
-          // Spatial half of continuity: a compass phrase from the TOP-LEVEL
-          // geos only (a nested geo's pos is in its parent's local frame —
-          // a phrase from it would claim the wrong place on the city map).
-          const hintById = new Map(
-            geo.entities
-              .filter((g) => g.entity_id && !g.parent_id)
-              .map((g) => [
-                g.entity_id as string,
-                locationPhrase(g, geo.bounds),
-              ])
-          );
-          for (const wc of world_context) {
-            const s = sizeById.get(wc.id);
-            if (s) {
-              wc.footprint = s.footprint;
-              wc.height = s.height;
-            }
-            const hint = hintById.get(wc.id);
-            if (hint) wc.location_hint = hint;
-          }
-        } catch {
-          // size enrichment is best-effort; never block generation
+    try {
+      const parsed = JSON.parse(rawText) as GenerateRequestBody;
+      let mutated = false;
+      // A reopened node's page image arrives as its STORE URL; on the docker
+      // stack that's a localhost minio URL the VLM providers refuse to fetch.
+      // Inline our own stored bytes to a data URL (best-effort; see
+      // inlineStoredImage).
+      if (parsed?.image && !parsed.image.startsWith("data:")) {
+        const inlined = await inlineStoredImage(parsed.image);
+        if (inlined) {
+          parsed.image = inlined;
+          mutated = true;
         }
-        upstreamBody = JSON.stringify({ ...parsed, world_context });
-        mutated = false; // serialized above, inlined image included
       }
+      // The conditioning stack (style/parent/region refs) has the same problem:
+      // a reopened session's refs arrive as STORE URLs — on the docker stack
+      // that's a localhost minio URL fal's servers can't fetch, and the whole
+      // edit fails with invalid_request. Inline each (best-effort, per entry;
+      // a foreign/public URL passes through unchanged).
+      if (parsed?.condition_image_urls?.length) {
+        const refs = parsed.condition_image_urls;
+        const inlinedRefs = await Promise.all(
+          refs.map(async (u) =>
+            u && !u.startsWith("data:") ? ((await inlineStoredImage(u)) ?? u) : u,
+          ),
+        );
+        if (inlinedRefs.some((u, i) => u !== refs[i])) {
+          parsed.condition_image_urls = inlinedRefs;
+          mutated = true;
+        }
+      }
+      if (parsed && parsed.session_id && parsed.query && !parsed.world_context) {
+        const world_context = await resolveEntitiesForPrompt({
+          sessionId: parsed.session_id,
+          query: parsed.query,
+          parentTitle: parsed.parent_title ?? null,
+          parentQuery: parsed.parent_query ?? null,
+          parentNodeId: parsed.current_node_id || null,
+        });
+        if (world_context.length > 0) {
+          // FIX C: join geometric size (footprint/height) from the session's
+          // world_map so the planner can keep recurring entities at a consistent
+          // relative scale across pages. Best-effort — a missing/empty map just
+          // omits sizes and the planner behaves exactly as before.
+          try {
+            const geo = await getWorldMap(parsed.session_id);
+            const sizeById = new Map(
+              geo.entities
+                .filter((g) => g.entity_id)
+                .map((g) => [
+                  g.entity_id as string,
+                  { footprint: g.footprint, height: g.height },
+                ])
+            );
+            // Spatial half of continuity: a compass phrase from the TOP-LEVEL
+            // geos only (a nested geo's pos is in its parent's local frame —
+            // a phrase from it would claim the wrong place on the city map).
+            const hintById = new Map(
+              geo.entities
+                .filter((g) => g.entity_id && !g.parent_id)
+                .map((g) => [
+                  g.entity_id as string,
+                  locationPhrase(g, geo.bounds),
+                ])
+            );
+            for (const wc of world_context) {
+              const s = sizeById.get(wc.id);
+              if (s) {
+                wc.footprint = s.footprint;
+                wc.height = s.height;
+              }
+              const hint = hintById.get(wc.id);
+              if (hint) wc.location_hint = hint;
+            }
+          } catch {
+            // size enrichment is best-effort; never block generation
+          }
+          upstreamBody = JSON.stringify({ ...parsed, world_context });
+          mutated = false; // serialized above, inlined image included
+        }
+      }
+      if (mutated) upstreamBody = JSON.stringify(parsed);
+    } catch {
+      // Body is presumably already the right shape (or malformed enough
+      // that the backend will surface the error). Forward verbatim.
+      upstreamBody = rawText;
     }
-    if (mutated) upstreamBody = JSON.stringify(parsed);
-  } catch {
-    // Body is presumably already the right shape (or malformed enough
-    // that the backend will surface the error). Forward verbatim.
-    upstreamBody = rawText;
+
+    const upstream = await fetch(joinModalUrl(modalUrl, "/sse/generate"), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        [TRACE_HEADER]: traceId,
+        ...modalAuthHeaders(),
+      },
+      body: upstreamBody,
+    });
+
+    if (!upstream.ok || !upstream.body) {
+      return NextResponse.json(
+        { error: `Upstream returned HTTP ${upstream.status}`, trace_id: traceId },
+        { status: 502, headers: { [TRACE_HEADER]: traceId } }
+      );
+    }
+
+    // Work has started upstream — keep the key so a replay is refused.
+    keepClaim = true;
+    return new Response(upstream.body, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+        [TRACE_HEADER]: traceId,
+      },
+    });
+  } finally {
+    // Release on every non-success exit (429 cap, 502 upstream, or a thrown
+    // error) so a stuck key never permanently 409s a legitimate retry.
+    if (genKey && !keepClaim) await releaseIdempotencyKey(genKey);
   }
-
-  const upstream = await fetch(joinModalUrl(modalUrl, "/sse/generate"), {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      [TRACE_HEADER]: traceId,
-      ...modalAuthHeaders(),
-    },
-    body: upstreamBody,
-  });
-
-  if (!upstream.ok || !upstream.body) {
-    return NextResponse.json(
-      { error: `Upstream returned HTTP ${upstream.status}`, trace_id: traceId },
-      { status: 502, headers: { [TRACE_HEADER]: traceId } }
-    );
-  }
-
-  return new Response(upstream.body, {
-    status: 200,
-    headers: {
-      "Content-Type": "text/event-stream",
-      "Cache-Control": "no-cache, no-transform",
-      Connection: "keep-alive",
-      [TRACE_HEADER]: traceId,
-    },
-  });
 }

--- a/apps/web/lib/idempotency.test.ts
+++ b/apps/web/lib/idempotency.test.ts
@@ -14,6 +14,10 @@ const fakeCollection = {
   async findOne(f: { _id: string }) {
     return store.get(f._id) ?? null;
   },
+  async deleteOne(f: { _id: string }) {
+    const had = store.delete(f._id);
+    return { deletedCount: had ? 1 : 0 };
+  },
   async updateOne(
     f: { _id: string },
     update: { $set?: Record<string, unknown> },
@@ -37,6 +41,7 @@ vi.mock("./db", () => ({
 import {
   claimIdempotencyKey,
   getIdempotentResult,
+  releaseIdempotencyKey,
   saveIdempotentResult,
 } from "./idempotency";
 
@@ -55,6 +60,13 @@ describe("idempotency", () => {
   it("first claim is fresh, a replay is a duplicate", async () => {
     expect(await claimIdempotencyKey("gen:abc")).toBe("fresh");
     expect(await claimIdempotencyKey("gen:abc")).toBe("duplicate");
+  });
+
+  it("a released key can be claimed fresh again", async () => {
+    expect(await claimIdempotencyKey("gen:abc")).toBe("fresh");
+    expect(await claimIdempotencyKey("gen:abc")).toBe("duplicate");
+    await releaseIdempotencyKey("gen:abc"); // a failed gen frees the key
+    expect(await claimIdempotencyKey("gen:abc")).toBe("fresh");
   });
 
   it("result cache round-trips for replays", async () => {

--- a/apps/web/lib/idempotency.ts
+++ b/apps/web/lib/idempotency.ts
@@ -54,6 +54,15 @@ export async function claimIdempotencyKey(
   }
 }
 
+/**
+ * Release a claimed key (delete the doc) so a request that did NOT complete its
+ * work frees the key for a legitimate retry. No-op when Mongo isn't configured.
+ */
+export async function releaseIdempotencyKey(key: string): Promise<void> {
+  if (!configured()) return;
+  await (await keys()).deleteOne({ _id: key });
+}
+
 /** The cached JSON result for a key, or null if none/unconfigured. */
 export async function getIdempotentResult<T>(key: string): Promise<T | null> {
   if (!configured()) return null;

--- a/apps/web/lib/mse-player.ts
+++ b/apps/web/lib/mse-player.ts
@@ -25,6 +25,9 @@ export function attachMSE(video: HTMLVideoElement): MSEController {
   let sourceBuffer: SourceBuffer | null = null;
   const pending: Uint8Array[] = [];
   let destroyed = false;
+  // Init mime stashed so sourceopen can create the SourceBuffer if the init
+  // packet raced ahead of it (readyState still "closed" at append time).
+  let initMime: string | null = null;
 
   const drain = (): void => {
     if (destroyed || !sourceBuffer) return;
@@ -47,6 +50,9 @@ export function attachMSE(video: HTMLVideoElement): MSEController {
   };
 
   mediaSource.addEventListener("sourceopen", () => {
+    // If the init packet arrived before sourceopen, readyState was "closed"
+    // then and the SourceBuffer was never created — create it now, then drain.
+    if (initMime) ensureSourceBuffer(initMime);
     drain();
   });
 
@@ -55,6 +61,7 @@ export function attachMSE(video: HTMLVideoElement): MSEController {
       if (destroyed) return;
       if (packet.header.is_init_segment) {
         const mime = `${packet.header.media_type}; codecs="${codecsFromHeader(packet.header)}"`;
+        initMime = mime;
         ensureSourceBuffer(mime);
       }
       pending.push(packet.payload);


### PR DESCRIPTION
The three follow-ups deferred from #110, implemented via Omnigent (each bug confirmed in the call graph before fixing), reviewed, and gate-green.

## 1. Stale `supports_refs` picker metadata
`model_router.py` advertised `supports_refs=true` for the nano-banana text-to-image slugs, claiming fresh-gen honours reference images. False since #109 — the text-to-image endpoints accept but IGNORE `image_urls`; real conditioning is edit/continue only. Set `supports_refs=False` for the three nano slugs; `supports_edit` and all edit-capable entries untouched. *(picker metadata only — no routing impact.)*

## 2. Idempotency key never released on failed generation
`generate-page/route.ts` claimed `gen:<key>` but never released it on the 502 / cap-429 / thrown-error paths, so a reused traceId was permanently refused with 409. Added `releaseIdempotencyKey` (`idempotency.ts`) and a `try/finally` with a `keepClaim` flag: released on every non-success exit, kept only when the 200 stream actually starts (a genuine duplicate still 409s). Large diff = re-indentation from the new try-nesting; inner logic unchanged.

## 3. MediaSource init-segment race
`mse-player.ts` — if the init packet arrived before `sourceopen` (`readyState` still `closed`), `ensureSourceBuffer` early-returned and the buffer was never created → permanent stall. Now stash the init mime and (re)create the buffer in the `sourceopen` handler; normal (sourceopen-first) ordering is a no-op there, unchanged.

## Tests
`test_model_router` supports_refs assertion; `idempotency.test.ts` release round-trip. MSE test skipped — no MediaSource in jsdom.

## Verification
`make eval` green — backend pytest/ruff/mypy + web vitest **642**/tsc + no circular deps.