### PR TITLE
fix(ui): figure toolbar fits ≤390px — Around/⊞ geo were untappable on mobile

### DIFF
--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -3535,7 +3535,11 @@ export default function PlayPage() {
                 </div>
               )}
 
-            <div className="absolute right-3 top-3 flex gap-2">
+            {/* Capped + wrapping: at ≤390px this row is wider than the frame
+                and used to hang off BOTH edges — Around/⊞ geo were fully
+                off-screen and untappable (UI_AUDIT #13). Right-anchored with
+                intrinsic width, so desktop renders identically. */}
+            <div className="absolute right-3 top-3 flex max-w-[calc(100%-1.5rem)] flex-wrap justify-end gap-2">
               <button
                 type="button"
                 onClick={triggerExpand}

--- a/docs/UI_AUDIT.md
+++ b/docs/UI_AUDIT.md
@@ -81,8 +81,12 @@ is better at "what is this".
     (`tests/recon_bench`) is the right place to measure how much it costs.
 12. ✅ **Edit-verdict chip can overlap narrow screens** — moved to the
     bottom-left toast corner, wraps, max-width capped.
-13. **Mobile pass** — breadcrumbs, codex panel and the geo inset all want a
-    ≤390px audit; only the coach and breadcrumb were touched here.
+13. ✅ **Mobile pass** — audited at 390×844 with DOM measurements (2026-07-04):
+    breadcrumbs (358px ✓), open codex drawer (384px ✓), geo inset (218px ✓),
+    query toolbar (wraps ✓), session panel (✓). One real bug found and fixed:
+    the figure toolbar (Around/⊞ geo/Codex/Edit/Animate) was 543px pinned
+    right — Around and ⊞ geo hung fully off-screen and were untappable. Now
+    capped at the frame width and wraps (desktop byte-identical).
 
 ## Where the eval system hooks in
 


### PR DESCRIPTION
UI_AUDIT #13, done as a DOM-measurement audit at 390×844 against the live stack (not a blind CSS pass):

| Surface | 390px verdict |
|---|---|
| Breadcrumbs / SpatialPath | ✓ 358px, wraps |
| Query toolbar | ✓ wraps, no overflow |
| Codex drawer (open) | ✓ 384px, fully visible |
| Geo inset (⊞ minimap) | ✓ 218px, fits |
| Session panel | ✓ |
| **Figure toolbar** | ✗ **543px pinned right — `Around` at L=−181, `⊞ geo` fully off-screen, untappable by touch** |

The fix is one class change: cap the row at the frame width + `flex-wrap justify-end`. Intrinsic width means desktop renders identically; at 390 it wraps to two right-aligned rows — re-measured live after rebuild: **W=332, H=57, all 8 buttons visible and tappable** (screenshot in the audit trail).

661 web tests green, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)