### PR TITLE
feat(corpus): per-chain view (interior|exterior) + measurable-chain sourcing criteria

### DIFF
--- a/apps/modal-backend/tests/descent_bench/runner.py
+++ b/apps/modal-backend/tests/descent_bench/runner.py
@@ -67,7 +67,11 @@ async def _score_chain(chain: dict[str, Any], aspect: str) -> dict[str, Any]:
     region = _region_crop(parent_bytes, chain["anchor"])
     region_url = image_provider.encode_data_url(region)
     label = chain["label"]
-    base = f"A closer, interior view of {label}, a place within the parent map."
+    # Default "interior" enters the place; a chain can set view="exterior" for a
+    # closer OUTSIDE view — the shape that measures place_lift when the parent
+    # already draws a distinctive exterior (tests/map_corpus/chains.py docs).
+    view = chain.get("view", "interior")
+    base = f"A closer, {view} view of {label}, a place within the parent map."
     preamble = image_provider.conditioning_preamble(["region"], "place_scene")
     model = _model()
 

--- a/apps/modal-backend/tests/map_corpus/chains.py
+++ b/apps/modal-backend/tests/map_corpus/chains.py
@@ -5,6 +5,31 @@ spot, generate an "enter" view, and score it against the REAL child image.
 The link lives on the child's MANIFEST row (parent_id + parent_ref) — the child
 needs no description of its own; its ground truth is the photo. The parent must
 have a (verified) corpus description so parent_ref resolves to a position.
+
+Sourcing a chain that actually MEASURES place_lift (learned the hard way):
+
+  1. The parent must depict the child's SPECIFIC identity, not a generic icon.
+     The seeded manor::church -> Chester nave chain scores place_lift=0 because a
+     village-map church glyph carries no Chester-specific identity to transfer —
+     continuity_with (footprint) is 9, but there is nothing to *place*-match.
+
+  2. Mind the exterior/interior gap. The descent prompt generates a *closer view*
+     of the place; by default that view is "interior". A map crop shows a
+     building's EXTERIOR, so it can only transfer identity the interior shares —
+     a distinctive DOME, a footprint, a silhouette. A plain facade -> an
+     arbitrary hall will not move place_lift (both the conditioned and baseline
+     gens guess a generic interior). Two chain shapes DO measure:
+       (a) interior-predictive: a distinctive exterior that defines the inside
+           (a domed rotunda on the map -> its domed reading room), or
+       (b) exterior-closeup: set the child row's `view: "exterior"` and pair a
+           map building with an exterior closeup of the SAME building — a
+           distinctive silhouette transfers and place_lift becomes measurable.
+
+  3. Prefer same-medium pairs, or lean on score_place_match (medium-agnostic):
+     an illustrated parent -> a photographed child is fine for place_lift (it
+     ignores medium) but sinks style_lift, which stays a secondary signal.
+
+  Row shape for a chain child: {..., parent_id, parent_ref, view?: "interior"}.
 """
 from __future__ import annotations
 
@@ -47,6 +72,10 @@ def descent_chains(
                 "parent_filename": parent_row["filename"],
                 "label": anchor["label"],
                 "anchor": anchor,
+                # "interior" (default) enters the place; "exterior" generates a
+                # closer OUTSIDE view — the shape that measures place_lift when
+                # the map already draws a distinctive exterior (see module docs).
+                "view": str(row.get("view", "interior")),
             }
         )
     return out

--- a/apps/modal-backend/tests/map_corpus/test_chains.py
+++ b/apps/modal-backend/tests/map_corpus/test_chains.py
@@ -43,3 +43,18 @@ def test_descent_chains_resolves_linked_rows_only() -> None:
     assert c["parent_filename"] == "manor.jpg"
     assert c["label"] == "Church"
     assert c["anchor"]["pos"] == {"x": 52.1, "y": 35.5}
+    assert c["view"] == "interior"  # default when the row omits it
+
+
+def test_descent_chains_honours_exterior_view() -> None:
+    # A chain child can opt into a closer EXTERIOR view (place_lift measurable
+    # for map-drawn distinctive buildings) via `view` on its row.
+    manifest = [
+        {"id": "manor", "filename": "manor.jpg", "tier": "map"},
+        {
+            "id": "mill-close", "filename": "mill.jpg", "tier": "closeup",
+            "parent_id": "manor", "parent_ref": "mill", "view": "exterior",
+        },
+    ]
+    chains = descent_chains(manifest, {"manor": _parent()})
+    assert len(chains) == 1 and chains[0]["view"] == "exterior"


### PR DESCRIPTION
## Why

The corpus has one seeded golden descent chain (manor::church → Chester nave) and it scores **place_lift = 0**. Digging in, the root cause isn't just the generic church icon — it's **structural**:

- The descent prompt hardcoded *"interior view"*. A map crop shows a building's **exterior**, so it can only transfer identity the interior shares. A plain facade → an arbitrary hall can't move place_lift (both the region-conditioned gen and the fresh baseline just guess a generic interior). `continuity_with` (footprint) still reads 9 — there's simply nothing to *place*-match.

So "source more golden chains" was aimed at a target that, for exterior-map → interior chains, can't move. This PR fixes the enabler and writes down what actually measures.

## Changes

- **`chains.py`**: thread a per-chain `view` (default `"interior"`, fully back-compat) from the child manifest row. A child can now set `view: "exterior"` for a closer **outside** view — the shape where a distinctive map-drawn building (silhouette, dome) *does* transfer and place_lift becomes measurable.
- **`descent_bench/runner.py`**: the base prompt uses the chain's view.
- **`chains.py` module docs**: the measurable-chain **sourcing criteria** — parent must depict the child's *specific* identity; mind the exterior/interior gap (interior-predictive dome, or exterior-closeup with `view`); prefer same-medium or lean on the medium-agnostic `place_match` judge. So future sourcing targets chains that can move place_lift instead of repeating Chester.

## Verification

- Existing chain resolves byte-identically — dry run still reports 1 chain, $0.
- +1 test for the `view="exterior"` override; `view` defaults to `"interior"`.
- map_corpus + descent tests green, ruff + mypy clean.

## Not in this PR (needs a paid step — proposing separately)

Actually *sourcing* a measurable chain (a distinctive map building + a same-identity closeup, or an interior-predictive dome) plus annotating the new parent (paid) and running the descent eval. Scoping that as a follow-up rather than spending unprompted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)