### PR TITLE
fix(ui): World-mode pill stops burying the figure toolbar at ≤390px

### DIFF
--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -3238,10 +3238,15 @@ export default function PlayPage() {
               type="button"
               onClick={() => setWorldEnabled(false)}
               title="World Mode is ON — a tap ENTERS the tapped place (classic explore explains it instead). Click to switch back."
+              aria-label="World Mode is on — tap enters places. Switch back to classic explore."
+              // Icon-only below sm: at ≤390px the full-text pill (~187px) sat
+              // UNDER the top-right toolbar and its z-10 stole clicks from
+              // Around/⊞ geo (UI_AUDIT #13; #131 wrapped the toolbar but not
+              // this collision). Desktop keeps the label (sm:inline) → identical.
               className="pointer-events-auto absolute start-3 top-3 z-10 flex select-none items-center gap-1 rounded-full border border-emerald-700/40 bg-emerald-50/85 px-2.5 py-1 text-xs font-medium text-emerald-900 backdrop-blur transition hover:bg-emerald-100"
             >
               <span aria-hidden>🌍</span>
-              <span>World — tap enters places</span>
+              <span className="hidden sm:inline">World — tap enters places</span>
             </button>
           )}
           <div className="relative aspect-[16/9] w-full">
@@ -3543,8 +3548,10 @@ export default function PlayPage() {
             {/* Capped + wrapping: at ≤390px this row is wider than the frame
                 and used to hang off BOTH edges — Around/⊞ geo were fully
                 off-screen and untappable (UI_AUDIT #13). Right-anchored with
-                intrinsic width, so desktop renders identically. */}
-            <div className="absolute right-3 top-3 flex max-w-[calc(100%-1.5rem)] flex-wrap justify-end gap-2">
+                intrinsic width, so desktop renders identically. z-10 matches
+                the World pill so, on any residual overlap at narrow widths,
+                this later-in-DOM toolbar wins the stack and stays tappable. */}
+            <div className="absolute right-3 top-3 z-10 flex max-w-[calc(100%-1.5rem)] flex-wrap justify-end gap-2">
               <button
                 type="button"
                 onClick={triggerExpand}


### PR DESCRIPTION
## The bug

At ≤390px the '🌍 World — tap enters places' pill (top-left, `z-10`) and the Around / ⊞ geo / Codex / Edit toolbar (top-right) both claim the figure's top row. Their combined width overflows the frame, so the pill's 187px label sat **under** the toolbar and its `z-10` stole the clicks — `elementFromPoint` returned the pill, and Playwright couldn't tap ⊞ geo at all (`subtree intercepts pointer events`). #131 wrapped the toolbar's width but never touched this pill collision, so Around/geo were still unreachable on mobile.

## The fix (2 lines, desktop byte-identical)

- The pill label collapses to just the 🌍 icon below `sm` (`hidden sm:inline`); the full text returns at `≥sm`, so the desktop pill is still 187px. An `aria-label` carries the meaning when the text is hidden.
- The toolbar gains `z-10` to match the pill. It renders later in the DOM, so on any residual pixel overlap it now wins the stack and stays tappable.

## Verified live (demo-world stack, 390px)

- Pill shrinks 187px → 37px; the toolbar (Around · ⊞ geo · Codex · Edit) is fully visible on the top row.
- `elementFromPoint` at the pill/Around overlap point (55, 420) resolves to the **Around button**, not the pill; geo/Around/Codex all receive hits; ⊞ geo clicks cleanly (previously timed out on interception).
- At 1440px the pill is back to full text (187px) — desktop unchanged.

Before/after: `~/Desktop/ofb-visuals-2026-07-02/m390-{geo-overlay,pill-fixed}.png`.

Pure responsive-class + z-index change (no logic) — 670 web tests green, tsc clean, no circular deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)