### PR TITLE
feat(ui): polish debt — G shortcut, unlocalized-entities note, prefetch HUD wiring, verdict toast corner

### DIFF
--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -1803,6 +1803,7 @@ export default function PlayPage() {
     onOpenQuickbar: () => setQuickbarOpen(true),
     onToggleHelp: () => setHelpOpen((h) => !h),
     onToggleCodex: () => setCodexOpen((c) => !c),
+    onToggleGeoOverlay: () => setGeoOverlayOn((g) => !g),
     onExpandOutward: triggerExpand,
     onCloseOverlays: () => {
       setHelpOpen(false);
@@ -2012,6 +2013,7 @@ export default function PlayPage() {
       inflight.clear();
       const ac = new AbortController();
       inflight.set(key, ac);
+      hudEmit("prefetch:inflight", { n: inflight.size });
       // The per-page budget is consumed only on a SUCCESSFUL cache write below
       // (mirroring the precompute path). Counting it up-front would let a few
       // empty/failed resolves exhaust the budget and kill prefetch for the page.
@@ -2070,6 +2072,7 @@ export default function PlayPage() {
           // Best-effort. Click handler will fall back to the in-band VLM.
         } finally {
           inflight.delete(key);
+          hudEmit("prefetch:inflight", { n: inflight.size });
         }
       })();
     };
@@ -2308,6 +2311,12 @@ export default function PlayPage() {
         hint || worldEnabled
           ? undefined
           : cache.get(bucketKey(currentNodeId, click.x_pct, click.y_pct));
+      // HUD visibility for the silent hover warming (UI_AUDIT #10): count
+      // only clicks where the shortcut was eligible — a deliberate skip
+      // (hint / world mode) is neither a hit nor a miss.
+      if (!hint && !worldEnabled) {
+        hudEmit(cached ? "prefetch:hit" : "prefetch:miss", {});
+      }
       // Image conditioning: build the weighted reference stack from the CLEAN
       // parent (not the marker-annotated one) — region crop at the tap → whole
       // parent → session root as the anti-drift anchor (skipped when this page
@@ -3319,7 +3328,9 @@ export default function PlayPage() {
               )}
 
               {editVerdictChip && (
-                <div className="absolute left-1/2 top-3 z-20 flex -translate-x-1/2 items-center gap-2 whitespace-nowrap rounded-full bg-black/70 px-3 py-1 text-xs text-white">
+                // Toast corner (UI_AUDIT #12): the old top-centre nowrap pill
+                // overflowed narrow screens and overlapped the toolbar chips.
+                <div className="absolute bottom-3 left-3 z-20 flex max-w-[calc(100%-1.5rem)] flex-wrap items-center gap-2 rounded-full bg-black/70 px-3 py-1 text-xs text-white">
                   <span>{editVerdictChip.text}</span>
                   {editVerdictChip.revertTo && (
                     <button
@@ -3563,7 +3574,7 @@ export default function PlayPage() {
                   "rounded-full px-3 py-1 text-xs text-white disabled:opacity-50 " +
                   (geoOverlayOn ? "bg-emerald-600" : "bg-slate-600/85 hover:bg-slate-600")
                 }
-                title="Geometry layer — draw each entity's detected coordinate box on the image"
+                title="Geometry layer (G) — draw each entity's detected coordinate box on the image"
               >
                 ⊞ geo
               </button>

--- a/apps/web/components/PlayPage/EntityHoverOverlay.test.tsx
+++ b/apps/web/components/PlayPage/EntityHoverOverlay.test.tsx
@@ -59,7 +59,9 @@ describe("EntityHoverOverlay", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it("skips entities with no bbox for the current node", () => {
+  it("shows the not-yet-localized note when known entities have no bbox here", () => {
+    // UI_AUDIT #9: chips on + a silent empty layer read as "broken" — a
+    // known-but-unlocalized codex now gets a corner note instead of nothing.
     const { container } = render(
       <EntityHoverOverlay
         nodeId="n1"
@@ -67,10 +69,9 @@ describe("EntityHoverOverlay", () => {
         enabled
       />
     );
-    // Overlay container DOES NOT render at all when there's nothing to
-    // show — keeps the DOM clean and avoids an empty z-index layer
-    // intercepting nothing on top of the image.
-    expect(container.firstChild).toBeNull();
+    expect(container.textContent).toContain("not yet localized");
+    // Still a pass-through layer — never intercepts image clicks.
+    expect(container.querySelector("button")).toBeNull();
   });
 
   it("renders a chip per entity with a bbox on the current node", () => {

--- a/apps/web/components/PlayPage/EntityHoverOverlay.tsx
+++ b/apps/web/components/PlayPage/EntityHoverOverlay.tsx
@@ -35,8 +35,9 @@ interface VisibleChip {
  * the bounding box so percentages map 1:1 to pixels.
  *
  * Pre-Phase-4 entities have no bbox in `appearance_bboxes` for the
- * current node and are silently skipped — the codex still lists them,
- * just without an on-image affordance.
+ * current node and get no dot; when NONE of the known entities are
+ * localized on this page a small corner note says so (UI_AUDIT #9) —
+ * chips-on with a silent empty layer read as "broken".
  */
 export function EntityHoverOverlay({
   nodeId,
@@ -63,7 +64,24 @@ export function EntityHoverOverlay({
     return out;
   }, [enabled, nodeId, entities]);
 
-  if (!enabled || visible.length === 0) return null;
+  // Entities the codex genuinely knows (same pruning as the chip loop).
+  const known = useMemo(
+    () => entities.filter((e) => e.appearance || e.facts.length > 0).length,
+    [entities],
+  );
+
+  if (!enabled || !nodeId) return null;
+  if (visible.length === 0) {
+    if (known === 0) return null;
+    return (
+      <div aria-hidden className="pointer-events-none absolute inset-0 z-10">
+        <span className="absolute bottom-2 right-2 rounded-full bg-black/60 px-2 py-0.5 text-[10px] text-white/80 backdrop-blur-sm">
+          {known} {known === 1 ? "entity" : "entities"} known · not yet
+          localized on this page
+        </span>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/apps/web/components/PlayPage/HelpOverlay.tsx
+++ b/apps/web/components/PlayPage/HelpOverlay.tsx
@@ -28,6 +28,7 @@ export function HelpOverlay({ onClose }: Props) {
           <Row k="M" v="Toggle map view" />
           <Row k="T" v="Toggle time-scrubber" />
           <Row k="K" v="Toggle codex" />
+          <Row k="G" v="Toggle the geometry layer (⊞ geo)" />
           <Row k="E" v="Look around (bloom neighbours)" />
           <Row k="/" v="Jump to page…" />
           <Row k="?" v="This help" />

--- a/apps/web/hooks/useKeyboardShortcuts.test.tsx
+++ b/apps/web/hooks/useKeyboardShortcuts.test.tsx
@@ -12,6 +12,7 @@ function makeHandlers(overrides: Partial<KeyboardShortcutHandlers> = {}): Keyboa
     onOpenQuickbar: vi.fn(),
     onToggleHelp: vi.fn(),
     onToggleCodex: vi.fn(),
+    onToggleGeoOverlay: vi.fn(),
     onExpandOutward: vi.fn(),
     onCloseOverlays: vi.fn(),
     anyOverlayOpen: false,
@@ -77,6 +78,14 @@ describe("useKeyboardShortcuts", () => {
     press({ key: "E" });
     press({ key: "e" });
     expect(handlers.onExpandOutward).toHaveBeenCalledTimes(2);
+  });
+
+  it("G toggles the geo overlay (case-insensitive)", () => {
+    const handlers = makeHandlers();
+    cleanup = renderHook(() => useKeyboardShortcuts(handlers)).unmount;
+    press({ key: "G" });
+    press({ key: "g" });
+    expect(handlers.onToggleGeoOverlay).toHaveBeenCalledTimes(2);
   });
 
   it("Esc only fires close when an overlay is open", () => {

--- a/apps/web/hooks/useKeyboardShortcuts.ts
+++ b/apps/web/hooks/useKeyboardShortcuts.ts
@@ -10,6 +10,8 @@ export interface KeyboardShortcutHandlers {
   onOpenQuickbar: () => void;
   onToggleHelp: () => void;
   onToggleCodex: () => void;
+  /** Toggle the ⊞ geo overlay (entity boxes/borders on the image). */
+  onToggleGeoOverlay: () => void;
   /** Bloom the world around the current page (mode:"expand"). */
   onExpandOutward: () => void;
   onCloseOverlays: () => void;
@@ -34,6 +36,7 @@ export interface KeyboardShortcutHandlers {
  *   M / m    Toggle map view
  *   T / t    Toggle time-scrubber
  *   K / k    Toggle codex panel
+ *   G / g    Toggle the ⊞ geo overlay
  *   E / e    Expand outward (bloom neighbours)
  *   /        Open quickbar
  *   ?        Toggle help overlay
@@ -48,6 +51,7 @@ export function useKeyboardShortcuts(handlers: KeyboardShortcutHandlers): void {
     onOpenQuickbar,
     onToggleHelp,
     onToggleCodex,
+    onToggleGeoOverlay,
     onExpandOutward,
     onCloseOverlays,
     anyOverlayOpen,
@@ -93,6 +97,9 @@ export function useKeyboardShortcuts(handlers: KeyboardShortcutHandlers): void {
       } else if (e.key.toLowerCase() === "k") {
         e.preventDefault();
         onToggleCodex();
+      } else if (e.key.toLowerCase() === "g") {
+        e.preventDefault();
+        onToggleGeoOverlay();
       } else if (e.key.toLowerCase() === "e") {
         e.preventDefault();
         onExpandOutward();
@@ -116,6 +123,7 @@ export function useKeyboardShortcuts(handlers: KeyboardShortcutHandlers): void {
     onOpenQuickbar,
     onToggleHelp,
     onToggleCodex,
+    onToggleGeoOverlay,
     onExpandOutward,
     onCloseOverlays,
   ]);

--- a/docs/UI_AUDIT.md
+++ b/docs/UI_AUDIT.md
@@ -68,18 +68,19 @@ is better at "what is this".
    guaranteed. Now only the 6 largest footprints carry names.
 7. ✅ **Breadcrumb overflow** on deep trails — collapses to root › … › last
    two with an expander.
-8. **`⊞ geo` and entity-chip toggles are buried** — discoverable only by
-   reading the toolbar; a keyboard shortcut (`G`) and a hint would help.
-9. **Entity chips need `appearance_bboxes[nodeId]`** — pre-Phase-4 extracts
-   show no on-image affordance even when the codex knows the entity; a
-   placeholder ("not yet localized") would close the gap.
-10. **Hover-prefetch is invisible** — silent VLM warming on hover has no
-    debug surface; a dev HUD toggle would make cost behaviour visible.
+8. ✅ **`⊞ geo` toggle discoverability** — `G` shortcut + button title hint +
+   HelpOverlay row (2026-07-02).
+9. ✅ **Entity chips need `appearance_bboxes[nodeId]`** — chips-on with a
+   known-but-unlocalized codex now shows a corner note ("N entities known ·
+   not yet localized on this page") instead of a silent empty layer.
+10. ✅ **Hover-prefetch is invisible** — the debug HUD already had
+    hit/miss/inflight counters but nothing emitted the events; the prefetch
+    fire/finish and the click-time shortcut read now emit them.
 11. **`view.layout_register_mismatch` silently suppresses layout steering**
     (backend) — logged but invisible to the user; the eval track
     (`tests/recon_bench`) is the right place to measure how much it costs.
-12. **Edit-verdict chip can overlap narrow screens** — toast-corner
-    placement would be safer.
+12. ✅ **Edit-verdict chip can overlap narrow screens** — moved to the
+    bottom-left toast corner, wraps, max-width capped.
 13. **Mobile pass** — breadcrumbs, codex panel and the geo inset all want a
     ≤390px audit; only the coach and breadcrumb were touched here.
 


### PR DESCRIPTION
Works through `docs/UI_AUDIT.md` items 8–12 (the concrete ones):

- **#8 — `G` shortcut**: toggles the `⊞ geo` overlay; follows the M/T/K/E pattern in `useKeyboardShortcuts`, hinted in the button title and the `?` help overlay. New case-insensitivity test.
- **#9 — unlocalized-entities note**: chips toggled on with a codex full of pre-Phase-4 (bbox-less) entities used to render a silent empty layer that read as broken. Now a small pointer-events-none corner note: "N entities known · not yet localized on this page". Stale extraction stubs still render nothing; the flipped test documents the new intent.
- **#10 — prefetch HUD wiring**: the debug HUD already *subscribed* to `prefetch:hit/miss/inflight` but nothing ever emitted them — the counters sat at 0 forever. The hover fire/finish and the click-time shortcut read now emit; deliberate skips (hint present / world mode) count as neither hit nor miss.
- **#12 — verdict chip**: moved from top-centre `whitespace-nowrap` (overflowed ≤390px and overlapped the toolbar chips) to a bottom-left toast corner with wrap + max-width.

Left open on purpose: **#11** (`layout_register_mismatch` visibility — the audit itself says the recon bench is the right measure, not UI) and **#13** (the mobile ≤390px audit — needs live-browser eyeballing, not a blind CSS pass).

Gates: 648 web tests green, tsc clean, no circular deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)