### PR TITLE
feat(web): in-session expand connectors — relation rides Page, hydration, and the map views

### DIFF
--- a/apps/web/app/api/sessions/[id]/route.ts
+++ b/apps/web/app/api/sessions/[id]/route.ts
@@ -45,6 +45,11 @@ export async function GET(req: Request, { params }: Params) {
       aspect_ratio: row.aspect_ratio,
       click_in_parent: row.click_in_parent,
       sources: row.sources,
+      // How the node hangs off its parent (descend/expand/ascend/edit) — the
+      // ?continue= hydration rides it onto the in-session Page so the map
+      // views can render breadth vs depth like the atlas. Additive: old
+      // clients ignore it, and toRow defaults missing Mongo values "descend".
+      relation: row.relation,
       scene_view: row.scene_view,
       geo_extracted: row.geo_extracted,
       created_at: row.created_at,

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -116,6 +116,13 @@ import { selectNeighbors } from "@/lib/scale-neighbors";
 import { sceneCloseupSpec } from "@/lib/scene-closeup";
 import { childrenOf, projectTopDown, toAbsoluteEntities } from "@/lib/world-geometry";
 import { viewNeutralAppearance } from "@/lib/appearance";
+// The in-session page graph node — lives in lib/session-pages.ts so the
+// ?continue= hydration mapper (nodeToPage) is a testable pure function.
+import {
+  nodeToPage,
+  type Page,
+  type SessionNodeWire,
+} from "@/lib/session-pages";
 import { useImageMorph } from "@/hooks/useImageMorph";
 import {
   PREFETCH_LRU_MAX,
@@ -150,32 +157,6 @@ const ON_RAMP_COACH_ENABLED = ["1", "true", "yes"].includes(
 const ENTER_COACH_ENABLED = ["1", "true", "yes"].includes(
   (process.env.NEXT_PUBLIC_ENTER_COACH ?? "").toLowerCase(),
 );
-
-interface Page {
-  nodeId: string | null;
-  sessionId: string;
-  query: string;
-  title: string;
-  imageDataUrl: string | null;
-  // Set when this page was generated as a child of another via a tap.
-  parentId?: string | null;
-  // Where the user clicked on the parent page (0..1). Used by the map
-  // view to position the child tile inside the parent's rect.
-  clickInParent?: { xPct: number; yPct: number };
-  // Web-search citations the planner used. Hydrated from the SSE final
-  // event and from /api/nodes/[id] on permalink replay. Empty when web
-  // search returned nothing or is disabled.
-  sources?: Citation[];
-  // The view this page was entered from (geo tap). Its focus_id scopes the
-  // minimap to the place you're inside; null/absent on the world map + classic
-  // pages → the minimap shows the whole world frame.
-  sceneView?: SceneView | null;
-  // Whether entity extraction has already run for this node (read back from
-  // Mongo on revisit/reload). Gates the auto-localize effect so a revisit never
-  // silently re-runs the non-deterministic VLM pass. Absent on freshly-created
-  // pages this session → the in-memory attempt guard covers them instead.
-  geoExtracted?: boolean;
-}
 
 function newSessionId(): string {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
@@ -909,6 +890,9 @@ export default function PlayPage() {
                 title: evt.page_title,
                 imageDataUrl: evt.image_data_url,
                 sources: evtSources,
+                // Mirror the persist body: an edit is a REVISION. Tap/fresh
+                // stay absent = descend.
+                ...(body.mode === "edit" ? { relation: "edit" as const } : {}),
               });
               // Flip the morph gate so the decode-then-reveal effect runs
               // ONLY on the final image, not on streamed progress partials.
@@ -973,6 +957,9 @@ export default function PlayPage() {
                     imageDataUrl: evt.image_data_url,
                     parentId: body.current_node_id || null,
                     sources: evtSources,
+                    // Same relation the persist body sent — so the in-session
+                    // map reads this page like the atlas will after a reload.
+                    ...(body.mode === "edit" ? { relation: "edit" as const } : {}),
                     sceneView: body.scene_view
                       ? { ...body.scene_view, node_id: saved.id }
                       : null,
@@ -1767,6 +1754,9 @@ export default function PlayPage() {
         imageDataUrl: a.imageDataUrl,
         parentId: null,
         sceneView: a.sceneView,
+        // The ascend route inserts the container node as relation:"ascend" —
+        // carry the same on the live Page so map chrome reads it correctly.
+        relation: "ascend",
       };
       setHistory((prev) => {
         const items = prev.items.map((p) =>
@@ -1853,41 +1843,12 @@ export default function PlayPage() {
           { headers: { [TRACE_HEADER]: hydrationTrace } }
         );
         if (!res.ok) return;
-        const data = (await res.json()) as {
-          nodes: Array<{
-            id: string;
-            parent_id: string | null;
-            session_id: string;
-            query: string;
-            page_title: string;
-            image_url: string;
-            click_in_parent: { x_pct: number; y_pct: number } | null;
-            sources?: { url: string; title: string | null }[] | null;
-            scene_view?: SceneView | null;
-            geo_extracted?: boolean;
-          }>;
-        };
+        const data = (await res.json()) as { nodes: SessionNodeWire[] };
         if (cancelled) return;
         if (!data.nodes?.length) return;
-        const items: Page[] = data.nodes.map((n) => ({
-          nodeId: n.id,
-          sessionId: n.session_id,
-          query: n.query,
-          title: n.page_title,
-          imageDataUrl: n.image_url,
-          parentId: n.parent_id,
-          sources: Array.isArray(n.sources) ? n.sources : [],
-          sceneView: n.scene_view ?? null,
-          geoExtracted: n.geo_extracted ?? false,
-          ...(n.click_in_parent
-            ? {
-                clickInParent: {
-                  xPct: n.click_in_parent.x_pct,
-                  yPct: n.click_in_parent.y_pct,
-                },
-              }
-            : {}),
-        }));
+        // Node rows carry `relation` (expand/edit/ascend/descend) — nodeToPage
+        // rides it onto each Page so the map views keep breadth vs depth.
+        const items: Page[] = data.nodes.map(nodeToPage);
         const last = items[items.length - 1];
         const trail = last && last.nodeId ? [last.nodeId] : [];
         setHistory({ items, trail, trailIdx: trail.length - 1 });
@@ -3195,6 +3156,7 @@ export default function PlayPage() {
               imageDataUrl: p.imageDataUrl,
               title: p.title,
               ...(p.clickInParent ? { clickInParent: p.clickInParent } : {}),
+              ...(p.relation ? { relation: p.relation } : {}),
             }))}
           activeNodeId={page?.nodeId ?? null}
           onSelect={selectFromMap}
@@ -3918,6 +3880,7 @@ export default function PlayPage() {
               imageDataUrl: p.imageDataUrl,
               title: p.title,
               ...(p.clickInParent ? { clickInParent: p.clickInParent } : {}),
+              ...(p.relation ? { relation: p.relation } : {}),
             }))}
           activeNodeId={page?.nodeId ?? null}
           onExpand={() => setViewMode("map")}

--- a/apps/web/components/session-minimap.test.tsx
+++ b/apps/web/components/session-minimap.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+
+import SessionMinimap from "./session-minimap";
+import type { LayoutInput } from "@/lib/world-layout";
+
+function page(partial: Partial<LayoutInput> & { nodeId: string }): LayoutInput {
+  return {
+    parentId: null,
+    imageDataUrl: null,
+    title: partial.nodeId,
+    ...partial,
+  };
+}
+
+describe("SessionMinimap relation tint", () => {
+  it("tints expand tiles teal so breadth reads apart from tap-in ink", () => {
+    const { container } = render(
+      <SessionMinimap
+        pages={[
+          page({ nodeId: "root" }),
+          page({ nodeId: "down", parentId: "root", relation: "descend" }),
+          page({ nodeId: "out", parentId: "root", relation: "expand" }),
+        ]}
+        activeNodeId="root"
+        onExpand={() => {}}
+        onJump={() => {}}
+      />,
+    );
+    const tile = (title: string) =>
+      container.querySelector<HTMLElement>(`button[title="${title}"]`);
+    // Expand tile: the atlas/world-map teal (13,148,136).
+    expect(tile("out")!.getAttribute("data-relation")).toBe("expand");
+    expect(tile("out")!.style.background).toMatch(/13,\s*148,\s*136/);
+    // Descend tile keeps the ink fill.
+    expect(tile("down")!.style.background).toMatch(/15,\s*15,\s*15/);
+  });
+
+  it("active tile stays red even when it is an expand page", () => {
+    const { container } = render(
+      <SessionMinimap
+        pages={[
+          page({ nodeId: "root" }),
+          page({ nodeId: "out", parentId: "root", relation: "expand" }),
+        ]}
+        activeNodeId="out"
+        onExpand={() => {}}
+        onJump={() => {}}
+      />,
+    );
+    const active = container.querySelector<HTMLElement>(
+      '[data-relation="expand"]',
+    );
+    expect(active!.style.background).toMatch(/239,\s*68,\s*68/);
+  });
+});

--- a/apps/web/components/session-minimap.tsx
+++ b/apps/web/components/session-minimap.tsx
@@ -76,10 +76,15 @@ export default function SessionMinimap({
       >
         {laid.map((p) => {
           const isActive = p.nodeId === activeNodeId;
+          // Breadth (expand-bloomed) tiles read teal so they don't pass as
+          // tap-in (descend) ink. Same teal as the atlas / world-map expand
+          // edges — rgba(13,148,136,…), see components/atlas-view.tsx.
+          const isExpand = p.relation === "expand";
           return (
             <button
               key={p.nodeId}
               type="button"
+              data-relation={p.relation ?? "descend"}
               onClick={() => onJump(p.nodeId)}
               className={
                 "absolute rounded-sm transition-transform " +
@@ -92,7 +97,9 @@ export default function SessionMinimap({
                 height: Math.max(2, p.rect.h * box.scale),
                 background: isActive
                   ? "rgba(239,68,68,0.95)"
-                  : "rgba(15,15,15,0.55)",
+                  : isExpand
+                    ? "rgba(13,148,136,0.75)"
+                    : "rgba(15,15,15,0.55)",
                 outline: isActive
                   ? "2px solid rgba(239,68,68,0.6)"
                   : "none",

--- a/apps/web/components/world-map.relation.test.tsx
+++ b/apps/web/components/world-map.relation.test.tsx
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+
+import WorldMap from "./world-map";
+import type { LayoutInput } from "@/lib/world-layout";
+
+/**
+ * In-session expand connectors — the in-page 🗺 map must read breadth
+ * (expand blooms) distinctly from depth (taps), matching the atlas: teal
+ * edges + hollow tap-anchorless styling for expand vs ink + red dot for
+ * descend. The layout math is world-layout.test.ts territory; this pins the
+ * relation → edge/tile-badge rendering contract. Like the atlas scale tests,
+ * children get a clickInParent so layoutPages emits connectors at all.
+ */
+
+function page(partial: Partial<LayoutInput> & { nodeId: string }): LayoutInput {
+  return {
+    parentId: null,
+    imageDataUrl: null,
+    title: partial.nodeId,
+    ...partial,
+  };
+}
+
+const PAGES: LayoutInput[] = [
+  page({ nodeId: "root" }),
+  page({
+    nodeId: "down",
+    parentId: "root",
+    relation: "descend",
+    clickInParent: { xPct: 0.3, yPct: 0.5 },
+  }),
+  page({
+    nodeId: "out",
+    parentId: "root",
+    relation: "expand",
+    clickInParent: { xPct: 0.7, yPct: 0.5 },
+  }),
+];
+
+describe("WorldMap in-session relation rendering", () => {
+  it("styles an expand edge teal, distinct from the descend ink + red tap dot", () => {
+    const { container } = render(
+      <WorldMap
+        pages={PAGES}
+        activeNodeId="root"
+        onSelect={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    const expandEdge = container.querySelector('g[data-relation="expand"]');
+    const descendEdge = container.querySelector('g[data-relation="descend"]');
+    expect(expandEdge).not.toBeNull();
+    expect(descendEdge).not.toBeNull();
+    // Teal (13,148,136) stroke + expand arrowhead for breadth…
+    expect(expandEdge!.querySelector("path")?.getAttribute("stroke")).toContain(
+      "13,148,136",
+    );
+    expect(
+      expandEdge!.querySelector("path")?.getAttribute("marker-end"),
+    ).toContain("expand");
+    // …vs ink stroke + red source dot for depth.
+    expect(
+      descendEdge!.querySelector("path")?.getAttribute("stroke"),
+    ).toContain("15,15,15");
+    expect(
+      descendEdge!.querySelector("circle")?.getAttribute("fill"),
+    ).toContain("239,68,68");
+  });
+
+  it("badges an expand tile as 'expanded' (the read for bloomed pages without a tap point)", () => {
+    const { container } = render(
+      <WorldMap
+        pages={PAGES}
+        activeNodeId="root"
+        onSelect={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    const badges = [
+      ...container.querySelectorAll('[data-testid="map-tile-kind"]'),
+    ].map((b) => b.getAttribute("title") ?? "");
+    expect(badges.some((t) => /expanded/.test(t))).toBe(true);
+    expect(badges.some((t) => /inside/.test(t))).toBe(true);
+  });
+});

--- a/apps/web/lib/session-pages.test.ts
+++ b/apps/web/lib/session-pages.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { nodeToPage, type SessionNodeWire } from "./session-pages";
+
+function wire(overrides: Partial<SessionNodeWire> = {}): SessionNodeWire {
+  return {
+    id: "n1",
+    parent_id: null,
+    session_id: "s1",
+    query: "q",
+    page_title: "t",
+    image_url: "https://cdn/img.jpg",
+    click_in_parent: null,
+    ...overrides,
+  };
+}
+
+describe("nodeToPage (?continue= hydration)", () => {
+  it("maps the node row onto a Page (fields + click point)", () => {
+    const p = nodeToPage(
+      wire({
+        parent_id: "n0",
+        click_in_parent: { x_pct: 0.25, y_pct: 0.75 },
+        sources: [{ url: "https://a", title: "A" }],
+      }),
+    );
+    expect(p.nodeId).toBe("n1");
+    expect(p.sessionId).toBe("s1");
+    expect(p.title).toBe("t");
+    expect(p.imageDataUrl).toBe("https://cdn/img.jpg");
+    expect(p.parentId).toBe("n0");
+    expect(p.clickInParent).toEqual({ xPct: 0.25, yPct: 0.75 });
+    expect(p.sources).toEqual([{ url: "https://a", title: "A" }]);
+  });
+
+  it("rides relation from the node row — an expand-bloomed child hydrates as an expand Page", () => {
+    expect(nodeToPage(wire({ relation: "expand" })).relation).toBe("expand");
+    expect(nodeToPage(wire({ relation: "edit" })).relation).toBe("edit");
+    expect(nodeToPage(wire({ relation: "ascend" })).relation).toBe("ascend");
+  });
+
+  it("keeps explicit descend (the atlas/layout key their nesting shrink on it)", () => {
+    expect(nodeToPage(wire({ relation: "descend" })).relation).toBe("descend");
+  });
+
+  it("leaves relation absent when a pre-relation server omits it (descend semantics)", () => {
+    expect("relation" in nodeToPage(wire())).toBe(false);
+  });
+});

--- a/apps/web/lib/session-pages.ts
+++ b/apps/web/lib/session-pages.ts
@@ -1,0 +1,77 @@
+import type { Citation, NodeRelation, SceneView } from "@openflipbook/config";
+
+/** The in-session page graph node (play page state + history + map views). */
+export interface Page {
+  nodeId: string | null;
+  sessionId: string;
+  query: string;
+  title: string;
+  imageDataUrl: string | null;
+  // Set when this page was generated as a child of another via a tap.
+  parentId?: string | null;
+  // Where the user clicked on the parent page (0..1). Used by the map
+  // view to position the child tile inside the parent's rect.
+  clickInParent?: { xPct: number; yPct: number };
+  // Web-search citations the planner used. Hydrated from the SSE final
+  // event and from /api/nodes/[id] on permalink replay. Empty when web
+  // search returned nothing or is disabled.
+  sources?: Citation[];
+  // The view this page was entered from (geo tap). Its focus_id scopes the
+  // minimap to the place you're inside; null/absent on the world map + classic
+  // pages → the minimap shows the whole world frame.
+  sceneView?: SceneView | null;
+  // Whether entity extraction has already run for this node (read back from
+  // Mongo on revisit/reload). Gates the auto-localize effect so a revisit never
+  // silently re-runs the non-deterministic VLM pass. Absent on freshly-created
+  // pages this session → the in-memory attempt guard covers them instead.
+  geoExtracted?: boolean;
+  // How this page hangs off its parent ("expand" = bloomed neighbour,
+  // "edit" = revision, "ascend" = OUTWARD container). Absent = descend (a
+  // tap-in / fresh page) — same default the server applies on the wire, so
+  // the in-session map/minimap read breadth vs depth like the atlas does.
+  relation?: NodeRelation;
+}
+
+/** One node as served by GET /api/sessions/[id] (the ?continue= hydration). */
+export interface SessionNodeWire {
+  id: string;
+  parent_id: string | null;
+  session_id: string;
+  query: string;
+  page_title: string;
+  image_url: string;
+  click_in_parent: { x_pct: number; y_pct: number } | null;
+  sources?: { url: string; title: string | null }[] | null;
+  scene_view?: SceneView | null;
+  geo_extracted?: boolean;
+  // Optional for back-compat with servers that predate the field; the node
+  // rows always carry it in Mongo (defaulted "descend" by toRow).
+  relation?: NodeRelation;
+}
+
+/** Server node row → in-session Page, for ?continue= hydration. */
+export function nodeToPage(n: SessionNodeWire): Page {
+  return {
+    nodeId: n.id,
+    sessionId: n.session_id,
+    query: n.query,
+    title: n.page_title,
+    imageDataUrl: n.image_url,
+    parentId: n.parent_id,
+    sources: Array.isArray(n.sources) ? n.sources : [],
+    sceneView: n.scene_view ?? null,
+    geoExtracted: n.geo_extracted ?? false,
+    // Explicit "descend" rides through too (not collapsed to absent) — the
+    // atlas gets the same concrete value off NodeRow, and world-layout keys
+    // its zoom-in nesting shrink on the explicit form.
+    ...(n.relation ? { relation: n.relation } : {}),
+    ...(n.click_in_parent
+      ? {
+          clickInParent: {
+            xPct: n.click_in_parent.x_pct,
+            yPct: n.click_in_parent.y_pct,
+          },
+        }
+      : {}),
+  };
+}

--- a/docs/AUDIT_BOX.md
+++ b/docs/AUDIT_BOX.md
@@ -56,9 +56,10 @@ recovery from arbitrary generated images. Treat as research, not a quick fix.
 baseline; no regression elsewhere.
 
 ## Smaller debt (pick up opportunistically)
-- **In-session expand connectors**: `relation` ("expand" vs "descend") isn't on the in-session
-  `Page` type, so the atlas can't distinguish breadth from depth. Also `relation` is never set
-  on `persistNode` (all default "descend"). Thread it through `WorldMap` + `SessionMinimap`.
+- ~~**In-session expand connectors**~~ — DONE (2026-07-03): `relation` now rides the in-session
+  `Page` (lib/session-pages.ts), the ?continue= hydration, and the `WorldMap`/`SessionMinimap`
+  mappings; minimap tints expand tiles teal. Note the persistNode half was stale: expand
+  (useExpandBloom) and edit already sent `relation`; ascend inserts server-side.
 - ~~**mypy coverage split (CI hygiene)**~~ — already aligned: both `make eval` and CI run
   `mypy providers obs.py generate.py` (verified 2026-07-02).
 - **UI discoverability** (`docs/UI_AUDIT.md`): `⊞ geo` / entity-chip toggles are buried — add a


### PR DESCRIPTION
The AUDIT_BOX "smaller debt" item — with a twist found during the audit: the claim *"relation is never set on persistNode"* was stale. The wire was fine (`useExpandBloom` sends `relation:"expand"`, edit sends `"edit"`, ascend inserts server-side). The REAL gaps:

1. **The in-session `Page` type had no `relation`** — so page.tsx's mappings into WorldMap/SessionMinimap dropped it, and WorldMap's fully-built relation rendering (teal expand edges, violet edit, ink+red-dot descend, tile badges) was silently dead for live sessions.
2. **`GET /api/sessions/[id]` omitted `relation`** — `?continue=` hydration could never see it, and that's the only path expand pages enter the session graph.

Changes: `Page` moved to `lib/session-pages.ts` (+ `relation?: NodeRelation`, a testable `nodeToPage` hydration mapper), relation set at the client construction sites (edit, ascend; tap/fresh stay absent = descend semantics unchanged), the sessions route returns `relation` (additive), SessionMinimap tints expand tiles the atlas teal (source-of-truth comment pointing at atlas-view).

Tests: 3 new suites (session-pages mapper, world-map relation rendering, session-minimap tiles) — **661 web tests green, tsc clean, no circular deps**, verified independently on the commit.

Deliberately untouched: `layoutPages`' connector emission (edges require `clickInParent` — pre-existing shared behavior, identical in the atlas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)