### PR TITLE
chore(demo): record-geo — SSE-safe load, real-signal sequencing, ring-targeted enter

### DIFF
--- a/scripts/record-demo/record-geo.ts
+++ b/scripts/record-demo/record-geo.ts
@@ -56,17 +56,6 @@ async function waitStable(page: Page, timeout: number): Promise<string> {
   throw new Error("image never stabilized");
 }
 
-async function waitChanged(page: Page, prev: string, timeout: number): Promise<string> {
-  await page.waitForFunction(
-    (p) => {
-      const el = document.querySelector('img[alt^="Generated illustration"]');
-      return !!el && el.getAttribute("src") !== p;
-    },
-    prev,
-    { timeout },
-  );
-  return waitStable(page, timeout);
-}
 
 async function tap(page: Page, xPct: number, yPct: number): Promise<void> {
   const box = await img(page).boundingBox();
@@ -109,7 +98,7 @@ async function main(): Promise<void> {
   await page.waitForTimeout(400);
   console.log("[geo] generating the map");
   await page.getByRole("button", { name: "Go" }).click();
-  const mapSrc = await waitStable(page, GEN_TIMEOUT);
+  await waitStable(page, GEN_TIMEOUT);
   await page.waitForTimeout(2500);
 
   // Session id (for the atlas leg) — the atlas link is persist-gated and can
@@ -130,17 +119,54 @@ async function main(): Promise<void> {
   console.log("[geo] session:", session);
 
   // ── 2. The numeric world — coordinate overlay + minimap ─────────────────────
+  // Extraction (entity boxes/polygons/labels + the enter rings) lands well
+  // AFTER the image stabilizes — toggling ⊞ geo early puts an EMPTY overlay
+  // on camera (take-2 lesson). Wait for the markers/labels to exist first.
+  console.log("[geo] waiting for extraction (rings/labels)");
+  await page
+    .waitForFunction(
+      () =>
+        document.querySelectorAll("[data-entity-id], [data-label-id]").length >
+        0,
+      undefined,
+      { timeout: 90_000 },
+    )
+    .catch(() => console.log("[geo] extraction markers never appeared — continuing"));
   console.log("[geo] coordinate overlay");
   const geo = page.getByRole("button", { name: /geo$/ }).first();
   if ((await geo.count()) && (await geo.getAttribute("aria-pressed")) !== "true") {
     await geo.click();
   }
-  await page.waitForTimeout(3500); // linger on the coords + minimap
+  await page.waitForTimeout(4000); // linger on the populated coords + minimap
 
   // ── 3. Go IN — level down ───────────────────────────────────────────────────
-  console.log("[geo] go in (Unseen University)");
-  await tap(page, 0.16, 0.42);
-  await waitChanged(page, mapSrc, GEN_TIMEOUT);
+  // Tap a REAL enterable place: the centre of the first enter-ring marker
+  // (falls back to the historical hardcoded point when no ring rendered).
+  const ring = await page.evaluate(() => {
+    const m = document.querySelector("[data-entity-id]");
+    if (!m) return null;
+    const r = (m as HTMLElement).getBoundingClientRect();
+    const img = document
+      .querySelector('img[alt^="Generated illustration"]')
+      ?.getBoundingClientRect();
+    if (!img || !img.width) return null;
+    return {
+      x: (r.x + r.width / 2 - img.x) / img.width,
+      y: (r.y + r.height / 2 - img.y) / img.height,
+    };
+  });
+  console.log("[geo] go in", ring ? `(ring at ${ring.x.toFixed(2)},${ring.y.toFixed(2)})` : "(fallback point)");
+  await tap(page, ring?.x ?? 0.16, ring?.y ?? 0.42);
+  // Completion = the trail grew (persist-gated step counter) — NEVER the img
+  // src: the progressive draft swaps src long before the final lands (the
+  // take-2 bug: we "finished" mid-generation and the entered page never made
+  // it on camera).
+  await page.waitForFunction(
+    () => /step 2 of/.test(document.body.innerText),
+    undefined,
+    { timeout: GEN_TIMEOUT },
+  );
+  await waitStable(page, GEN_TIMEOUT);
   await page.waitForTimeout(3500); // linger on the entered place
 
   // ── 3b. Step back OUT — the spatial breadcrumb takes you home ───────────────
@@ -148,6 +174,13 @@ async function main(): Promise<void> {
   const back = page.getByRole("button", { name: "← back" }).first();
   if (await back.count()) {
     await back.click().catch(() => {});
+    await page
+      .waitForFunction(
+        () => /step 1 of 2/.test(document.body.innerText),
+        undefined,
+        { timeout: 15_000 },
+      )
+      .catch(() => {});
     await page.waitForTimeout(3000); // linger back on the map (overlay persists)
   }
 
@@ -155,6 +188,13 @@ async function main(): Promise<void> {
   if (session) {
     console.log("[geo] atlas: zoom out to the whole chain");
     await page.goto(`${BASE}/atlas/${session}`, { waitUntil: "load" });
+    // Both nodes must be on the board before the zoom choreography — the
+    // take-2 atlas showed "1 pages" because the child hadn't persisted yet.
+    await page
+      .waitForFunction(() => /2 pages/.test(document.body.innerText), undefined, {
+        timeout: 30_000,
+      })
+      .catch(() => console.log("[geo] atlas still shows 1 page — continuing"));
     await page.waitForTimeout(2800);
     const fit = page.getByRole("button", { name: /fit all/i }).first();
     if (await fit.count()) await fit.click().catch(() => {});

--- a/scripts/record-demo/record-geo.ts
+++ b/scripts/record-demo/record-geo.ts
@@ -91,7 +91,11 @@ async function main(): Promise<void> {
 
   // ── 1. A world from scratch ────────────────────────────────────────────────
   console.log("[geo] opening play");
-  await page.goto(`${BASE}/play`, { waitUntil: "networkidle" });
+  // domcontentloaded, NOT networkidle: /play holds a persistent Mongo
+  // change-stream SSE open, so networkidle never fires (the record-ankh
+  // lesson) — wait for the query box instead.
+  await page.goto(`${BASE}/play`, { waitUntil: "domcontentloaded" });
+  await page.getByRole("textbox").first().waitFor({ timeout: 30_000 });
   await page.waitForTimeout(1200);
   await page.getByRole("button", { name: "Vintage" }).click().catch(() => {});
   await page.waitForTimeout(400);
@@ -108,13 +112,18 @@ async function main(): Promise<void> {
   const mapSrc = await waitStable(page, GEN_TIMEOUT);
   await page.waitForTimeout(2500);
 
-  // Session id (for the atlas leg) — retry until the "↗ atlas" link is present.
+  // Session id (for the atlas leg) — the atlas link is persist-gated and can
+  // land ~10s after the image stabilizes, so poll long and fall back to the
+  // localStorage session key the play page maintains.
   let session: string | null = null;
-  for (let i = 0; i < 12 && !session; i++) {
+  for (let i = 0; i < 30 && !session; i++) {
     session = await page.evaluate(() => {
       const a = document.querySelector('a[href*="/atlas/"]');
       const m = (a?.getAttribute("href") ?? "").match(/\/atlas\/(session_[a-z0-9-]+)/i);
-      return m ? m[1] : null;
+      if (m) return m[1];
+      const ls = window.localStorage.getItem("openflipbook.lastSession") ?? "";
+      const lm = ls.match(/session_[a-z0-9-]+/i);
+      return lm ? lm[0] : null;
     });
     if (!session) await page.waitForTimeout(800);
   }
@@ -133,6 +142,14 @@ async function main(): Promise<void> {
   await tap(page, 0.16, 0.42);
   await waitChanged(page, mapSrc, GEN_TIMEOUT);
   await page.waitForTimeout(3500); // linger on the entered place
+
+  // ── 3b. Step back OUT — the spatial breadcrumb takes you home ───────────────
+  console.log("[geo] step back out");
+  const back = page.getByRole("button", { name: "← back" }).first();
+  if (await back.count()) {
+    await back.click().catch(() => {});
+    await page.waitForTimeout(3000); // linger back on the map (overlay persists)
+  }
 
   // ── 4. Levels up/down + zoom — the atlas nested chain ───────────────────────
   if (session) {


### PR DESCRIPTION
The geo demo recorder produced broken clips because it sequenced on proxies instead of real state. Fixed in two rounds — the second round exists because I shipped the first calling it 'verified' when only the LOG was verified, and a frame-by-frame audit of the clip said otherwise.

## Round 1 (plumbing)
- `networkidle` never fires on /play (persistent change-stream SSE) → `domcontentloaded` + wait for the query box
- the atlas link is persist-gated (~10s late) → 30s poll + localStorage fallback (take 1 logged `session: null` and silently skipped the whole atlas leg)
- added the step-back-OUT beat

## Round 2 (sequencing on real signals — the take-2 audit findings)
- **Empty overlay on camera**: ⊞ geo was toggled while extraction was still `localizing…` → the script now waits for the enter-ring / DOM-label markers to exist first
- **Fake enter completion**: the img src changes when the progressive DRAFT lands, long before the final → completion is the persist-gated step counter (`step 2 of`), then image stability (the record-ankh lesson)
- **"1 pages" atlas**: navigated before the child persisted → waits for `2 pages`
- The tap now targets the centre of a real enterable ring (hardcoded point kept as fallback)

## Verified — by reading the frames this time
Take 3 audited at one frame per 2s, all 22 read: planning → labeled draft preview → final map → **populated** geo overlay (boxes + segmenter polygons + labels + world-coords minimap, codex 6) → ring-targeted enter completing on camera (`step 2 of 2`, same engraved style as the parent — the judged enter holding the medium) → step back with overlay intact → atlas with both tiles + zoom choreography. 43.8s @3.3×.

🤖 Generated with [Claude Code](https://claude.com/claude-code)