### PR TITLE
feat(geo): register the B1 plan plane onto the image frame at seeding

### DIFF
--- a/apps/web/app/api/world/[sessionId]/extract/route.ts
+++ b/apps/web/app/api/world/[sessionId]/extract/route.ts
@@ -1,7 +1,12 @@
 import { NextResponse } from "next/server";
 import { markNodeGeoExtracted, recordError, updateNodeEstimatedView } from "@/lib/db";
 import { listPriorEntitiesForExtraction, mergeExtraction } from "@/lib/world";
-import { deriveGeoFromExtraction } from "@/lib/world-map";
+import {
+  deriveGeoFromExtraction,
+  getWorldMap,
+  registerPlanToImage,
+  upsertEntityGeos,
+} from "@/lib/world-map";
 import { MAP_IMAGE_FRAME } from "@/lib/geo-tap";
 import { readServerEnv } from "@/lib/env";
 import { envFlag } from "@/lib/env-flag";
@@ -180,6 +185,9 @@ export async function POST(req: Request, { params }: Params) {
     // seeding FAILED is left un-stamped and a later visit retries — instead of
     // locking in a half-seeded map that disagrees with the codex forever.
     let geoSeedOk = true;
+    // Additive response field: the plan→image register fit when one was
+    // applied this pass (observability for AUDIT_BOX §4's seeding half).
+    let planRegistration: Record<string, number | boolean> | null = null;
     // Geometric world (GEOMETRIC_WORLD): seed derived map coordinates from the
     // entities localized on this node — the world map populates for free. Default
     // scene_view = a top-down map so each bbox maps straight into a normalized
@@ -278,6 +286,32 @@ export async function POST(req: Request, { params }: Params) {
               null,
               upstreamView?.scale_tier,
             );
+            // Register the B1 authored plane onto the image register: the
+            // solver's geo_plan_* entities historically coexisted with the
+            // extraction seeds as two planes that never met (AUDIT_BOX §4).
+            // With ≥2 label matches, fit the similarity plan→image and move
+            // the plan geos into the frame every consumer already reads.
+            // Best-effort — a failure never blocks the extraction response.
+            try {
+              const snap = await getWorldMap(sessionId);
+              const reg = registerPlanToImage(
+                snap.entities,
+                new Date().toISOString(),
+              );
+              if (reg) {
+                await upsertEntityGeos(sessionId, reg.updated);
+                planRegistration = {
+                  scale: Number(reg.fit.scale.toFixed(3)),
+                  tx: Number(reg.fit.tx.toFixed(1)),
+                  ty: Number(reg.fit.ty.toFixed(1)),
+                  flip_x: reg.fit.flipX,
+                  residual: Number(reg.fit.residual.toFixed(2)),
+                  matched: reg.fit.matched,
+                };
+              }
+            } catch {
+              // registration is strictly additive polish
+            }
           }
         }
       } catch (err) {
@@ -329,6 +363,7 @@ export async function POST(req: Request, { params }: Params) {
         updated_entities: merged.updated_ids
           .map(projectName)
           .filter((e): e is EntityDigest => e !== null),
+        ...(planRegistration ? { plan_registration: planRegistration } : {}),
         trace_id: traceId,
       },
       { headers: { [TRACE_HEADER]: traceId } }

--- a/apps/web/lib/world-geometry.test.ts
+++ b/apps/web/lib/world-geometry.test.ts
@@ -6,7 +6,9 @@ import { describe, expect, it } from "vitest";
 import type { ObserverPose } from "@openflipbook/config";
 
 import {
+  applySimilarity,
   cropEntities,
+  fitSimilarity,
   neighborsOf,
   project,
   projectScene,
@@ -174,5 +176,52 @@ describe("toAbsoluteEntities (nested → absolute frame)", () => {
     expect(out[1]!.pos.y).toBeCloseTo(30);
     expect(out[1]!.footprint.w).toBeCloseTo(20); // 4000 × 0.005
     expect(out[1]!.footprint.d).toBeCloseTo(10);
+  });
+});
+
+// TS twin of the python fit tests (tests/recon_bench/test_recon.py) — the two
+// implementations must agree; any drift fails one side or the other.
+describe("fitSimilarity (parity with recon_bench fit_alignment)", () => {
+  const PTS = [
+    { x: 10, y: 10 },
+    { x: 50, y: 30 },
+    { x: 90, y: 50 },
+    { x: 30, y: 45 },
+  ];
+  const pairs = (t: (p: { x: number; y: number }) => { x: number; y: number }) =>
+    PTS.map((p) => [p, t(p)] as [typeof p, typeof p]);
+
+  it("recovers a pure translation", () => {
+    const a = fitSimilarity(pairs((p) => ({ x: p.x + 7, y: p.y - 3 })))!;
+    expect(a.flipX).toBe(false);
+    expect(a.scale).toBeCloseTo(1.0, 6);
+    expect(a.tx).toBeCloseTo(7);
+    expect(a.ty).toBeCloseTo(-3);
+    expect(a.residual).toBeCloseTo(0, 6);
+  });
+
+  it("recovers scale and the x-flip register", () => {
+    const s = fitSimilarity(pairs((p) => ({ x: 1.5 * p.x - 10, y: 1.5 * p.y + 5 })))!;
+    expect(s.scale).toBeCloseTo(1.5);
+    expect(s.flipX).toBe(false);
+    const f = fitSimilarity(pairs((p) => ({ x: 100 - p.x, y: p.y })))!;
+    expect(f.flipX).toBe(true);
+    expect(f.residual).toBeCloseTo(0, 6);
+  });
+
+  it("clamps scale to 2 (residual stays honest) and needs two pairs", () => {
+    const a = fitSimilarity(pairs((p) => ({ x: 5 * p.x, y: 5 * p.y })))!;
+    expect(a.scale).toBe(2.0);
+    expect(a.residual).toBeGreaterThan(0);
+    expect(fitSimilarity([[PTS[0]!, PTS[0]!]])).toBeNull();
+  });
+
+  it("applySimilarity round-trips a known fit", () => {
+    const out = applySimilarity(
+      { scale: 1.5, tx: -10, ty: 5, flipX: false, residual: 0, matched: 4 },
+      { x: 10, y: 10 },
+    );
+    expect(out.x).toBeCloseTo(5);
+    expect(out.y).toBeCloseTo(20);
   });
 });

--- a/apps/web/lib/world-geometry.ts
+++ b/apps/web/lib/world-geometry.ts
@@ -419,6 +419,72 @@ export function toAbsoluteEntities<
   });
 }
 
+export interface SimilarityFit {
+  scale: number;
+  tx: number;
+  ty: number;
+  flipX: boolean;
+  residual: number; // RMS distance after transform, frame units
+  matched: number;
+}
+
+// The seeded map frame is 100 wide (MAP_IMAGE_FRAME) — the x-flip candidate
+// mirrors over it. Local const to avoid a geo-tap import cycle; the python
+// twin (tests/recon_bench/_align.py FRAME_W) uses the same value.
+const _FIT_FRAME_W = 100;
+
+/** Least-squares uniform scale + translation over (from, to) point pairs;
+ *  tries the x-flipped register too and keeps the lower residual. Scale
+ *  clamped [0.5, 2]; null when < 2 pairs (nothing to anchor). TS port of
+ *  tests/recon_bench/_align.fit_alignment — keep the two in lockstep. */
+export function fitSimilarity(
+  pairs: [WorldVec2, WorldVec2][],
+): SimilarityFit | null {
+  if (pairs.length < 2) return null;
+  let best: SimilarityFit | null = null;
+  for (const flip of [false, true]) {
+    const src = pairs.map(([f]) => ({
+      x: flip ? _FIT_FRAME_W - f.x : f.x,
+      y: f.y,
+    }));
+    const dst = pairs.map(([, t]) => t);
+    const n = pairs.length;
+    const sx = src.reduce((a, p) => a + p.x, 0) / n;
+    const sy = src.reduce((a, p) => a + p.y, 0) / n;
+    const dx = dst.reduce((a, p) => a + p.x, 0) / n;
+    const dy = dst.reduce((a, p) => a + p.y, 0) / n;
+    let num = 0;
+    let den = 0;
+    for (let i = 0; i < n; i++) {
+      num += (src[i]!.x - sx) * (dst[i]!.x - dx) + (src[i]!.y - sy) * (dst[i]!.y - dy);
+      den += (src[i]!.x - sx) ** 2 + (src[i]!.y - sy) ** 2;
+    }
+    let s = den > 1e-9 ? num / den : 1.0;
+    s = Math.max(0.5, Math.min(2.0, s));
+    const tx = dx - s * sx;
+    const ty = dy - s * sy;
+    let sq = 0;
+    for (let i = 0; i < n; i++) {
+      sq += (s * src[i]!.x + tx - dst[i]!.x) ** 2 + (s * src[i]!.y + ty - dst[i]!.y) ** 2;
+    }
+    const cand: SimilarityFit = {
+      scale: s,
+      tx,
+      ty,
+      flipX: flip,
+      residual: Math.sqrt(sq / n),
+      matched: n,
+    };
+    if (best === null || cand.residual < best.residual) best = cand;
+  }
+  return best;
+}
+
+export function applySimilarity(f: SimilarityFit, p: WorldVec2): WorldVec2 {
+  const x = f.flipX ? _FIT_FRAME_W - p.x : p.x;
+  return { x: f.scale * x + f.tx, y: f.scale * p.y + f.ty };
+}
+
 /** Axis-aligned bounds over entities' OWN pos+footprint (no parent resolve) —
  *  the LOCAL frame of a place's interior, where each child's pos is local. */
 export function localBounds<

--- a/apps/web/lib/world-map.test.ts
+++ b/apps/web/lib/world-map.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { EntityGeoEdit, WorldEntityGeo } from "@openflipbook/config";
 
-import { __test, ladderDisagreement } from "./world-map";
+import { __test, ladderDisagreement, registerPlanToImage } from "./world-map";
 
 const { applyGeoUpsert, recomputeBounds, applyEntityEdit, blastRadius, buildGeoReferences } =
   __test;
@@ -262,5 +262,74 @@ describe("ladderDisagreement (INV-4: one ladder)", () => {
   it("never fires when a rung is unknown (back-compat)", () => {
     expect(ladderDisagreement(null, "city", 99)).toBeNull();
     expect(ladderDisagreement("city", undefined, 99)).toBeNull();
+  });
+});
+
+describe("registerPlanToImage (plan plane → image register)", () => {
+  // Plan geos (solver output): geo_plan_* ids, no codex link. Image seeds:
+  // extraction-derived, entity-linked. Labels are the join key.
+  const plan = (ref: string, label: string, x: number, y: number): WorldEntityGeo => ({
+    ...geo(`geo_plan_${ref}`, "derived", x, y),
+    label,
+    entity_id: null,
+  });
+  const img = (id: string, label: string, x: number, y: number): WorldEntityGeo => ({
+    ...geo(id, "derived", x, y),
+    label,
+  });
+
+  it("registers an offset+scaled plan onto its label-matched seeds", () => {
+    // True transform: scale 1.5, translate (+10, +10). Two anchors + one
+    // unmatched plan entity that must ride along on the fitted transform.
+    const geos = [
+      plan("tower", "The Tower", 10, 10),
+      plan("harbor", "Harbor", 30, 20),
+      plan("wood", "Dark Wood", 50, 40),
+      img("geo_tower", "the tower", 25, 25),
+      img("geo_harbor", "The old Harbor docks", 55, 40), // fuzzy label match
+    ];
+    const reg = registerPlanToImage(geos, "t9")!;
+    expect(reg.fit.scale).toBeCloseTo(1.5);
+    expect(reg.fit.tx).toBeCloseTo(10);
+    expect(reg.fit.ty).toBeCloseTo(10);
+    expect(reg.fit.flipX).toBe(false);
+    expect(reg.fit.matched).toBe(2);
+    expect(reg.updated).toHaveLength(3); // ALL plans move, matched or not
+    const wood = reg.updated.find((g) => g.id === "geo_plan_wood")!;
+    expect(wood.pos.x).toBeCloseTo(85); // 1.5·50 + 10
+    expect(wood.pos.y).toBeCloseTo(70);
+    expect(wood.footprint.w).toBeCloseTo(9); // 6 × 1.5 — sizes scale too
+    expect(wood.height).toBeCloseTo(6); // 4 × 1.5
+    expect(wood.updated_at).toBe("t9");
+  });
+
+  it("null when fewer than 2 label matches (nothing to anchor)", () => {
+    expect(
+      registerPlanToImage(
+        [plan("a", "Tower", 10, 10), plan("b", "Harbor", 30, 20), img("geo_x", "Tower", 40, 40)],
+        "t",
+      ),
+    ).toBeNull();
+  });
+
+  it("null when already in register (idempotent write path)", () => {
+    expect(
+      registerPlanToImage(
+        [plan("a", "Tower", 10, 10), plan("b", "Harbor", 30, 20),
+         img("geo_a", "Tower", 10, 10), img("geo_b", "Harbor", 30, 20)],
+        "t",
+      ),
+    ).toBeNull();
+  });
+
+  it("null without plans, and unlinked map props are not anchors", () => {
+    expect(registerPlanToImage([img("geo_a", "Tower", 1, 1)], "t")).toBeNull();
+    const prop = { ...img("geo_p", "Tower", 40, 40), entity_id: null };
+    expect(
+      registerPlanToImage(
+        [plan("a", "Tower", 10, 10), plan("b", "Harbor", 30, 20), prop],
+        "t",
+      ),
+    ).toBeNull();
   });
 });

--- a/apps/web/lib/world-map.ts
+++ b/apps/web/lib/world-map.ts
@@ -19,12 +19,15 @@ import { getDb, recordError } from "./db";
 import { envFlag } from "./env-flag";
 import { optimisticReplace } from "./optimistic-update";
 import {
+  applySimilarity,
   estimateGeoFromBBox,
+  fitSimilarity,
   localBounds,
   localExtent,
   mapPolygonToCrop,
   siblingsOf,
   toAbsoluteEntities,
+  type SimilarityFit,
 } from "./world-geometry";
 
 // Per-session geometric world map (entity coordinates). Mirrors the world_state
@@ -499,6 +502,71 @@ export async function deriveGeoFromExtraction(
     }
   }
   return upsertEntityGeos(sessionId, geos);
+}
+
+// ── Plan→image register (AUDIT_BOX §4, the tractable half of metric pose) ────
+
+/** Register the B1 authored plane onto the image register. The solver's
+ *  `geo_plan_*` entities and the extraction-seeded `geo_*` entities describe
+ *  the same places in two frames that historically never met — the plan
+ *  where the description put things, the seeds where the model painted them.
+ *  This fits a similarity (same math the recon bench proves recoverable:
+ *  fitSimilarity, scale-clamped + optional x-flip) from plan positions to
+ *  their label-matched image seeds and re-expresses ALL plan geos into the
+ *  image frame — the one frame every consumer (taps, rings, labels, bounds)
+ *  already reads. Pure; returns null when there is nothing to do:
+ *  no plan geos, fewer than 2 label matches, or the fit is already ≈identity
+ *  (a prior registration — keeps the write path idempotent). */
+export function registerPlanToImage(
+  geos: WorldEntityGeo[],
+  nowIso: string,
+): { updated: WorldEntityGeo[]; fit: SimilarityFit } | null {
+  const plans = geos.filter(
+    (g) => g.id.startsWith("geo_plan_") && (g.parent_id ?? null) === null,
+  );
+  if (plans.length === 0) return null;
+  const images = geos.filter(
+    (g) =>
+      !g.id.startsWith("geo_plan_") &&
+      (g.parent_id ?? null) === null &&
+      g.entity_id !== null,
+  );
+  if (images.length === 0) return null;
+  const norm = (s: string) => s.toLowerCase().trim();
+  const byLabel = new Map(images.map((g) => [norm(g.label), g]));
+  const pairs: [WorldVec2, WorldVec2][] = [];
+  for (const p of plans) {
+    const key = norm(p.label);
+    const hit =
+      byLabel.get(key) ??
+      images.find((g) => {
+        const k = norm(g.label);
+        return k.length > 0 && (k.includes(key) || key.includes(k));
+      });
+    if (hit) pairs.push([p.pos, hit.pos]);
+  }
+  const fit = fitSimilarity(pairs);
+  if (fit === null) return null;
+  // Already registered (or trivially in register): skip the churn.
+  if (
+    !fit.flipX &&
+    Math.abs(fit.scale - 1) < 0.02 &&
+    Math.abs(fit.tx) < 0.5 &&
+    Math.abs(fit.ty) < 0.5
+  ) {
+    return null;
+  }
+  const updated = plans.map((p) => ({
+    ...p,
+    pos: applySimilarity(fit, p.pos),
+    footprint: {
+      w: p.footprint.w * fit.scale,
+      d: p.footprint.d * fit.scale,
+    },
+    height: p.height * fit.scale,
+    updated_at: nowIso,
+  }));
+  return { updated, fit };
 }
 
 export const __test = {


### PR DESCRIPTION
## What

AUDIT_BOX §4's residue, the tractable half of metric pose recovery: the layout solver's `geo_plan_*` entities and the extraction-seeded `geo_*` entities describe the same places in **two frames that never met** — the plan where the description put things, the image seeds where the model actually painted them. Every consumer (taps, rings, labels, bounds, minimap) reads the image frame, so the plan plane was dead weight sitting at unrelated coordinates.

This registers the plan plane onto the image frame at seeding time:

- **`lib/world-geometry`**: `fitSimilarity` / `applySimilarity` — a TS port of the recon bench's `fit_alignment` (least-squares uniform scale + translation, tries the x-flip register over the 100-wide frame, scale clamped [0.5, 2], `null` under 2 pairs). Same math the bench already proves recoverable on synthetic transforms.
- **`lib/world-map`**: `registerPlanToImage` — label-matches plans to entity-linked image seeds (exact, then substring), fits the similarity over the matched anchors, and re-expresses **all** plan geos (pos, footprint, height) into the image frame. Pure function; returns `null` when there are no plans, fewer than 2 anchors, or the fit is already ≈identity — so the write path is idempotent across repeat extractions.
- **extract route**: after top-level map seeding, runs the registration best-effort and surfaces the fit as an additive `plan_registration` response field (`scale/tx/ty/flip_x/residual/matched`) for the HUD/debugging. A registration failure never blocks the extraction response.

## Tests

- `world-geometry.test.ts`: parity suite mirroring `tests/recon_bench/test_recon.py` shape-for-shape (translation recovery, scale+flip recovery, clamp honesty, <2 pairs → null, apply round-trip) — the TS/python twins can't silently drift.
- `world-map.test.ts`: offset+scaled plan registers onto seeds with unmatched plans riding along (pos, footprint, height all re-expressed); fuzzy label anchor; <2 matches → null; ≈identity → null; unlinked map props are not anchors.

## Gates

- web: vitest 669 passed (87 files), `tsc --noEmit` clean, no circular deps.
- Wire change is additive-only (`plan_registration` optional response field); no flag needed — with no `geo_plan_*` entities present the function no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)