### PR TITLE
chore(eval,obs): height metrics only when measurable; steering suppression countable live

### DIFF
--- a/apps/modal-backend/providers/generate_modes/tap.py
+++ b/apps/modal-backend/providers/generate_modes/tap.py
@@ -792,6 +792,11 @@ async def stream_tap(
         # the UI shows an "unverified render" chip so flap-era style drift
         # is visible instead of silent.
         final_payload["render_unjudged"] = True
+    if layout_suppressed:
+        # Additive (UI_AUDIT #11): layout steering was dropped because the
+        # bins were projected for a different camera register — the debug
+        # HUD counts these so suppression frequency is finally observable.
+        final_payload["layout_suppressed"] = True
     yield _sse(final_payload, trace_id)
     log(
         "info",

--- a/apps/modal-backend/tests/eval_baselines.json
+++ b/apps/modal-backend/tests/eval_baselines.json
@@ -73,10 +73,10 @@
     },
     "height_order": {
       "metric": "height_order_mean",
-      "baseline": 0.75,
+      "baseline": 0.82,
       "regression_band": 0.15,
       "n_min": 3,
-      "source": "recon_bench height_order sub-metric — tracks entity height ordering fidelity"
+      "source": "re-baselined 2026-07-04 over the HEIGHT-BEARING cells of the 12-cell v1+v2 run (mean 0.821, n=8) after the honesty fix: maps with no built heights (mars, astronomical) no longer score 0.0 on a metric they can't have — the key is absent, like an absent judge. One genuine 0 (treasure/direct/v1) stays in"
     },
     "continuity": {
       "metric": "hop2_step_in_mean",

--- a/apps/modal-backend/tests/recon_bench/runner.py
+++ b/apps/modal-backend/tests/recon_bench/runner.py
@@ -290,15 +290,21 @@ def recon_fns(sweep: dict[str, Any]) -> dict[str, Any]:
             "pos_raw": round(geo["pos_raw"], 3),
             "pos_aligned": round(geo["pos_aligned"], 3),
             "size": round(geo["size"], 3),
-            "height_order": round(
-                heights_lib.height_order_score(expected_h, observed_h), 3
-            ),
-            "height_abs": round(
-                heights_lib.height_abs_score(expected_h, observed_h), 3
-            ),
             # judges arrive 0-10; composite consumes 0-1
             **{k: round(v / 10.0, 3) for k, v in judge_scores.items()},
         }
+        # Height metrics only when the corpus map HAS heights — an
+        # astronomical map (mars) carries no built heights, and scoring it
+        # 0.0 on a metric it can't have dragged the sweep mean below the
+        # baseline in BOTH arms. Absent key = excluded from the composite
+        # (weights∩scores) and from the baseline mean, like an absent judge.
+        if expected_h:
+            scores["height_order"] = round(
+                heights_lib.height_order_score(expected_h, observed_h), 3
+            )
+            scores["height_abs"] = round(
+                heights_lib.height_abs_score(expected_h, observed_h), 3
+            )
         # Register instrumentation (UI_AUDIT #11's bench half): persist the
         # fitted similarity per cell so every report shows the drift SHAPE
         # (scale hitting the 0.5 clamp + translation is the signature) instead

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -914,6 +914,11 @@ export default function PlayPage() {
                   revertTo: null,
                 });
               }
+              if (evt.layout_suppressed) {
+                // Camera-register mismatch dropped layout steering — the
+                // debug HUD counts how often (UI_AUDIT #11's live half).
+                hudEmit("layout:suppressed", {});
+              }
               void persistNode(
                 {
                   parent_id: body.current_node_id || null,

--- a/apps/web/components/debug-hud.tsx
+++ b/apps/web/components/debug-hud.tsx
@@ -51,6 +51,7 @@ export default function DebugHud() {
   const [prefetchHits, setPrefetchHits] = useState(0);
   const [prefetchMisses, setPrefetchMisses] = useState(0);
   const [prefetchInflight, setPrefetchInflight] = useState(0);
+  const [layoutSuppressed, setLayoutSuppressed] = useState(0);
   const [worldEntities, setWorldEntities] = useState<{
     total: number;
     recent: WorldEntry[];
@@ -111,6 +112,7 @@ export default function DebugHud() {
       const n = (p as { n?: number })?.n;
       if (typeof n === "number") setPrefetchInflight(n);
     });
+    sub("layout:suppressed", () => setLayoutSuppressed((n) => n + 1));
     sub("world:extracted", (p: unknown) => {
       const v = p as {
         added?: number;
@@ -194,7 +196,8 @@ export default function DebugHud() {
           prefetch {hitRate} ({prefetchHits}/{total})
         </div>
         <div>inflight {prefetchInflight}</div>
-        <div className="col-span-2">commits {commitCountRef.current}</div>
+        <div>steer-drop {layoutSuppressed}</div>
+        <div>commits {commitCountRef.current}</div>
       </div>
       {sse.length > 0 && (
         <div className="mt-1 border-t border-green-200/20 pt-1">

--- a/apps/web/lib/trace.ts
+++ b/apps/web/lib/trace.ts
@@ -39,7 +39,10 @@ export type HudEventName =
   | "morph:end"
   | "react:commit"
   | "world:extracted"
-  | "world:extract_error";
+  | "world:extract_error"
+  // Layout steering suppressed for a render (camera-register mismatch) —
+  // counted by the debug HUD (UI_AUDIT #11).
+  | "layout:suppressed";
 
 type Listener = (payload: unknown) => void;
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -336,6 +336,10 @@ export interface GenerateFinalEvent {
   // flap): the kept image shipped without a verdict. Additive; absent on
   // paths that are unjudged by design (fresh, zoom_continue).
   render_unjudged?: boolean;
+  // Layout steering was suppressed for this render (the expected-layout bins
+  // were projected for a different camera register). Additive — the debug
+  // HUD counts these (UI_AUDIT #11).
+  layout_suppressed?: boolean;
   // Running estimated spend ($) for this session — coarse, mirrors
   // docs/COSTS.md prices (providers/spend.py). Additive; absent on older
   // backends.


### PR DESCRIPTION
Two follow-ups from the register-drift run (#132):

1. **height_order honesty.** Mars (astronomical map, no built heights) scored 0.0 on a metric it cannot have — in BOTH arms — dragging the sweep mean below the 0.75 baseline and firing a phantom REGRESSION. Now the `height_order`/`height_abs` keys are simply absent when the corpus map has no heights (excluded from composite and baseline mean, exactly like an absent judge). Re-baselined over the 8 height-bearing cells: **0.82±0.15** — and the one *genuine* zero (treasure/direct/v1) stays in the mean, because that one is real signal.
2. **UI_AUDIT #11, live half** (the bench half shipped in #132): when the camera-register mismatch suppresses layout steering, the `final` event now carries `layout_suppressed` (additive) and the debug HUD counts it (`steer-drop N`). The analysis flagged that every tap-enter into complex/landscape-shaped places silently drops steering — now there's a number instead of a buried log line.

Gates: backend pytest + ruff + mypy, web 661 + tsc + circular — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)