### PR TITLE
feat(wander): auto-explore — let the world explore itself, hands-free

### DIFF
--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -67,6 +67,7 @@ import { MorphImagePair } from "@/components/PlayPage/MorphImagePair";
 import { StrokeOverlay } from "@/components/PlayPage/StrokeOverlay";
 import { ClickRipple } from "@/components/PlayPage/ClickRipple";
 import { BlankTapNudge } from "@/components/PlayPage/BlankTapNudge";
+import { useWander } from "@/hooks/useWander";
 import { BranchBeacons } from "@/components/PlayPage/BranchBeacons";
 import { GeneratingBanner } from "@/components/PlayPage/GeneratingBanner";
 import { Quickbar } from "@/components/PlayPage/Quickbar";
@@ -432,6 +433,8 @@ export default function PlayPage() {
     const t = setTimeout(() => setBlankTap(null), 1700); // just past the fade
     return () => clearTimeout(t);
   }, [blankTap]);
+  // Wander (auto-explore): the world explores itself, hands-free. See useWander.
+  const [wandering, setWandering] = useState(false);
   // ⌘/Ctrl-click hint capture via an inline floating input anchored at the
   // click point. The promise resolves to the typed hint (or null on
   // cancel/Esc) so the click handler can stay a single async function.
@@ -1554,6 +1557,21 @@ export default function PlayPage() {
       })
     );
   }, []);
+
+  // Wander (auto-explore): reuse the ranked precompute candidates + the tap flow
+  // to let the world explore itself, hands-free. Toggled by the ▶ button.
+  const stopWander = useCallback(() => setWandering(false), []);
+  useWander({
+    active: wandering,
+    phase,
+    nodeId: page?.nodeId ?? null,
+    imageDataUrl: page?.imageDataUrl ?? null,
+    title: page?.title ?? "",
+    query: page?.query ?? "",
+    outputLocale: resolveOutputLocale(outputLocale),
+    dispatchTapAt,
+    onExhausted: stopWander,
+  });
 
   // The geo-aware section of the right-click menu (E2): target-aware actions
   // routed to the primitives that already exist — runEdit (E1 mask path),
@@ -3587,6 +3605,22 @@ export default function PlayPage() {
                 the World pill so, on any residual overlap at narrow widths,
                 this later-in-DOM toolbar wins the stack and stays tappable. */}
             <div className="absolute right-3 top-3 z-10 flex max-w-[calc(100%-1.5rem)] flex-wrap justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setWandering((w) => !w)}
+                aria-pressed={wandering}
+                disabled={!page?.imageDataUrl}
+                className={
+                  "flex items-center gap-1.5 rounded-full px-3 py-1 text-xs text-white disabled:opacity-50 " +
+                  (wandering
+                    ? "animate-pulse bg-fuchsia-600"
+                    : "bg-fuchsia-600/85 hover:bg-fuchsia-600")
+                }
+                title="Wander — let the world explore itself, tapping the most interesting spot each page. Tap again to stop."
+              >
+                <span aria-hidden>{wandering ? "⏸" : "▶"}</span>
+                {wandering ? "Wandering…" : "Wander"}
+              </button>
               <button
                 type="button"
                 onClick={triggerExpand}

--- a/apps/web/hooks/useWander.ts
+++ b/apps/web/hooks/useWander.ts
@@ -1,0 +1,133 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+interface WanderCandidate {
+  x_pct: number;
+  y_pct: number;
+  salience?: number;
+}
+
+interface Options {
+  /** Whether wander is currently on. */
+  active: boolean;
+  /** The play page's generation phase; we only auto-tap while "ready". */
+  phase: string;
+  /** Current page identity + fields, passed as primitives so the effect only
+   *  re-arms when the page actually changes (not on every parent re-render). */
+  nodeId: string | null;
+  imageDataUrl: string | null;
+  title: string;
+  query: string;
+  /** Resolved output locale to pass through to the candidate resolver. */
+  outputLocale: string | null;
+  /** Fire the existing tap flow at a normalized point (reuses everything). */
+  dispatchTapAt: (xPct: number, yPct: number) => void;
+  /** Called when wander can't continue (no candidates / error) so the caller
+   *  can toggle it off. */
+  onExhausted: () => void;
+  /** ms to linger on a freshly-arrived page before the next auto-tap. */
+  lingerMs?: number;
+}
+
+/**
+ * Auto-explore ("Wander"): while active and the page is idle, fetch the ranked
+ * clickable regions for the current page, pick one of the most salient, and
+ * fire a real tap at it after a short linger — so the world explores itself,
+ * hands-free, deeper page by page. Reuses the precompute-candidates resolver
+ * and the page's own tap flow; stops on toggle-off or when a page yields no
+ * candidates. Picking randomly among the top few avoids ping-ponging between
+ * two pages.
+ */
+export function useWander({
+  active,
+  phase,
+  nodeId,
+  imageDataUrl,
+  title,
+  query,
+  outputLocale,
+  dispatchTapAt,
+  onExhausted,
+  lingerMs = 2600,
+}: Options): void {
+  // The last node we auto-tapped FROM, so a page is only wandered once even as
+  // the effect re-runs.
+  const tappedFrom = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!active) {
+      tappedFrom.current = null;
+      return;
+    }
+    // Only auto-tap from a settled page whose pixels we can resolve, and only
+    // once per node.
+    if (
+      phase !== "ready" ||
+      !nodeId ||
+      !imageDataUrl?.startsWith("data:") ||
+      tappedFrom.current === nodeId
+    ) {
+      return;
+    }
+    tappedFrom.current = nodeId;
+
+    const ac = new AbortController();
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    void (async () => {
+      try {
+        const res = await fetch("/api/precompute-candidates", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            image_data_url: imageDataUrl,
+            parent_title: title,
+            parent_query: query,
+            output_locale: outputLocale,
+            max_candidates: 6,
+          }),
+          signal: ac.signal,
+        });
+        if (!res.ok) {
+          onExhausted();
+          return;
+        }
+        const data = (await res.json()) as { candidates?: WanderCandidate[] };
+        const cands = (data.candidates ?? []).filter(
+          (c) => typeof c?.x_pct === "number" && typeof c?.y_pct === "number"
+        );
+        if (cands.length === 0) {
+          onExhausted();
+          return;
+        }
+        cands.sort((a, b) => (b.salience ?? 0) - (a.salience ?? 0));
+        // Wander with a little serendipity: a random pick among the top 3 keeps
+        // the journey from looping between the two most-salient spots.
+        const pool = cands.slice(0, Math.min(3, cands.length));
+        const pick = pool[Math.floor(Math.random() * pool.length)]!;
+        timer = setTimeout(() => {
+          if (!ac.signal.aborted) dispatchTapAt(pick.x_pct, pick.y_pct);
+        }, lingerMs);
+      } catch {
+        // Aborted (page changed / toggled off) or network error — the next
+        // ready page re-arms; a hard failure surfaces as no next tap.
+      }
+    })();
+
+    return () => {
+      ac.abort();
+      if (timer) clearTimeout(timer);
+    };
+  }, [
+    active,
+    phase,
+    nodeId,
+    imageDataUrl,
+    title,
+    query,
+    outputLocale,
+    dispatchTapAt,
+    onExhausted,
+    lingerMs,
+  ]);
+}


### PR DESCRIPTION
feat(wander): auto-explore — let the world explore itself, hands-free

A ▶ Wander button (surprise-me): toggle it on and the app taps the most
salient region of each page, generates the next, lingers a beat, and keeps
descending — a cinematic hands-free journey deeper into your world. Tap it
again (⏸ Wandering…) to take back the wheel.

- hooks/useWander.ts: while active + idle, POST /api/precompute-candidates
  for the current page, pick randomly among the top-3 salient regions (avoids
  ping-ponging), and fire the EXISTING tap flow via dispatchTapAt after a
  ~2.6s linger. One auto-tap per node (tappedFrom ref); aborts cleanly on
  page change / toggle-off; stops when a page yields no candidates. Page
  fields passed as primitives so the linger timer isn't aborted by unrelated
  re-renders.
- play page: a fuchsia ▶/⏸ toolbar button + the hook wiring. Fully additive —
  reuses the region-precompute and the tap flow verbatim, no existing UX
  changes.

Live-verified: toggled on → auto-explored 4 nodes hands-free
(city map → district → citadel → fortress interior); toggle-off settled and
stopped (no advance for 30s). Web vitest 670 + tsc + circular green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
