### PR TITLE
feat(motion): zoom toward the tapped point while the next page decodes

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -67,9 +67,18 @@ h3,
   100% { opacity: 1;   filter: blur(0px) saturate(1.0); }
 }
 
+/* Slow push-in toward the tapped point while the next page decodes: the dead
+ * wait before the draft reads as "diving into what you touched", not "stuck".
+ * transform-origin is set inline to the tap px; honours reduce-motion below. */
+@keyframes ec-morph-zoom {
+  0%   { transform: scale(1); }
+  100% { transform: scale(1.06); }
+}
+
 .ec-morph-old {
-  animation: ec-shimmer 1.4s ease-in-out infinite;
-  will-change: opacity, filter;
+  animation: ec-shimmer 1.4s ease-in-out infinite,
+             ec-morph-zoom 7s cubic-bezier(0.22, 0.61, 0.36, 1) forwards;
+  will-change: opacity, filter, transform;
 }
 
 .ec-morph-new {

--- a/apps/web/components/PlayPage/MorphImagePair.tsx
+++ b/apps/web/components/PlayPage/MorphImagePair.tsx
@@ -51,6 +51,12 @@ export function MorphImagePair({
           style={{
             opacity: morphFx.phase === "reveal" ? 0 : 1,
             transition: "opacity 480ms cubic-bezier(0.22, 0.61, 0.36, 1)",
+            // Push the wait-phase zoom toward the tapped point (ox/oy are px in
+            // this layer's own box). Falls back to centre if no origin.
+            transformOrigin:
+              typeof morphFx.ox === "number" && typeof morphFx.oy === "number"
+                ? `${morphFx.ox}px ${morphFx.oy}px`
+                : "center",
           }}
           draggable={false}
         />


### PR DESCRIPTION
The ~5s dead-zone before the progressive draft was just a shimmer over the old page — reads as *stuck*. Now the outgoing image slowly pushes in toward the exact spot you tapped (`transform-origin` = the tap px, already on `morphFx.ox/oy`), so the wait feels like **diving into what you touched**.

- Composes with the existing shimmer + ink-bloom reveal; a one-shot 7s ease-out scale→1.06 that holds until the draft blooms in.
- Reduce-motion already resets `.ec-morph-old` transforms → inert there.
- Figure is `overflow-hidden` so the zoom clips cleanly.

Web vitest 670 + tsc + circular green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)