### PR TITLE
fix(motion): make zoom-into-tap a real dive into the tapped region

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -67,17 +67,20 @@ h3,
   100% { opacity: 1;   filter: blur(0px) saturate(1.0); }
 }
 
-/* Slow push-in toward the tapped point while the next page decodes: the dead
- * wait before the draft reads as "diving into what you touched", not "stuck".
- * transform-origin is set inline to the tap px; honours reduce-motion below. */
+/* A real push-in toward the tapped point while the next page decodes: the wait
+ * genuinely previews "diving into what you touched" — the tapped region grows to
+ * fill the frame (≈2.6×), softening slightly as it rushes in, then the next page
+ * blooms from that same point. transform-origin is set inline to the tap px;
+ * reduce-motion resets it below. `filter` here (last in the animation list) wins
+ * over ec-shimmer's, so it owns the depth blur; shimmer keeps the opacity pulse. */
 @keyframes ec-morph-zoom {
-  0%   { transform: scale(1); }
-  100% { transform: scale(1.06); }
+  0%   { transform: scale(1);   filter: blur(0px); }
+  100% { transform: scale(2.6); filter: blur(1px); }
 }
 
 .ec-morph-old {
   animation: ec-shimmer 1.4s ease-in-out infinite,
-             ec-morph-zoom 7s cubic-bezier(0.22, 0.61, 0.36, 1) forwards;
+             ec-morph-zoom 5.5s cubic-bezier(0.3, 0.7, 0.4, 1) forwards;
   will-change: opacity, filter, transform;
 }
 


### PR DESCRIPTION
The load-wait zoom was scale **1.06** — a ~6% wiggle, imperceptible (and invisible sped-up in a clip). So "zoom into the tapped point" was baseless: the tapped feature barely moved, then the page cut to an unrelated-looking generation.

Now it's a **real push-in**: the outgoing image scales ~2.6× toward the tap px over the load, so the tapped region grows to fill the frame.

**Verified live** (stills in `~/Desktop/ofb-visuals-2026-07-02/feature-studies/dive-{before,mid,after}.png`): tap the skull on a treasure island → the skull fills the screen → the next page blooms from that point into "The Heart of Skull Rock". A slight blur sells the rush-in; `ec-morph-zoom` owns `filter` (last in the animation list) so shimmer keeps only the opacity pulse. `reduce-motion` still resets it to no transform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)