### PR TITLE
chore(husky): commit-msg hook to strip coauthor trailers

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+# Strip Co-authored-by: trailers (repo policy). `|| true`: grep exits 1 when it
+# selects zero lines (empty msg / trailer-only), which would abort under `sh -e`.
+grep -viE '^[[:space:]]*co-authored-by:' "$1" > "$1.tmp" || true
+mv "$1.tmp" "$1"

--- a/.husky/commit-msg.test.sh
+++ b/.husky/commit-msg.test.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+# Runnable check for the commit-msg hook. Run: sh .husky/commit-msg.test.sh
+set -e
+hook="$(dirname "$0")/commit-msg"
+tmp="$(mktemp)"
+trap 'rm -f "$tmp" "$tmp.tmp"' EXIT
+
+# 1. Co-authored-by line is stripped; other lines survive.
+printf 'feat: thing\n\nbody line\nCo-authored-by: omnigent <noreply@omnigent.ai>\n' > "$tmp"
+sh -e "$hook" "$tmp"
+grep -qi 'co-authored-by' "$tmp" && { echo "FAIL: trailer survived"; exit 1; }
+grep -q 'body line' "$tmp" || { echo "FAIL: body line dropped"; exit 1; }
+
+# 2. No-trailer message is left byte-for-byte identical.
+printf 'fix: no trailer here\n\ndetails\n' > "$tmp"
+before="$(cat "$tmp")"
+sh -e "$hook" "$tmp"
+[ "$before" = "$(cat "$tmp")" ] || { echo "FAIL: no-trailer message altered"; exit 1; }
+
+# 3. Trailer-only message -> empty, hook still exits 0, no stray .tmp left behind.
+printf 'Co-authored-by: omnigent <noreply@omnigent.ai>\n' > "$tmp"
+sh -e "$hook" "$tmp"
+[ -s "$tmp" ] && { echo "FAIL: trailer-only message not emptied"; exit 1; }
+[ -e "$tmp.tmp" ] && { echo "FAIL: stray .tmp left behind"; exit 1; }
+
+echo "ok"


### PR DESCRIPTION
## What

Adds a repo-level husky `commit-msg` hook that deletes every line matching (case-insensitively) `^[[:space:]]*co-authored-by:` from the commit message, enforcing the repo policy that no such trailer survives in any commit.

```sh
grep -viE '^[[:space:]]*co-authored-by:' "$1" > "$1.tmp" || true
mv "$1.tmp" "$1"
```

## Why the `|| true` (not a bare `&&`)

husky v9 runs hooks with `sh -e`. `grep` exits **1** when it selects zero lines (an empty message, or a message that is *only* trailer lines). A bare `... && mv` would then skip the `mv` — aborting the commit and leaving a stray `$1.tmp` behind. `|| true` neutralizes that so the hook always exits 0 and never leaves a temp file. Portable across BSD (macOS) and GNU (Linux).

## Notes

- Matches the existing `pre-commit` hook's format (husky v9, no shebang boilerplate); executable bit set.
- Does **not** touch the existing `pre-commit` (lint-staged) hook — it still runs.
- `.husky/commit-msg.test.sh` is a tiny runnable check (`sh .husky/commit-msg.test.sh`) covering: trailer stripped, no-trailer message unchanged, trailer-only → empty with no stray `.tmp`. Husky only wires exact hook names, so this sibling is never invoked as a hook.
- No new dependencies. Repo-level only — no global/`core.hooksPath` config committed.

## Proof (this PR's own commit)

The commit that adds the hook was itself created **without** `--no-verify`; an appended `Co-authored-by:` trailer was stripped by the hook. `git log --format='%B' origin/main..HEAD` is trailer-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)