### PR TITLE
fix(obs): harden the five silent failure paths (AUDIT_BOX §3)

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -715,8 +715,10 @@ async def _run_grounding(
                         cast("list[dict[str, Any]]", segs),
                     ),
                 )
-            except Exception:  # best-effort: a SAM3 failure keeps the detector boxes
-                pass
+            except Exception as exc:  # best-effort: a SAM3 failure keeps the detector boxes
+                from obs import log
+
+                log("warn", "grounding.sam3_failed", error=f"{type(exc).__name__}: {exc}")
         return grounding.diff(expected, observed)
 
     async def _repair(img: Any, report: Any) -> Any | None:
@@ -746,7 +748,7 @@ async def _run_grounding(
         # never break generation, so any error degrades to (original, no summary).
         from obs import log
 
-        log("info", "grounding.failed", error=f"{type(exc).__name__}: {exc}")
+        log("warn", "grounding.failed", error=f"{type(exc).__name__}: {exc}")
         return result, None
     # `repaired` = the kept image differs from what we rendered (a corrective edit
     # actually survived), not merely that a repair was attempted.
@@ -2199,15 +2201,20 @@ async def extract_entities_endpoint(req: Request, body: ExtractEntitiesBody):
                             "extract.segment_failed",
                             error=f"{type(exc).__name__}: {exc}",
                         )
+            located = sum(1 for e in result.added if e.bbox) + sum(
+                1 for u in result.updated if u.bbox
+            )
+            total = len(result.added) + len(result.updated)
+            # Zero located out of a non-empty catalogue means the overlay and
+            # the world map get nothing this pass — that's a warn, not a stat.
             log(
-                "info",
+                "warn" if total and not located else "info",
                 "extract.localized",
-                located=sum(1 for e in result.added if e.bbox)
-                + sum(1 for u in result.updated if u.bbox),
-                total=len(result.added) + len(result.updated),
+                located=located,
+                total=total,
             )
         except Exception as exc:  # best-effort — geometry localization is optional
-            log("info", "extract.localize_failed", error=f"{type(exc).__name__}: {exc}")
+            log("warn", "extract.localize_failed", error=f"{type(exc).__name__}: {exc}")
 
     # Estimate the camera instead of assuming top-down (maps are often 2.5D).
     # Returned on the response so the web side can store it on the node and
@@ -2226,7 +2233,7 @@ async def extract_entities_endpoint(req: Request, body: ExtractEntitiesBody):
                 pitch_deg=view["pitch_deg"],
             )
         except Exception as exc:
-            log("info", "extract.view_failed", error=f"{type(exc).__name__}: {exc}")
+            log("warn", "extract.view_failed", error=f"{type(exc).__name__}: {exc}")
 
     def _entity_payload(e: llm_provider.ExtractedEntity) -> dict:
         return {

--- a/apps/modal-backend/providers/ratelimit.py
+++ b/apps/modal-backend/providers/ratelimit.py
@@ -18,10 +18,22 @@ _buckets: OrderedDict[str, tuple[float, float]] = OrderedDict()  # ip -> (tokens
 _MAX_BUCKETS = 4096
 
 
+_warned_bad_rpm = False
+
+
 def rpm() -> float:
+    raw = os.environ.get("RATE_LIMIT_RPM", "")
     try:
-        return max(0.0, float(os.environ.get("RATE_LIMIT_RPM", "") or 0.0))
+        return max(0.0, float(raw or 0.0))
     except ValueError:
+        # A typo'd RATE_LIMIT_RPM used to silently disarm the limiter — say so
+        # once instead of never (warn-per-container, not per-request).
+        global _warned_bad_rpm
+        if not _warned_bad_rpm:
+            _warned_bad_rpm = True
+            from obs import log
+
+            log("warn", "ratelimit.bad_rpm", value=raw)
         return 0.0
 
 
@@ -50,5 +62,7 @@ def allow(ip: str) -> bool:
 
 
 def reset_for_tests() -> None:
+    global _warned_bad_rpm
     with _lock:
         _buckets.clear()
+    _warned_bad_rpm = False

--- a/apps/modal-backend/tests/test_generate_geometry.py
+++ b/apps/modal-backend/tests/test_generate_geometry.py
@@ -192,11 +192,18 @@ async def test_run_grounding_degrades_on_detector_error(
         raise RuntimeError("vlm 429")
 
     monkeypatch.setattr(detector, "detect", boom)
+    import obs
+
+    events: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        obs, "log", lambda level, event, **kw: events.append((level, event))
+    )
     img = _fake_img()
     out_img, summary = await generate._run_grounding(
         img, _EXP, repair_on=False, abort=_noop_abort
     )
     assert out_img is img and summary is None  # best-effort: never breaks gen
+    assert ("warn", "grounding.failed") in events  # ...but never silently
 
 
 async def test_run_grounding_verify_only_low_score_not_repaired(
@@ -295,6 +302,50 @@ async def test_extract_localizes_missing_bboxes(
     assert bb["w_pct"] == pytest.approx(0.2)
     # FIX 1b: the estimated camera rides on the response (no more top-down assumption)
     assert payload["view"] == {"level": "map", "projection": "oblique", "pitch_deg": -45.0}
+
+
+async def test_extract_detector_failure_degrades_loudly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Localization stays best-effort — a detector blow-up never blocks the
+    # extract response — but the degradation must leave a warn, not silence.
+    monkeypatch.setenv("GEOMETRIC_WORLD", "true")
+    import obs
+    from providers import detector as _det
+    from providers import view_estimator as _ve
+
+    events: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        obs, "log", lambda level, event, **kw: events.append((level, event))
+    )
+
+    async def fake_view(_bytes, _caption=""):
+        return {"level": "map", "projection": "oblique", "pitch_deg": -45.0}
+
+    async def fake_extract(**_kwargs):
+        return _llm.EntityExtractionResult(
+            added=[
+                _llm.ExtractedEntity(
+                    kind="place", name="Unseen University", appearance="tower",
+                    aliases=[], facts=[], state={}, confidence=0.9, bbox=None,
+                )
+            ],
+            updated=[],
+        )
+
+    async def boom_detect(_bytes, _labels):
+        raise RuntimeError("vlm 429")
+
+    monkeypatch.setattr(_ve, "estimate_view", fake_view)
+    monkeypatch.setattr(_llm, "extract_entities", fake_extract)
+    monkeypatch.setattr(_det, "detect", boom_detect)
+    body = generate.ExtractEntitiesBody(
+        session_id="s", node_id="n", image_data_url="data:image/jpeg;base64,QUJD"
+    )
+    resp = await generate.extract_entities_endpoint(SimpleNamespace(headers={}), body)
+    payload = _json.loads(resp.body)
+    assert payload["result"]["added"][0]["bbox"] is None  # degraded, not broken
+    assert ("warn", "extract.localize_failed") in events
 
 
 async def test_edit_entities_endpoint_returns_plan(

--- a/apps/modal-backend/tests/test_ratelimit.py
+++ b/apps/modal-backend/tests/test_ratelimit.py
@@ -3,7 +3,25 @@ from __future__ import annotations
 
 import pytest
 
+import obs
 from providers import ratelimit
+
+
+def test_malformed_rpm_warns_once_and_disables(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A typo'd RATE_LIMIT_RPM used to silently turn the limiter OFF — it still
+    # degrades to off (never blocks traffic on a config error) but now says so,
+    # once per container, not per request.
+    monkeypatch.setenv("RATE_LIMIT_RPM", "sixty")
+    ratelimit.reset_for_tests()
+    events: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        obs, "log", lambda level, event, **kw: events.append((level, event))
+    )
+    assert ratelimit.rpm() == 0.0
+    assert ratelimit.allow("A")  # limiter off, requests pass
+    assert ratelimit.rpm() == 0.0  # second read: no second warn
+    assert events.count(("warn", "ratelimit.bad_rpm")) == 1
+    ratelimit.reset_for_tests()
 
 
 def test_eviction_is_lru_not_fifo(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/apps/web/lib/image-click-annotate.test.ts
+++ b/apps/web/lib/image-click-annotate.test.ts
@@ -99,8 +99,10 @@ afterEach(() => {
 describe("annotateClickPoint", () => {
   it("returns the original dataUrl when canvas 2D context is unavailable", async () => {
     vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(null);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const out = await annotateClickPoint(ORIGINAL_DATA_URL, 0.5, 0.5);
     expect(out).toBe(ORIGINAL_DATA_URL);
+    expect(warn).toHaveBeenCalled(); // degradation must be loud
   });
 
   it("paints crosshair primitives onto the canvas and returns the encoded data URL", async () => {
@@ -158,8 +160,10 @@ describe("annotateStroke", () => {
 
   it("returns the original dataUrl when canvas 2D context is unavailable", async () => {
     vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(null);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const out = await annotateStroke(ORIGINAL_DATA_URL, realStroke);
     expect(out).toBe(ORIGINAL_DATA_URL);
+    expect(warn).toHaveBeenCalled(); // degradation must be loud
   });
 
   it("draws moveTo + lineTo for each stroke point and returns the encoded data URL", async () => {

--- a/apps/web/lib/image-click.ts
+++ b/apps/web/lib/image-click.ts
@@ -135,7 +135,11 @@ export async function annotateClickPoint(
   canvas.width = img.naturalWidth;
   canvas.height = img.naturalHeight;
   const ctx = canvas.getContext("2d");
-  if (!ctx) return dataUrl;
+  if (!ctx) {
+    // The VLM gets an unannotated image — click resolution degrades. Say so.
+    console.warn("annotateClickPoint: no 2D canvas context, sending unannotated image");
+    return dataUrl;
+  }
 
   ctx.drawImage(img, 0, 0);
 
@@ -201,7 +205,11 @@ export async function annotateStroke(
   canvas.width = img.naturalWidth;
   canvas.height = img.naturalHeight;
   const ctx = canvas.getContext("2d");
-  if (!ctx) return dataUrl;
+  if (!ctx) {
+    // The VLM never sees the user's scribble — click resolution degrades.
+    console.warn("annotateStroke: no 2D canvas context, sending unannotated image");
+    return dataUrl;
+  }
 
   ctx.drawImage(img, 0, 0);
 

--- a/apps/web/lib/stream-client.test.ts
+++ b/apps/web/lib/stream-client.test.ts
@@ -2,9 +2,64 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   MAX_RECONNECTS,
+  packetPlan,
   reconnectDelayMs,
   startLTXStream,
 } from "./stream-client";
+
+describe("packetPlan (resume dedup / sequence path)", () => {
+  it("fresh media packet appends and advances the sequence", () => {
+    expect(packetPlan({ sequence: 0 }, -1)).toEqual({
+      append: true,
+      end: false,
+      nextLastSequence: 0,
+    });
+    expect(packetPlan({ sequence: 5 }, 3)).toEqual({
+      append: true,
+      end: false,
+      nextLastSequence: 5,
+    });
+  });
+
+  it("replayed duplicate after a resume is skipped, sequence unchanged", () => {
+    expect(packetPlan({ sequence: 3 }, 3)).toEqual({
+      append: false,
+      end: false,
+      nextLastSequence: 3,
+    });
+    // out-of-order stale packet — also skipped, never rewinds
+    expect(packetPlan({ sequence: 1 }, 3)).toEqual({
+      append: false,
+      end: false,
+      nextLastSequence: 3,
+    });
+  });
+
+  it("a duplicate carrying `final` still ends the stream", () => {
+    expect(packetPlan({ sequence: 3, final: true }, 3)).toEqual({
+      append: false,
+      end: true,
+      nextLastSequence: 3,
+    });
+  });
+
+  it("init segments always append and never advance the media sequence", () => {
+    // A re-dial needs the codec init again even when its sequence looks stale.
+    expect(packetPlan({ sequence: 0, is_init_segment: true }, 7)).toEqual({
+      append: true,
+      end: false,
+      nextLastSequence: 7,
+    });
+  });
+
+  it("final on a fresh packet appends AND ends", () => {
+    expect(packetPlan({ sequence: 9, final: true }, 8)).toEqual({
+      append: true,
+      end: true,
+      nextLastSequence: 9,
+    });
+  });
+});
 
 describe("reconnectDelayMs", () => {
   it("backs off 500ms → 1s → 2s, capped at 4s", () => {

--- a/apps/web/lib/stream-client.ts
+++ b/apps/web/lib/stream-client.ts
@@ -41,6 +41,29 @@ export function reconnectDelayMs(attempt: number): number {
   return Math.min(4000, 500 * 2 ** attempt);
 }
 
+/** Decide what to do with an incoming packet given the last appended media
+ * sequence. After a resume the worker may replay segments we already
+ * appended — duplicates are skipped (re-appending confuses the SourceBuffer)
+ * but a duplicate carrying `final` still ends the stream. Init segments
+ * always append (a re-dial needs the codec init again) and never advance
+ * the sequence. Pure — pinned by tests. */
+export function packetPlan(
+  header: { is_init_segment?: boolean; sequence: number; final?: boolean },
+  lastSequence: number
+): { append: boolean; end: boolean; nextLastSequence: number } {
+  const end = header.final === true;
+  if (!header.is_init_segment && header.sequence <= lastSequence) {
+    return { append: false, end, nextLastSequence: lastSequence };
+  }
+  return {
+    append: true,
+    end,
+    nextLastSequence: header.is_init_segment
+      ? lastSequence
+      : Math.max(lastSequence, header.sequence),
+  };
+}
+
 function newStreamId(): string {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
     return `ltx_stream_${crypto.randomUUID()}`;
@@ -112,28 +135,18 @@ export function startLTXStream(config: StreamConfig): StreamClient {
       if (!(event.data instanceof ArrayBuffer)) return;
       try {
         const packet = parseLTXF(event.data);
-        const seq = packet.header.sequence;
-        // After a resume the worker may replay segments we already appended
-        // — drop duplicates (re-appending confuses the SourceBuffer); init
-        // segments always pass (a re-dial needs the codec init again).
-        if (!packet.header.is_init_segment && seq <= lastSequence) {
-          if (packet.header.final) {
-            gotFinal = true;
-            endStream();
+        const plan = packetPlan(packet.header, lastSequence);
+        if (plan.append) {
+          await controller.appendPacket(packet);
+          lastSequence = plan.nextLastSequence;
+          if (statusRef.current !== "playing") {
+            setStatus("playing");
+            void config.video.play().catch(() => {
+              // Autoplay may be blocked; user must click the video. Non-fatal.
+            });
           }
-          return;
         }
-        await controller.appendPacket(packet);
-        if (!packet.header.is_init_segment) {
-          lastSequence = Math.max(lastSequence, seq);
-        }
-        if (statusRef.current !== "playing") {
-          setStatus("playing");
-          void config.video.play().catch(() => {
-            // Autoplay may be blocked; user must click the video. Non-fatal.
-          });
-        }
-        if (packet.header.final) {
+        if (plan.end) {
           gotFinal = true;
           endStream();
         }


### PR DESCRIPTION
Works through `docs/AUDIT_BOX.md` item 3 — each degradation path now emits a signal, none of them change the happy path:

| Path | Before | After |
|---|---|---|
| extract localize / view estimate (`generate.py`) | `info` logs, invisible | `warn`; plus `extract.localized` warns when 0 of N entities got a box |
| grounding SAM3 refine (`_run_grounding`) | bare `except: pass` | `warn grounding.sam3_failed` |
| grounding loop catch-all | `info` | `warn` |
| `RATE_LIMIT_RPM` parse (`providers/ratelimit.py`) | typo silently disarms the limiter | still degrades to off, but warns once per container |
| LTX stream resume dedup (`lib/stream-client.ts`) | logic embedded in the socket handler, untested | extracted to pure `packetPlan()`, behavior identical, 5 unit tests pin duplicate-skip / final-on-duplicate / init-segment / no-rewind |
| click annotation (`lib/image-click.ts`) | null 2D context silently sends the VLM an unannotated image | `console.warn`, asserted in the existing ctx-null tests |

## Tests
- `test_ratelimit.py::test_malformed_rpm_warns_once_and_disables`
- `test_generate_geometry.py::test_extract_detector_failure_degrades_loudly` + warn assertion added to the existing grounding degrade test
- `stream-client.test.ts`: new `packetPlan` suite; `image-click-annotate.test.ts`: warn assertions
- Full backend pytest + ruff + mypy green; web vitest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)