### PR TITLE
fix(docker,docs): ship public/ in the web image; BYO-KEYS truth pass — on-ramp acceptance

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -47,6 +47,9 @@ RUN addgroup --system --gid 1001 nodejs \
  && adduser --system --uid 1001 nextjs
 COPY --from=builder --chown=nextjs:nodejs /repo/apps/web/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /repo/apps/web/.next/static ./apps/web/.next/static
+# Next standalone does NOT bundle public/ — without this copy every static
+# asset (theme-init.js, og.png, demo media) 404s on the docker stack.
+COPY --from=builder --chown=nextjs:nodejs /repo/apps/web/public ./apps/web/public
 USER nextjs
 EXPOSE 3000
 CMD ["node", "apps/web/server.js"]

--- a/docs/AUDIT_BOX.md
+++ b/docs/AUDIT_BOX.md
@@ -9,18 +9,16 @@ Run the **SUSPECT THIS FIRST** list in `.cursor/rules/openflipbook.mdc`. Most "r
 across past sessions were env/.env traps (qwen 429, fal model pin, docker build-time vars),
 not code. Rule out env before touching code.
 
-## 1. On-ramp milestone  — priority: HIGH (only remaining roadmap milestone)
-**Goal:** make openflipbook approachable for a first-time user without changing anything for
-existing users.
-- Sane default flags for a fresh clone / `make demo` (what's ON by default, what stays OFF).
-- A guided first session (passive, additive — a coach hint, not a gate). Existing
-  `FirstRunCoach` is the hook; do not add interstitials.
-- BYO-keys story: tighten `docs/BYO-KEYS.md` + `.env.example` so a newcomer gets to a
-  generated page with the fewest steps.
-**Files:** `docs/BYO-KEYS.md`, `apps/modal-backend/.env.example`, `Makefile` (`demo`),
-`apps/web/components/PlayPage/FirstRunCoach.tsx`, README's "why this exists" paragraph.
-**Acceptance:** a clean machine reaches a first generated page following only the docs;
-existing flow byte-identical; voice stays chill/first-person.
+## 1. ✅ On-ramp milestone  — DONE (fresh-clone acceptance run passed 2026-07-05)
+The acceptance test ran for real: fresh `git clone` from GitHub into a clean dir, README
+quickstart verbatim (`cp .env.example .env` + the two keys, `make demo`), `/status` green,
+first generated page reached ("How A Watt Steam Engine Operates" — pixels verified, codex
+extracted 5 entities, first-run coach chip showed), one tap → a coherent step-2 page in the
+same style. Coach shipped earlier (#100), sane defaults + `make demo-world` (#121).
+The run's one product find: the web Dockerfile never copied `public/` into the standalone
+runner, so `theme-init.js`/`og.png` 404'd on every docker-stack load (console error on a
+newcomer's first page) — fixed alongside the doc pass (Postgres→Mongo, `pip install modal`,
+table un-split, stale click-bench/step-8 futures).
 
 ## 2. ✅ Wire `expected_layout` → render  — DONE (the doc lagged the code)
 `projectScene`/`projectTopDown` (web `lib/world-geometry.ts`) ride

--- a/docs/BYO-KEYS.md
+++ b/docs/BYO-KEYS.md
@@ -23,9 +23,9 @@ Endless Canvas has no hosted backend. To deploy to Modal + R2 yourself you need 
 
 1. **OpenRouter API key** — planning + VLM click interpretation + web search.
 2. **fal API key** — image generation (nano-banana).
-3. **Modal account + token** — hosts the orchestration FastAPI app (and, once step 8 lands, the LTX-2 video worker).
+3. **Modal account + token** — hosts the orchestration FastAPI app (and, optionally, the LTX streaming-video worker `ltx_stream.py`).
 4. **Cloudflare R2 bucket** — blob storage for generated images.
-5. **Postgres database** — metadata for the node graph. Any Postgres works (Railway, Neon, Supabase, local).
+5. **MongoDB database** — the node graph + world state. Railway's one-click Mongo or Atlas M0 (free) both work.
 
 Optional for v1:
 
@@ -37,12 +37,12 @@ Optional for v1:
 |---|---|---|
 | OpenRouter | <https://openrouter.ai/keys> | `OPENROUTER_API_KEY` |
 | fal | <https://fal.ai/dashboard/keys> | `FAL_KEY` |
-| Modal | `brew install modal-cli && modal token new` | (stored on disk) |
+| Modal | `pip install modal && modal token new` | (stored on disk) |
 | Cloudflare R2 | Cloudflare dash → R2 → Manage tokens. Needs *Object Read & Write*. | `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET` |
 | R2 public URL | Enable the R2 bucket's public dev URL, or attach a custom domain. | `R2_PUBLIC_BASE_URL` |
+| MongoDB | Railway → Add MongoDB (or Atlas M0 free). | `MONGODB_URI`, `MONGODB_DB` |
 
 > **Enable CORS on the R2 bucket** (Cloudflare dash → R2 → bucket → Settings → CORS) with `AllowedOrigins` = your web origin and `AllowedMethods: [GET]`. Image conditioning crops the parent on a canvas client-side; without CORS the cross-origin image taints the canvas and the "from corners" region crop silently falls back to whole-parent conditioning. Minio (the `make demo` stack) sends CORS by default, so this only applies to the hosted R2 path.
-| MongoDB | Railway → Add MongoDB (or Atlas M0 free). | `MONGODB_URI`, `MONGODB_DB` |
 
 ## 2. Set Modal secrets
 
@@ -143,8 +143,9 @@ right subject, and small local VLMs are weak at structured output. The backend
 detects this and walks a fallback ladder — `json_object` → forced tool-call →
 prompt-with-repair — so a weak model degrades to *thinner but valid* grounding
 instead of crashing. It does **not** make a 7B model ground like Gemini. Want to
-know which models actually hold up? That's what the click-bench (next milestone)
-is for. If your model supports JSON mode but isn't auto-detected, pin it with
+know which models actually hold up? Run the click-bench
+(`tests/click_bench/` — `leaderboard.py` compares models on your own key). If
+your model supports JSON mode but isn't auto-detected, pin it with
 `LLM_STRUCTURED_OUTPUT=json_object`.
 
 Web search is OpenRouter-only; it's skipped on direct/local providers (the
@@ -167,6 +168,9 @@ cost/lock-in lever — but image quality varies a lot by model.
 
 Expected cost per "page explored": ~$0.02–0.03 of mixed spend, mostly fal.
 
-## Future: live video toggle (step 8)
+## Optional: live video streaming
 
-Will add a second Modal app (`ltx_stream.py`) deploying a GPU class. Costs jump to ~$2–4/GPU-hr while actively streaming — that's why it's a per-page toggle, and why the demo site only shows a prerecorded clip.
+`modal deploy ltx_stream.py` deploys the GPU streaming worker; put its WS URL in
+`NEXT_PUBLIC_LTX_WS_URL` (step 4). Costs jump to ~$2–4/GPU-hr while actively
+streaming — that's why it's a per-page toggle and the default animate path is the
+cheap one-shot fal clip instead.


### PR DESCRIPTION
## What

Ran AUDIT_BOX §1's acceptance test for real: fresh `git clone https://github.com/eren23/openflipbook` into a clean dir, README quickstart **verbatim** (`cp .env.example .env`, fill the two keys, `make demo`), then a browser session as a newcomer.

**The path works**: `/status` green (fal + openrouter detected), `"how does a steam engine work"` → a real generated page ("How A Watt Steam Engine Operates" — legible labeled diagram, codex extracted 5 entities, first-run coach chip showed, session ≈$0.21), one tap → a coherent step-2 piston page in the same style. Screenshots in `~/Desktop/ofb-visuals-2026-07-02/onramp-*.png`.

## The product find

`apps/web/Dockerfile`'s runner stage copies `.next/standalone` + `.next/static` but **never `public/`** — Next standalone doesn't bundle it. So on every docker-stack load, `theme-init.js` and `og.png` 404: a console error on a newcomer's very first page, no theme-flash guard, no social card. One `COPY` line fixes it — **verified live** on the fresh clone (rebuilt web image: 404→200 with real content, console clean on reload).

## Doc truth pass (docs/BYO-KEYS.md)

- Hosted checklist item 5 said **Postgres** — the stack is Mongo (the table and step 4 already said so).
- The CORS blockquote sat mid-table, splitting it — the MongoDB row rendered orphaned outside the table. Moved the note below the table.
- `brew install modal-cli` — no such formula exists; now `pip install modal`.
- "click-bench (next milestone)" and "Future: live video toggle (step 8) / will add ltx_stream.py" described long-shipped things in future tense; now present-tense with real paths.

Plus: strike AUDIT_BOX §1 with the run's receipts.

## Gates

Docker build verified live (the only code change is the Dockerfile COPY); docs otherwise. CI covers web/python as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)