### PR TITLE
feat(taps): tap = zoom in, for real — route place-taps through zoom_continue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,6 +100,11 @@ FAL_EDIT_TIER=balanced
 # VIEW_LOOP_ACCEPT_CONFORMANCE=7
 # VIEW_LOOP_ACCEPT_SAME_PLACE=6
 # VIEW_LOOP_RETRY_BUDGET_S=240
+# Classic tap-zoom: a tap the classifier reads as a concrete place/thing
+# zoom-continues the tapped region (Kontext — the pixels you tapped, closer)
+# instead of fresh-generating a lookalike; concepts/diagram parts keep the
+# fresh labelled explainer. Default ON; kill-switch below.
+# TAP_ZOOM_CONTINUE=true
 
 # --- Web (apps/web/.env.local) ---
 # Cloudflare R2 (S3-compatible)

--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -282,6 +282,10 @@ class GenerateBody(BaseModel):
     prefetched_subject: str | None = None
     prefetched_style: str | None = None
     prefetched_subject_context: str | None = None
+    # The prefetch's enter_as classification (scene|submap|explainer) — lets a
+    # warm classic tap route to the faithful zoom (TAP_ZOOM_CONTINUE) without a
+    # second resolve. Whitelist-mapped in tap.py; anything else is ignored.
+    prefetched_enter_as: str | None = None
     # World Mode semi-autonomy already resolved the tap client-side; this carries
     # the resolver's spatial-anchor note back so the planner can keep the
     # entered place's neighbours where the parent map had them.
@@ -1312,6 +1316,7 @@ async def precompute_candidates(req: Request, body: PrecomputeBody):
                     "subject": c.subject,
                     "style": c.style,
                     "salience": c.salience,
+                    "enter_as": c.enter_as,
                 }
                 for c in cands
             ],

--- a/apps/modal-backend/providers/generate_modes/tap.py
+++ b/apps/modal-backend/providers/generate_modes/tap.py
@@ -40,6 +40,26 @@ _ENTER_AS_TO_RENDER: dict[str, str] = {
     "explainer": "explainer",
 }
 
+# Classic-mode twin (TAP_ZOOM_CONTINUE): a tap on a concrete place/thing
+# zoom-continues the tapped pixels (Kontext) instead of fresh-generating a
+# lookalike — the region crop the client already sends finally BITES (the
+# fresh path's fal nano ignores refs). Register split on purpose: `submap`
+# rides the cartographic zoom register; `scene` rides place_closeup's "view"
+# register ("from the SAME viewpoint the reference shows") so a tapped castle
+# in a watercolor scene doesn't get map wording. `explainer` maps to nothing —
+# concepts/diagram parts keep today's fresh labelled explainer.
+_CLASSIC_ENTER_AS_TO_RENDER: dict[str, str] = {
+    "scene": "place_closeup",
+    "submap": "place_submap",
+}
+
+
+def _classic_zoom_mode(enter_as: str | None) -> str | None:
+    """The classic tap's zoom render mode, or None to stay fresh."""
+    if not env_flag("TAP_ZOOM_CONTINUE", "true"):
+        return None
+    return _CLASSIC_ENTER_AS_TO_RENDER.get((enter_as or "").strip().lower())
+
 
 async def stream_tap(
     body: GenerateBody,
@@ -130,6 +150,25 @@ async def stream_tap(
             surroundings_behind_effective = (
                 _sanitize_hint(body.surroundings_behind, 240) or None
             )
+            # Classic warm tap: the prefetch cache carried the classifier's
+            # enter_as — route zoomable taps to the faithful Kontext zoom
+            # without a second resolve. Needs a region ref to bite (else
+            # select_operation falls back to fresh anyway).
+            if (
+                not effective_world_mode
+                and not render_mode
+                and body.condition_image_urls
+            ):
+                mapped = _classic_zoom_mode(body.prefetched_enter_as)
+                if mapped:
+                    render_mode = mapped
+                    log(
+                        "info",
+                        "tap.zoom_route",
+                        enter_as=body.prefetched_enter_as,
+                        render_mode=mapped,
+                        source="prefetched",
+                    )
             yield _sse(
                 {
                     "type": "status",
@@ -160,6 +199,22 @@ async def stream_tap(
                 render_mode = _ENTER_AS_TO_RENDER.get(
                     resolution.enter_as, "explainer"
                 )
+            elif (
+                not effective_world_mode
+                and not render_mode
+                and body.condition_image_urls
+            ):
+                # Classic cold tap: the in-band resolve just classified it.
+                mapped = _classic_zoom_mode(resolution.enter_as)
+                if mapped:
+                    render_mode = mapped
+                    log(
+                        "info",
+                        "tap.zoom_route",
+                        enter_as=resolution.enter_as,
+                        render_mode=mapped,
+                        source="resolved",
+                    )
             if resolution.subject:
                 effective_query = resolution.subject
                 yield _sse(

--- a/apps/modal-backend/providers/llm/click.py
+++ b/apps/modal-backend/providers/llm/click.py
@@ -78,6 +78,10 @@ class ClickCandidate:
     subject: str
     style: str
     salience: float
+    # scene | submap | explainer — same classification as ClickResolution, so a
+    # warm tap on a precomputed bucket can route to the faithful zoom without a
+    # second resolve (TAP_ZOOM_CONTINUE).
+    enter_as: str = "explainer"
 
 
 # JSON Schemas for the structured-output ladder. Used as the `tool` rung's
@@ -131,6 +135,10 @@ CANDIDATES_SCHEMA: dict[str, Any] = {
                     "subject": {"type": "string"},
                     "style": {"type": "string"},
                     "salience": {"type": "number"},
+                    "enter_as": {
+                        "type": "string",
+                        "enum": ["scene", "submap", "explainer"],
+                    },
                 },
                 "required": ["x_pct", "y_pct", "subject"],
             },
@@ -213,6 +221,20 @@ async def click_to_subject(
                 "Return an empty array when you are confident or when `enter_as` "
                 "is \"explainer\"."
             )
+    else:
+        # Classic mode classifies too (TAP_ZOOM_CONTINUE): a tap on a concrete
+        # place/thing zoom-continues the tapped pixels instead of fresh-generating
+        # a lookalike; abstract concepts keep the fresh labelled explainer.
+        world_clause = (
+            " (9) `enter_as` — one of \"scene\", \"submap\", or \"explainer\": "
+            "\"scene\" when the crosshair is on a concrete place or physical "
+            "thing the user would move CLOSER to (a building, landmark, room, "
+            "vehicle, creature, terrain feature); \"submap\" when the parent "
+            "image reads as a map or plan and the target is a sub-area best "
+            "shown as a closer map; \"explainer\" when it is an abstract "
+            "concept, mechanism, process, or diagram element best served by a "
+            "fresh labelled diagram."
+        )
     system = (
         "You examine a generated illustration of the page titled "
         f"'{parent_title}' (user query: '{parent_query}'). A red crosshair with "
@@ -466,7 +488,13 @@ async def precompute_click_candidates(
         "\"subject\": \"2-8 word noun phrase\", "
         "\"style\": \"<=30 word visual style sentence — same for every "
         "candidate, describing this illustration's medium/palette/line-work\", "
-        "\"salience\": 0..1}, ...]}. Coordinates are 0..1 with origin at the "
+        "\"salience\": 0..1, "
+        "\"enter_as\": \"scene|submap|explainer\"}, ...]}. `enter_as`: "
+        "\"scene\" = a concrete place or physical thing the reader would move "
+        "CLOSER to; \"submap\" = the page reads as a map/plan and this is a "
+        "sub-area best shown as a closer map; \"explainer\" = an abstract "
+        "concept, mechanism, or diagram element best served by a fresh "
+        "labelled diagram. Coordinates are 0..1 with origin at the "
         "top-left of the image. Sort by salience descending."
         + locale_clause
     )
@@ -517,6 +545,7 @@ async def precompute_click_candidates(
         style = str(entry.get("style", "")).strip()
         if not subject:
             continue
+        enter_as_raw = str(entry.get("enter_as", "")).strip().lower()
         out.append(
             ClickCandidate(
                 x_pct=x,
@@ -524,6 +553,11 @@ async def precompute_click_candidates(
                 subject=subject,
                 style=style,
                 salience=max(0.0, min(1.0, sal)),
+                enter_as=(
+                    enter_as_raw
+                    if enter_as_raw in ("scene", "submap", "explainer")
+                    else "explainer"
+                ),
             )
         )
         if len(out) >= max_candidates:

--- a/apps/modal-backend/tests/conftest.py
+++ b/apps/modal-backend/tests/conftest.py
@@ -50,6 +50,8 @@ _SCRUB = (
     # Enter-via-edit (default ON — scrub so a host kill-switch can't silently
     # flip the routing tests) + the edit-tier knobs it can interact with.
     "ENTER_EDIT_REF",
+    # Classic tap-zoom routing (default ON — same hermeticity reasoning).
+    "TAP_ZOOM_CONTINUE",
     # View grammar (default ON — same hermeticity reasoning).
     "VIEW_GRAMMAR",
     "FAL_ENTER_MODEL",

--- a/apps/modal-backend/tests/test_click_resolution.py
+++ b/apps/modal-backend/tests/test_click_resolution.py
@@ -255,3 +255,101 @@ def test_build_parses_surroundings_and_defaults_empty() -> None:
         {"subject": "x"}, x_pct=0.5, y_pct=0.5, fallback_subject="X"
     )
     assert bare.surroundings == ""
+
+
+# ---------- classic-mode classification (TAP_ZOOM_CONTINUE) ------------------
+#
+# Classic taps classify too now: the prompt asks for `enter_as` in BOTH modes
+# (wording differs), and precompute candidates carry it so warm taps can route
+# to the faithful zoom without a second resolve.
+
+
+def test_click_prompt_asks_enter_as_in_classic_mode(monkeypatch) -> None:
+    import asyncio
+    from unittest.mock import AsyncMock
+
+    from providers.llm import click as click_mod
+
+    captured: dict = {}
+
+    async def fake_complete_json(**kwargs):
+        captured["messages"] = kwargs.get("messages")
+        return {"subject": "x"}
+
+    monkeypatch.setattr(click_mod._llm, "_complete_json", AsyncMock(side_effect=fake_complete_json))
+    asyncio.run(
+        click_mod.click_to_subject(
+            image_data_url="data:image/jpeg;base64,x",
+            x_pct=0.5,
+            y_pct=0.5,
+            parent_title="T",
+            parent_query="q",
+            world_mode=False,
+        )
+    )
+    system = str(captured["messages"][0]["content"])
+    assert "`enter_as`" in system
+    # classic wording, not the world-mode "step INTO" phrasing
+    assert "move CLOSER to" in system
+    assert "step INTO" not in system
+
+
+def test_click_prompt_world_mode_wording_unchanged(monkeypatch) -> None:
+    import asyncio
+    from unittest.mock import AsyncMock
+
+    from providers.llm import click as click_mod
+
+    captured: dict = {}
+
+    async def fake_complete_json(**kwargs):
+        captured["messages"] = kwargs.get("messages")
+        return {"subject": "x"}
+
+    monkeypatch.setattr(click_mod._llm, "_complete_json", AsyncMock(side_effect=fake_complete_json))
+    asyncio.run(
+        click_mod.click_to_subject(
+            image_data_url="data:image/jpeg;base64,x",
+            x_pct=0.5,
+            y_pct=0.5,
+            parent_title="T",
+            parent_query="q",
+            world_mode=True,
+        )
+    )
+    system = str(captured["messages"][0]["content"])
+    assert "step INTO" in system  # the world clause is byte-identical
+    assert "place_form" in system
+
+
+def test_precompute_candidates_parse_enter_as(monkeypatch) -> None:
+    import asyncio
+    from unittest.mock import AsyncMock
+
+    from providers.llm import click as click_mod
+
+    async def fake_complete_json(**kwargs):
+        return {
+            "candidates": [
+                {"x_pct": 0.2, "y_pct": 0.3, "subject": "castle", "salience": 0.9,
+                 "enter_as": "scene"},
+                {"x_pct": 0.6, "y_pct": 0.5, "subject": "legend box", "salience": 0.5,
+                 "enter_as": "bogus-value"},
+                {"x_pct": 0.8, "y_pct": 0.7, "subject": "harbor", "salience": 0.7},
+            ]
+        }
+
+    monkeypatch.setattr(click_mod._llm, "_complete_json", AsyncMock(side_effect=fake_complete_json))
+    cands = asyncio.run(
+        click_mod.precompute_click_candidates(
+            image_data_url="data:image/jpeg;base64,x",
+            parent_title="T",
+            parent_query="q",
+        )
+    )
+    by_subject = {c.subject: c for c in cands}
+    assert by_subject["castle"].enter_as == "scene"
+    # non-whitelisted value coerces to the safe default
+    assert by_subject["legend box"].enter_as == "explainer"
+    # absent → default
+    assert by_subject["harbor"].enter_as == "explainer"

--- a/apps/modal-backend/tests/test_generate_enter.py
+++ b/apps/modal-backend/tests/test_generate_enter.py
@@ -283,3 +283,157 @@ def test_same_place_judge_defaults_to_step_in(monkeypatch) -> None:
     assert generate._same_place_judge(judge) is judge.score_step_in
     monkeypatch.setenv("ENTER_STEP_IN_JUDGE", "false")
     assert generate._same_place_judge(judge) is judge.score_continuation
+
+
+# ---------- classic tap-zoom (TAP_ZOOM_CONTINUE, default ON) ------------------
+#
+# "Zooming in just creates a new image, similar but totally different": classic
+# taps rode the FRESH text-to-image path, whose fal nano endpoints IGNORE the
+# region ref the client sends. These pin the fix — a tap the classifier reads
+# as a concrete place/thing (enter_as scene|submap) rides the same Kontext
+# zoom_continue as a world submap tap, so the arrival IS the tapped region.
+
+
+def _mock_continue(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    cont = AsyncMock(
+        return_value=GeneratedImage(
+            b"jpeg", "image/jpeg", "fal-ai/flux-pro/kontext", "r4"
+        )
+    )
+    monkeypatch.setattr(image_edit_mod, "continue_image", cont)
+    return cont
+
+
+def _classic_body(**over: Any) -> GenerateBody:
+    """A classic (world OFF) warm tap: no render_mode from the client, the
+    prefetch cache carried the classification."""
+    defaults: dict[str, Any] = {
+        "render_mode": None,
+        "world_mode": False,
+        "prefetched_enter_as": "submap",
+    }
+    defaults.update(over)
+    return _tap_body(**defaults)
+
+
+async def test_classic_tap_prefetched_enter_as_submap_zoom_continues(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_plan(monkeypatch)
+    edit = _mock_edit(monkeypatch)
+    cont = _mock_continue(monkeypatch)
+    gen = _mock_fresh(monkeypatch)
+
+    await _collect(_event_stream(_classic_body(), "t1"))
+
+    cont.assert_awaited_once()
+    assert cont.await_args.args[0] == "data:r"  # the region crop is the source
+    edit.assert_not_awaited()
+    gen.assert_not_awaited()
+
+
+async def test_classic_tap_prefetched_enter_as_scene_zoom_continues(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # `scene` maps to place_closeup — the VIEW register ("from the SAME
+    # viewpoint the reference shows"), not the cartographic map wording, so a
+    # tapped castle in a watercolor scene doesn't get map instructions.
+    _mock_plan(monkeypatch)
+    _mock_edit(monkeypatch)
+    cont = _mock_continue(monkeypatch)
+    gen = _mock_fresh(monkeypatch)
+
+    await _collect(_event_stream(_classic_body(prefetched_enter_as="scene"), "t1"))
+
+    cont.assert_awaited_once()
+    gen.assert_not_awaited()
+    instruction = cont.await_args.args[1]
+    assert "from the SAME viewpoint the reference shows" in instruction
+
+
+async def test_classic_tap_prefetched_enter_as_explainer_stays_fresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Concepts / diagram parts keep the fresh labelled explainer — the
+    # product's "tap = topical depth" survives where it's the point.
+    monkeypatch.setenv("PROGRESSIVE_DRAFT", "false")
+    _mock_plan(monkeypatch)
+    edit = _mock_edit(monkeypatch)
+    cont = _mock_continue(monkeypatch)
+    gen = _mock_fresh(monkeypatch)
+
+    await _collect(
+        _event_stream(_classic_body(prefetched_enter_as="explainer"), "t1")
+    )
+
+    gen.assert_awaited_once()
+    cont.assert_not_awaited()
+    edit.assert_not_awaited()
+
+
+async def test_classic_tap_zoom_kill_switch_stays_fresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TAP_ZOOM_CONTINUE", "false")
+    monkeypatch.setenv("PROGRESSIVE_DRAFT", "false")
+    _mock_plan(monkeypatch)
+    _mock_edit(monkeypatch)
+    cont = _mock_continue(monkeypatch)
+    gen = _mock_fresh(monkeypatch)
+
+    await _collect(_event_stream(_classic_body(), "t1"))
+
+    gen.assert_awaited_once()
+    cont.assert_not_awaited()
+
+
+async def test_classic_cold_tap_classified_scene_zoom_continues(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # No prefetch — the in-band resolve classifies, and the classic router
+    # maps it the same way.
+    from providers.llm import ClickResolution
+
+    _mock_plan(monkeypatch)
+    _mock_edit(monkeypatch)
+    cont = _mock_continue(monkeypatch)
+    gen = _mock_fresh(monkeypatch)
+    monkeypatch.setattr(
+        llm_mod,
+        "click_to_subject",
+        AsyncMock(
+            return_value=ClickResolution(
+                subject="The Skull Rock", style="watercolor", enter_as="scene"
+            )
+        ),
+    )
+
+    await _collect(
+        _event_stream(
+            _classic_body(prefetched_subject=None, prefetched_enter_as=None), "t1"
+        )
+    )
+
+    cont.assert_awaited_once()
+    gen.assert_not_awaited()
+
+
+async def test_classic_zoom_without_region_stays_fresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # No condition refs → nothing to zoom into; the router must not set a
+    # zoom mode it can't honour (select_operation would fall back anyway,
+    # but place_* would still flip the planner register).
+    monkeypatch.setenv("PROGRESSIVE_DRAFT", "false")
+    _mock_plan(monkeypatch)
+    cont = _mock_continue(monkeypatch)
+    gen = _mock_fresh(monkeypatch)
+
+    await _collect(
+        _event_stream(
+            _classic_body(condition_image_urls=None, condition_roles=None), "t1"
+        )
+    )
+
+    gen.assert_awaited_once()
+    cont.assert_not_awaited()

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -67,21 +67,29 @@ h3,
   100% { opacity: 1;   filter: blur(0px) saturate(1.0); }
 }
 
-/* A real push-in toward the tapped point while the next page decodes: the wait
- * genuinely previews "diving into what you touched" — the tapped region grows to
- * fill the frame (≈2.6×), softening slightly as it rushes in, then the next page
- * blooms from that same point. transform-origin is set inline to the tap px;
- * reduce-motion resets it below. `filter` here (last in the animation list) wins
- * over ec-shimmer's, so it owns the depth blur; shimmer keeps the opacity pulse. */
+/* The DIVE: only applied when the tap is KNOWN to zoom-continue (classifier
+ * said scene/submap), so the motion's promise matches the pixels — the tapped
+ * region grows to fill the frame at exactly the magnification the Kontext
+ * arrival renders (--ec-dive-scale = 1/REGION_FRAC, set inline from TS).
+ * transform-origin = the clamped region-crop centre. `filter` here (last in
+ * the list) wins over ec-shimmer's, so it owns the depth blur; shimmer keeps
+ * the opacity pulse. Reduce-motion resets it below. */
 @keyframes ec-morph-zoom {
-  0%   { transform: scale(1);   filter: blur(0px); }
-  100% { transform: scale(2.6); filter: blur(1px); }
+  0%   { transform: scale(1);                             filter: blur(0px); }
+  100% { transform: scale(var(--ec-dive-scale, 2.38));    filter: blur(1px); }
 }
 
 .ec-morph-old {
   animation: ec-shimmer 1.4s ease-in-out infinite,
              ec-morph-zoom 5.5s cubic-bezier(0.3, 0.7, 0.4, 1) forwards;
   will-change: opacity, filter, transform;
+}
+
+/* Non-zoom taps (fresh explainer arrivals) keep the pre-dive wait look:
+ * shimmer only, no push-in — the motion never over-promises. */
+.ec-morph-shimmer {
+  animation: ec-shimmer 1.4s ease-in-out infinite;
+  will-change: opacity, filter;
 }
 
 .ec-morph-new {
@@ -108,6 +116,7 @@ h3,
     animation: none !important;
   }
   .ec-morph-old,
+  .ec-morph-shimmer,
   .ec-morph-new {
     animation: none !important;
     transition: opacity 180ms linear !important;

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ChangeEvent, CSSProperties, DragEvent, FormEvent } from "react";
 import type {
   Citation,
+  EnterAs,
   EntityEditPlan,
   GenerateRequestBody,
   GenerateEvent,
@@ -50,7 +51,13 @@ import { useLoopKnobs, wireFields } from "@/hooks/useSpeedPreset";
 import { useSharedSession } from "@/hooks/useSharedSession";
 import { useExpandBloom } from "@/hooks/useExpandBloom";
 import { type Ascended, useAscend } from "@/hooks/useAscend";
-import { buildConditionRefs, cropBox, orderedRefs } from "@/lib/image-condition";
+import {
+  buildConditionRefs,
+  cropBox,
+  diveOriginPx,
+  orderedRefs,
+  REGION_FRAC,
+} from "@/lib/image-condition";
 import { enterAsToRenderMode, findRevisitTarget } from "@/lib/world-mode";
 import { usePersistedLocale } from "@/hooks/usePersistedLocale";
 import { usePersistedTheme } from "@/hooks/usePersistedTheme";
@@ -435,6 +442,13 @@ export default function PlayPage() {
   }, [blankTap]);
   // Wander (auto-explore): the world explores itself, hands-free. See useWander.
   const [wandering, setWandering] = useState(false);
+  // The click handler closes over state at dispatch time; Wander's synthetic
+  // taps must read the LIVE value (withhold zoom routing mid-wander), so
+  // mirror it into a ref.
+  const wanderingRef = useRef(false);
+  useEffect(() => {
+    wanderingRef.current = wandering;
+  }, [wandering]);
   // ⌘/Ctrl-click hint capture via an inline floating input anchored at the
   // click point. The promise resolves to the typed hint (or null on
   // cancel/Esc) so the click handler can stay a single async function.
@@ -1961,6 +1975,7 @@ export default function PlayPage() {
             subject: string;
             style: string;
             salience: number;
+            enter_as?: string;
           }[];
         };
         if (!Array.isArray(data.candidates)) return;
@@ -1971,7 +1986,11 @@ export default function PlayPage() {
           if ((counts.get(scope) ?? 0) >= PREFETCH_PER_PAGE) break;
           const key = bucketKey(nodeId, c.x_pct, c.y_pct);
           if (cache.has(key)) continue;
-          cache.set(key, { subject: c.subject, style: c.style });
+          cache.set(key, {
+            subject: c.subject,
+            style: c.style,
+            ...(typeof c.enter_as === "string" ? { enter_as: c.enter_as } : {}),
+          });
           counts.set(scope, (counts.get(scope) ?? 0) + 1);
           // LRU evict oldest entries when we exceed the global cap.
           if (cache.size > PREFETCH_LRU_MAX) {
@@ -2054,6 +2073,7 @@ export default function PlayPage() {
             confidence?: number;
             point?: { x: number; y: number } | null;
             bbox?: { x: number; y: number; w: number; h: number } | null;
+            enter_as?: string;
           };
           if (data.subject) {
             cache.set(key, {
@@ -2068,6 +2088,9 @@ export default function PlayPage() {
                 : {}),
               ...(data.point ? { point: data.point } : {}),
               ...(data.bbox ? { bbox: data.bbox } : {}),
+              ...(typeof data.enter_as === "string"
+                ? { enter_as: data.enter_as }
+                : {}),
             });
             pageBucketCounts.set(
               pageScope,
@@ -2293,17 +2316,51 @@ export default function PlayPage() {
       const reduceMotion =
         typeof window !== "undefined" &&
         window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+      // The prefetch verdict is needed BEFORE the morph starts: it decides both
+      // the blank-tap rejection below and whether the wait-phase may DIVE (only
+      // a tap that is KNOWN to zoom-continue earns the push-in — anything else
+      // gets the honest shimmer). Skip when a hint is present (the prefetch was
+      // resolved without the user's note) or in World Mode (backend classifies).
+      const cached =
+        hint || worldEnabled
+          ? undefined
+          : cache.get(bucketKey(currentNodeId, click.x_pct, click.y_pct));
+      const willZoom =
+        !hint &&
+        !worldEnabled &&
+        !wanderingRef.current &&
+        cached?.groundable !== false &&
+        (cached?.enter_as === "scene" || cached?.enter_as === "submap");
+      // Dive converges on the CLAMPED region-crop centre (an edge tap clamps
+      // the crop inward, and the arrival renders that crop) — in element px
+      // over the object-fit:contain content rect.
+      let diveOx = px;
+      let diveOy = py;
+      if (willZoom) {
+        const content = objectContainRect(
+          rect.width,
+          rect.height,
+          img.naturalWidth,
+          img.naturalHeight
+        );
+        if (content) {
+          const o = diveOriginPx(click.x_pct, click.y_pct, REGION_FRAC, content);
+          diveOx = o.x;
+          diveOy = o.y;
+        }
+      }
       setMorphFx({
-        ox: px,
-        oy: py,
+        ox: diveOx,
+        oy: diveOy,
         prevImg: currentImage,
         nextImg: null,
         phase: "wait",
         isFinal: false,
         startedAt: nowMs(),
         reduceMotion,
+        dive: willZoom,
       });
-      hudEmit("morph:start", { ox: px, oy: py, t: nowMs() });
+      hudEmit("morph:start", { ox: diveOx, oy: diveOy, t: nowMs() });
       let annotated = currentImage;
       try {
         annotated = await annotateClickPoint(
@@ -2315,15 +2372,6 @@ export default function PlayPage() {
         // Fall back to the raw image + numeric coords if canvas taint or
         // decode failed. VLM still gets the text coords as a hint.
       }
-      // Skip the prefetched-subject shortcut when a hint is present — the
-      // hover prefetch was resolved without the user's note, so it would
-      // ignore the angle they just typed.
-      // In World Mode we skip the hover-prefetch shortcut so the backend always
-      // classifies the tap (scene / sub-map / explainer) and frames the page.
-      const cached =
-        hint || worldEnabled
-          ? undefined
-          : cache.get(bucketKey(currentNodeId, click.x_pct, click.y_pct));
       // HUD visibility for the silent hover warming (UI_AUDIT #10): count
       // only clicks where the shortcut was eligible — a deliberate skip
       // (hint / world mode) is neither a hit nor a miss.
@@ -2513,6 +2561,15 @@ export default function PlayPage() {
               prefetched_style: cached.style,
               ...(cached.subject_context
                 ? { prefetched_subject_context: cached.subject_context }
+                : {}),
+              // Zoomable classification → the backend routes this tap to the
+              // faithful Kontext zoom (TAP_ZOOM_CONTINUE). Withheld while
+              // Wandering: auto-taps stay topical, or compounding region
+              // crops would degrade the descent after a few hops.
+              ...(cached.enter_as &&
+              (cached.enter_as === "scene" || cached.enter_as === "submap") &&
+              !wanderingRef.current
+                ? { prefetched_enter_as: cached.enter_as as EnterAs }
                 : {}),
             }
           : {}),

--- a/apps/web/components/PlayPage/MorphImagePair.tsx
+++ b/apps/web/components/PlayPage/MorphImagePair.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import type { RefObject, TransitionEvent } from "react";
+import type { CSSProperties, RefObject, TransitionEvent } from "react";
 
 import type { MorphFx } from "@/hooks/useImageMorph";
-import { inkMorphStyle } from "@/lib/morph-style";
+import { DIVE_END_SCALE, inkMorphStyle } from "@/lib/morph-style";
 
 interface Props {
   imgRef: RefObject<HTMLImageElement | null>;
@@ -46,18 +46,31 @@ export function MorphImagePair({
           aria-hidden
           className={
             "absolute inset-0 block h-full w-full object-contain select-none " +
-            (morphFx.phase === "wait" && !morphFx.reduceMotion ? "ec-morph-old" : "")
+            (morphFx.phase === "wait" && !morphFx.reduceMotion
+              ? // Dive only when the arrival is KNOWN to be a zoom-continuation
+                // of the tapped region; otherwise the old gentle shimmer, so
+                // the motion never promises a zoom the fresh path won't keep.
+                morphFx.dive
+                ? "ec-morph-old"
+                : "ec-morph-shimmer"
+              : "")
           }
-          style={{
-            opacity: morphFx.phase === "reveal" ? 0 : 1,
-            transition: "opacity 480ms cubic-bezier(0.22, 0.61, 0.36, 1)",
-            // Push the wait-phase zoom toward the tapped point (ox/oy are px in
-            // this layer's own box). Falls back to centre if no origin.
-            transformOrigin:
-              typeof morphFx.ox === "number" && typeof morphFx.oy === "number"
-                ? `${morphFx.ox}px ${morphFx.oy}px`
-                : "center",
-          }}
+          style={
+            {
+              opacity: morphFx.phase === "reveal" ? 0 : 1,
+              transition: "opacity 480ms cubic-bezier(0.22, 0.61, 0.36, 1)",
+              // Push the wait-phase dive toward the region-crop centre (ox/oy
+              // px in this layer's box). Falls back to centre if no origin.
+              transformOrigin:
+                typeof morphFx.ox === "number" && typeof morphFx.oy === "number"
+                  ? `${morphFx.ox}px ${morphFx.oy}px`
+                  : "center",
+              // Single TS source of truth for the dive's end scale — derived
+              // from the region-crop fraction so the motion ends where the
+              // zoom-continued arrival begins.
+              "--ec-dive-scale": String(DIVE_END_SCALE),
+            } as CSSProperties
+          }
           draggable={false}
         />
       ) : null}

--- a/apps/web/hooks/useImageMorph.ts
+++ b/apps/web/hooks/useImageMorph.ts
@@ -13,6 +13,13 @@ export interface MorphFx {
   isFinal: boolean;
   startedAt: number;
   reduceMotion: boolean;
+  /**
+   * True only when the tap is KNOWN to zoom-continue (classifier said
+   * scene/submap): the wait phase pushes into the tapped region and the
+   * arrival really is that region, closer. Absent/false → shimmer only, so
+   * the motion never promises a zoom the fresh path won't deliver.
+   */
+  dive?: boolean;
 }
 
 /**

--- a/apps/web/hooks/usePrefetchCache.ts
+++ b/apps/web/hooks/usePrefetchCache.ts
@@ -26,6 +26,12 @@ export interface PrefetchEntry {
   confidence?: number;
   point?: PrefetchPoint | null;
   bbox?: PrefetchBBox | null;
+  /**
+   * scene | submap | explainer — the resolver's classification of the tapped
+   * thing. Zoomable taps (scene/submap) route to the faithful Kontext
+   * zoom-continuation server-side (TAP_ZOOM_CONTINUE) and dive client-side.
+   */
+  enter_as?: string;
 }
 
 export const PREFETCH_PER_PAGE = 6;

--- a/apps/web/lib/image-condition.test.ts
+++ b/apps/web/lib/image-condition.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { cropBox, orderedRefs, regionUpscale } from "./image-condition";
+import { cropBox, diveOriginPx, orderedRefs, REGION_FRAC, regionUpscale } from "./image-condition";
 
 /**
  * Pure core of the image-conditioning reference stack: where the region crop
@@ -83,5 +83,28 @@ describe("buildConditionRefs regionWhole (transition tap)", () => {
     });
     expect(refs.roles).toEqual(["region", "style"]);
     expect(refs.urls[0]).toBe("data:image/jpeg;base64,UEFSRU5U");
+  });
+});
+
+describe("diveOriginPx (the dive's convergence point)", () => {
+  const content = { offsetX: 10, offsetY: 20, width: 1000, height: 500 };
+
+  it("centred tap: origin = the tap itself, in element px", () => {
+    const o = diveOriginPx(0.5, 0.5, REGION_FRAC, content);
+    expect(o.x).toBeCloseTo(10 + 0.5 * 1000);
+    expect(o.y).toBeCloseTo(20 + 0.5 * 500);
+  });
+
+  it("edge tap: origin is the CLAMPED crop centre, not the raw tap", () => {
+    // Tap at the very corner — cropBox clamps to [0, frac], so its centre is
+    // frac/2 in from the edge; the arrival renders that crop, so the dive
+    // must aim there.
+    const o = diveOriginPx(0, 0, REGION_FRAC, content);
+    expect(o.x).toBeCloseTo(10 + (REGION_FRAC / 2) * 1000);
+    expect(o.y).toBeCloseTo(20 + (REGION_FRAC / 2) * 500);
+  });
+
+  it("REGION_FRAC is the conditioning default", () => {
+    expect(REGION_FRAC).toBe(0.42);
   });
 });

--- a/apps/web/lib/image-condition.ts
+++ b/apps/web/lib/image-condition.ts
@@ -18,6 +18,35 @@ export interface ConditionRefs {
 }
 
 /**
+ * The default region-crop fraction per axis: a tap conditions on the 42% box
+ * around it. The dive animation's end scale derives from this (1/0.42 ≈ 2.38)
+ * so the load-wait push-in lands where the zoom-continued arrival begins.
+ */
+export const REGION_FRAC = 0.42;
+
+/**
+ * Where the dive animation should converge, in element px: the CENTER of the
+ * clamped region crop (not the raw tap — an edge tap clamps the crop inward, and
+ * the zoom-continued arrival renders THAT crop, so the dive must aim at it).
+ * `content` is the object-fit:contain rect of the image inside its element
+ * (lib/image-click.objectContainRect). Pure.
+ */
+export function diveOriginPx(
+  xPct: number,
+  yPct: number,
+  frac: number,
+  content: { offsetX: number; offsetY: number; width: number; height: number },
+): { x: number; y: number } {
+  const box = cropBox(xPct, yPct, frac);
+  const cx = box.x + box.w / 2;
+  const cy = box.y + box.h / 2;
+  return {
+    x: content.offsetX + cx * content.width,
+    y: content.offsetY + cy * content.height,
+  };
+}
+
+/**
  * Crop rectangle (normalised 0..1) of `frac` per axis, centred on the click and
  * clamped so it stays inside the image. Pure — the geometry the region crop draws.
  */
@@ -148,7 +177,7 @@ export async function buildConditionRefs(opts: {
           cropBox(
             opts.click!.xPct,
             opts.click!.yPct,
-            opts.regionFrac ?? 0.42,
+            opts.regionFrac ?? REGION_FRAC,
           ),
       );
     } catch {

--- a/apps/web/lib/morph-style.test.ts
+++ b/apps/web/lib/morph-style.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest";
+import { REGION_FRAC } from "./image-condition";
 
 import type { MorphFx } from "@/hooks/useImageMorph";
 
-import { inkMorphStyle } from "./morph-style";
+import { DIVE_END_SCALE, inkMorphStyle } from "./morph-style";
 
 const baseFx: MorphFx = {
   ox: 120,
@@ -62,5 +63,11 @@ describe("inkMorphStyle", () => {
     const revealS = inkMorphStyle({ ...baseFx, phase: "reveal", reduceMotion: true });
     expect(revealS?.maskImage).toBeUndefined();
     expect(revealS?.opacity).toBe(1);
+  });
+});
+
+describe("DIVE_END_SCALE (motion promise = pixel reality)", () => {
+  it("derives from the region-crop fraction the arrival renders", () => {
+    expect(DIVE_END_SCALE).toBeCloseTo(1 / REGION_FRAC, 6);
   });
 });

--- a/apps/web/lib/morph-style.ts
+++ b/apps/web/lib/morph-style.ts
@@ -1,6 +1,14 @@
 import type { CSSProperties } from "react";
 
 import type { MorphFx } from "@/hooks/useImageMorph";
+import { REGION_FRAC } from "@/lib/image-condition";
+
+/**
+ * The dive's end scale = the magnification the zoom-continued arrival applies
+ * (the REGION_FRAC crop re-rendered to the full frame). Deriving it keeps the
+ * motion's promise and the pixels' reality in lockstep.
+ */
+export const DIVE_END_SCALE = 1 / REGION_FRAC;
 
 const MASK_GRADIENT = "radial-gradient(circle, #000 55%, transparent 78%)";
 const MASK_TRANSITION =

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -133,6 +133,10 @@ export interface GenerateRequestBody {
   // frames"). Backend feeds this to plan_page as authoritative meaning so
   // ambiguous phrases stay in the parent's domain.
   prefetched_subject_context?: string;
+  // The prefetch's enter_as classification. Lets a warm classic tap route to
+  // the faithful zoom-continuation (TAP_ZOOM_CONTINUE) without a second
+  // resolve; backend whitelist-maps it, anything else is ignored.
+  prefetched_enter_as?: EnterAs;
   // World Mode: the resolver's spatial-anchor note ("river to the south, the
   // Citadel NE") carried back so the planner keeps the entered place's
   // neighbours where the parent map had them. Mirrors GenerateBody.
@@ -267,9 +271,10 @@ export interface ResolveClickResponse {
   confidence?: number;
   point?: ResolveClickPoint | null;
   bbox?: ResolveClickBBox | null;
-  // World Mode: the resolver's read of what was tapped (a place to step into, a
-  // sub-area to map closer, or a concept to explain) + up to two short
-  // clarifying questions (semi autonomy only). Absent in classic mode.
+  // The resolver's read of what was tapped (a place to step into / move closer
+  // to, a sub-area to map closer, or a concept to explain). Classified in EVERY
+  // mode since TAP_ZOOM_CONTINUE — classic mode uses it to route zoomable taps
+  // to the faithful Kontext continuation. Clarifiers: world semi autonomy only.
   enter_as?: EnterAs;
   clarifiers?: string[];
   // World Mode spatial anchor: what sits AROUND the tapped spot and in which

--- a/scripts/record-demo/record-features.ts
+++ b/scripts/record-demo/record-features.ts
@@ -41,6 +41,33 @@ interface H {
 
 const imgLoc = (p: Page) => p.locator('img[alt^="Generated illustration"]').first();
 
+/** Convert IMAGE-frame fractions (what resolvers/candidates use) to viewport
+ *  px through the object-fit:contain content rect, so letterboxing doesn't
+ *  skew taps. Falls back to element-box fractions if natural size is absent. */
+async function imageFramePoint(
+  p: Page,
+  xPct: number,
+  yPct: number,
+): Promise<{ x: number; y: number }> {
+  const pt = await imgLoc(p).evaluate(
+    (el, f) => {
+      const img = el as HTMLImageElement;
+      const r = img.getBoundingClientRect();
+      if (!img.naturalWidth || !img.naturalHeight) {
+        return { x: r.left + r.width * f.x, y: r.top + r.height * f.y };
+      }
+      const na = img.naturalWidth / img.naturalHeight;
+      const ba = r.width / r.height;
+      let w = r.width, h = r.height, ox = 0, oy = 0;
+      if (na > ba) { h = r.width / na; oy = (r.height - h) / 2; }
+      else { w = r.height * na; ox = (r.width - w) / 2; }
+      return { x: r.left + ox + w * f.x, y: r.top + oy + h * f.y };
+    },
+    { x: xPct, y: yPct },
+  );
+  return pt;
+}
+
 const h: H = {
   base: BASE,
   img: imgLoc,
@@ -73,14 +100,12 @@ const h: H = {
     throw new Error("image never stabilized");
   },
   async hover(p, xPct, yPct) {
-    const box = await imgLoc(p).boundingBox();
-    if (!box) throw new Error("no image box");
-    await p.mouse.move(box.x + box.width * xPct, box.y + box.height * yPct, { steps: 6 });
+    const pt = await imageFramePoint(p, xPct, yPct);
+    await p.mouse.move(pt.x, pt.y, { steps: 6 });
   },
   async tap(p, xPct, yPct) {
-    const box = await imgLoc(p).boundingBox();
-    if (!box) throw new Error("no image box");
-    await p.mouse.move(box.x + box.width * xPct, box.y + box.height * yPct, { steps: 4 });
+    const pt = await imageFramePoint(p, xPct, yPct);
+    await p.mouse.move(pt.x, pt.y, { steps: 4 });
     await p.mouse.down();
     await p.mouse.up();
   },
@@ -190,19 +215,40 @@ const smarterTaps: Study = {
 const zoomIntoTap: Study = {
   name: "zoom-into-tap",
   async run(p, h) {
+    // Capture the candidates BEFORE seeding — the response listener must be
+    // armed when the page's precompute fires.
+    let candidates: { x_pct: number; y_pct: number; enter_as?: string }[] = [];
+    const candWait = p
+      .waitForResponse((r) => r.url().includes("/precompute-candidates"), {
+        timeout: 90_000,
+      })
+      .then(async (r) => {
+        const j = (await r.json().catch(() => null)) as {
+          candidates?: typeof candidates;
+        } | null;
+        candidates = j?.candidates ?? [];
+      })
+      .catch(() => {});
     await h.seed(p, "a colorful treasure map of a pirate island with a big skull rock", {
       world: false,
       style: "Storybook",
     });
-    await h.caption(p, "Zoom into the tapped point while the next page loads");
-    await p.waitForTimeout(1200);
-    // The zoom plays in the ~5s AFTER the tap, before the draft — hold on it.
+    await h.caption(p, "Tap a thing → the page ZOOMS INTO those exact pixels");
+    // Wait for the precompute so the tap lands on a WARM zoomable candidate —
+    // that's what arms both the client dive and the prefetched zoom route.
+    await candWait;
+    await p.waitForTimeout(1000);
+    const zoomable = candidates.find(
+      (c) => c.enter_as === "scene" || c.enter_as === "submap",
+    );
+    const [tx, ty] = zoomable ? [zoomable.x_pct, zoomable.y_pct] : [0.5, 0.42];
     const before = h.node(p);
-    await h.tap(p, 0.5, 0.42);
-    await p.waitForTimeout(5200); // capture the push-in toward the tap
+    await h.tap(p, tx, ty);
+    await p.waitForTimeout(5200); // the dive: pushing into the tapped region
     await h.waitNodeChange(p, before, GEN_TIMEOUT).catch(() => {});
     await h.waitStable(p);
-    await p.waitForTimeout(1500);
+    await h.caption(p, "The arrival IS the tapped region — same pixels, closer");
+    await p.waitForTimeout(2500);
   },
 };
 


### PR DESCRIPTION
## The complaint

> "zooming in just creates a new image, similar but totally different"

Correct. Classic taps rode the **fresh text-to-image** path, and fal nano **ignores reference images** (`refs=0` hardcoded) — so the region crop the client builds around every tap was a **no-op**, and the arrival was always a lookalike reinvention. The CSS dive (#144/#149) made the mismatch louder.

## The fix (routing, not new machinery)

The faithful path already existed — the wideRegionCut contract: `place_submap` + region ref → `zoom_continue` → Kontext `continue_image` ($0.04 vs $0.15, keeps landmarks/palette/line-work). This PR routes taps into it, **classification-gated** (Eren's call): **places/things zoom, diagrams stay fresh.**

- **Classify everywhere**: the click resolver now asks for `enter_as` in classic mode too (scene = concrete place/thing you'd move CLOSER to; submap = map sub-area; explainer = concept/mechanism → keeps the fresh labelled explainer). World-mode prompt bytes unchanged. **Precompute candidates carry `enter_as`** — load-bearing, since the 6 hottest buckets come from precompute and hover skips filled buckets.
- **Route**: `tap.py` maps `{scene → place_closeup, submap → place_submap}` under **`TAP_ZOOM_CONTINUE` (default ON, kill-switch)**. Register split on purpose: `scene` rides the view register ("from the SAME viewpoint the reference shows"), not map wording. Warm taps route via the new additive `prefetched_enter_as`; cold taps via the in-band resolve.
- **The dive is now honest AND registered**: fires only when the tap is KNOWN to zoom, ends at exactly the arrival's magnification (`DIVE_END_SCALE = 1/REGION_FRAC ≈ 2.38`), converges on the **clamped region-crop centre** (edge taps aim at what will actually render). Non-zoom taps get the old shimmer.
- **Wander stays topical** (withholds the classification): compounding region crops would degrade an auto-descent.

## Tests

6 routing tests (submap/scene registers, explainer-fresh, kill-switch, cold-tap classify, no-region fresh) + classic/world prompt pins + candidates parse + `diveOriginPx` centred/clamped + `DIVE_END_SCALE` derivation. Full backend pytest + ruff + mypy; web 674 vitest + tsc + circular — green.

## Cost/UX

Zoom taps get **cheaper** ($0.04 Kontext vs $0.15 nano) and skip the draft race (the dive covers Kontext's ~20s). Kontext lettering on magnified labels is shielded by the explainer classification.

Live verification + re-recorded clip to follow on this PR before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
