### PR TITLE
refactor(backend): extract ascend (OUTWARD) mode into its own module

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -1267,143 +1267,17 @@ async def _event_stream(
         # — the web /ascend route persists the reparent. Isolated like edit/expand:
         # returns early, never touches the tap/query single-`final` path below.
         if body.mode == "ascend":
-            if not (env_flag("SCALE_LADDER_NAV") and env_flag("SCALE_OUTWARD")):
-                yield _sse(
-                    {"type": "error", "message": "OUTWARD disabled (SCALE_LADDER_NAV+SCALE_OUTWARD)"},
-                    trace_id,
-                )
-                return
-            if not body.image:
-                yield _sse(
-                    {"type": "error", "message": "ascend mode requires an image"}, trace_id
-                )
-                return
-            from_tier = (body.scene_view.scale_tier if body.scene_view else None) or "city"
-            to_tier = model_router.coarser_tier(from_tier)
-            if to_tier is None:
-                yield _sse(
-                    {"type": "error", "message": f"no coarser rung above '{from_tier}'"},
-                    trace_id,
-                )
-                return
-            pw, ph = _frame_dims(body.aspect_ratio)
-            style_lock = (body.session_style_anchor or "").strip() or None
-            # DEFAULT = the fresh `scale_parent` container: a seamless wider view of
-            # the SAME world in the SAME medium, the source as a small sub-region
-            # (live-verified far more coherent than the outpaint, which leaves the
-            # source a rectangle inset). The centered outpaint is opt-in
-            # (SCALE_OUTWARD_OUTPAINT) for pixel-preservation, and only for a
-            # same-plane hop — and now STEERS its margin with the medium so it isn't
-            # photoreal. Astronomical (medium-flip) hops are always fresh.
-            use_outpaint = (
-                env_flag("SCALE_OUTWARD_OUTPAINT")
-                and model_router.select_outward_op(from_tier, to_tier) == "outpaint_zoomout"
-            )
-            yield _sse({"type": "status", "stage": "rendering"}, trace_id)
-            await _abort_if_disconnected("pre-ascend")
-            # View grammar on the OUTWARD hop (V1 must-fix 7, split by path):
-            # the pixel-preserving paths (outpaint margin / edit instruction)
-            # keep the SOURCE's persisted view — coherence with the pixels they
-            # extend; the fresh container is a NEW map and gets the policy's
-            # deliberate top-down camera.
-            src_view: dict | None = None
-            if _view_grammar_on() and body.scene_view and body.scene_view.view:
-                src_view = body.scene_view.view.model_dump(exclude_none=True)
-            from providers.prompt_library import camera as camera_lib
-            from providers.prompt_library import instructions as instructions_lib
-            from providers.prompt_library import policy as view_policy
-            from providers.prompt_library.types import ViewSpec as ViewSpecDict
+            from providers.generate_modes.ascend import stream_ascend
 
-            outward_rider = instructions_lib.outward_clause(
-                cast("ViewSpecDict | None", src_view)
-            )
-            try:
-                if use_outpaint:
-                    medium = style_lock or "the same hand-drawn art style as the centre"
-                    margin = (
-                        f"{medium}; extend OUTWARD into the surrounding "
-                        f"{to_tier.replace('_', ' ')}, drawn in the SAME style as the "
-                        "centre — one continuous view, NOT a photograph, no photorealism"
-                    )
-                    if outward_rider:
-                        margin += ". " + outward_rider
-                    img = await image_edit_provider.expand_image_zoomout(
-                        body.image, 3.0, pw, ph, prompt=margin
-                    )
-                    page_title = f"The surrounding {to_tier.replace('_', ' ')}".title()
-                    final_prompt = f"outward outpaint: {from_tier} -> {to_tier}"
-                else:
-                    plan = await llm.plan_page(
-                        query=(
-                            f"the {to_tier.replace('_', ' ')} that contains "
-                            f"{body.query or 'this place'}"
-                        ),
-                        web_search=False,
-                        style_anchor=style_lock,
-                        render_mode="scale_parent",
-                    )
-                    if env_flag("SCALE_OUTWARD_EDIT_REF", "true"):
-                        # The source ref is a no-op on the text-to-image endpoint
-                        # (research 01-model-bakeoff); the edit endpoint honors it, so
-                        # the container continues the source's medium + content instead
-                        # of free-styling. Default ON (kill-switch =false) — the inert
-                        # ref path exists only as the revert.
-                        medium = style_lock or "the same hand-drawn art style as the centre"
-                        ascend_instr = (
-                            f"Zoom OUT to reveal the surrounding {to_tier.replace('_', ' ')}, "
-                            f"keeping this exact view as the centre. {medium}; one continuous "
-                            "view in that style, NOT a photograph, no photorealism."
-                        )
-                        if outward_rider:
-                            ascend_instr += " " + outward_rider
-                        img = await image_edit_provider.edit_image(
-                            body.image, ascend_instr
-                        )
-                    else:
-                        # Fresh container = a NEW map: state the deliberate
-                        # top-down camera (None on astro rungs → legacy bytes).
-                        ascend_prompt = plan.prompt
-                        if _view_grammar_on():
-                            asc_view = view_policy.default_view(
-                                render_mode="scale_parent",
-                                world_mode=True,
-                                scale_tier=to_tier,
-                            )
-                            cam = camera_lib.camera_clause(
-                                asc_view, medium=style_lock or None
-                            )
-                            if cam:
-                                ascend_prompt += "\n\n" + cam
-                        img = await image_provider.generate_image(
-                            ascend_prompt, body.aspect_ratio, reference_urls=[body.image]
-                        )
-                    page_title = plan.page_title or f"The surrounding {to_tier.replace('_', ' ')}".title()
-                    final_prompt = plan.prompt
-            except Exception as exc:
-                log("warn", "ascend.failed", error=f"{type(exc).__name__}: {exc}")
-                record_error("ascend", exc)
-                yield _sse({"type": "error", "message": f"ascend failed: {exc}"}, trace_id)
-                return
-            data_url = await _asyncio.to_thread(
-                image_provider.encode_data_url, img.jpeg_bytes, img.mime_type
-            )
-            # Spend accounting: this OUTWARD hop made a real paid image call —
-            # record it (like the tap/draft paths) so the cap actually counts it.
-            spend.record_generation(body.session_id, img.model)
-            yield _sse(
-                {
-                    "type": "ascend_ready",
-                    "page_title": page_title,
-                    "image_data_url": data_url,
-                    "image_model": img.model,
-                    "prompt_author_model": "",
-                    "final_prompt": final_prompt,
-                    "scale_tier": to_tier,
-                    "from_tier": from_tier,
-                    "session_id": body.session_id,
-                },
+            async for frame in stream_ascend(
+                body,
                 trace_id,
-            )
+                _sse=_sse,
+                _frame_dims=_frame_dims,
+                _view_grammar_on=_view_grammar_on,
+                _abort_if_disconnected=_abort_if_disconnected,
+            ):
+                yield frame
             return
 
         # Expand mode blooms the world AROUND the focal subject: propose a few

--- a/apps/modal-backend/providers/generate_modes/__init__.py
+++ b/apps/modal-backend/providers/generate_modes/__init__.py
@@ -1,0 +1,6 @@
+"""Per-mode SSE stream handlers extracted from generate._event_stream.
+
+Each handler is an async generator that yields the exact same `_sse(...)` frames
+the inline branch used to, threading generate.py's stream helpers explicitly so
+this package never reaches back into generate.py's module globals.
+"""

--- a/apps/modal-backend/providers/generate_modes/ascend.py
+++ b/apps/modal-backend/providers/generate_modes/ascend.py
@@ -1,0 +1,173 @@
+"""OUTWARD / zoom-out (`ascend`) SSE stream, extracted from generate._event_stream.
+
+Synthesize the CONTAINER that holds the current root and stream it back as
+`ascend_ready` — the web /ascend route persists the reparent. Isolated like
+edit/expand: yields its own frames and returns, never touching the tap/query
+single-`final` path. Behaviour is byte-identical to the former inline branch;
+generate.py's stream helpers (`_sse`, `_frame_dims`, `_view_grammar_on`,
+`_abort_if_disconnected`) are threaded in as parameters.
+"""
+
+from __future__ import annotations
+
+import asyncio as _asyncio
+from collections.abc import AsyncIterator, Awaitable, Callable
+from typing import TYPE_CHECKING, cast
+
+from _env import env_flag
+from obs import log, record_error
+from providers import image as image_provider
+from providers import image_edit as image_edit_provider
+from providers import llm, model_router, spend
+
+if TYPE_CHECKING:
+    from generate import GenerateBody
+
+
+async def stream_ascend(
+    body: GenerateBody,
+    trace_id: str,
+    *,
+    _sse: Callable[..., bytes],
+    _frame_dims: Callable[[str], tuple[int, int]],
+    _view_grammar_on: Callable[[], bool],
+    _abort_if_disconnected: Callable[[str], Awaitable[None]],
+) -> AsyncIterator[bytes]:
+    if not (env_flag("SCALE_LADDER_NAV") and env_flag("SCALE_OUTWARD")):
+        yield _sse(
+            {"type": "error", "message": "OUTWARD disabled (SCALE_LADDER_NAV+SCALE_OUTWARD)"},
+            trace_id,
+        )
+        return
+    if not body.image:
+        yield _sse(
+            {"type": "error", "message": "ascend mode requires an image"}, trace_id
+        )
+        return
+    from_tier = (body.scene_view.scale_tier if body.scene_view else None) or "city"
+    to_tier = model_router.coarser_tier(from_tier)
+    if to_tier is None:
+        yield _sse(
+            {"type": "error", "message": f"no coarser rung above '{from_tier}'"},
+            trace_id,
+        )
+        return
+    pw, ph = _frame_dims(body.aspect_ratio)
+    style_lock = (body.session_style_anchor or "").strip() or None
+    # DEFAULT = the fresh `scale_parent` container: a seamless wider view of
+    # the SAME world in the SAME medium, the source as a small sub-region
+    # (live-verified far more coherent than the outpaint, which leaves the
+    # source a rectangle inset). The centered outpaint is opt-in
+    # (SCALE_OUTWARD_OUTPAINT) for pixel-preservation, and only for a
+    # same-plane hop — and now STEERS its margin with the medium so it isn't
+    # photoreal. Astronomical (medium-flip) hops are always fresh.
+    use_outpaint = (
+        env_flag("SCALE_OUTWARD_OUTPAINT")
+        and model_router.select_outward_op(from_tier, to_tier) == "outpaint_zoomout"
+    )
+    yield _sse({"type": "status", "stage": "rendering"}, trace_id)
+    await _abort_if_disconnected("pre-ascend")
+    # View grammar on the OUTWARD hop (V1 must-fix 7, split by path):
+    # the pixel-preserving paths (outpaint margin / edit instruction)
+    # keep the SOURCE's persisted view — coherence with the pixels they
+    # extend; the fresh container is a NEW map and gets the policy's
+    # deliberate top-down camera.
+    src_view: dict | None = None
+    if _view_grammar_on() and body.scene_view and body.scene_view.view:
+        src_view = body.scene_view.view.model_dump(exclude_none=True)
+    from providers.prompt_library import camera as camera_lib
+    from providers.prompt_library import instructions as instructions_lib
+    from providers.prompt_library import policy as view_policy
+    from providers.prompt_library.types import ViewSpec as ViewSpecDict
+
+    outward_rider = instructions_lib.outward_clause(
+        cast("ViewSpecDict | None", src_view)
+    )
+    try:
+        if use_outpaint:
+            medium = style_lock or "the same hand-drawn art style as the centre"
+            margin = (
+                f"{medium}; extend OUTWARD into the surrounding "
+                f"{to_tier.replace('_', ' ')}, drawn in the SAME style as the "
+                "centre — one continuous view, NOT a photograph, no photorealism"
+            )
+            if outward_rider:
+                margin += ". " + outward_rider
+            img = await image_edit_provider.expand_image_zoomout(
+                body.image, 3.0, pw, ph, prompt=margin
+            )
+            page_title = f"The surrounding {to_tier.replace('_', ' ')}".title()
+            final_prompt = f"outward outpaint: {from_tier} -> {to_tier}"
+        else:
+            plan = await llm.plan_page(
+                query=(
+                    f"the {to_tier.replace('_', ' ')} that contains "
+                    f"{body.query or 'this place'}"
+                ),
+                web_search=False,
+                style_anchor=style_lock,
+                render_mode="scale_parent",
+            )
+            if env_flag("SCALE_OUTWARD_EDIT_REF", "true"):
+                # The source ref is a no-op on the text-to-image endpoint
+                # (research 01-model-bakeoff); the edit endpoint honors it, so
+                # the container continues the source's medium + content instead
+                # of free-styling. Default ON (kill-switch =false) — the inert
+                # ref path exists only as the revert.
+                medium = style_lock or "the same hand-drawn art style as the centre"
+                ascend_instr = (
+                    f"Zoom OUT to reveal the surrounding {to_tier.replace('_', ' ')}, "
+                    f"keeping this exact view as the centre. {medium}; one continuous "
+                    "view in that style, NOT a photograph, no photorealism."
+                )
+                if outward_rider:
+                    ascend_instr += " " + outward_rider
+                img = await image_edit_provider.edit_image(
+                    body.image, ascend_instr
+                )
+            else:
+                # Fresh container = a NEW map: state the deliberate
+                # top-down camera (None on astro rungs → legacy bytes).
+                ascend_prompt = plan.prompt
+                if _view_grammar_on():
+                    asc_view = view_policy.default_view(
+                        render_mode="scale_parent",
+                        world_mode=True,
+                        scale_tier=to_tier,
+                    )
+                    cam = camera_lib.camera_clause(
+                        asc_view, medium=style_lock or None
+                    )
+                    if cam:
+                        ascend_prompt += "\n\n" + cam
+                img = await image_provider.generate_image(
+                    ascend_prompt, body.aspect_ratio, reference_urls=[body.image]
+                )
+            page_title = plan.page_title or f"The surrounding {to_tier.replace('_', ' ')}".title()
+            final_prompt = plan.prompt
+    except Exception as exc:
+        log("warn", "ascend.failed", error=f"{type(exc).__name__}: {exc}")
+        record_error("ascend", exc)
+        yield _sse({"type": "error", "message": f"ascend failed: {exc}"}, trace_id)
+        return
+    data_url = await _asyncio.to_thread(
+        image_provider.encode_data_url, img.jpeg_bytes, img.mime_type
+    )
+    # Spend accounting: this OUTWARD hop made a real paid image call —
+    # record it (like the tap/draft paths) so the cap actually counts it.
+    spend.record_generation(body.session_id, img.model)
+    yield _sse(
+        {
+            "type": "ascend_ready",
+            "page_title": page_title,
+            "image_data_url": data_url,
+            "image_model": img.model,
+            "prompt_author_model": "",
+            "final_prompt": final_prompt,
+            "scale_tier": to_tier,
+            "from_tier": from_tier,
+            "session_id": body.session_id,
+        },
+        trace_id,
+    )
+    return


### PR DESCRIPTION
## What

Pure, behavior-preserving refactor: move the inline `if body.mode == "ascend"` block out of the 3043-line `apps/modal-backend/generate.py` (`_event_stream`) into a dedicated async-generator module.

- **New module:** `apps/modal-backend/providers/generate_modes/ascend.py` — `async def stream_ascend(...)`, plus a new `generate_modes/` package (`__init__.py`).
- **generate.py:** the inline block (previously **lines 1269–1407**, 139 lines) is replaced by a thin 13-line dispatch that `async for`s over `stream_ascend` and `return`s. Net: `1 file changed, 10 insertions(+), 136 deletions(-)`.

## Behavior preserved (byte-identical)

- Same SSE frames in the same order: the flag-gate `error`, the `image`-required `error`, the no-coarser-rung `error`, `status`/`rendering`, the inner `ascend failed` `error`, and the final `ascend_ready` payload (unchanged shape/fields).
- Same early-returns, same flag gates (`SCALE_LADDER_NAV` + `SCALE_OUTWARD`, `SCALE_OUTWARD_OUTPAINT`, `SCALE_OUTWARD_EDIT_REF`), same inner `try/except` → `record_error("ascend", …)`.
- Same `spend.record_generation(body.session_id, img.model)` accounting.
- **Both sub-paths kept:** the opt-in centered outpaint (`expand_image_zoomout`) and the fresh `scale_parent` container — including the `SCALE_OUTWARD_EDIT_REF` edit-ref path and the legacy fresh text-to-image path.
- The block sat inside `_event_stream`'s outer `try` (`except CancelledError` / `except Exception`); wrapping the extracted generator in `async for … yield` at the same site preserves that exception routing (a `CancelledError` from `_abort_if_disconnected` still bubbles to the clean-cancel handler; other exceptions still hit the generic error frame).

## How deps were threaded

- **Cross-module deps import at the new module top:** `env_flag` (`_env`), `log`/`record_error` (`obs`), `image`/`image_edit`/`llm`/`model_router`/`spend` (`providers`), `asyncio`, `cast`.
- **generate.py's own private stream helpers are passed in as parameters** — `_sse`, `_frame_dims`, `_view_grammar_on`, and the `_abort_if_disconnected` closure. No importing generate.py's globals, no monkeypatching.
- Provider calls stay as **module-attribute access** (`image_provider.generate_image(...)`, `llm.plan_page(...)`), so the existing `monkeypatch.setattr(providers.image, ...)` tests keep biting.

No new dependencies. No changes to other mode branches (edit/expand/tap). The existing `tests/test_generate_ascend.py` (8 tests, calls `_event_stream` directly) passes unchanged.

## `make eval` (green, from the worktree root)

```
cd apps/modal-backend && .venv/bin/ruff check . && .venv/bin/mypy providers obs.py generate.py
All checks passed!
Success: no issues found in 38 source files
cd apps/web && pnpm exec vitest run && pnpm exec tsc --noEmit && pnpm run check:circular
 Test Files  84 passed (84)
      Tests  642 passed (642)
✔ No circular dependency found!
```
Backend `pytest -m "not paid"` exited 0 (all pass). Full `make eval` exit code: 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)