### PR TITLE
fix(judge): stop silent score=0 when the judge model reasons before the JSON

### DIFF
--- a/apps/modal-backend/providers/judge.py
+++ b/apps/modal-backend/providers/judge.py
@@ -47,7 +47,7 @@ def _image_block(image_bytes: bytes) -> dict[str, object]:
 def _parse_judgement(raw: str) -> JudgeResult:
     cleaned = raw.strip()
     match = _SCORE_RE.search(cleaned)
-    score = float(match.group(1)) if match else 0.0
+    score = float(match.group(1)) if match else None
     rationale = ""
     try:
         parsed = json.loads(cleaned[cleaned.find("{") : cleaned.rfind("}") + 1])
@@ -59,7 +59,31 @@ def _parse_judgement(raw: str) -> JudgeResult:
         if "score" in parsed:
             score = float(parsed["score"])
     except Exception:
-        rationale = cleaned[:300]
+        # Truncated/reasoning-preambled reply (gemini-3-flash prepends a "thought"
+        # then a JSON that max_tokens cuts off — the boxes-bug class). Walk the
+        # partial with the shared salvage decoder before giving up.
+        from providers.llm.client import salvage_json
+
+        salvaged, _ = salvage_json(cleaned)
+        if isinstance(salvaged, dict):
+            rationale = str(salvaged.get("rationale", ""))[:300]
+            if "score" in salvaged:
+                score = float(salvaged["score"])
+        if not rationale:
+            rationale = cleaned[:300]
+    if score is None:
+        # LOUD, not silent: a judge that can't produce a score used to default to
+        # 0.0 and read as "totally unlike" — corrupting every recon/descent cell
+        # it touched. Surface it so a broken judge call can't hide as a real 0.
+        from obs import log
+
+        log(
+            "warn",
+            "judge.unparseable",
+            raw_head=cleaned[:120],
+            model=_judge_model(),
+        )
+        return JudgeResult(score=0.0, rationale=f"UNPARSEABLE: {cleaned[:200]}", raw=cleaned[:500])
     return JudgeResult(score=score, rationale=rationale, raw=cleaned[:500])
 
 
@@ -69,8 +93,16 @@ async def _ask_judge(
     from providers import llm
 
     client = llm._client()
+    # Suppress the reasoning preamble: gemini-3-flash (the default judge) prepends
+    # a "thought" before the JSON on hard comparisons, which then blows the token
+    # budget and truncates the score — a silent 0. Forcing JSON-only keeps the
+    # content parseable; the bumped budget is headroom for the rationale.
+    system_json_only = (
+        system + " Respond with ONLY the JSON object and nothing else — "
+        "no reasoning, no preamble, no markdown fences."
+    )
     messages: list[Any] = [
-        {"role": "system", "content": system},
+        {"role": "system", "content": system_json_only},
         {
             "role": "user",
             "content": [{"type": "text", "text": user_text}, *image_blocks],
@@ -80,7 +112,7 @@ async def _ask_judge(
         model=_judge_model(),
         messages=messages,
         temperature=0.0,
-        max_tokens=200,
+        max_tokens=400,
     )
     raw = response.choices[0].message.content or ""
     return _parse_judgement(raw)

--- a/apps/modal-backend/tests/test_judge_place_match.py
+++ b/apps/modal-backend/tests/test_judge_place_match.py
@@ -49,3 +49,39 @@ async def test_score_place_match_is_medium_agnostic_and_passes_both_images(
     b64 = base64.b64encode(b"GENERATED-DESCENT").decode("ascii")
     assert a64 in blocks[0]["image_url"]["url"]
     assert b64 in blocks[1]["image_url"]["url"]
+
+
+# --- _parse_judgement robustness (the silent-zero bug, pure) ---------------
+#
+# gemini-3-flash (the default judge) prepends a "thought" reasoning preamble on
+# hard comparisons; max_tokens then truncates the JSON before the score. The old
+# parser defaulted a truncated/absent score to 0.0 — reading as "totally unlike"
+# and corrupting every recon/descent cell it touched. Fixes: a legit 0 stays 0,
+# a truncated reply is marked UNPARSEABLE (loud, not a silent real 0), and a
+# reasoning-preambled-then-JSON reply is salvaged.
+
+
+def test_parse_clean_json() -> None:
+    r = judge._parse_judgement('{"score": 8, "rationale": "same tower"}')
+    assert r.score == 8.0 and r.rationale == "same tower"
+
+
+def test_parse_legit_zero_is_preserved() -> None:
+    # A real "unrelated place" 0 must survive — not be confused with a failure.
+    r = judge._parse_judgement('{"score": 0, "rationale": "unrelated"}')
+    assert r.score == 0.0
+    assert r.rationale == "unrelated"
+    assert "UNPARSEABLE" not in r.rationale
+
+
+def test_parse_truncated_thought_is_loud_not_silent_zero() -> None:
+    # The exact wild failure: reasoning preamble + JSON cut off before the number.
+    r = judge._parse_judgement('thought\n{"score":')
+    assert r.score == 0.0  # can't recover a score
+    assert r.rationale.startswith("UNPARSEABLE")  # but it says so, loudly
+
+
+def test_parse_salvages_reasoning_preamble_then_json() -> None:
+    # A preamble followed by a COMPLETE json object → salvage recovers the score.
+    r = judge._parse_judgement('Let me think. The dome matches.\n{"score": 9, "rationale": "dome"}')
+    assert r.score == 9.0


### PR DESCRIPTION
## The bug

The default VLM judge (`gemini-3-flash-preview`) prepends a **"thought" reasoning preamble** before its JSON on hard comparisons. With `max_tokens=200`, the reply truncates right at `{"score":` — before the number. `_parse_judgement` then defaulted the missing score to **0.0**, which reads as *"totally unlike"* and **silently corrupted every recon / descent / continuity / view-loop / edit cell** that tripped it.

Caught while debugging why a descent `place_lift` was ~0: an *illustrated* US Capitol vs a *real Capitol photo* scored **0** on the medium-agnostic judge — when it's unmistakably the same place. The raw reply was literally `'thought\n{"score":'`. A parse failure wearing a real score's clothes.

## The fix

- **`_ask_judge`**: force JSON-only (`"no reasoning, no preamble, no markdown"`) so the reasoning model stops preambling, + `max_tokens` 200 → 400 for rationale headroom. With this, the same comparison returns a clean `{"score": 10, ...}` (verified live).
- **`_parse_judgement`**: `score` starts `None`, not `0`. On a `json.loads` failure, walk the partial with the shared `salvage_json` decoder (the #127 boxes-bug class fix). If a score *still* can't be found, log a loud `judge.unparseable` warning and mark the rationale `UNPARSEABLE` — a broken judge call can no longer masquerade as a real 0. A **legitimate** 0 is preserved and never marked.

## Verification

- Live: the illustrated-Capitol comparison that returned `0` now returns `10` with a real rationale.
- +4 pure parse tests (clean / legit-zero / truncated-thought-loud / salvage-preamble).
- Full free suite green, ruff + mypy clean.

**Baseline note:** recon/descent baselines pinned before this fix undercount any cell whose judge reply truncated — re-pin on the next paid run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
