### PR TITLE
test(e2e): fix stale style-pin assertion (session_style_anchor)

### DIFF
--- a/apps/web/e2e/style-pin.spec.ts
+++ b/apps/web/e2e/style-pin.spec.ts
@@ -37,8 +37,13 @@ test("pinning style propagates style_anchor to next /api/generate-page request",
   expect(raw, "POST /api/generate-page must carry a body").not.toBeNull();
   const body = JSON.parse(raw!);
 
-  // The style anchor field name is `style_anchor` (snake-case) on the wire —
-  // see apps/modal-backend/generate.py GenerateRequestBody.
-  expect(body.style_anchor).toBeTruthy();
-  expect(typeof body.style_anchor).toBe("object");
+  // The pinned style rides on `session_style_anchor` (a STRING) — set from
+  // `styleAnchor.style` in app/play/page.tsx, consumed by
+  // generate.py GenerateRequestBody.session_style_anchor: str. (The old
+  // `style_anchor` object field this test asserted no longer exists on the wire.)
+  expect(
+    body.session_style_anchor,
+    "pinning a style must ride on session_style_anchor",
+  ).toBeTruthy();
+  expect(typeof body.session_style_anchor).toBe("string");
 });


### PR DESCRIPTION
The `style-pin` e2e asserted `body.style_anchor` was a truthy **object**, but the app sends the pinned style as **`session_style_anchor` (a string)** — `styleAnchor.style` in `app/play/page.tsx` → `generate.py` `GenerateRequestBody.session_style_anchor: str`. No bare `style_anchor` field exists on the wire; the assertion was **stale**.

It went unnoticed because this spec runs only in the label-gated, real-stack `e2e` CI job — not the per-PR `e2e-mock` gate. Under the mock stack it failed (mock emits a style string, not the asserted object).

**Fix:** assert the real contract (`session_style_anchor` is a truthy string).

**Verification:** full Playwright suite now **4/4 green** under `MOCK_PROVIDERS=1` (bottom-ui, click-to-next, deeplink, style-pin). Test-only change — no production code touched.