### PR TITLE
perf(extract): overlap the view estimate with the extract→detect→segment chain

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -2087,6 +2087,25 @@ async def extract_entities_endpoint(req: Request, body: ExtractEntitiesBody):
         scene_desc_len=len(body.scene_description or ""),
         image_kb=img_size_kb,
     )
+    # Decode the image once for both geometry passes (localize + view-estimate)
+    # and start the camera estimate NOW — it needs only pixels + caption, so it
+    # overlaps the whole extract→detect→segment chain instead of tailing it
+    # (the geo overlay used to lag the image by the full sequential sum).
+    geo_img_bytes = b""
+    if _geometric_world_on():
+        try:
+            _, _, _gb64 = body.image_data_url.partition(",")
+            geo_img_bytes = base64.b64decode(_gb64) if _gb64 else b""
+        except Exception:
+            geo_img_bytes = b""
+    view_task: _asyncio.Task[ViewEstimate] | None = None
+    if geo_img_bytes:
+        from providers import view_estimator as _view
+
+        view_task = _asyncio.create_task(
+            _view.estimate_view(geo_img_bytes, body.caption)
+        )
+
     try:
         result = await llm_provider.extract_entities(
             image_data_url=body.image_data_url,
@@ -2096,6 +2115,8 @@ async def extract_entities_endpoint(req: Request, body: ExtractEntitiesBody):
         )
     except Exception as exc:
         record_error("extract_entities", exc, node_id=body.node_id)
+        if view_task is not None:
+            view_task.cancel()
         return _err_json(exc, trace_id)
 
     # Localize the catalogued entities so the world map can seed and the overlay
@@ -2103,15 +2124,6 @@ async def extract_entities_endpoint(req: Request, body: ExtractEntitiesBody):
     # images; the purpose-built detector reliably returns one box per label.
     # Detector boxes are centre-based → store top-left for the EntityBBox shape.
     # Gated + best-effort: a failure here never blocks the extract response.
-    # Decode the image once for both geometry passes (localize + view-estimate).
-    geo_img_bytes = b""
-    if _geometric_world_on():
-        try:
-            _, _, _gb64 = body.image_data_url.partition(",")
-            geo_img_bytes = base64.b64decode(_gb64) if _gb64 else b""
-        except Exception:
-            geo_img_bytes = b""
-
     if geo_img_bytes and (result.added or result.updated):
         try:
             from providers import detector as _detector
@@ -2213,11 +2225,9 @@ async def extract_entities_endpoint(req: Request, body: ExtractEntitiesBody):
     # Returned on the response so the web side can store it on the node and
     # back-project the localized boxes at the right angle. Best-effort.
     view: ViewEstimate | None = None
-    if geo_img_bytes:
+    if view_task is not None:
         try:
-            from providers import view_estimator as _view
-
-            view = await _view.estimate_view(geo_img_bytes, body.caption)
+            view = await view_task
             log(
                 "info",
                 "extract.view",

--- a/apps/modal-backend/tests/test_generate_geometry.py
+++ b/apps/modal-backend/tests/test_generate_geometry.py
@@ -297,6 +297,37 @@ async def test_extract_localizes_missing_bboxes(
     assert payload["view"] == {"level": "map", "projection": "oblique", "pitch_deg": -45.0}
 
 
+async def test_extract_view_overlaps_extract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The view estimate must run CONCURRENTLY with entity extraction (it only
+    # needs pixels + caption). Sequential execution deadlocks this pairing:
+    # the extractor blocks until the view stage has started.
+    import asyncio
+
+    monkeypatch.setenv("GEOMETRIC_WORLD", "true")
+    from providers import view_estimator as _ve
+
+    view_started = asyncio.Event()
+
+    async def fake_view(_bytes, _caption=""):
+        view_started.set()
+        return {"level": "map", "projection": "top_down", "pitch_deg": -90.0}
+
+    async def fake_extract(**_kwargs):
+        await asyncio.wait_for(view_started.wait(), 2.0)
+        return _llm.EntityExtractionResult(added=[], updated=[])
+
+    monkeypatch.setattr(_ve, "estimate_view", fake_view)
+    monkeypatch.setattr(_llm, "extract_entities", fake_extract)
+    body = generate.ExtractEntitiesBody(
+        session_id="s", node_id="n", image_data_url="data:image/jpeg;base64,QUJD"
+    )
+    resp = await generate.extract_entities_endpoint(SimpleNamespace(headers={}), body)
+    payload = _json.loads(resp.body)
+    assert payload["view"]["projection"] == "top_down"
+
+
 async def test_edit_entities_endpoint_returns_plan(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## The lag

The geo overlay trails the rendered image by ~a minute: `/extract-entities` ran four model calls strictly sequentially (extract VLM → detector → SAM3 → view estimator), and the whole chain only starts after the client persists the node.

Reading the data flow: detector needs the extractor's labels, SAM3 needs the detector's boxes — genuinely sequential. The **view estimator needs only the decoded image + caption**, yet ran last.

## The change

- Decode `geo_img_bytes` first and start `estimate_view` as a task **before** entity extraction; await it where its result is consumed. Its full round-trip now overlaps the rest of the chain — on every pass, including the second pass of the client's 0/0 re-fire (which already skips detector/SAM).
- Cancel the task if extraction itself fails (the existing early-return path).
- Wire shape, response, logs: unchanged. Web side: zero changes.

Server-side extraction kick was evaluated and skipped: `node_id` is minted at persist and the overlay repaint rides the client-emitted `world:extracted` event — bad cost/benefit for ~2-6s more.

## Tests

`test_generate_geometry.py::test_extract_view_overlaps_extract` — the extractor blocks until the view stage has started; sequential execution times out, concurrent passes and the response still carries `view`. Full backend suite + ruff + mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)