### PR TITLE
fix(world): nested entities draw, hit-test, and label at their resolved absolute position

### DIFF
--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -114,7 +114,7 @@ import { matchEntityLabel } from "@/lib/entity-label-match";
 import { focusOnMap } from "@/lib/click-route";
 import { selectNeighbors } from "@/lib/scale-neighbors";
 import { sceneCloseupSpec } from "@/lib/scene-closeup";
-import { childrenOf, projectTopDown } from "@/lib/world-geometry";
+import { childrenOf, projectTopDown, toAbsoluteEntities } from "@/lib/world-geometry";
 import { viewNeutralAppearance } from "@/lib/appearance";
 import { useImageMorph } from "@/hooks/useImageMorph";
 import {
@@ -2623,10 +2623,14 @@ export default function PlayPage() {
         const pointer = normalizeClickOnImage(evt, img);
         if (pointer) {
           const frame = page?.sceneView?.map_crop ?? MAP_IMAGE_FRAME;
+          // Nested places resolve to their absolute map pos/footprint —
+          // post-ascend the whole map is nested, so the old top-level-only
+          // filter killed the enter ring everywhere.
           hoverEnterable =
             focusOnMap(
-              geoMap.entities.filter(
-                (e) => e.kind === "place" && (e.parent_id ?? null) === null,
+              toAbsoluteEntities(
+                geoMap.entities.filter((e) => e.kind === "place"),
+                geoMap.entities,
               ),
               frame,
               pointer,

--- a/apps/web/components/PlayPage/EnterableMarkers.test.tsx
+++ b/apps/web/components/PlayPage/EnterableMarkers.test.tsx
@@ -34,18 +34,36 @@ function markerIds(container: HTMLElement): string[] {
 }
 
 describe("EnterableMarkers (W3 idle enter affordance)", () => {
-  it("rings top-level places on the map; items and nested children stay quiet", () => {
+  it("rings places on the map; items and out-of-crop children stay quiet", () => {
     const { container } = render(
       <EnterableMarkers
         entities={[
           geo("palace", 50, 30),
           geo("sword", 40, 20, { kind: "item" }),
+          // Resolves to (110, 60) — outside the 100×60 frame → culled.
           geo("hall", 60, 30, { parent_id: "palace" }),
         ]}
         currentView={null}
       />,
     );
     expect(markerIds(container)).toEqual(["palace"]);
+  });
+
+  it("nested places ring at their RESOLVED absolute position (post-ascend map)", () => {
+    // After an OUTWARD ascend every former root is nested under P at
+    // parent-local coords (the -8400 shape); it must still ring at its
+    // conserved absolute spot instead of vanishing with the old
+    // top-level-only filter.
+    const { container } = render(
+      <EnterableMarkers
+        entities={[
+          geo("p", 50, 30, { scale: 0.005, footprint: { w: 100, d: 60 } }),
+          geo("palace", -2000, 0, { parent_id: "p" }), // → absolute (40, 30)
+        ]}
+        currentView={null}
+      />,
+    );
+    expect(markerIds(container).sort()).toEqual(["p", "palace"]);
   });
 
   it("inside an entered place (scene frame) → renders nothing", () => {

--- a/apps/web/components/PlayPage/EnterableMarkers.tsx
+++ b/apps/web/components/PlayPage/EnterableMarkers.tsx
@@ -5,7 +5,7 @@ import type { MapCrop, SceneView, WorldEntityGeo } from "@openflipbook/config";
 
 import { useContainRect } from "@/hooks/useContainRect";
 import { MAP_IMAGE_FRAME } from "@/lib/geo-tap";
-import { cropEntities } from "@/lib/world-geometry";
+import { cropEntities, toAbsoluteEntities } from "@/lib/world-geometry";
 
 interface Props {
   /** The geo world map's entities (all of them; this component scopes). */
@@ -40,10 +40,13 @@ export function EnterableMarkers({
     // Inside an entered place the frame is a scene, not the map — no rings.
     if (currentView && currentView.level !== "map") return [];
     const frame: MapCrop = currentView?.map_crop ?? MAP_IMAGE_FRAME;
-    // Top-level places only: nested children live in their parent's frame
-    // and would project to the wrong spot on the city map.
-    const places = entities.filter(
-      (e) => e.kind === "place" && (e.parent_id ?? null) === null,
+    // Nested places resolve through their parent chain to the absolute map
+    // frame (after an OUTWARD ascend every former root is nested — the old
+    // top-level-only filter blanked the whole map); the crop culls whatever
+    // resolves outside the displayed window.
+    const places = toAbsoluteEntities(
+      entities.filter((e) => e.kind === "place"),
+      entities,
     );
     return cropEntities(places, frame).map((e) => ({
       id: e.id,

--- a/apps/web/components/PlayPage/MapLabelOverlay.tsx
+++ b/apps/web/components/PlayPage/MapLabelOverlay.tsx
@@ -10,6 +10,7 @@ import {
   layoutLabels,
   type LabelInput,
 } from "@/lib/map-labels";
+import { toAbsoluteEntities } from "@/lib/world-geometry";
 
 interface Props {
   /** The page the labels overlay. */
@@ -56,10 +57,12 @@ export function MapLabelOverlay({
       }
     }
     if (fromBBoxes.length > 0) return layoutLabels(fromBBoxes);
-    // Fallback: top-level geo footprints through the seeded map frame.
+    // Fallback: geo anchors through the seeded map frame — nested entities
+    // resolved to absolute pos (anchorsFromGeo culls what lands outside).
     const frame = currentView?.map_crop ?? MAP_IMAGE_FRAME;
-    const topLevel = geoEntities.filter((e) => (e.parent_id ?? null) === null);
-    return layoutLabels(anchorsFromGeo(topLevel, frame));
+    return layoutLabels(
+      anchorsFromGeo(toAbsoluteEntities(geoEntities, geoEntities), frame),
+    );
   }, [nodeId, entities, geoEntities, currentView]);
 
   if (placed.length === 0) return null;

--- a/apps/web/lib/geo-tap.ts
+++ b/apps/web/lib/geo-tap.ts
@@ -17,6 +17,7 @@ import {
   cropEntities,
   projectScene,
   resolveAbsolutePos,
+  toAbsoluteEntities,
 } from "./world-geometry";
 
 // The image-world frame a top-down map is seeded in: estimateGeoFromBBox maps
@@ -216,15 +217,15 @@ export function geoTapRequest(
       ? currentView.focus_id ?? null
       : null;
   // The entities the tap can land on: the whole map at top level, else the
-  // current place's children (in their local frame). At map level, only
-  // TOP-LEVEL entities are hit-testable — children carry coords LOCAL to
-  // their parent's frame, and hit-testing those as world coords lets a
-  // child at local (50,30) shadow a real landmark (the hover affordance
-  // already filters this way; the tap path didn't).
+  // current place's children (in their local frame). At map level, nested
+  // entities are RESOLVED to their absolute pos + unit-scaled footprint
+  // before hit-testing — raw parent-local coords let a child at local
+  // (50,30) shadow a real landmark, and the old top-level-only filter made
+  // every entity untappable after an OUTWARD ascend reparented the roots.
   const candidates = insideId
     ? { entities: childrenOf(map.entities, insideId), bounds: map.bounds }
     : {
-        entities: map.entities.filter((e) => (e.parent_id ?? null) === null),
+        entities: toAbsoluteEntities(map.entities, map.entities),
         bounds: map.bounds,
       };
   if (candidates.entities.length === 0) return null;

--- a/apps/web/lib/scale-tree.test.ts
+++ b/apps/web/lib/scale-tree.test.ts
@@ -4,7 +4,11 @@ import type { WorldEntityGeo } from "@openflipbook/config";
 import { tierMetricMultiplier } from "@openflipbook/config";
 
 import { reparent, reparentRoots } from "./scale-tree";
-import { type FrameNode, resolveAbsolutePos } from "./world-geometry";
+import {
+  type FrameNode,
+  resolveAbsoluteFrame,
+  resolveAbsolutePos,
+} from "./world-geometry";
 
 // Build a WorldEntityGeo with sensible defaults; override what a test cares about.
 function geo(over: Partial<WorldEntityGeo> & Pick<WorldEntityGeo, "id">): WorldEntityGeo {
@@ -73,6 +77,36 @@ describe("scale-tree reparent (B2 OUTWARD)", () => {
     for (const id of ["c", "a", "b", "a1"]) {
       expect(afterAbs.get(id)!.x).toBeCloseTo(beforeAbs.get(id)!.x, 9);
       expect(afterAbs.get(id)!.y).toBeCloseTo(beforeAbs.get(id)!.y, 9);
+    }
+  });
+
+  it("INV-1 extends to footprints: absolute extents are conserved too", () => {
+    // reExpressUnder divides the footprint by pScale alongside pos, so
+    // pos + footprint stay ONE consistent parent-local frame — resolving
+    // (footprint × unit) recovers the original absolute extent.
+    const absFootprints = (geos: WorldEntityGeo[]) => {
+      const byId = new Map<string, FrameNode>(geos.map((g) => [g.id, g]));
+      const out = new Map<string, { w: number; d: number }>();
+      for (const g of geos) {
+        const f = resolveAbsoluteFrame(g.id, byId);
+        if (f) out.set(g.id, { w: g.footprint.w * f.unit, d: g.footprint.d * f.unit });
+      }
+      return out;
+    };
+    const before = cityTree();
+    const beforeFp = absFootprints(before);
+    const region = geo({
+      id: "p",
+      pos: { x: 50, y: 30 },
+      footprint: { w: 90, d: 60 },
+      scale_tier: "region",
+      source: "user",
+    });
+    const { geos: after } = reparent(before, "c", region, NOW);
+    const afterFp = absFootprints(after);
+    for (const id of ["c", "a", "b", "a1"]) {
+      expect(afterFp.get(id)!.w).toBeCloseTo(beforeFp.get(id)!.w, 9);
+      expect(afterFp.get(id)!.d).toBeCloseTo(beforeFp.get(id)!.d, 9);
     }
   });
 

--- a/apps/web/lib/scale-tree.ts
+++ b/apps/web/lib/scale-tree.ts
@@ -62,6 +62,10 @@ function reExpressUnder(
     parent_id: parentId,
     pos: { x: (node.pos.x - parentPos.x) / pScale, y: (node.pos.y - parentPos.y) / pScale },
     scale: (node.scale ?? 1) / pScale,
+    // The footprint rides the same affine inverse so pos + footprint stay one
+    // consistent parent-local frame (INV-1 for extents too): resolving back
+    // to absolute multiplies both by the same unit and recovers the original.
+    footprint: { w: node.footprint.w / pScale, d: node.footprint.d / pScale },
     source: "user", // protect the new edge from a later derived re-seed (SOURCE_RANK)
     updated_at: nowIso,
   };

--- a/apps/web/lib/world-geometry.test.ts
+++ b/apps/web/lib/world-geometry.test.ts
@@ -148,3 +148,31 @@ describe("projectTopDown (flat map, no observer)", () => {
     expect([b.h_pos, b.v_pos, b.size]).toEqual(["far-left", "top", "small"]);
   });
 });
+
+describe("toAbsoluteEntities (nested → absolute frame)", () => {
+  it("resolves nested pos + unit-scales footprint; top-level passes through", async () => {
+    const { toAbsoluteEntities } = await import("./world-geometry");
+    const all = [
+      {
+        id: "p",
+        parent_id: null,
+        pos: { x: 50, y: 30 },
+        scale: 0.005,
+        footprint: { w: 100, d: 60 },
+      },
+      // The post-ascend shape: parent-local coords in old-frame magnitudes.
+      {
+        id: "c",
+        parent_id: "p",
+        pos: { x: -8400, y: 0 },
+        footprint: { w: 4000, d: 2000 },
+      },
+    ];
+    const out = toAbsoluteEntities(all, all);
+    expect(out[0]).toBe(all[0]); // top-level: same reference, byte-identical
+    expect(out[1]!.pos.x).toBeCloseTo(8); // 50 + (-8400 × 0.005) — INV-1
+    expect(out[1]!.pos.y).toBeCloseTo(30);
+    expect(out[1]!.footprint.w).toBeCloseTo(20); // 4000 × 0.005
+    expect(out[1]!.footprint.d).toBeCloseTo(10);
+  });
+});

--- a/apps/web/lib/world-geometry.ts
+++ b/apps/web/lib/world-geometry.ts
@@ -354,6 +354,23 @@ export function resolveAbsolutePos(
   id: string,
   byId: Map<string, FrameNode>,
 ): WorldVec2 | null {
+  return resolveAbsoluteFrame(id, byId)?.pos ?? null;
+}
+
+export interface AbsoluteFrame {
+  pos: WorldVec2;
+  // The multiplier converting the node's parent-frame units (the units its
+  // own pos and footprint are expressed in) to absolute units — the product
+  // of the ancestor scales ABOVE it. 1 for a top-level entity.
+  unit: number;
+}
+
+/** resolveAbsolutePos plus the frame unit — for consumers that must
+ *  re-express extents (footprints, hit boxes) alongside positions. */
+export function resolveAbsoluteFrame(
+  id: string,
+  byId: Map<string, FrameNode>,
+): AbsoluteFrame | null {
   // Collect self → root (cycle-guarded), then compose root → down.
   const chain: FrameNode[] = [];
   const seen = new Set<string>();
@@ -368,13 +385,38 @@ export function resolveAbsolutePos(
   let x = 0;
   let y = 0;
   let scaleAccum = 1;
+  let unit = 1;
   for (let i = chain.length - 1; i >= 0; i--) {
     const n = chain[i]!;
     x += n.pos.x * scaleAccum;
     y += n.pos.y * scaleAccum;
+    unit = scaleAccum;
     scaleAccum *= n.scale ?? 1;
   }
-  return { x, y };
+  return { pos: { x, y }, unit };
+}
+
+/** Re-express entities in the ABSOLUTE (root map) frame: compose each nested
+ *  entity's parent chain for pos and scale its footprint by the same unit.
+ *  After an OUTWARD ascend every former root is nested under the synthesized
+ *  parent, so consumers that filtered to `parent_id === null` and read raw
+ *  pos saw an empty map (the -8400 demo bug). Top-level entities pass through
+ *  untouched — pre-nesting data stays byte-identical. `all` supplies the
+ *  parent chains: pass the full map, not the filtered subset. */
+export function toAbsoluteEntities<
+  T extends FrameNode & { footprint: { w: number; d: number } },
+>(subset: T[], all: FrameNode[]): T[] {
+  const byId = new Map(all.map((e) => [e.id, e]));
+  return subset.map((e) => {
+    if ((e.parent_id ?? null) === null) return e;
+    const f = resolveAbsoluteFrame(e.id, byId);
+    if (!f) return e;
+    return {
+      ...e,
+      pos: f.pos,
+      footprint: { w: e.footprint.w * f.unit, d: e.footprint.d * f.unit },
+    };
+  });
 }
 
 /** Axis-aligned bounds over entities' OWN pos+footprint (no parent resolve) —

--- a/docs/AUDIT_BOX.md
+++ b/docs/AUDIT_BOX.md
@@ -59,8 +59,8 @@ baseline; no regression elsewhere.
 - **In-session expand connectors**: `relation` ("expand" vs "descend") isn't on the in-session
   `Page` type, so the atlas can't distinguish breadth from depth. Also `relation` is never set
   on `persistNode` (all default "descend"). Thread it through `WorldMap` + `SessionMinimap`.
-- **mypy coverage split (CI hygiene)**: `make eval` checks `generate.py` + 5 files; CI checks
-  `providers` but not `generate.py`. Align the two lists.
+- ~~**mypy coverage split (CI hygiene)**~~ — already aligned: both `make eval` and CI run
+  `mypy providers obs.py generate.py` (verified 2026-07-02).
 - **UI discoverability** (`docs/UI_AUDIT.md`): `⊞ geo` / entity-chip toggles are buried — add a
   `G` shortcut + hint. Hover-prefetch + suppressed layout steering have no debug surface.
 - **Mobile pass**: ≤390px audit for breadcrumbs, codex panel, geo inset.

--- a/docs/SESSION_AUDIT.md
+++ b/docs/SESSION_AUDIT.md
@@ -95,10 +95,8 @@ tests. **Everything else in B2 is unbuilt** — see `PLAN_OUTWARD.md`.
    `providers/generate_modes/ascend.py`; see `PLAN_OUTWARD.md` Phase E notes).
 7. **Merged local branches** — `feat/consistency-fixes`, `feat/eval`, `feat/world-from-description`,
    `fix/centre-empty-region` are merged; tidy locally.
-8. **mypy coverage split (CI hygiene)** — `make eval` type-checks `generate.py` + 5 provider
-   files; CI type-checks `providers` but **not** `generate.py`. The union is covered, but neither
-   gate alone is complete (a `generate.py` type error passes CI; a `layout_solver.py` one passes
-   `make eval`). Cheap follow-up: align the two file lists.
+8. **mypy coverage split (CI hygiene)** — ~~align the two file lists~~ **already aligned**:
+   both `make eval` and CI run `mypy providers obs.py generate.py` (verified 2026-07-02).
 9. **Style ref on non-default edit paths** — the `pro`/`flux-pro/kontext` edit tier drops the
    style exemplar (singular `image_url`), and `continue_image` (World-Mode submap zoom) takes no
    style ref at all. Default edit tier is `balanced`=nano-banana-pro (which *does* use the ref),


### PR DESCRIPTION
## The bug (Ankh demo, 2026-06-14, unfixed since)

`reExpressUnder` mints INV-1-conserving parent-local coords on ascend (the `-8400` values are *correct*), but after one OUTWARD every former root becomes nested — and every map-frame consumer filtered `parent_id === null` and read raw `e.pos`. Net effect: one ascend and the map goes dead — no enter rings, no DOM labels, no hover ring, no geometric taps.

## The fix

Two halves, one boundary:

1. **Mint-side consistency** (`lib/scale-tree.ts`): `reExpressUnder` rescaled `pos` and `scale` but not `footprint`, leaving extents stranded in the old frame's units. It now divides the footprint by the same `pScale`, so INV-1 extends to extents — resolving `footprint × unit` recovers the original absolute size (new golden test).
2. **One consumer boundary** (`lib/world-geometry.ts`): new `resolveAbsoluteFrame` (pos + the unit multiplier) and `toAbsoluteEntities` (resolve pos, unit-scale footprint; top-level entities pass through by reference — pre-nesting data byte-identical). `resolveAbsolutePos` now delegates; its tests untouched. The four consumers — `EnterableMarkers`, `MapLabelOverlay`'s geo fallback, the hover enter-affordance in `play/page.tsx`, and `geoTapRequest`'s map-level candidates — drop the top-level-only filters and consume resolved entities. The existing crop culls whatever resolves outside the displayed window, which also retires the old "child at local (50,30) shadows a landmark" hazard the tap-path comment worried about: resolved coords put children where they actually are, with unit-scaled (tiny) hit boxes.

`WorldMiniMap` already resolved (it was the in-repo template).

Also strikes the stale mypy-coverage-split item in AUDIT_BOX/SESSION_AUDIT — `make eval` and CI have been running the identical `mypy providers obs.py generate.py` list for a while.

## Tests
- `scale-tree.test.ts`: footprint-INV golden (before/after absolute extents match to 1e-9).
- `world-geometry.test.ts`: `toAbsoluteEntities` resolves the exact demo shape (`-8400 × 0.005`) and passes top-level through by reference.
- `EnterableMarkers.test.tsx`: nested place rings at its resolved spot; out-of-crop child stays culled.
- Full web suite 650 green, tsc clean, no circular deps.

Known ceiling (unchanged, AUDIT_BOX §4): cross-rung *visual* registration is still relative-not-metric — resolved coords are exact in the pre-ascend frame; on the freshly rendered parent image they're as registered as the render is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)