### PR TITLE
fix(geo): plan register anchors renamed painted labels via token overlap

### DIFF
--- a/apps/web/lib/world-map.test.ts
+++ b/apps/web/lib/world-map.test.ts
@@ -303,6 +303,35 @@ describe("registerPlanToImage (plan plane → image register)", () => {
     expect(wood.updated_at).toBe("t9");
   });
 
+  it("anchors renamed painted labels via shared tokens (live fishing-village fixture)", () => {
+    // Verbatim from the 2026-07-05 live run (session_1abbb3ba…): the painter
+    // renamed every plan feature, substring matching found only Market Square
+    // (1 anchor < 2), and the registration silently never fired.
+    const geos = [
+      plan("crescent_bay", "Crescent Bay", 50, 30),
+      plan("market_square", "Market Square", 50, 38),
+      plan("pine_forest", "Dark Pine Forest", 42, 38),
+      plan("white_lighthouse", "White Lighthouse", 42, 30),
+      plan("wooden_harbor", "Wooden Harbor", 58, 30),
+      img("geo_a", "North Point Lighthouse", 55.7, 11.52),
+      img("geo_b", "Old Harbor Piers", 85.4, 11.34),
+      img("geo_c", "Central Market Square", 41.4, 35.64),
+      img("geo_d", "Whispering Pines Ridge", 10.6, 37.86),
+      img("geo_e", "Crescent Basin", 68.8, 38.28),
+      img("geo_f", "Fisherman's Wharf", 89.4, 48.36),
+    ];
+    const reg = registerPlanToImage(geos, "t9")!;
+    expect(reg).not.toBeNull();
+    // lighthouse/harbor/pine/crescent anchor through token overlap; the
+    // generic halves (north/old/white/dark/ridge) don't create false pairs.
+    expect(reg.fit.matched).toBeGreaterThanOrEqual(4);
+    // The painted spread is much wider than the solver cluster — the fit
+    // must scale UP, and every plan (matched or not) rides the transform.
+    expect(reg.fit.scale).toBeGreaterThan(1);
+    expect(reg.updated).toHaveLength(5);
+    expect(reg.updated.every((g) => g.updated_at === "t9")).toBe(true);
+  });
+
   it("null when fewer than 2 label matches (nothing to anchor)", () => {
     expect(
       registerPlanToImage(

--- a/apps/web/lib/world-map.ts
+++ b/apps/web/lib/world-map.ts
@@ -533,17 +533,51 @@ export function registerPlanToImage(
   );
   if (images.length === 0) return null;
   const norm = (s: string) => s.toLowerCase().trim();
-  const byLabel = new Map(images.map((g) => [norm(g.label), g]));
-  const pairs: [WorldVec2, WorldVec2][] = [];
+  // The painter RENAMES features (live case, 2026-07-05 fishing village:
+  // plan "White Lighthouse" painted as "North Point Lighthouse", "Wooden
+  // Harbor" as "Old Harbor Piers") — exact/substring matching alone found 1
+  // anchor out of 5 and the registration never fired. So the tiers are:
+  // exact > substring > shared significant tokens (stop-worded, s-stemmed:
+  // "lighthouse"/"harbor"/"pine" anchor; "north"/"old"/"white" don't),
+  // greedily assigned unique on both sides.
+  const GENERIC = new Set([
+    "the", "and", "old", "new", "big", "small", "great", "little",
+    "north", "south", "east", "west", "upper", "lower", "inner", "outer",
+    "central", "grand", "dark", "white", "black", "red", "blue", "green",
+    "golden", "silver", "point", "side", "shore", "ridge", "district",
+  ]);
+  const sig = (s: string) =>
+    new Set(
+      norm(s)
+        .split(/[^a-z0-9]+/)
+        .map((t) => t.replace(/s$/, ""))
+        .filter((t) => t.length > 2 && !GENERIC.has(t)),
+    );
+  const candidates: { p: WorldEntityGeo; g: WorldEntityGeo; score: number }[] =
+    [];
   for (const p of plans) {
-    const key = norm(p.label);
-    const hit =
-      byLabel.get(key) ??
-      images.find((g) => {
-        const k = norm(g.label);
-        return k.length > 0 && (k.includes(key) || key.includes(k));
-      });
-    if (hit) pairs.push([p.pos, hit.pos]);
+    const a = norm(p.label);
+    if (!a) continue;
+    const ta = sig(a);
+    for (const g of images) {
+      const b = norm(g.label);
+      if (!b) continue;
+      let score = 0;
+      if (a === b) score = Infinity;
+      else if (a.includes(b) || b.includes(a)) score = 100;
+      else for (const t of ta) if (sig(b).has(t)) score++;
+      if (score > 0) candidates.push({ p, g, score });
+    }
+  }
+  candidates.sort((x, y) => y.score - x.score);
+  const usedP = new Set<string>();
+  const usedG = new Set<string>();
+  const pairs: [WorldVec2, WorldVec2][] = [];
+  for (const c of candidates) {
+    if (usedP.has(c.p.id) || usedG.has(c.g.id)) continue;
+    usedP.add(c.p.id);
+    usedG.add(c.g.id);
+    pairs.push([c.p.pos, c.g.pos]);
   }
   const fit = fitSimilarity(pairs);
   if (fit === null) return null;


### PR DESCRIPTION
## What

Task-#23 live verification of #134 immediately found the feature inert in the wild: the painter **renames features**. First live run (fishing village): plan `White Lighthouse` was painted as `North Point Lighthouse`, `Wooden Harbor` as `Old Harbor Piers`, `Crescent Bay` as `Crescent Basin` — exact+substring matching found **1 anchor out of 5**, under the ≥2 minimum, so `registerPlanToImage` silently returned null every time.

Matching is now tiered: **exact > substring > shared significant tokens** — stop-worded and s-stemmed, so `lighthouse` / `harbor` / `pine` anchor while `north` / `old` / `white` / `ridge` can't mint false pairs — with greedy unique assignment on both sides.

## Receipts (verify OUTPUT, not process)

Fixed image rebuilt into the running demo-world stack, second fresh world generated (desert oasis). The painter renamed all five features **again** (`Stone Citadel`→`The Sandstone Citadel`, `Old Aqueduct`→`Ancient Eastern Aqueduct`, `Southern Spring`→`Emerald Spring Pond`, …):

- **Wire**: extract response carried `plan_registration: {scale: 0.94, tx: -8.8, ty: 3.8, flip_x: false, residual: 7.71, matched: 5}` — 5/5 anchored.
- **DB**: all `geo_plan_*` rows re-expressed to fitted float positions + scaled footprints + fresh `updated_at`, each landing near its renamed painted twin (citadel Δ≈7 → the honest residual).
- **Pixels**: geo overlay screenshot archived (`~/Desktop/ofb-visuals-2026-07-02/oasis-geo-overlay.png`).

The first live session's labels are committed **verbatim as a regression fixture** (`world-map.test.ts`) — the exact renames that broke the naive matcher.

## Gates

vitest 670 passed (incl. new fixture), tsc clean, no circular deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)