### PR TITLE
fix(loop): cumulative deadline — long critic-retry enters finish instead of 502ing

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -46,6 +46,11 @@ from _env import env_flag
 
 APP_NAME = "openflipbook-generate"
 
+# Modal kills the container at this wall-clock limit — the render/edit loops
+# derive their cumulative deadline from it so a long critic-retry enter always
+# finishes with its best attempt instead of dying at the edge as a 502.
+INGRESS_TIMEOUT_S = 900
+
 image = (
     modal.Image.debian_slim(python_version="3.12")
     .pip_install_from_requirements("requirements.txt")
@@ -1536,6 +1541,13 @@ async def _event_stream(
                     )
 
                 loop_cfg = render_loop.loop_config_from_env(body.max_attempts)
+                # Leave 180s for the final attempt's judge tail + post-loop
+                # grounding/encode; floor of 60s so one slow planner can't
+                # zero the render budget.
+                loop_deadline = _time.monotonic() + max(
+                    60.0,
+                    INGRESS_TIMEOUT_S - 180.0 - (_time.perf_counter() - started),
+                )
                 loop_attempts: list[Attempt] = []
                 async for loop_att in render_loop.iter_attempts(
                     _render_enter,
@@ -1550,6 +1562,7 @@ async def _event_stream(
                     judge_medium=judge.score_style_pair,
                     family=enter_family,
                     abort=_abort_if_disconnected,
+                    deadline_s=loop_deadline,
                 ):
                     loop_attempts.append(loop_att)
                     # Stream only verdict-REJECTED attempts (a correction is
@@ -2451,7 +2464,7 @@ async def trace_abort_stats(limit: int = 100) -> dict:
     return {"ok": True, "service": APP_NAME, **abort_stats(clamped)}
 
 
-@app.function(secrets=secrets, min_containers=0, timeout=600)
+@app.function(secrets=secrets, min_containers=0, timeout=INGRESS_TIMEOUT_S)
 @modal.asgi_app()
 def fastapi_ingress():
     return fastapi_app

--- a/apps/modal-backend/providers/edit_loop.py
+++ b/apps/modal-backend/providers/edit_loop.py
@@ -155,6 +155,7 @@ async def iter_edit_attempts[ImageT: Rendered](
     feedback: Callable[..., str] = edit_retry_feedback_clause,
     abort: Callable[[str], Awaitable[None]] | None = None,
     clock: Callable[[], float] = time.monotonic,
+    deadline_s: float | None = None,
 ) -> AsyncIterator[EditAttempt]:
     """Yield attempts until acceptance / budget / max attempts. Attempt-0
     render exceptions PROPAGATE (the caller's error path); retry-render
@@ -235,6 +236,14 @@ async def iter_edit_attempts[ImageT: Rendered](
         if config.retry_budget_s > 0 and latency > config.retry_budget_s:
             log("info", "edit.loop.budget_stop", attempt=index, latency_s=round(latency, 1))
             return
+        if deadline_s is not None:
+            # Cumulative wall-clock guard — mirror of render_loop: this
+            # attempt's total predicts the next; stop before the container
+            # deadline and keep the best attempt so far.
+            now = clock()
+            if now + (now - started) > deadline_s:
+                log("info", "edit.loop.deadline_stop", attempt=index)
+                return
         suffix = feedback(
             alignment_rationale=(
                 alignment.rationale

--- a/apps/modal-backend/providers/generate_modes/edit.py
+++ b/apps/modal-backend/providers/generate_modes/edit.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio as _asyncio
 import base64
+import time as _time
 from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
@@ -116,6 +117,10 @@ async def stream_edit(
             inp_result = await _render_inpaint("")
         else:
             edit_cfg = edit_loop.edit_loop_config_from_env(body.max_attempts)
+            # generate.INGRESS_TIMEOUT_S (900) minus a 180s tail for the
+            # final attempt's judges + encode — the loop must finish with
+            # its best attempt before Modal kills the container.
+            edit_deadline = _time.monotonic() + 720.0
             edit_attempts: list[EditAttempt] = []
             # The alignment judge checks the inside crop against the
             # fill DESCRIPTION (the region's expected final content) —
@@ -131,6 +136,7 @@ async def stream_edit(
                 instruction=described,
                 config=edit_cfg,
                 abort=_abort_if_disconnected,
+                deadline_s=edit_deadline,
             ):
                 edit_attempts.append(edit_att)
                 # Stream only verdict-REJECTED attempts (a correction

--- a/apps/modal-backend/providers/render_loop.py
+++ b/apps/modal-backend/providers/render_loop.py
@@ -175,6 +175,7 @@ async def iter_attempts[ImageT: Rendered](
     feedback: Callable[..., str] = retry_feedback_clause,
     abort: Callable[[str], Awaitable[None]] | None = None,
     clock: Callable[[], float] = time.monotonic,
+    deadline_s: float | None = None,
 ) -> AsyncIterator[Attempt]:
     """Yield attempts until acceptance / budget / max attempts. The caller
     (the SSE generator) can emit a progress frame between yields. Attempt-0
@@ -254,6 +255,14 @@ async def iter_attempts[ImageT: Rendered](
         if config.retry_budget_s > 0 and latency > config.retry_budget_s:
             log("info", "view.loop.budget_stop", attempt=index, latency_s=round(latency, 1))
             return
+        if deadline_s is not None:
+            # Cumulative wall-clock guard: this attempt's total (render+judges)
+            # is the estimate for the next one — never start an attempt that
+            # would blow past the container deadline; keep-best still applies.
+            now = clock()
+            if now + (now - started) > deadline_s:
+                log("info", "view.loop.deadline_stop", attempt=index)
+                return
         suffix = feedback(
             projection,
             conformance_rationale=(

--- a/apps/modal-backend/tests/test_edit_loop.py
+++ b/apps/modal-backend/tests/test_edit_loop.py
@@ -108,6 +108,28 @@ async def _drain(render: _Render, *, alignment: object, medium: object) -> list[
     return attempts
 
 
+async def test_cumulative_deadline_stops_retry() -> None:
+    # Mirror of render_loop's guard: a 100s attempt predicts 200 > 150.
+    ticks = iter([0.0, 100.0, 100.0])
+    render = _Render([_inside_edit(), _inside_edit()])
+    attempts = []
+    async for a in edit_loop.iter_edit_attempts(
+        render,
+        source_bytes=_jpg(_base()),
+        mask_png=_mask_png(),
+        region_box=_BOX,
+        judge_alignment=_judge(3.0, 9.0),  # type: ignore[arg-type]
+        judge_medium=_judge(9.0),  # type: ignore[arg-type]
+        instruction="a red panel",
+        config=_CFG,
+        clock=lambda: next(ticks),
+        deadline_s=150.0,
+    ):
+        attempts.append(a)
+    assert len(attempts) == 1 and not attempts[0].accepted
+    assert render.suffixes == [""]  # no retry spent
+
+
 async def test_accept_at_one_spends_one_render() -> None:
     render = _Render([_inside_edit()])
     attempts = await _drain(render, alignment=_judge(9.0), medium=_judge(9.0))

--- a/apps/modal-backend/tests/test_render_loop.py
+++ b/apps/modal-backend/tests/test_render_loop.py
@@ -183,6 +183,34 @@ async def test_retry_budget_guard() -> None:
     assert len(attempts2) == 2
 
 
+async def test_cumulative_deadline_stops_retry() -> None:
+    # Attempt 0 takes 100s (render+judges); predicting another 100s attempt
+    # would land at 200 > deadline 150 — stop with keep-best, no retry.
+    ticks = iter([0.0, 100.0, 100.0])
+    render = AsyncMock(return_value=_Img(b"a"))
+    attempts = await _drain(
+        render=render, projection="top_down", region_bytes=b"r",
+        judge_conformance=AsyncMock(return_value=_j(3.0)),
+        judge_same_place=AsyncMock(return_value=_j(9.0)),
+        config=_cfg(retry_budget_s=0.0), clock=lambda: next(ticks),
+        deadline_s=150.0,
+    )
+    assert len(attempts) == 1
+    render.assert_awaited_once()
+    assert conclude(attempts).image.jpeg_bytes == b"a"
+    # A far deadline lets the retry proceed.
+    ticks2 = iter([0.0, 100.0, 100.0, 101.0, 101.0])
+    render2 = AsyncMock(side_effect=[_Img(b"a"), _Img(b"b")])
+    attempts2 = await _drain(
+        render=render2, projection="top_down", region_bytes=b"r",
+        judge_conformance=AsyncMock(side_effect=[_j(3.0), _j(9.0)]),
+        judge_same_place=AsyncMock(return_value=_j(9.0)),
+        config=_cfg(retry_budget_s=0.0), clock=lambda: next(ticks2),
+        deadline_s=10_000.0,
+    )
+    assert len(attempts2) == 2
+
+
 def test_data_url_bytes() -> None:
     import base64
 


### PR DESCRIPTION
## The bug

The intermittent 502 on long enters (known since the Ankh demo run): the render loop's `retry_budget_s` is **per-attempt and render-only** — `latency` is measured around the render call alone, judges excluded, nothing cumulative. Worst case: 4 attempts × (239s render + ~183s judge tail) ≈ 1690s, all inside a Modal function with `timeout=600`. Modal kills the container mid-stream; the web proxy maps it to a 502. The SSE heartbeat (already in place) covers proxy body timeouts but can't save a killed container.

## The fix

- `render_loop.iter_attempts` + `edit_loop.iter_edit_attempts` (same guard, same bug) take an optional `deadline_s`. After each rejected attempt, this attempt's total (render+judges) predicts the next one's cost: if it would blow past the deadline, stop and let `conclude()` keep the best attempt — which already existed, so stopping early is safe by construction.
- The enter path derives the deadline from `INGRESS_TIMEOUT_S` − 180s (final-attempt judge tail + post-loop grounding/encode) − elapsed planning time, floored at 60s.
- The edit-region loop mirrors it with the same margin.
- Ingress timeout 600 → 900 as the belt for a single pathological hung render no predictive guard can pre-empt.

## Tests

- `test_render_loop.py::test_cumulative_deadline_stops_retry` — injected-clock: a 100s attempt vs a 150s deadline stops at 1 attempt, keep-best holds; a far deadline lets the retry proceed.
- `test_edit_loop.py::test_cumulative_deadline_stops_retry` — the mirror.
- Full backend suite + ruff + mypy green. Existing budget/tick tests untouched.

**Note:** prod effect needs a Modal deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)