### PR TITLE
feat(taps): judge every zoom-continued tap (step-in gate + keep-best retry)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,6 +105,11 @@ FAL_EDIT_TIER=balanced
 # instead of fresh-generating a lookalike; concepts/diagram parts keep the
 # fresh labelled explainer. Default ON; kill-switch below.
 # TAP_ZOOM_CONTINUE=true
+# Zoom judge: every zoom-continued tap is checked by the step-in judge (the
+# arrival must be the SAME region, closer) with one keep-best retry on a
+# fail. ~$0.001 + 2-5s per tap; a failed first try adds one Kontext ($0.04).
+# TAP_ZOOM_JUDGE=true
+# TAP_ZOOM_ACCEPT=6.0
 
 # --- Web (apps/web/.env.local) ---
 # Cloudflare R2 (S3-compatible)

--- a/apps/modal-backend/providers/generate_modes/tap.py
+++ b/apps/modal-backend/providers/generate_modes/tap.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio as _asyncio
 import base64
 import contextlib
+import os
 import time as _time
 from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import TYPE_CHECKING, Any, cast
@@ -575,11 +576,74 @@ async def stream_tap(
     result: Any = None
     main_task: _asyncio.Task | None = None
     if use_continuation and region_ref is not None:
-        main_task = _asyncio.create_task(
-            image_edit_provider.continue_image(
+
+        async def _judged_zoom() -> Any:
+            """Kontext zoom with a step-in judge + one keep-best retry.
+
+            Every zoom flavour funnels here (classic scene/closeup + submap,
+            world submap, wideRegionCut), so one gate covers them all: the
+            arrival must be the tapped region seen CLOSER (score_step_in — a
+            wider redraw or an unrelated scene fails), else retry once with
+            the critic's rationale folded in and keep the better attempt.
+            TAP_ZOOM_JUDGE default ON; judge failures never block the tap.
+            """
+            first = await image_edit_provider.continue_image(
                 region_ref, zoom_instruction, model_override=body.image_model
             )
-        )
+            if not env_flag("TAP_ZOOM_JUDGE", "true") or body.verify is False:
+                return first
+            from providers import judge, render_loop
+
+            region_bytes = render_loop.data_url_bytes(region_ref)
+            if region_bytes is None:
+                return first
+            try:
+                accept = float(os.environ.get("TAP_ZOOM_ACCEPT", "6.0"))
+            except ValueError:
+                accept = 6.0
+            step_in = _same_place_judge(judge)
+            try:
+                verdict = await step_in(region_bytes, first.jpeg_bytes)
+            except Exception:
+                return first
+            log(
+                "info",
+                "tap.zoom_judge",
+                attempt=1,
+                score=verdict.score,
+                accepted=verdict.score >= accept,
+            )
+            if verdict.score >= accept:
+                return first
+            # One deadline-aware retry (same margin discipline as the render
+            # loop: never start an attempt the ingress window can't fit).
+            remaining = ingress_timeout_s - 120.0 - (_time.perf_counter() - started)
+            if remaining < 45.0:
+                return first
+            retry_instruction = (
+                zoom_instruction
+                + " A previous attempt was rejected by a reviewer: \""
+                + (verdict.rationale or "not recognisably the same region, closer")[:200]
+                + "\". Render the SAME tapped region again — identical structures,"
+                " palette and line work — just seen closer."
+            )
+            try:
+                second = await image_edit_provider.continue_image(
+                    region_ref, retry_instruction, model_override=body.image_model
+                )
+                verdict2 = await step_in(region_bytes, second.jpeg_bytes)
+            except Exception:
+                return first
+            log(
+                "info",
+                "tap.zoom_judge",
+                attempt=2,
+                score=verdict2.score,
+                accepted=verdict2.score >= accept,
+            )
+            return second if verdict2.score >= verdict.score else first
+
+        main_task = _asyncio.create_task(_judged_zoom())
     elif use_enter_edit and enter_source is not None:
         # ONE selection for both the instruction's family grammar and the
         # dispatch: explicit per-request model > the steep-aware router

--- a/apps/modal-backend/tests/conftest.py
+++ b/apps/modal-backend/tests/conftest.py
@@ -50,8 +50,11 @@ _SCRUB = (
     # Enter-via-edit (default ON — scrub so a host kill-switch can't silently
     # flip the routing tests) + the edit-tier knobs it can interact with.
     "ENTER_EDIT_REF",
-    # Classic tap-zoom routing (default ON — same hermeticity reasoning).
+    # Classic tap-zoom routing + its judge (default ON — same hermeticity
+    # reasoning).
     "TAP_ZOOM_CONTINUE",
+    "TAP_ZOOM_JUDGE",
+    "TAP_ZOOM_ACCEPT",
     # View grammar (default ON — same hermeticity reasoning).
     "VIEW_GRAMMAR",
     "FAL_ENTER_MODEL",

--- a/apps/modal-backend/tests/test_generate_enter.py
+++ b/apps/modal-backend/tests/test_generate_enter.py
@@ -10,6 +10,7 @@ generate.py imports `modal` at module level (deploy-only); stub it before import
 
 from __future__ import annotations
 
+import base64 as _b64
 import json
 import sys
 from typing import Any
@@ -437,3 +438,157 @@ async def test_classic_zoom_without_region_stays_fresh(
 
     gen.assert_awaited_once()
     cont.assert_not_awaited()
+
+
+# ---------- the zoom judge (TAP_ZOOM_JUDGE, default ON) ----------------------
+#
+# Every zoom-continued tap is checked by the step-in judge (the arrival must
+# be the SAME region, closer) with ONE keep-best retry. Judge failures and
+# stub refs (undecodable data URLs) never block the tap.
+
+
+def _region_data_url(payload: bytes = b"region-crop") -> str:
+    return "data:image/jpeg;base64," + _b64.b64encode(payload).decode()
+
+
+def _mock_step_in(monkeypatch: pytest.MonkeyPatch, scores: list[float]) -> AsyncMock:
+    from providers import judge as judge_mod
+    from providers.judge import JudgeResult
+
+    step = AsyncMock(
+        side_effect=[JudgeResult(s, f"verdict {s}", "raw") for s in scores]
+    )
+    monkeypatch.setattr(judge_mod, "score_step_in", step)
+    return step
+
+
+async def test_zoom_judge_pass_is_single_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_plan(monkeypatch)
+    _mock_edit(monkeypatch)
+    cont = _mock_continue(monkeypatch)
+    _mock_fresh(monkeypatch)
+    step = _mock_step_in(monkeypatch, [7.5])
+
+    await _collect(
+        _event_stream(
+            _classic_body(
+                condition_image_urls=[_region_data_url(), "data:p"],
+                condition_roles=["region", "parent"],
+            ),
+            "t1",
+        )
+    )
+
+    cont.assert_awaited_once()
+    step.assert_awaited_once()
+    assert step.await_args.args[0] == b"region-crop"  # judged vs the REGION
+
+
+async def test_zoom_judge_fail_retries_with_rationale_and_keeps_best(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_plan(monkeypatch)
+    _mock_edit(monkeypatch)
+    first = GeneratedImage(b"jpeg-first", "image/jpeg", "fal-ai/flux-pro/kontext", "r1")
+    second = GeneratedImage(b"jpeg-second", "image/jpeg", "fal-ai/flux-pro/kontext", "r2")
+    cont = AsyncMock(side_effect=[first, second])
+    monkeypatch.setattr(image_edit_mod, "continue_image", cont)
+    _mock_fresh(monkeypatch)
+    _mock_step_in(monkeypatch, [4.0, 8.0])  # fail → retry wins
+
+    events = await _collect(
+        _event_stream(
+            _classic_body(
+                condition_image_urls=[_region_data_url(), "data:p"],
+                condition_roles=["region", "parent"],
+            ),
+            "t1",
+        )
+    )
+
+    assert cont.await_count == 2
+    retry_instruction = cont.await_args_list[1].args[1]
+    assert "rejected by a reviewer" in retry_instruction
+    assert "verdict 4.0" in retry_instruction  # the critic's rationale rides in
+    final = next(e for e in events if e["type"] == "final")
+    assert _b64.b64encode(b"jpeg-second").decode() in final["image_data_url"]
+
+
+async def test_zoom_judge_keep_best_prefers_first_when_retry_worse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_plan(monkeypatch)
+    _mock_edit(monkeypatch)
+    first = GeneratedImage(b"jpeg-first", "image/jpeg", "fal-ai/flux-pro/kontext", "r1")
+    second = GeneratedImage(b"jpeg-second", "image/jpeg", "fal-ai/flux-pro/kontext", "r2")
+    cont = AsyncMock(side_effect=[first, second])
+    monkeypatch.setattr(image_edit_mod, "continue_image", cont)
+    _mock_fresh(monkeypatch)
+    _mock_step_in(monkeypatch, [4.0, 3.0])  # retry is WORSE → keep first
+
+    events = await _collect(
+        _event_stream(
+            _classic_body(
+                condition_image_urls=[_region_data_url(), "data:p"],
+                condition_roles=["region", "parent"],
+            ),
+            "t1",
+        )
+    )
+
+    assert cont.await_count == 2
+    final = next(e for e in events if e["type"] == "final")
+    assert _b64.b64encode(b"jpeg-first").decode() in final["image_data_url"]
+
+
+async def test_zoom_judge_kill_switch_skips_judge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TAP_ZOOM_JUDGE", "false")
+    _mock_plan(monkeypatch)
+    _mock_edit(monkeypatch)
+    cont = _mock_continue(monkeypatch)
+    _mock_fresh(monkeypatch)
+    step = _mock_step_in(monkeypatch, [9.0])
+
+    await _collect(
+        _event_stream(
+            _classic_body(
+                condition_image_urls=[_region_data_url(), "data:p"],
+                condition_roles=["region", "parent"],
+            ),
+            "t1",
+        )
+    )
+
+    cont.assert_awaited_once()
+    step.assert_not_awaited()
+
+
+async def test_zoom_judge_error_never_blocks_the_tap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from providers import judge as judge_mod
+
+    _mock_plan(monkeypatch)
+    _mock_edit(monkeypatch)
+    cont = _mock_continue(monkeypatch)
+    _mock_fresh(monkeypatch)
+    monkeypatch.setattr(
+        judge_mod, "score_step_in", AsyncMock(side_effect=RuntimeError("judge down"))
+    )
+
+    events = await _collect(
+        _event_stream(
+            _classic_body(
+                condition_image_urls=[_region_data_url(), "data:p"],
+                condition_roles=["region", "parent"],
+            ),
+            "t1",
+        )
+    )
+
+    cont.assert_awaited_once()
+    assert any(e["type"] == "final" for e in events)


### PR DESCRIPTION
Closes the 'classic zooms are unjudged' caveat from #150. Every zoom flavour funnels through one judged coroutine (classic scene/closeup + submap, world submap, wideRegionCut share the call site):

- **`score_step_in(region_crop, arrival)`** — the arrival must be the SAME tapped region seen **closer**; a wider redraw or a reinvention fails.
- On fail: **one deadline-aware retry** with the critic's rationale folded into the zoom instruction, **keep-best** by score.
- `TAP_ZOOM_JUDGE` default ON (kill-switch) + `TAP_ZOOM_ACCEPT` (6.0). Judge failures / undecodable refs never block the tap.
- Cost: ~$0.001 + a few seconds per zoom tap; a failed first try adds one Kontext ($0.04).

Tests: pass = single attempt (judged against the region bytes); fail = retry carries the rationale + keep-best in both directions; kill-switch skips; judge error never blocks. Full backend pytest + ruff + mypy green.

Live verification on the rebuilt stack to follow on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)