### PR TITLE
bench(click): denoise the leaderboard — --runs N averaging + 20 cases

### DIFF
--- a/apps/modal-backend/tests/click_bench/README.md
+++ b/apps/modal-backend/tests/click_bench/README.md
@@ -33,18 +33,21 @@ OPENROUTER_API_KEY=... .venv/bin/python -m tests.click_bench.runner \
   --out tests/click_bench/reports/latest.json
 ```
 
-Multi-model leaderboard (the "which VLM should I use" table):
+Multi-model leaderboard (the "which VLM should I use" table). `--runs N`
+repeats each model N times and reports **mean ± stdev** — VLM click resolution
+is non-deterministic, so a single run can't rank models that sit close together:
 
 ```bash
 OPENROUTER_API_KEY=... .venv/bin/python -m tests.click_bench.leaderboard \
-  --fixtures tests/click_bench/fixtures/synthetic.json \
-  --models google/gemini-3-flash-preview,qwen/qwen3-vl-8b-instruct,openai/gpt-4o \
+  --fixtures tests/click_bench/fixtures/v1.json \
+  --runs 3 \
+  --models google/gemini-3-flash-preview,openai/gpt-4o,openai/gpt-4o-mini,qwen/qwen3-vl-8b-instruct \
   --out tests/click_bench/reports/leaderboard.md
 ```
 
-Both hit a real VLM (one call per case per model), so they need a key and are
-never run by the default `pytest`. With the multi-provider change you can bench
-a local model too — set `LLM_PROVIDER=custom` + `LLM_BASE_URL` first.
+Both hit a real VLM (one call per case per model per run), so they need a key and
+are never run by the default `pytest`. With the multi-provider change you can
+bench a local model too — set `LLM_PROVIDER=custom` + `LLM_BASE_URL` first.
 
 ## Fixtures
 
@@ -52,55 +55,58 @@ a local model too — set `LLM_PROVIDER=custom` + `LLM_BASE_URL` first.
   `_gen_synthetic.py`. They make the bench runnable from a cold start; they are
   **not** a real signal. Regenerate with
   `python -m tests.click_bench._gen_synthetic`.
-- `fixtures/v1.json` — **real illustrations**: 15 cases over three generated
-  fantasy maps from live sessions (`images/real/`), 12 groundable taps + 3
+- `fixtures/v1.json` — **real illustrations**: 20 cases over three generated
+  fantasy maps from live sessions (`images/real/`), 17 groundable taps + 3
   blank-parchment rejection cases. Tap points are detector-verified entity
   centroids, each eyeballed against the rendered map (several maps print the
   feature name in-image, so ground truth is human-checkable). See
   `_meta.how_to_add_cases` to extend it.
 
-## Latest leaderboard (2026-07-05, `fixtures/v1.json`, 15 cases)
+## Latest leaderboard (2026-07-05, `fixtures/v1.json`, 20 cases, **3 runs, mean±stdev**)
 
 Reports land in the gitignored `reports/`; this snapshot is the durable record.
-Single run per model — treat as **indicative, not definitive** (see caveat).
+Run cost: ~$0.71 for this 3-run × 4-model × 20-case pass. gemini-2.5-pro is
+excluded — an earlier run established it echoes the page title verbatim on every
+tap (0% pass, stable); running it three more times is wasted spend.
 
 | Model | Subject pass | Composite | Rejection recall | Groundable acc | p50 ms | ~$/tap |
 | --- | --- | --- | --- | --- | --- | --- |
-| google/gemini-3-flash-preview | 92% | 0.856 | 67% | 93% | 5372 | $0.0010 |
-| openai/gpt-4o-mini | 92% | 0.857 | 0% | 80% | 4339 | $0.0057 |
-| qwen/qwen3-vl-8b-instruct | 92% | 0.814 | 0% | 80% | 3495 | $0.0003 |
-| openai/gpt-4o | 83% | 0.775 | 0% | 80% | 6572 | $0.0047 |
-| google/gemini-2.5-pro | 0% | 0.223 | 0% | 80% | 7305 | $0.0037 |
+| openai/gpt-4o-mini | 78% ±3 | 0.749 ±0.026 | 0% | 85% | 4745 | $0.0057 |
+| google/gemini-3-flash-preview | 76% ±0 | 0.757 ±0.006 | 44% ±19 | 92% ±3 | 4530 | $0.0010 |
+| openai/gpt-4o | 75% ±3 | 0.752 ±0.025 | 0% | 85% | 5451 | $0.0047 |
+| qwen/qwen3-vl-8b-instruct | 73% ±3 | 0.697 ±0.029 | 0% | 85% | 2588 | $0.0003 |
 
 `~$/tap` = avg prompt tokens (incl. the image) × input price + ~60 output ×
 output price, at early-2026 OpenRouter rates.
 
-**What holds across runs (real signal):**
+**What the denoised run shows:**
 
-- **The top four cluster within noise.** gemini-3-flash, gpt-4o-mini, qwen3-vl-8b
-  and gpt-4o all land ~0.78–0.86 composite / 83–92% pass. Which one tops the
-  table flips between runs (an earlier run on the same fixtures had gpt-4o at 92%
-  and gemini-flash at 75%) — 15 cases × single run can't separate them. Don't
-  read the #1 row as a winner.
-- **A small open model holds up.** `qwen3-vl-8b-instruct` grounds as well as the
-  frontier models here and is **20× cheaper** than gpt-4o-mini per tap. For the
-  default click path it's a serious option — the README's central "does a small
-  VLM ground a tap" question answers *yes* on these maps.
-- **gemini-2.5-pro doesn't ground — it echoes the page title.** 0% pass, and its
-  prediction for every tap is the parent map's title verbatim ("Crescent Bay
-  Fishing Village"). A stable, reproducible failure mode; do not use it here.
-- **Almost nothing rejects a blank tap.** Rejection recall is 0% for four of five
-  models — tap empty parchment and the resolver confabulates a nearby named
-  feature instead of flagging `groundable=false`. Only gemini-flash rejects
-  (33–67% across runs). The groundability gate is the weakest link the product
-  rides on, and this bench now measures it.
+- **The four grounders are statistically tied on subject accuracy.** 73–78% pass
+  / 0.70–0.76 composite, all with overlapping ±stdev. Three runs confirm what a
+  single run couldn't: there is no meaningful gap between gpt-4o-mini, gemini-3-flash
+  and gpt-4o at grounding a tap on these maps. Don't read the #1 row as a winner.
+- **gemini-3-flash wins on *reliability*, not raw pass.** Identical subject-pass on
+  all three runs (±0), tightest composite (±0.006), the best groundable-accuracy
+  (92%), and the **only model that rejects a blank tap at all** (44% vs 0%). For a
+  click path where a wrong-but-confident subject spawns a garbage page, "stable +
+  knows when it's lost" beats a point of raw accuracy.
+- **A small open model holds up.** `qwen3-vl-8b-instruct` is within a few points of
+  the frontier and **20× cheaper per tap** than gpt-4o-mini, at the lowest latency
+  (2.6s). A serious default-click candidate — the bench's central "does a small VLM
+  ground a tap" question answers *yes*.
+- **Nothing rejects a blank tap except gemini-flash.** Rejection recall is 0% for
+  three of four models across all runs — tap empty parchment and the resolver
+  confabulates a nearby named feature instead of flagging `groundable=false`. The
+  groundability gate is the product's weakest link, now measured.
 - **gpt-4o-mini is secretly the costliest.** It bills ~37k tokens per tap — OpenAI
   mini models apply a ~33× image-token multiplier — versus ~1.7k for every other
   model. Despite the cheapest per-token price it lands at ~$0.0057/tap, pricier
   than full gpt-4o. Cheapest-looking ≠ cheapest on images.
 
-**Caveat:** VLM click resolution is non-deterministic and the set is small (15).
-For a ranking you'd act on, grow the fixtures and average ≥3 runs per model.
+**Still small (20 cases).** Three runs pin the variance (the ± columns), so the
+"they're tied" conclusion is trustworthy; a *finer* ranking would need more cases,
+not more runs. The five new v1 cases deliberately include hard "named water" taps
+(harbor channel, crescent basin) that pulled every model down from the 15-case set.
 
 ## Not covered yet
 

--- a/apps/modal-backend/tests/click_bench/fixtures/v1.json
+++ b/apps/modal-backend/tests/click_bench/fixtures/v1.json
@@ -169,6 +169,66 @@
       "notes": "masted ships moored in the harbour basin"
     },
     {
+      "case_id": "harbor_sea_rocks",
+      "image_path": "images/real/harbor_aethelgard.jpg",
+      "x_pct": 0.085,
+      "y_pct": 0.825,
+      "parent_title": "The Bustling Fantasy Harbor of Aethelgard",
+      "parent_query": "a fantasy harbor town seen from above",
+      "expected_subject": "sea rocks",
+      "alternates": ["The Western Sea-Spray Rocks", "crystal rocks", "the rocks", "rocky shore", "reef"],
+      "groundable": true,
+      "notes": "glowing crystal rocks in the water, lower-left"
+    },
+    {
+      "case_id": "harbor_mana_crystal",
+      "image_path": "images/real/harbor_aethelgard.jpg",
+      "x_pct": 0.138,
+      "y_pct": 0.155,
+      "parent_title": "The Bustling Fantasy Harbor of Aethelgard",
+      "parent_query": "a fantasy harbor town seen from above",
+      "expected_subject": "floating crystal",
+      "alternates": ["The Floating Mana Crystal", "glowing crystal", "the crystal", "magic crystal"],
+      "groundable": true,
+      "notes": "glowing crystal floating above the lighthouse spire"
+    },
+    {
+      "case_id": "harbor_channel",
+      "image_path": "images/real/harbor_aethelgard.jpg",
+      "x_pct": 0.355,
+      "y_pct": 0.685,
+      "parent_title": "The Bustling Fantasy Harbor of Aethelgard",
+      "parent_query": "a fantasy harbor town seen from above",
+      "expected_subject": "harbor channel",
+      "alternates": ["The Harbor Entrance Channel", "harbor entrance", "the channel", "harbor water", "the harbor", "water"],
+      "groundable": true,
+      "notes": "open water at the harbour mouth between the piers — a hard 'named water' tap"
+    },
+    {
+      "case_id": "oasis_merchant_row",
+      "image_path": "images/real/oasis_town.jpg",
+      "x_pct": 0.496,
+      "y_pct": 0.584,
+      "parent_title": "Desert Oasis Town",
+      "parent_query": "a desert oasis town with a caravan bazaar at the heart",
+      "expected_subject": "buildings",
+      "alternates": ["Merchant's Row", "shops", "houses", "market street", "town buildings", "the stalls"],
+      "groundable": true,
+      "notes": "row of urban buildings west of the bazaar, labelled \"Merchant's Row\""
+    },
+    {
+      "case_id": "fishing_basin",
+      "image_path": "images/real/fishing_village.jpg",
+      "x_pct": 0.688,
+      "y_pct": 0.638,
+      "parent_title": "Crescent Bay Fishing Village",
+      "parent_query": "a fishing village on a crescent bay",
+      "expected_subject": "bay",
+      "alternates": ["Crescent Basin", "the basin", "the bay", "harbor water", "water", "the sea"],
+      "groundable": true,
+      "notes": "tap lands on the 'Crescent Basin' label over the open bay water"
+    },
+    {
       "case_id": "oasis_blank_bottomleft",
       "image_path": "images/real/oasis_town.jpg",
       "x_pct": 0.13,

--- a/apps/modal-backend/tests/click_bench/leaderboard.py
+++ b/apps/modal-backend/tests/click_bench/leaderboard.py
@@ -23,10 +23,47 @@ from __future__ import annotations
 import argparse
 import asyncio
 import os
+import statistics
 from pathlib import Path
 from typing import Any
 
 from .runner import run_bench
+
+# Metrics that vary run-to-run (VLM non-determinism) — these get mean±stdev
+# across `--runs`. Count keys (n, n_*) are deterministic, carried from run 1.
+_AGG_METRICS = (
+    "subject_pass_rate",
+    "composite_mean",
+    "composite_median",
+    "rejection_recall",
+    "groundable_accuracy",
+    "latency_p50_ms",
+    "latency_p95_ms",
+    "latency_mean_ms",
+)
+
+
+def aggregate_summaries(summaries: list[dict[str, Any]]) -> dict[str, Any]:
+    """Fold N per-run summaries into one: each varying metric becomes its mean,
+    with a parallel `std` map (sample stdev, 0.0 for a single run). Counts are
+    carried from the first run. Pure — the denoise math for `--runs`."""
+    if not summaries:
+        return {"runs": 0}
+    out: dict[str, Any] = dict(summaries[0])
+    std: dict[str, float] = {}
+    for key in _AGG_METRICS:
+        vals = [
+            s[key]
+            for s in summaries
+            if isinstance(s.get(key), (int, float)) and not isinstance(s.get(key), bool)
+        ]
+        if not vals:
+            continue
+        out[key] = round(statistics.mean(vals), 4)
+        std[key] = round(statistics.stdev(vals), 4) if len(vals) > 1 else 0.0
+    out["runs"] = len(summaries)
+    out["std"] = std
+    return out
 
 _HEADERS = [
     "Model",
@@ -43,24 +80,33 @@ def _is_number(v: Any) -> bool:
     return isinstance(v, (int, float)) and not isinstance(v, bool)
 
 
-def _fmt_pct(v: Any) -> str:
-    return f"{v * 100:.0f}%" if _is_number(v) else "—"
+def _fmt_pct(v: Any, sd: Any = None) -> str:
+    if not _is_number(v):
+        return "—"
+    tail = f" ±{sd * 100:.0f}" if _is_number(sd) and sd > 0 else ""
+    return f"{v * 100:.0f}%{tail}"
 
 
-def _fmt_num(v: Any, nd: int = 3) -> str:
-    return f"{v:.{nd}f}" if _is_number(v) else "—"
+def _fmt_num(v: Any, nd: int = 3, sd: Any = None) -> str:
+    if not _is_number(v):
+        return "—"
+    tail = f" ±{sd:.{nd}f}" if _is_number(sd) and sd > 0 else ""
+    return f"{v:.{nd}f}{tail}"
 
 
 def _row_cells(row: dict[str, Any]) -> list[str]:
     s = row.get("summary", {})
+    # `std` present only for multi-run (aggregate_summaries); single runs render
+    # byte-identically because every std lookup returns None.
+    std = s.get("std", {})
     return [
         str(row.get("model", "?")),
         str(s.get("n", "—")),
-        _fmt_pct(s.get("subject_pass_rate")),
-        _fmt_num(s.get("composite_mean")),
-        _fmt_pct(s.get("rejection_recall")),
-        _fmt_pct(s.get("groundable_accuracy")),
-        _fmt_num(s.get("latency_p50_ms"), nd=0),
+        _fmt_pct(s.get("subject_pass_rate"), std.get("subject_pass_rate")),
+        _fmt_num(s.get("composite_mean"), sd=std.get("composite_mean")),
+        _fmt_pct(s.get("rejection_recall"), std.get("rejection_recall")),
+        _fmt_pct(s.get("groundable_accuracy"), std.get("groundable_accuracy")),
+        _fmt_num(s.get("latency_p50_ms"), nd=0, sd=std.get("latency_p50_ms")),
     ]
 
 
@@ -85,16 +131,25 @@ async def run_leaderboard(
     fixtures_path: Path,
     models: list[str],
     *,
+    runs: int = 1,
     reports_dir: Path | None = None,
 ) -> list[dict[str, Any]]:
-    """Run the bench once per model and return rows ready for render_markdown."""
+    """Run the bench `runs` times per model and return rows ready for
+    render_markdown. With runs>1 each row's summary is the mean±stdev across
+    runs (VLM click resolution is non-deterministic — one run can't rank)."""
     rows: list[dict[str, Any]] = []
     for model in models:
-        out_path = (
-            reports_dir / f"{model.replace('/', '_')}.json" if reports_dir else None
-        )
-        report = await run_bench(fixtures_path, model_override=model, out_path=out_path)
-        rows.append({"model": report.model, "summary": report.summary})
+        slug = model.replace("/", "_")
+        summaries: list[dict[str, Any]] = []
+        for i in range(max(1, runs)):
+            suffix = "" if runs == 1 else f".run{i + 1}"
+            out_path = reports_dir / f"{slug}{suffix}.json" if reports_dir else None
+            report = await run_bench(
+                fixtures_path, model_override=model, out_path=out_path
+            )
+            summaries.append(report.summary)
+        summary = aggregate_summaries(summaries) if runs > 1 else summaries[0]
+        rows.append({"model": model, "summary": summary})
     return rows
 
 
@@ -117,6 +172,12 @@ def _cli() -> None:
         default=None,
         help="write the markdown table here (also printed to stdout)",
     )
+    parser.add_argument(
+        "--runs",
+        type=int,
+        default=1,
+        help="runs per model; >1 reports mean±stdev (denoises VLM variance)",
+    )
     args = parser.parse_args()
 
     if not os.environ.get("OPENROUTER_API_KEY"):
@@ -124,7 +185,9 @@ def _cli() -> None:
 
     models = [m.strip() for m in args.models.split(",") if m.strip()]
     reports_dir = args.out.parent / "models" if args.out else None
-    rows = asyncio.run(run_leaderboard(args.fixtures, models, reports_dir=reports_dir))
+    rows = asyncio.run(
+        run_leaderboard(args.fixtures, models, runs=args.runs, reports_dir=reports_dir)
+    )
     md = render_markdown(rows)
     print(md)
     if args.out is not None:

--- a/apps/modal-backend/tests/test_click_bench.py
+++ b/apps/modal-backend/tests/test_click_bench.py
@@ -301,6 +301,64 @@ def test_render_markdown_tolerates_missing_metrics() -> None:
     assert "broken" in md
 
 
+# ---------- multi-run aggregation (denoise, pure) -----------------------
+
+
+def test_aggregate_summaries_means_and_stdev() -> None:
+    runs = [
+        {"n": 15, "subject_pass_rate": 0.80, "composite_mean": 0.70, "latency_p50_ms": 100.0},
+        {"n": 15, "subject_pass_rate": 0.90, "composite_mean": 0.80, "latency_p50_ms": 200.0},
+    ]
+    agg = leaderboard.aggregate_summaries(runs)
+    assert agg["runs"] == 2
+    assert agg["n"] == 15  # counts carried, not averaged
+    assert agg["subject_pass_rate"] == pytest.approx(0.85)
+    assert agg["composite_mean"] == pytest.approx(0.75)
+    # sample stdev of {0.8, 0.9} = 0.0707…
+    assert agg["std"]["subject_pass_rate"] == pytest.approx(0.0707, abs=1e-3)
+    assert agg["std"]["latency_p50_ms"] == pytest.approx(70.71, abs=1e-2)
+
+
+def test_aggregate_summaries_single_run_zero_std() -> None:
+    agg = leaderboard.aggregate_summaries([{"n": 5, "subject_pass_rate": 0.6}])
+    assert agg["runs"] == 1
+    assert agg["subject_pass_rate"] == pytest.approx(0.6)
+    assert agg["std"]["subject_pass_rate"] == 0.0
+    assert leaderboard.aggregate_summaries([]) == {"runs": 0}
+
+
+def test_aggregate_summaries_skips_absent_metric() -> None:
+    # gemini-2.5-pro-style: some runs error and omit a metric entirely.
+    runs = [
+        {"n": 3, "subject_pass_rate": 0.5, "rejection_recall": 0.4},
+        {"n": 3, "subject_pass_rate": 0.7},  # no rejection_recall this run
+    ]
+    agg = leaderboard.aggregate_summaries(runs)
+    assert agg["subject_pass_rate"] == pytest.approx(0.6)
+    # single present value → mean of it, std 0 (not a crash)
+    assert agg["rejection_recall"] == pytest.approx(0.4)
+    assert agg["std"]["rejection_recall"] == 0.0
+
+
+def test_render_markdown_shows_pm_when_std_present() -> None:
+    agg = leaderboard.aggregate_summaries(
+        [
+            {"n": 15, "subject_pass_rate": 0.80, "composite_mean": 0.70},
+            {"n": 15, "subject_pass_rate": 0.90, "composite_mean": 0.80},
+        ]
+    )
+    md = leaderboard.render_markdown([{"model": "m", "summary": agg}])
+    assert "±" in md  # variance surfaced for a multi-run row
+
+
+def test_render_markdown_single_run_has_no_pm() -> None:
+    # Byte-compat: a plain single-run summary (no `std`) renders without ±.
+    md = leaderboard.render_markdown(
+        [_row("m", n=15, subject_pass_rate=0.8, composite_mean=0.7)]
+    )
+    assert "±" not in md
+
+
 # ---------- synthetic smoke fixtures ------------------------------------
 
 


### PR DESCRIPTION
Follow-up to #139: makes the click-leaderboard a ranking you can actually trust.

## The problem

A single VLM run can't separate close models — click resolution is non-deterministic. The same 15-case fixtures gave gpt-4o **92% one run and 75% the next**. The #1 row was noise.

## Changes

- **`leaderboard.py`: `--runs N`** repeats each model N times and reports **mean ± stdev** per metric (`aggregate_summaries`, pure + unit-tested). Single runs render byte-identically (no `std` → no `±`), so existing behaviour is unchanged. +5 tests.
- **`v1.json`: 15 → 20 cases** (+5 verified taps: sea rocks, mana crystal, harbor channel, merchant row, crescent basin — including deliberately hard 'named water' taps that discriminate better). Each overlaid + eyeballed before commit.

## Denoised result (3 runs × 4 models × 20 cases, ~$0.71)

| Model | Subject pass | Composite | Rejection | Groundable acc | ~$/tap |
|---|---|---|---|---|---|
| gpt-4o-mini | 78% ±3 | 0.749 ±0.026 | 0% | 85% | $0.0057 |
| gemini-3-flash | 76% ±0 | 0.757 ±0.006 | 44% ±19 | 92% ±3 | $0.0010 |
| gpt-4o | 75% ±3 | 0.752 ±0.025 | 0% | 85% | $0.0047 |
| qwen3-vl-8b | 73% ±3 | 0.697 ±0.029 | 0% | 85% | $0.0003 |

- **The four grounders are statistically tied** on subject accuracy — overlapping ±. Three runs confirm what one couldn't: no meaningful gap. Don't read #1 as a winner.
- **gemini-3-flash wins on reliability** — identical pass all three runs (±0), tightest composite, best groundable-acc, and the *only* model that rejects a blank tap (44% vs 0%). For a click path where a confident-wrong subject spawns a garbage page, that beats a point of raw accuracy.
- **qwen3-vl-8b holds within a few points at 20× less cost** + lowest latency — a real default-click candidate.
- **Rejection ≈0% for everyone else is stable, not noise** — the groundability gate is the weak link.
- gemini-2.5-pro excluded (an earlier run established a stable 0% page-title-echo; re-running it is wasted spend).

## Gates

click_bench pytest green (26 tests incl. 5 new aggregation/rendering tests), ruff + mypy clean. Data + harness only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)