### PR TITLE
fix(ascend): judged + label-suppressed container renders; unverified renders get a chip

### DIFF
--- a/apps/modal-backend/providers/generate_modes/ascend.py
+++ b/apps/modal-backend/providers/generate_modes/ascend.py
@@ -11,8 +11,9 @@ generate.py's stream helpers (`_sse`, `_frame_dims`, `_view_grammar_on`,
 from __future__ import annotations
 
 import asyncio as _asyncio
+import time as _time
 from collections.abc import AsyncIterator, Awaitable, Callable
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from _env import env_flag
 from obs import log, record_error
@@ -22,6 +23,7 @@ from providers import llm, model_router, spend
 
 if TYPE_CHECKING:
     from generate import GenerateBody
+    from providers.edit_loop import EditAttempt
 
 
 async def stream_ascend(
@@ -83,6 +85,16 @@ async def stream_ascend(
     outward_rider = instructions_lib.outward_clause(
         cast("ViewSpecDict | None", src_view)
     )
+    # DOM-labels mode: the container is a map too — render it label-free like
+    # every other map path (the un-suppressed ascend hallucinated big baked
+    # title lettering, e.g. "THE LAND OF IMAGINATION").
+    no_lettering = ""
+    if body.suppress_map_labels:
+        from providers.prompt_library.style import NO_LETTERING
+
+        no_lettering = NO_LETTERING
+    render_unjudged = False
+    billed_images = 1
     try:
         if use_outpaint:
             medium = style_lock or "the same hand-drawn art style as the centre"
@@ -93,6 +105,8 @@ async def stream_ascend(
             )
             if outward_rider:
                 margin += ". " + outward_rider
+            if no_lettering:
+                margin += ". " + no_lettering
             img = await image_edit_provider.expand_image_zoomout(
                 body.image, 3.0, pw, ph, prompt=margin
             )
@@ -122,13 +136,70 @@ async def stream_ascend(
                 )
                 if outward_rider:
                     ascend_instr += " " + outward_rider
-                img = await image_edit_provider.edit_image(
-                    body.image, ascend_instr
-                )
+                if no_lettering:
+                    ascend_instr += " " + no_lettering
+                # The container hop IS a whole-image judged edit: nano-banana
+                # edit follows refs loosely, and the un-judged ascend shipped
+                # a full medium break (painterly session → antique chart).
+                # Same harness as EDIT_REGION's whole-image arm: alignment
+                # (did it zoom out as asked) + medium (same hand as the
+                # source), keep-best, critic feedback folded into the retry,
+                # deadline mirroring generate.INGRESS_TIMEOUT_S - 180s.
+                from providers import edit_loop, judge
+                from providers.render_loop import data_url_bytes
+
+                source_bytes = data_url_bytes(body.image)
+                if source_bytes is None:
+                    # Remote-ref source can't feed the medium judge — render
+                    # once and say so instead of pretending it was verified.
+                    img = await image_edit_provider.edit_image(
+                        body.image, ascend_instr
+                    )
+                    render_unjudged = True
+                else:
+                    ascend_cfg = edit_loop.edit_loop_config_from_env(
+                        body.max_attempts
+                    )
+                    ascend_deadline = _time.monotonic() + 720.0
+                    captured_instr = ascend_instr
+                    source_url: str = body.image
+
+                    async def _render_ascend(suffix: str) -> Any:
+                        instr = (
+                            captured_instr
+                            if not suffix
+                            else f"{captured_instr}\n\n{suffix}"
+                        )
+                        return await image_edit_provider.edit_image(
+                            source_url, instr
+                        )
+
+                    ascend_attempts: list[EditAttempt] = []
+                    async for asc_att in edit_loop.iter_edit_attempts(
+                        _render_ascend,
+                        source_bytes=source_bytes,
+                        mask_png=None,
+                        region_box=None,
+                        judge_alignment=judge.score_prompt_alignment,
+                        judge_medium=judge.score_style_pair,
+                        instruction=ascend_instr,
+                        config=ascend_cfg,
+                        abort=_abort_if_disconnected,
+                        deadline_s=ascend_deadline,
+                    ):
+                        ascend_attempts.append(asc_att)
+                    asc_res = edit_loop.conclude_edit(ascend_attempts)
+                    img = cast("Any", asc_res.best.image)
+                    billed_images = max(1, len(ascend_attempts))
+                    # Critic degraded (judge failure → single blind attempt):
+                    # the render shipped without a verdict — flag it.
+                    render_unjudged = asc_res.best.alignment is None
             else:
                 # Fresh container = a NEW map: state the deliberate
                 # top-down camera (None on astro rungs → legacy bytes).
                 ascend_prompt = plan.prompt
+                if no_lettering:
+                    ascend_prompt += f"\n\n{no_lettering}"
                 if _view_grammar_on():
                     asc_view = view_policy.default_view(
                         render_mode="scale_parent",
@@ -153,21 +224,24 @@ async def stream_ascend(
     data_url = await _asyncio.to_thread(
         image_provider.encode_data_url, img.jpeg_bytes, img.mime_type
     )
-    # Spend accounting: this OUTWARD hop made a real paid image call —
-    # record it (like the tap/draft paths) so the cap actually counts it.
-    spend.record_generation(body.session_id, img.model)
-    yield _sse(
-        {
-            "type": "ascend_ready",
-            "page_title": page_title,
-            "image_data_url": data_url,
-            "image_model": img.model,
-            "prompt_author_model": "",
-            "final_prompt": final_prompt,
-            "scale_tier": to_tier,
-            "from_tier": from_tier,
-            "session_id": body.session_id,
-        },
-        trace_id,
-    )
+    # Spend accounting: this OUTWARD hop made real paid image calls (one per
+    # judged attempt) — record them so the cap actually counts them.
+    spend.record_generation(body.session_id, img.model, images=billed_images)
+    ascend_payload: dict[str, Any] = {
+        "type": "ascend_ready",
+        "page_title": page_title,
+        "image_data_url": data_url,
+        "image_model": img.model,
+        "prompt_author_model": "",
+        "final_prompt": final_prompt,
+        "scale_tier": to_tier,
+        "from_tier": from_tier,
+        "session_id": body.session_id,
+    }
+    if render_unjudged:
+        # Additive: present only when the critics could not gate this render
+        # (judge failure / remote-ref source) — the UI shows an "unverified
+        # render" chip instead of letting flap-era drift ship silently.
+        ascend_payload["render_unjudged"] = True
+    yield _sse(ascend_payload, trace_id)
     return

--- a/apps/modal-backend/providers/generate_modes/tap.py
+++ b/apps/modal-backend/providers/generate_modes/tap.py
@@ -320,6 +320,10 @@ async def stream_tap(
     # generation billed — judged loops overwrite with their attempt count,
     # the draft records itself at emission.
     billed_images = 1
+    # A JUDGED path that degraded (judge failure → the kept attempt shipped
+    # with no critic verdict) flags the final so the UI can mark the render.
+    # Paths that are unjudged BY DESIGN (fresh, zoom_continue) never set it.
+    render_unjudged = False
 
     # The deliberate camera (view grammar): user/persisted pin > policy >
     # None (legacy bytes). Resolved once; consumed by the layout clause,
@@ -626,6 +630,8 @@ async def stream_tap(
                     )
             result = render_loop.conclude(loop_attempts).image
             billed_images = max(1, len(loop_attempts))
+            kept = next((a for a in loop_attempts if a.image is result), None)
+            render_unjudged = kept is not None and kept.conformance is None
         else:
             main_task = _asyncio.create_task(
                 image_edit_provider.edit_image(
@@ -781,6 +787,11 @@ async def stream_tap(
     # off → key absent → unchanged wire shape).
     if grounding_summary is not None:
         final_payload["grounding"] = grounding_summary
+    if render_unjudged:
+        # Additive: only when a judged path degraded (critics unavailable) —
+        # the UI shows an "unverified render" chip so flap-era style drift
+        # is visible instead of silent.
+        final_payload["render_unjudged"] = True
     yield _sse(final_payload, trace_id)
     log(
         "info",

--- a/apps/modal-backend/tests/test_generate_ascend.py
+++ b/apps/modal-backend/tests/test_generate_ascend.py
@@ -275,3 +275,82 @@ async def test_ascend_outpaint_margin_carries_the_source_view_rider(
     margin = outpaint.await_args.kwargs.get("prompt") or ""
     assert "flat top-down overhead perspective" in margin
     assert "the camera simply rises" in margin
+
+
+def _mock_judges(monkeypatch: pytest.MonkeyPatch, ok: bool) -> None:
+    import providers.judge as judge_mod
+    from providers.judge import JudgeResult
+
+    if ok:
+        fn = AsyncMock(return_value=JudgeResult(score=9.0, rationale="", raw=""))
+    else:
+        fn = AsyncMock(side_effect=RuntimeError("judge down"))
+    monkeypatch.setattr(judge_mod, "score_prompt_alignment", fn)
+    monkeypatch.setattr(judge_mod, "score_style_pair", fn)
+
+
+# A decodable data-URL source (the "abc" in _ascend_body is invalid base64 and
+# routes to the remote-ref fallback) — required to arm the judged edit loop.
+_DECODABLE = "data:image/jpeg;base64,QUJD"
+
+
+async def test_ascend_edit_container_is_judged(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The container hop runs the whole-image edit loop: accepting critics →
+    # one render, NO render_unjudged on the wire (the un-judged ascend was
+    # how a full medium break shipped silently).
+    _enable(monkeypatch)
+    monkeypatch.delenv("SCALE_OUTWARD_OUTPAINT", raising=False)
+    _mock_fresh(monkeypatch)
+    edit = AsyncMock(
+        return_value=GeneratedImage(b"jpeg", "image/jpeg", "fal-ai/nano-banana-pro", "r")
+    )
+    monkeypatch.setattr(image_edit_mod, "edit_image", edit)
+    _mock_judges(monkeypatch, ok=True)
+
+    events = await _collect(_event_stream(_ascend_body(image=_DECODABLE), "t1"))
+    ready = next(e for e in events if e["type"] == "ascend_ready")
+    assert "render_unjudged" not in ready
+    edit.assert_awaited_once()  # accepted at one — no retry spend
+
+
+async def test_ascend_degraded_critics_flag_render_unjudged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Judge failure (an upstream flap) → single blind attempt, kept, but the
+    # wire says so: render_unjudged rides ascend_ready for the UI chip.
+    _enable(monkeypatch)
+    monkeypatch.delenv("SCALE_OUTWARD_OUTPAINT", raising=False)
+    _mock_fresh(monkeypatch)
+    edit = AsyncMock(
+        return_value=GeneratedImage(b"jpeg", "image/jpeg", "fal-ai/nano-banana-pro", "r")
+    )
+    monkeypatch.setattr(image_edit_mod, "edit_image", edit)
+    _mock_judges(monkeypatch, ok=False)
+
+    events = await _collect(_event_stream(_ascend_body(image=_DECODABLE), "t1"))
+    ready = next(e for e in events if e["type"] == "ascend_ready")
+    assert ready["render_unjudged"] is True
+    edit.assert_awaited_once()  # no blind re-roll without a critic
+
+
+async def test_ascend_suppresses_lettering_in_dom_labels_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # DOM-labels mode: the container map renders label-free like every other
+    # map path (the un-suppressed ascend hallucinated big baked title text).
+    _enable(monkeypatch)
+    monkeypatch.delenv("SCALE_OUTWARD_OUTPAINT", raising=False)
+    _mock_fresh(monkeypatch)
+    edit = AsyncMock(
+        return_value=GeneratedImage(b"jpeg", "image/jpeg", "fal-ai/nano-banana-pro", "r")
+    )
+    monkeypatch.setattr(image_edit_mod, "edit_image", edit)
+    _mock_judges(monkeypatch, ok=True)
+    from providers.prompt_library.style import NO_LETTERING
+
+    events = await _collect(
+        _event_stream(_ascend_body(image=_DECODABLE, suppress_map_labels=True), "t1")
+    )
+    assert next(e for e in events if e["type"] == "ascend_ready")
+    instr = edit.await_args.args[1]
+    assert NO_LETTERING in instr

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -921,6 +921,14 @@ export default function PlayPage() {
                   revertTo:
                     body.mode === "edit" ? body.current_node_id || null : null,
                 });
+              } else if (evt.render_unjudged) {
+                // A judged path shipped without a critic verdict (upstream
+                // flap killed the judges) — say so instead of letting style
+                // drift pass as verified. Same chip surface as edit verdicts.
+                setEditVerdictChip({
+                  text: "⚠ unverified render — critics were unavailable",
+                  revertTo: null,
+                });
               }
               void persistNode(
                 {
@@ -1770,6 +1778,12 @@ export default function PlayPage() {
       setPage(parentPage);
       setPhase("ready");
       setViewMode("page");
+      if (a.renderUnjudged) {
+        setEditVerdictChip({
+          text: "⚠ unverified render — critics were unavailable",
+          revertTo: null,
+        });
+      }
       const url = new URL(window.location.href);
       url.pathname = `/n/${a.parentNodeId}`;
       window.history.replaceState({}, "", url.toString());
@@ -1792,8 +1806,10 @@ export default function PlayPage() {
       imageDataUrl: page.imageDataUrl,
       aspectRatio: "16:9",
       sceneView: page.sceneView ?? null,
+      styleAnchor: styleAnchor?.style ?? null,
+      suppressMapLabels: worldEnabled && worldDomLabels,
     });
-  }, [page, sessionId, startAscend]);
+  }, [page, sessionId, startAscend, styleAnchor, worldEnabled, worldDomLabels]);
 
   useKeyboardShortcuts({
     onBack: goBack,

--- a/apps/web/hooks/useAscend.ts
+++ b/apps/web/hooks/useAscend.ts
@@ -18,6 +18,13 @@ export interface AscendRoot {
   imageDataUrl: string;
   aspectRatio: string;
   sceneView?: SceneView | null;
+  // The session style lock — the ascend used to be the ONE generate that
+  // didn't send it, so the container render only had the weak "same style
+  // as the centre" fallback holding the medium.
+  styleAnchor?: string | null;
+  // DOM-labels mode: ask for a label-free container map like every other
+  // map render (the un-suppressed ascend baked hallucinated title lettering).
+  suppressMapLabels?: boolean;
 }
 
 export interface Ascended {
@@ -27,6 +34,9 @@ export interface Ascended {
   imageDataUrl: string;
   sceneView: SceneView;
   scaleTier: ScaleTier;
+  // The container shipped without a critic verdict (judge failure) — the
+  // page surfaces an "unverified render" chip.
+  renderUnjudged: boolean;
 }
 
 // Drain the SSE stream until the single `ascend_ready` lands (or an error).
@@ -98,6 +108,10 @@ export function useAscend(onAscended: (a: Ascended) => void): {
               scene_view: root.sceneView ?? null,
               aspect_ratio: root.aspectRatio,
               web_search: false,
+              ...(root.styleAnchor
+                ? { session_style_anchor: root.styleAnchor }
+                : {}),
+              ...(root.suppressMapLabels ? { suppress_map_labels: true } : {}),
               trace_id: traceId,
             }),
             signal: ac.signal,
@@ -136,6 +150,7 @@ export function useAscend(onAscended: (a: Ascended) => void): {
             pageTitle: ready.page_title,
             imageDataUrl: ready.image_data_url,
             scaleTier: ready.scale_tier,
+            renderUnjudged: ready.render_unjudged === true,
             sceneView: {
               node_id: saved.parent_node_id,
               level: "map",

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -332,6 +332,10 @@ export interface GenerateFinalEvent {
   grounding?: GroundingSummary;
   // Judged mask-scoped edit verdict — present only on the EDIT_REGION path.
   edit_verdict?: EditVerdict;
+  // A JUDGED render path degraded (critics unavailable — e.g. an upstream
+  // flap): the kept image shipped without a verdict. Additive; absent on
+  // paths that are unjudged by design (fresh, zoom_continue).
+  render_unjudged?: boolean;
   // Running estimated spend ($) for this session — coarse, mirrors
   // docs/COSTS.md prices (providers/spend.py). Additive; absent on older
   // backends.
@@ -411,6 +415,9 @@ export interface GenerateAscendReadyEvent {
   scale_tier: ScaleTier;
   from_tier: ScaleTier;
   session_id: string;
+  // The container render shipped without a critic verdict (judge failure /
+  // remote-ref source). Additive — see GenerateFinalEvent.render_unjudged.
+  render_unjudged?: boolean;
   trace_id?: string;
 }
 


### PR DESCRIPTION
The morning 'what happened to consistency' session, root-caused with receipts:

1. **The ascend was the only unjudged render path.** The OUTWARD container hop shipped a full medium break (painterly session → antique engraved chart, complete with a hallucinated baked title — 'THE LAND OF IMAGINATION') even though the planner's prompt explicitly asked for "vibrant digital watercolor… same whimsical fantasy aesthetic". nano-banana edit follows refs loosely; nothing gated the result. Now the edit-ref container (the default path) runs the **whole-image edit loop** — alignment critic (did it zoom out as asked) + medium critic (same hand as the source), keep-best, critic feedback folded into the retry, the #117 cumulative deadline, per-attempt spend.
2. **Three client-side leaks on the ascend request**: it never sent `session_style_anchor` (the one generate that didn't — the medium had only the weak "same style as the centre" fallback), never sent `suppress_map_labels` (hence the baked title in DOM-labels mode), and had no verdict signal. All three threaded; `NO_LETTERING` now reaches all three ascend render paths.
3. **Degraded renders are visible**: during the same session an OpenRouter connection flap killed the judges and an enter shipped as a single unjudged attempt, silently. New additive wire field `render_unjudged` on `final` + `ascend_ready` — set ONLY when a judged path degraded (never on by-design-unjudged paths like fresh/zoom_continue) — and the play page shows an **"⚠ unverified render" chip** on the existing verdict-chip surface.

## Tests
- `test_generate_ascend.py`: +3 — accepting critics → judged, no flag, one render; judge failure → single blind attempt + `render_unjudged: true`; DOM-labels mode → `NO_LETTERING` in the edit instruction. (Existing 10 all still pass.)
- Full backend pytest + ruff + mypy green; web 653 + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)