### PR TITLE
fix(world): post-ascend minimap bounds + duplicate name tags

### DIFF
--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -3438,6 +3438,9 @@ export default function PlayPage() {
                 )}
               {worldEnabled &&
                 worldDomLabels &&
+                // The ⊞ geo debug layer already names every localized entity
+                // on its boxes — mounting both double-tags each place.
+                !geoOverlayOn &&
                 phase === "ready" &&
                 streamStatus === "off" &&
                 (!page?.sceneView || page.sceneView.level === "map") && (

--- a/apps/web/components/PlayPage/WorldMiniMap.test.tsx
+++ b/apps/web/components/PlayPage/WorldMiniMap.test.tsx
@@ -135,4 +135,21 @@ describe("WorldMiniMap", () => {
     expect(screen.queryAllByTestId("minimap-dot")).toHaveLength(0);
     expect(screen.queryByText(/world coords/i)).toBeNull();
   });
+
+  it("post-ascend: nested former roots still dot the world view with sane bounds", async () => {
+    // The OUTWARD reparent shape: P top-level with scale=pScale; old roots at
+    // parent-local coords/footprints. Dots resolve to absolutes; the stored
+    // (recomputed) bounds stay frame-sized — not the 8000-wide blowup.
+    const p = { ...ent("geo_p", "Region", 50, 30), footprint: { w: 100, d: 60 }, scale: 0.005 };
+    const cityA = { ...childEnt("a", "Harbor", 5000, 3000, "geo_p"), footprint: { w: 4000, d: 4000 } };
+    const cityB = { ...childEnt("b", "Lighthouse", -5900, 1260, "geo_p"), footprint: { w: 4000, d: 4000 } };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ok(mapPayload([p, cityA, cityB]))) as unknown as typeof fetch,
+    );
+    render(<WorldMiniMap sessionId="s1" />);
+    await waitFor(() => expect(screen.getByTestId("world-minimap")).toBeTruthy());
+    expect(screen.getAllByTestId("minimap-dot")).toHaveLength(3); // nobody vanishes
+    expect(screen.getByText(/world coords · 3 entities · bounds 100×60/)).toBeTruthy();
+  });
 });

--- a/apps/web/components/PlayPage/WorldMiniMap.tsx
+++ b/apps/web/components/PlayPage/WorldMiniMap.tsx
@@ -7,8 +7,7 @@ import {
   childrenOf,
   cropEntities,
   localBounds,
-  resolveAbsolutePos,
-  type FrameNode,
+  toAbsoluteEntities,
 } from "@/lib/world-geometry";
 import { worldToView, type ViewBox } from "@/lib/world-overlay";
 
@@ -64,14 +63,23 @@ export default function WorldMiniMap({
 
   const local = !!(kids && kids.length > 0);
   const submap = !local && !!crop;
+  // World views plot ABSOLUTE coords: resolve nested entities (post-ascend
+  // reparents, seeded interiors) once up front — pos + unit-scaled footprint
+  // — so the crop filter, the label budget, and the dots all agree. A local
+  // (inside-a-place) view IS the place's frame, so children plot raw.
+  const resolved = local
+    ? kids!
+    : toAbsoluteEntities(worldEntities, worldEntities);
   const entities = local
     ? kids!
     : submap
-      ? cropEntities(worldEntities, crop!)
-      : worldEntities;
+      ? cropEntities(resolved, crop!)
+      : resolved;
   if (entities.length === 0) return null;
   const bounds = local ? localBounds(kids!) : submap ? crop! : worldBounds;
-  const byId = new Map<string, FrameNode>(entities.map((e) => [e.id, e]));
+  // Parent lookups (tether lines) read from the full resolved set so a
+  // cropped-out parent still anchors its child's tether.
+  const byId = new Map(resolved.map((e) => [e.id, e]));
   // Label budget: tiny SVG text collides fast, so only the biggest
   // footprints get names — every entity keeps its dot. (A4 cheap fix.)
   const labelIds = new Set(
@@ -135,16 +143,14 @@ export default function WorldMiniMap({
         {/* centre of the frame */}
         <line x1={centre.x - 5} y1={centre.y} x2={centre.x + 5} y2={centre.y} stroke="#0f766e" strokeWidth={1} />
         <line x1={centre.x} y1={centre.y - 5} x2={centre.x} y2={centre.y + 5} stroke="#0f766e" strokeWidth={1} />
-        {/* entities at their (x,y). In the world view, sub-entities carry a pos
-            local to their place's frame → resolve up the parent chain + tether to
-            the parent. In a focused (local) view we ARE the place's frame, so plot
-            the children's local pos directly. */}
+        {/* entities at their (x,y) — already resolved to the view's frame
+            above (absolute for world views, local inside a place). Nested
+            entities keep a tether line to their parent. */}
         {entities.map((e) => {
-          const abs = local ? e.pos : (resolveAbsolutePos(e.id, byId) ?? e.pos);
-          const p = worldToView(abs, viewWindow, view);
+          const p = worldToView(e.pos, viewWindow, view);
           const nested = !local && !!(e.parent_id && byId.has(e.parent_id));
           const parentPos = nested
-            ? worldToView(resolveAbsolutePos(e.parent_id!, byId) ?? abs, viewWindow, view)
+            ? worldToView(byId.get(e.parent_id!)?.pos ?? e.pos, viewWindow, view)
             : null;
           return (
             <g key={e.id} data-testid="minimap-dot">

--- a/apps/web/lib/world-map.test.ts
+++ b/apps/web/lib/world-map.test.ts
@@ -106,6 +106,26 @@ describe("world-map merge core", () => {
     expect(b.x + b.w).toBeLessThanOrEqual(37);
     expect(b.y + b.h).toBeLessThanOrEqual(25);
   });
+
+  it("post-ascend re-expressed roots keep the bounds sane (the 8000×6828 blowup)", () => {
+    // The OUTWARD reparent shape: P at frame centre with scale=pScale; the old
+    // root re-expressed to parent-local pos AND footprint (÷0.005 = ×200). The
+    // resolved footprint (×unit) recovers the absolute 40×34 — bounds must be
+    // frame-sized, not 8000 wide (the raw-footprint bug the minimap exposed).
+    const p: WorldEntityGeo = {
+      ...geo("geo_p", "user", 50, 30),
+      footprint: { w: 100, d: 60 },
+      scale: 0.005,
+    };
+    const oldRoot: WorldEntityGeo = {
+      ...geo("geo_city", "user", -2000, 1000), // resolves to (40, 35)
+      parent_id: "geo_p",
+      footprint: { w: 8000, d: 6828 }, // 40×34.14 ÷ 0.005
+    };
+    const b = recomputeBounds([p, oldRoot]);
+    expect(b.w).toBeLessThanOrEqual(110); // P's own 100-wide footprint dominates
+    expect(b.h).toBeLessThanOrEqual(70);
+  });
 });
 
 describe("applyEntityEdit (P5 structured geo edits)", () => {

--- a/apps/web/lib/world-map.ts
+++ b/apps/web/lib/world-map.ts
@@ -20,11 +20,11 @@ import { envFlag } from "./env-flag";
 import { optimisticReplace } from "./optimistic-update";
 import {
   estimateGeoFromBBox,
+  localBounds,
   localExtent,
   mapPolygonToCrop,
-  resolveAbsolutePos,
   siblingsOf,
-  type FrameNode,
+  toAbsoluteEntities,
 } from "./world-geometry";
 
 // Per-session geometric world map (entity coordinates). Mirrors the world_state
@@ -132,27 +132,14 @@ export function applyGeoUpsert(
   return [...byId.values()];
 }
 
-/** The world bounds = the axis-aligned box covering every entity's footprint. */
+/** The world bounds = the axis-aligned box covering every entity's footprint.
+ *  Nested entities are resolved to the ABSOLUTE frame first — pos AND
+ *  footprint together (the old loop resolved pos but used the raw
+ *  parent-local footprint, so one post-ascend re-expressed root inflated the
+ *  stored bounds by 1/pScale — the "bounds 8000×6828" minimap blowup). */
 export function recomputeBounds(entities: WorldEntityGeo[]): MapCrop {
   if (entities.length === 0) return { x: 0, y: 0, w: 0, h: 0 };
-  // Sub-entities carry a pos LOCAL to their place's frame — resolve up the
-  // parent chain so a child's small/negative local coords don't skew the world
-  // bounds (a top-level entity resolves to itself).
-  const byId = new Map<string, FrameNode>(entities.map((e) => [e.id, e]));
-  let minX = Infinity;
-  let minY = Infinity;
-  let maxX = -Infinity;
-  let maxY = -Infinity;
-  for (const e of entities) {
-    const p = resolveAbsolutePos(e.id, byId) ?? e.pos;
-    const hw = e.footprint.w / 2;
-    const hd = e.footprint.d / 2;
-    minX = Math.min(minX, p.x - hw);
-    maxX = Math.max(maxX, p.x + hw);
-    minY = Math.min(minY, p.y - hd);
-    maxY = Math.max(maxY, p.y + hd);
-  }
-  return { x: minX, y: minY, w: maxX - minX, h: maxY - minY };
+  return localBounds(toAbsoluteEntities(entities, entities));
 }
 
 // ── Structured geo edits (natural-language-editable map) ─────────────────────


### PR DESCRIPTION
Eren's screenshot of the post-ascend map caught two real problems in the geo stack.

## 1. The minimap's "bounds 8000×6828" blowup

`recomputeBounds` (`lib/world-map.ts`) resolved each entity's **pos** through the parent chain but used the **raw parent-local footprint** — the fifth consumer #123 missed, and #123's (correct) footprint÷pScale rescale amplified it from latent to catastrophic: one re-expressed root's 40×34.14 footprint ÷ 0.005 = **exactly 8000×6828**, matching the screenshot digit for digit. The stored bounds then wrecked the minimap frame (dots collapsed at origin), `cropCentre`, and the location-phrase path.

Fix: `recomputeBounds` = `localBounds(toAbsoluteEntities(entities, entities))` — pos and footprint resolved **together** at the one write-path choke point (all three writers, every consumer). `WorldMiniMap` also resolves once up front: its crop filter no longer culls former roots on `map_crop` views, dots read resolved pos directly, and the label budget ranks true areas. Already-stored docs self-heal on the next geo write.

## 2. Double name tags with ⊞ geo + DOM labels

`GeometryOverlay` names every localized entity on its boxes; `MapLabelOverlay` labels the same `appearance_bboxes` centres. Both mounted = every place tagged twice. Fix: the label overlay doesn't mount while the geo debug layer is on (one condition).

## Verified live (same demo session)
- Mongo before: `bounds {w: 8000, h: 6828}` → after one geo write through the fixed path: **`{x:0, y:0, w:100, h:62.07}`**
- Minimap footer: `world coords · 4 entities · bounds 100×62`, all 4 dots spread correctly
- With ⊞ geo on: `[data-label-id]` count = 0 (single tags only)

## Tests
- `world-map.test.ts`: post-ascend fixture — re-expressed root (footprint 8000, P scale 0.005) → bounds ≤110, not 8000
- `WorldMiniMap.test.tsx`: nested former-roots fixture — 3 dots, footer `bounds 100×60`
- Full web suite 653 green, tsc clean

Out of scope (honest note): the sloppy box *placement* on the image (e.g. the harbor box over the town) is VLM detector localization quality — the known extraction ceiling measured by the eval benches, not a wiring bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)