### PR TITLE
chore: mojibake fix, missing flag docs, audit-doc truth-sync, README catch-up

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -128,6 +128,15 @@ NEXT_PUBLIC_LTX_WS_URL=
 # enter") instead of "rings = enterable places" (build-time; rebuild web).
 # NEXT_PUBLIC_ENTER_COACH=true
 
+# Mask-scoped judged edits UI (drag a region, the mask rides the edit). Needs
+# EDIT_REGION=true on the backend too (build-time; rebuild web after change).
+# NEXT_PUBLIC_EDIT_REGION=true
+
+# Kill-switch: =0 turns OFF the graceful world-tap degrade (un-routable taps
+# falling back to a faithful zoom). Default ON — leave it alone unless
+# debugging tap routing (build-time; rebuild web after change).
+# NEXT_PUBLIC_WORLD_TAP_DEGRADE=1
+
 # Dev-only scenario bench gallery at /dev/bench (build-time; rebuild web after change).
 # NEXT_PUBLIC_BENCH_UI=1
 # BENCH_REPORTS_DIR=apps/modal-backend/tests/scenario_lab/reports

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Sped up 4×: landing → `"how does a steam engine work"` deeplink → two click
 - **Time-scrubber (`T`).** Linear film-strip of every page in your trail; drag the scrubber to time-travel through your own exploration.
 - **Faster clicks.** As soon as a page renders, the VLM precomputes the 3–4 most clickable regions in the background, so most taps skip the resolve round-trip.
 - **Progressive render.** On the balanced/pro tiers the cheap fast model paints a draft in parallel, so you get something on screen seconds before the final lands. Toggle off with `PROGRESSIVE_DRAFT=false` if you'd rather save the extra fal call.
+- **Edit a page in place.** Describe a change and the page revises itself instead of spawning a child. With `EDIT_REGION` on you drag the exact region, the mask rides the edit, and a judge scores the result — verdict chip + one-click revert included.
+- **World Mode (off by default).** Flip `WORLD_MODE` and pages become places: tap a glowing region to *enter* it as a scene, go deeper, ascend back out, or pan to a logical neighbour — all rungs on one metric scale ladder. Every page gets its entities and camera extracted into a live geo overlay and a persistent world map, so revisiting a place brings back *that* place.
+- **Critic loop.** Long renders (entering a scene, masked edits) are judged by a panel of VLM critics — wrong camera, wrong place, or wrong art medium gets rejected and retried with the critic's rationale folded into the prompt. You watch it self-correct instead of staring at a spinner.
 - **BYO keys.** No hosted backend. Clone it, run it, pay your own bills.
 
 ```
@@ -133,6 +136,7 @@ docs/
 - **[docs/BYO-KEYS.md](docs/BYO-KEYS.md)** — credential + deploy walkthrough.
 - **[docs/DOCKER.md](docs/DOCKER.md)** — compose stack reference.
 - **[docs/LOCAL_DEV.md](docs/LOCAL_DEV.md)** — running without Docker.
+- **[docs/TESTING.md](docs/TESTING.md)** — the free gates + the paid eval benches (scenario lab, layout/style A/Bs, reconstruction bench).
 - **[infra/MONGO.md](infra/MONGO.md)** — document shape + index layout.
 
 ## Contributing

--- a/docs/AUDIT_BOX.md
+++ b/docs/AUDIT_BOX.md
@@ -22,18 +22,15 @@ existing users.
 **Acceptance:** a clean machine reaches a first generated page following only the docs;
 existing flow byte-identical; voice stays chill/first-person.
 
-## 2. Wire `expected_layout` → render  — priority: MEDIUM (closes a documented no-op)
-**Goal:** B1's solved geometry currently seeds `world_map` geos (tap-routable, overlay-visible)
-but does **not** steer the rendered pixels — the first render is description-driven. Make
-`projectScene` actually drive the render.
-**Files:** `apps/modal-backend/generate.py` (`_layout_clause_for`, `GenerateBody.expected_layout`),
-`apps/modal-backend/providers/geometry_prompt.py` (`layout_constraints`),
-`apps/modal-backend/providers/prompt_library/layout.py`. Doc: `docs/SESSION_AUDIT.md`
-(Simplification 1).
-**Acceptance:** with the flag on, solved positions visibly steer layout; `make eval-layout`
-(P3 layout-fidelity A/B) shows no regression vs baseline; flag off = byte-identical.
+## 2. ✅ Wire `expected_layout` → render  — DONE (the doc lagged the code)
+`projectScene`/`projectTopDown` (web `lib/world-geometry.ts`) ride
+`GenerateBody.expected_layout` and steer the prompt via `_layout_clause_for` →
+`geometry_prompt.layout_constraints`, gated by `WORLD_GEOMETRY_GEN` (default ON under an
+active world mode). Measured +0.33 layout fidelity in the A/B; the VLM-grounding verify
+checks the render against it. Suppressed only on a camera-register mismatch
+(`_layout_register_mismatch` — surfacing that suppression is UI_AUDIT debt #11).
 
-## 3. Harden silent failures  — priority: MEDIUM (reliability / observability)
+## 3. ✅ Harden silent failures  — DONE (PR #119)
 **Goal:** several degradation paths fail silently — surface a signal and add tests so they stop
 hiding. Each is small and independent; do them as separate flagged/observable changes.
 - Geometry localization best-effort drop (`generate.py:~2567-2650`): detector/view-estimate
@@ -67,4 +64,4 @@ baseline; no regression elsewhere.
 - **UI discoverability** (`docs/UI_AUDIT.md`): `⊞ geo` / entity-chip toggles are buried — add a
   `G` shortcut + hint. Hover-prefetch + suppressed layout steering have no debug surface.
 - **Mobile pass**: ≤390px audit for breadcrumbs, codex panel, geo inset.
-- **Cost**: stop uploading the inert fresh-gen reference image (ignored by the model anyway).
+- ~~**Cost**: stop uploading the inert fresh-gen reference image~~ — DONE (PR #109).

--- a/docs/SESSION_AUDIT.md
+++ b/docs/SESSION_AUDIT.md
@@ -81,13 +81,18 @@ tests. **Everything else in B2 is unbuilt** — see `PLAN_OUTWARD.md`.
 ## Deferred / tech-debt (carry forward)
 
 1. **`origin/backup/pre-purge`** — delete once a fresh clone is confirmed lean.
-2. **B1 `expected_layout` steering** — wire `projectScene` so the render reflects the solved
-   positions (today it's description-driven; the geos hold the layout).
+2. **B1 `expected_layout` steering** — ~~wire `projectScene` so the render reflects the solved
+   positions~~ **DONE since**: `projectScene`/`projectTopDown` output rides
+   `GenerateBody.expected_layout` and steers the prompt via `_layout_clause_for` →
+   `geometry_prompt.layout_constraints` (+0.33 layout fidelity in the A/B; on iff world mode /
+   `WORLD_GEOMETRY_GEN`).
 3. **B1 `inside` flat-nesting** — sub-frame nesting deferred.
-4. **A2 fresh-gen ref upload** — inert (fal ignores it); stop uploading to save cost.
+4. **A2 fresh-gen ref upload** — ~~inert (fal ignores it); stop uploading to save cost~~
+   **DONE** (PR #109 dropped the upload; the text medium-lock still carries style).
 5. **Flagged Kontext-scene path** — not built (intentional; the audit cautions it for map→scene).
-6. **B2 integration** — OUTWARD / AROUND / DEEPER / UI + the `scale_tier` plumbing through
-   `db`/`SceneView`/Pydantic + the parity fixture (the whole of `PLAN_OUTWARD.md`).
+6. **B2 integration** — ~~OUTWARD / AROUND / DEEPER / UI + the `scale_tier` plumbing~~
+   **DONE** (PRs #20–#26 shipped the whole ladder: OUTWARD/ascend now lives in
+   `providers/generate_modes/ascend.py`; see `PLAN_OUTWARD.md` Phase E notes).
 7. **Merged local branches** — `feat/consistency-fixes`, `feat/eval`, `feat/world-from-description`,
    `fix/centre-empty-region` are merged; tidy locally.
 8. **mypy coverage split (CI hygiene)** — `make eval` type-checks `generate.py` + 5 provider

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -7,7 +7,7 @@ export type GenerateMode = "query" | "tap" | "edit" | "expand" | "ascend";
 // scale-level: component = -1, peer = 0, container = +1.
 export type ScaleKind = "component" | "peer" | "container";
 
-// ââ Scale ladder (B2, SCALE_LADDER_NAV) ââââââââââââââââââââââââââââââââââââââ
+// ── Scale ladder (B2, SCALE_LADDER_NAV) ──────────────────────────────────────
 // An explicit, ordered, metric-anchored zoom axis: a node's COARSE absolute
 // "where on the zoom axis am I". Distinct from ScaleKind (relative:
 // component/peer/container) and from WorldEntityGeo.scale (fine metric: the size
@@ -19,7 +19,7 @@ export const SCALE_LADDER = [
 ] as const;
 export type ScaleTier = (typeof SCALE_LADDER)[number];
 
-// Order-of-magnitude metric anchor (metres) per rung â the bridge that makes the
+// Order-of-magnitude metric anchor (metres) per rung — the bridge that makes the
 // ladder metric-conserving. ~27 orders of magnitude end to end, so callers
 // store/compare in LOG space. `world` and `planet` share an anchor by design (a
 // "world" is a planet-surface framing); tierStep still separates them by index.
@@ -42,7 +42,7 @@ export function tierStep(from: ScaleTier, to: ScaleTier): number {
 export function tierMetricMultiplier(from: ScaleTier, to: ScaleTier): number {
   return SCALE_TIER_METERS[to] / SCALE_TIER_METERS[from];
 }
-// INV-2: the metric span must move monotonically with the rung step â going
+// INV-2: the metric span must move monotonically with the rung step — going
 // DEEPER (step > 0) shrinks it (multiplier <= 1), OUTWARD (step < 0) grows it
 // (multiplier >= 1); ==1 is allowed only between the deliberately-equal
 // world/planet rungs. A transition that violates this is a mis-classified rung
@@ -54,8 +54,8 @@ export function tierTransitionValid(from: ScaleTier, to: ScaleTier): boolean {
   return step > 0 ? m <= 1 : m >= 1;
 }
 // One rung FINER (toward `object`, DEEPER); clamps at `object`. The inverse of the
-// Python `model_router.coarser_tier` used by OUTWARD â together they make a tap a
-// `tierStep` of +1 and an OUTWARD â1 on the SAME ladder.
+// Python `model_router.coarser_tier` used by OUTWARD — together they make a tap a
+// `tierStep` of +1 and an OUTWARD −1 on the SAME ladder.
 export function finerTier(t: ScaleTier): ScaleTier {
   const i = tierIndex(t);
   return SCALE_LADDER[Math.min(i + 1, SCALE_LADDER.length - 1)] ?? t;
@@ -64,7 +64,7 @@ export function finerTier(t: ScaleTier): ScaleTier {
 // How a node relates to its parent: "descend" = went IN (a tap child, the
 // default), "expand" = bloomed OUT (a neighbour from mode:"expand"), "ascend" =
 // zoomed OUT to a synthesized container (the OUTWARD reparent, SCALE_OUTWARD),
-// "edit" = a REVISION of the parent (mode:"edit") â the same page changed, not
+// "edit" = a REVISION of the parent (mode:"edit") — the same page changed, not
 // a place inside it, so the graph chrome must not read it as a tap-in.
 export type NodeRelation = "descend" | "expand" | "ascend" | "edit";
 
@@ -74,7 +74,7 @@ export type VideoTier = "fast" | "balanced" | "pro";
 
 // World Mode (opt-in). `autonomy` "auto" generates straight away; "semi" first
 // surfaces the resolver's clarifying questions. `RenderMode` is how a tapped
-// subject is drawn â an immersive place you've stepped into, a closer
+// subject is drawn — an immersive place you've stepped into, a closer
 // cartographic map of a sub-area, or today's labelled explainer diagram.
 export type Autonomy = "auto" | "semi";
 // place_closeup = the descent ladder's closeup rung on a NON-map frame (a
@@ -116,7 +116,7 @@ export interface GenerateRequestBody {
   // it's a no-op until enabled). `edit_mask` is an opaque PNG data URL at the
   // page's natural dims, WHITE = edit / black = keep (flux fill's native
   // convention); `edit_region` is the drag selection that produced it,
-  // normalized to natural-image space â the mask drives the model, the box
+  // normalized to natural-image space — the mask drives the model, the box
   // scopes the judge's inside crop. Absent -> the legacy whole-image edit.
   edit_mask?: string;
   edit_region?: { x: number; y: number; w: number; h: number };
@@ -157,16 +157,16 @@ export interface GenerateRequestBody {
   // so recurring characters / places preserve their look across pages without
   // the user having to re-describe them.
   world_context?: WorldContextEntity[];
-  // Image conditioning â an ordered stack of reference images (data URLs) the
+  // Image conditioning — an ordered stack of reference images (data URLs) the
   // generator blends so the page belongs to the same world: region crop (the
-  // spot you came from) â whole parent â global style anchor. `condition_roles`
+  // spot you came from) → whole parent → global style anchor. `condition_roles`
   // labels each url in order so the backend can phrase the conditioning prompt.
-  // Built client-side (lib/image-condition.ts). Omit â today's text-only gen.
+  // Built client-side (lib/image-condition.ts). Omit → today's text-only gen.
   condition_image_urls?: string[];
   condition_roles?: string[];
   // World Mode (opt-in; the backend also gates it behind the WORLD_MODE env so
   // it's a no-op in prod until enabled). When on, a tap ENTERS the tapped place
-  // â a scene you stand in or a closer sub-map â instead of explaining a topic,
+  // — a scene you stand in or a closer sub-map — instead of explaining a topic,
   // and the place persists + reopens. `render_mode` explicitly overrides the
   // per-place framing the resolver would otherwise pick from `enter_as`.
   world_mode?: boolean;
@@ -183,7 +183,7 @@ export interface GenerateRequestBody {
   // B2 logical AROUND (mode:"expand", SCALE_AROUND_LOGICAL). The same-scale
   // neighbours the client already knows from geometry (excluded) + the focus's
   // rung, so the bloom proposes NEW peers at that scale. Ignored unless the flag
-  // is on; absent â today's unconstrained bloom.
+  // is on; absent → today's unconstrained bloom.
   known_neighbors?: string[];
   around_tier?: ScaleTier;
   // Geometric world (GEOMETRIC_WORLD). The scene's observer pose + level, and the
@@ -210,7 +210,7 @@ export interface WorldContextEntity {
   // Optional geometric size (world units) carried from the entity's
   // WorldEntityGeo when the web proxy resolves the slice. Lets the planner
   // hint a consistent relative scale for recurring entities across pages so a
-  // building rendered large once doesn't come back tiny next time. Omitted â
+  // building rendered large once doesn't come back tiny next time. Omitted →
   // today's behaviour (appearance text only).
   footprint?: { w: number; d: number };
   height?: number;
@@ -238,7 +238,7 @@ export interface ResolveClickRequestBody {
 }
 
 // VLM's best-estimate centroid of the resolved subject (0..1 in image
-// frame). Powers the "we think you tapped this â yes/try again" overlay.
+// frame). Powers the "we think you tapped this — yes/try again" overlay.
 export interface ResolveClickPoint {
   x: number;
   y: number;
@@ -326,11 +326,11 @@ export interface GenerateFinalEvent {
   // or the model returned none. Already domain-deduped, capped at ~3.
   sources?: Citation[];
   // Which non-fresh image operation rendered this page ("zoom_continue",
-  // "enter_scene"). Absent on the fresh path â additive, backwards-compat.
+  // "enter_scene"). Absent on the fresh path — additive, backwards-compat.
   image_op?: string;
-  // Geometric grounding summary â present only when VLM_GROUNDING was on.
+  // Geometric grounding summary — present only when VLM_GROUNDING was on.
   grounding?: GroundingSummary;
-  // Judged mask-scoped edit verdict â present only on the EDIT_REGION path.
+  // Judged mask-scoped edit verdict — present only on the EDIT_REGION path.
   edit_verdict?: EditVerdict;
   // Running estimated spend ($) for this session — coarse, mirrors
   // docs/COSTS.md prices (providers/spend.py). Additive; absent on older
@@ -391,7 +391,7 @@ export interface GenerateNeighborEvent {
   trace_id?: string;
 }
 
-// Terminal event of an expand bloom â the tray stops showing pending slots.
+// Terminal event of an expand bloom — the tray stops showing pending slots.
 export interface GenerateExpandDoneEvent {
   type: "expand_done";
   count: number;
@@ -499,7 +499,7 @@ export const DEFAULTS = {
 export type EntityKind = "person" | "place" | "item" | "creature";
 
 // Free-form key/value bag for causality (door=open, lantern=lit, mira_present=true).
-// Kept loose on purpose â the extractor emits whatever verbs/state words fit
+// Kept loose on purpose — the extractor emits whatever verbs/state words fit
 // the scene; the codex surface renders them as plain key:value chips.
 export type EntityState = Record<string, string | number | boolean>;
 
@@ -534,7 +534,7 @@ export interface Entity {
   // Atlas tile ids (== node ids in the current world-layout) the entity has
   // appeared on. Used for the atlas-pin overlay.
   appears_on_node_ids: string[];
-  // Sparse map of `node_id` â bounding box for the entity's appearance on
+  // Sparse map of `node_id` → bounding box for the entity's appearance on
   // that node. Populated by the extractor when it can localize the entity
   // in the image; omitted otherwise. Hover chips read this when rendering
   // the current page; atlas pins can use it to place markers within a
@@ -554,13 +554,13 @@ export interface Entity {
   updated_at: string;
 }
 
-// ââ Geometric world model ââââââââââââââââââââââââââââââââââââââââââââââââââââ
+// ── Geometric world model ────────────────────────────────────────────────────
 // A persistent 2D coordinate world: entities sit at numeric map positions with a
 // height + footprint; an observer has a pose; a rendered scene is a VIEW of the
 // in-frame entities from that pose (there is no single correct view). All
 // additive + dormant until GEOMETRIC_WORLD is enabled. The geometry engine
-// (apps/web/lib/world-geometry.ts â apps/modal-backend/providers/geometry.py)
-// projects (map + observer) â the per-frame layout below.
+// (apps/web/lib/world-geometry.ts ↔ apps/modal-backend/providers/geometry.py)
+// projects (map + observer) → the per-frame layout below.
 
 // A point in world units (arbitrary scale; origin top-left, +x east, +y south).
 export interface WorldVec2 {
@@ -573,7 +573,7 @@ export interface WorldVec2 {
 // Nested frames (the sub-entity consistency model): a place you can ENTER (the
 // Unseen University) is its own little world. Its sub-entities (Tower of Art,
 // Library, Great Hall) carry `parent_id` = that place's geo id, and their `pos`
-// is LOCAL to the parent's frame â so the University's internal layout is fixed
+// is LOCAL to the parent's frame — so the University's internal layout is fixed
 // ONCE and stays consistent across every view of it, and editing one ripples to
 // its siblings. Top-level city entities have `parent_id: null` (pos == world).
 export interface WorldEntityGeo {
@@ -592,14 +592,14 @@ export interface WorldEntityGeo {
   // default) = sits on the ground; >0 lifts it (a bird aloft, a clifftop castle,
   // a wall-mounted lantern). The projector reads `elevation ?? 0`.
   elevation?: number;
-  footprint: { w: number; d: number }; // ground extent: width (x) Ã depth (y)
+  footprint: { w: number; d: number }; // ground extent: width (x) × depth (y)
   // Per-frame scale: the size of ONE unit of THIS place's INTERIOR frame, in its
   // parent's units (default 1). Set when the place is first entered (its
-  // footprint extent Ã· the interior's local extent) so a child's local `pos`
-  // resolves to a true absolute position INSIDE this place. Metric â distinct
+  // footprint extent ÷ the interior's local extent) so a child's local `pos`
+  // resolves to a true absolute position INSIDE this place. Metric — distinct
   // from the categorical Entity.scale LOD bucket.
   scale?: number;
-  // Coarse absolute rung on SCALE_LADDER (city / place / room â¦) â which order of
+  // Coarse absolute rung on SCALE_LADDER (city / place / room …) — which order of
   // magnitude this entity's frame sits at, independent of the fine metric `scale`.
   // Optional; seeded by the view estimator, used by B2 scale navigation.
   scale_tier?: ScaleTier;
@@ -608,7 +608,7 @@ export interface WorldEntityGeo {
   state: EntityState;
   confidence: number; // 0..1
   // How this geometry was set: "user" (hand-placed, authoritative), "extracted"
-  // (a confirmed detection), or "derived" (back-projected from a bbox â a guess).
+  // (a confirmed detection), or "derived" (back-projected from a bbox — a guess).
   source: "extracted" | "user" | "derived";
   updated_at: string;
   // VLM-segmented border polygon (B2 segmenter), in the SAME frame as `pos`
@@ -621,7 +621,7 @@ export interface WorldEntityGeo {
   height_m?: number;
 }
 
-// Where the camera stands for a scene. Null observer â a top-down map view.
+// Where the camera stands for a scene. Null observer ⇒ a top-down map view.
 export interface ObserverPose {
   pos: WorldVec2;
   eye_height: number;
@@ -641,20 +641,20 @@ export interface MapCrop {
   h: number;
 }
 
-// What level a scene renders at â there is no single correct view.
+// What level a scene renders at — there is no single correct view.
 export type ViewLevel = "map" | "building" | "street" | "eye";
 
 // Render-INTENT camera vocabulary (the view grammar). Distinct from
 // ViewProjection below, which is the estimator's PERCEPTION read-out of an
 // already-generated image (estimator "perspective" maps to "eye_level" here).
 // A deliberate projection per render: flat 2D plan, 2.5D oblique bird's-eye,
-// true isometric, or 3D eye-level â plus optional numeric camera params.
+// true isometric, or 3D eye-level — plus optional numeric camera params.
 export type ViewSpecProjection = "top_down" | "oblique" | "isometric" | "eye_level";
 export interface ViewSpec {
   projection: ViewSpecProjection;
-  pitch_deg?: number; // camera tilt: -90 straight down â¦ 0 horizon
+  pitch_deg?: number; // camera tilt: -90 straight down … 0 horizon
   azimuth_deg?: number; // compass bearing of the gaze, 0 = north
-  // Qualitative register ("eye" â 1.7 world units) or a metric height.
+  // Qualitative register ("eye" ≈ 1.7 world units) or a metric height.
   camera_height?: "ground" | "eye" | "rooftop" | "aerial" | number;
   fov_deg?: number;
   // Who decided this view: the per-place policy, an explicit user pick
@@ -679,10 +679,10 @@ export interface SceneView {
   // stays consistent across re-entries. Null for a top-level map view.
   focus_id?: string | null;
   // Coarse absolute rung on SCALE_LADDER for this view (DEEPER stamps childTier,
-  // OUTWARD stamps parentTier) â so both directions share one ladder. Optional.
+  // OUTWARD stamps parentTier) — so both directions share one ladder. Optional.
   scale_tier?: ScaleTier;
   // The deliberate camera for this render (the view grammar). Absent/null on
-  // legacy nodes â the pre-grammar hardcoded behavior, byte-identical.
+  // legacy nodes ⇒ the pre-grammar hardcoded behavior, byte-identical.
   view?: ViewSpec | null;
   // How many times this place has already been entered (the client's revisit
   // count). >0 rotates the scene camera to another angle under
@@ -700,8 +700,8 @@ export interface ProjectedEntity {
   w_pct: number; // apparent size
   h_pct: number;
   depth: number; // distance from observer; lower = nearer (drawn on top)
-  // Coarse bins â what prompts + the VLM judge actually consume (honest: bins,
-  // not pixels). h_pos â far-left..far-right, v_pos â top|mid|bottom, size bin.
+  // Coarse bins — what prompts + the VLM judge actually consume (honest: bins,
+  // not pixels). h_pos ∈ far-left..far-right, v_pos ∈ top|mid|bottom, size bin.
   h_pos: string;
   v_pos: string;
   size: string;
@@ -709,14 +709,14 @@ export interface ProjectedEntity {
 
 // What the camera estimator reads out of a generated image, so the geometry
 // layer doesn't assume top-down. `projection` decides how a detection
-// box back-projects: top_down â the box is a footprint; oblique/perspective â
+// box back-projects: top_down → the box is a footprint; oblique/perspective →
 // its vertical extent reads as apparent height.
 export type ViewProjection = "top_down" | "oblique" | "perspective";
 export interface ViewEstimate {
   level: ViewLevel;
   projection: ViewProjection;
   pitch_deg: number;
-  // Coarse SCALE_LADDER rung the estimator read (or the ViewLevelâtier fallback).
+  // Coarse SCALE_LADDER rung the estimator read (or the ViewLevel→tier fallback).
   // Optional; mirrored in the Python ViewEstimate TypedDict (view_estimator.py).
   scale_tier?: ScaleTier;
   // The estimator's own 0..1 confidence. Gates the C12 node PATCH backend-side
@@ -733,7 +733,7 @@ export interface WorldMapSnapshot {
   updated_at: string;
 }
 
-// Backend â web wire format for one extraction pass. The web layer takes
+// Backend → web wire format for one extraction pass. The web layer takes
 // this, allocates ids for `added`, merges into the WorldStateDoc, emits
 // SSE events to subscribed frontends. State changes ride inside
 // `updated[].changes.state` rather than a separate channel; kept simple
@@ -760,7 +760,7 @@ export interface EntityUpdate {
   changes: Partial<Pick<Entity, "name" | "appearance" | "facts" | "state" | "aliases">>;
   confidence: number;
   // Re-localized box on THIS node: a recurring entity is detected again so it
-  // keeps an appearance_bbox per node â without it, geometry/overlay drop the
+  // keeps an appearance_bbox per node — without it, geometry/overlay drop the
   // entity on every re-appearance. Omitted when localization fails.
   bbox?: { x_pct: number; y_pct: number; w_pct: number; h_pct: number } | null;
   border?: [number, number][] | null;  // SAM3 polygon, same shape as ExtractedEntity
@@ -778,7 +778,7 @@ export interface ExtractEntitiesRequestBody {
   caption: string;
   // Lightweight summary of the world's current entities so the VLM can
   // diff. Web side selects the most relevant slice (recent + name-overlap
-  // candidates) before sending â full registry on every call wastes tokens.
+  // candidates) before sending — full registry on every call wastes tokens.
   prior_entities: Array<Pick<Entity, "id" | "kind" | "name" | "aliases" | "appearance">>;
   trace_id?: string;
 }
@@ -788,7 +788,7 @@ export interface ExtractEntitiesResponse {
   trace_id?: string;
 }
 
-// Snapshot returned by GET /api/world/:sessionId â used to hydrate the
+// Snapshot returned by GET /api/world/:sessionId — used to hydrate the
 // codex panel and the atlas overlay on permalink load.
 export interface WorldStateSnapshot {
   session_id: string;
@@ -807,10 +807,10 @@ export type WorldEntityMutation =
   | { op: "pin"; id: string; pinned: boolean }
   | { op: "set_appearance"; id: string; appearance: string; reference_image_url?: string | null };
 
-// ââ Geometry edits: NL-editable map ââââââââââââââââââââââââââââââââââââââââââ
+// ── Geometry edits: NL-editable map ──────────────────────────────────────────
 // A structured edit to the geometric world map (WorldEntityGeo by id). These are
 // what `edit_entities_nl` turns a natural-language instruction into ("move the
-// lighthouse north" â {op:"move", target, dx, dy}). `target` is a WorldEntityGeo
+// lighthouse north" → {op:"move", target, dx, dy}). `target` is a WorldEntityGeo
 // id; deltas are op-specific and in world units. Applied by lib/world-map.ts.
 export type EntityGeoEdit =
   | { op: "move"; target: string; dx: number; dy: number }
@@ -825,9 +825,9 @@ export type EntityGeoEdit =
       footprint?: { w: number; d: number };
     };
 
-// The result of an NL edit: the structured ops plus the blast-radius â the node
+// The result of an NL edit: the structured ops plus the blast-radius — the node
 // ids whose saved render references an edited entity and so are now stale (the
-// codex can offer "editing this restages N scenes â restage now?").
+// codex can offer "editing this restages N scenes — restage now?").
 export interface EntityEditPlan {
   edits: EntityGeoEdit[];
   blast_radius: string[];
@@ -843,7 +843,7 @@ export interface EditEntitiesRequestBody {
       "id" | "entity_id" | "label" | "pos" | "height" | "footprint" | "visual"
     >
   >;
-  // geo-id â node ids that show it; lets the backend compute blast-radius
+  // geo-id → node ids that show it; lets the backend compute blast-radius
   // without the full codex registry (web side builds it from appears_on_node_ids).
   references?: Record<string, string[]>;
   scene_view?: SceneView | null;
@@ -855,9 +855,9 @@ export interface EditEntitiesResponse {
   trace_id?: string;
 }
 
-// ââ Describe a place -> logical object world (WORLD_FROM_DESCRIPTION) âââââââââ
+// ── Describe a place -> logical object world (WORLD_FROM_DESCRIPTION) ─────────
 // Turn a natural-language place description into all its objects on the shared 2D
-// plane. The planner emits STRUCTURE (entities + relations), NEVER coordinates â
+// plane. The planner emits STRUCTURE (entities + relations), NEVER coordinates —
 // the deterministic solver (providers/layout_solver.py) turns relations into
 // WorldEntityGeo positions. All additive + flag-gated; no existing type changes.
 


### PR DESCRIPTION
Hygiene pass — no behavior changes.

- **Mojibake**: `packages/config/src/index.ts` had 52 comment lines of double-encoded UTF-8 (the known recurring gotcha: `──` headers, em dashes, `×`/`÷` all garbled). Reversed per-line via latin-1 round-trip; lines that were already valid UTF-8 can't round-trip so they were untouched. Diff verified comments-only.
- **`.env.example`**: `NEXT_PUBLIC_EDIT_REGION` and `NEXT_PUBLIC_WORLD_TAP_DEGRADE` existed in code but were undocumented.
- **Doc truth-sync** (the docs lagged the code):
  - `AUDIT_BOX.md` item 2 (wire `expected_layout` → render) has been done for a while — `_layout_clause_for` → `layout_constraints`, +0.33 layout fidelity in the A/B. Checked off with pointers.
  - Item 3 (silent failures) checked off → PR #119.
  - `SESSION_AUDIT.md` deferred items 2/4/6 marked done (#109, #113, #20–#26).
- **README**: three weeks behind — added in-place edits, World Mode / scale-ladder nav, and the critic loop to the TL;DR (same voice), linked `docs/TESTING.md`.

Not done on purpose: `providers/heights.py` was flagged as dead code in exploration, but it isn't — it's the segmenter/bench height-ladder brain (category priors, anchored absolute heights), unrelated to `generate._heights_for_view` (relative pairs from world_context). Left alone.

Web vitest green (642) after the config-package change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)