### PR TITLE
fix(image): retry fal's stochastic no-media failures in place

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -110,6 +110,11 @@ FAL_EDIT_TIER=balanced
 # fail. ~$0.001 + 2-5s per tap; a failed first try adds one Kontext ($0.04).
 # TAP_ZOOM_JUDGE=true
 # TAP_ZOOM_ACCEPT=6.0
+# fal sometimes fails a render stochastically (a 422 'no_media_generated' or a
+# 200 with an empty images array) — the SAME request usually succeeds on the
+# next try, so those are retried in place (3 attempts total). `false` reverts
+# to fail-fast. A deterministic decliner costs up to 3 attempts before erroring.
+# RETRY_NO_MEDIA=true
 
 # --- Web (apps/web/.env.local) ---
 # Cloudflare R2 (S3-compatible)

--- a/apps/modal-backend/providers/image.py
+++ b/apps/modal-backend/providers/image.py
@@ -45,6 +45,15 @@ class _EmptyImageResponse(RuntimeError):
     RuntimeError-catching caller behave exactly as before."""
 
 
+class _EmptyFalResult(RuntimeError):
+    """A fal call returned an empty `images` array. Raised INSIDE the retried
+    block (via `_fal_subscribe(require_images=True)`) so the tenacity loop gets
+    a chance at it — the failure is empirically stochastic (the same request
+    often succeeds on the next attempt, e.g. fal's no_media_generated class).
+    Message kept as "fal returned no images" for caller/test compat with the
+    _first_image safety net."""
+
+
 TIER_MODELS: dict[str, str] = {
     "fast":     "fal-ai/nano-banana",
     "balanced": "fal-ai/nano-banana-pro",
@@ -320,7 +329,7 @@ async def _generate_with_slug(
         refs=0,
     ) as ctx:
         result = await _fal_subscribe(
-            model, _args_for(model, prompt, aspect_ratio)
+            model, _args_for(model, prompt, aspect_ratio), require_images=True
         )
         image_info = _first_image(result)
         jpeg_bytes, mime = await _fetch_image_bytes(image_info)
@@ -608,12 +617,27 @@ def _is_retryable(exc: BaseException) -> bool:
     `openrouter:` image path) likewise wraps transport errors in its own
     types. Falls back to httpx exceptions for the post-fal CDN download path.
     """
+    from _env import env_flag
+
     if isinstance(exc, _EmptyImageResponse):
         # A no-image response fails FAST (not retried in place) so generate_image's
         # forced fal failover kicks in immediately — retrying a flaky/slow image
         # model 3x in place is what blew the upstream timeout -> "network error".
         return False
+    if isinstance(exc, _EmptyFalResult):
+        # fal's empty-images results are stochastic (the same request usually
+        # succeeds on retry) — kill-switch shared with the no_media class below.
+        return env_flag("RETRY_NO_MEDIA", "true")
     if isinstance(exc, fal_client.FalClientHTTPError):
+        # fal's no_media_generated (a 422 with a marker) is empirically
+        # STOCHASTIC — a retried identical request succeeds most of the time
+        # (verified live: a wander tap failed 422-no-media then rendered on
+        # retry). Other 4xx stay fail-fast.
+        if env_flag("RETRY_NO_MEDIA", "true") and (
+            getattr(exc, "error_type", None) == "no_media_generated"
+            or "no_media_generated" in str(exc)
+        ):
+            return True
         code = exc.status_code
         return code == 429 or 500 <= code < 600
     if isinstance(exc, fal_client.FalClientTimeoutError):
@@ -630,11 +654,19 @@ def _is_retryable(exc: BaseException) -> bool:
     return False
 
 
-async def _fal_subscribe(model: str, arguments: dict) -> dict:
+async def _fal_subscribe(
+    model: str, arguments: dict, *, require_images: bool = False
+) -> dict:
     """fal_client.subscribe_async with bounded exponential backoff.
 
     Three attempts max. Doesn't retry on auth/4xx-other so a misconfigured
     key fails fast. Wider safety net would mask real bugs.
+
+    `require_images=True` (the image-shaped endpoints) raises _EmptyFalResult
+    INSIDE the retried block when the result carries no images — fal sometimes
+    returns 200 with an empty array, and that class is stochastic exactly like
+    no_media_generated. Default False keeps non-image callers (segmenter,
+    video) byte-identical.
     """
     async for attempt in AsyncRetrying(
         stop=stop_after_attempt(3),
@@ -643,7 +675,17 @@ async def _fal_subscribe(model: str, arguments: dict) -> dict:
         reraise=True,
     ):
         with attempt:
-            return await fal_client.subscribe_async(
+            result = await fal_client.subscribe_async(
                 model, arguments=arguments, with_logs=False
             )
+            # Two success shapes exist: `images: [...]` (nano/kontext/fill) and
+            # BRIA Expand's singular `image` object — accept either, so a
+            # successful outpaint is never mistaken for an empty result.
+            if (
+                require_images
+                and not result.get("images")
+                and not isinstance(result.get("image"), dict)
+            ):
+                raise _EmptyFalResult("fal returned no images")
+            return result
     raise RuntimeError("unreachable")  # pragma: no cover

--- a/apps/modal-backend/providers/image_edit.py
+++ b/apps/modal-backend/providers/image_edit.py
@@ -96,6 +96,7 @@ async def edit_image(
         result = await _fal_subscribe(
             model,
             _edit_args_for(model, instruction, image_url, style_fal),
+            require_images=True,
         )
         image_info = _first_image(result)
         jpeg_bytes, mime = await _fetch_image_bytes(image_info)
@@ -213,7 +214,7 @@ async def continue_image(
     image_url = await to_fal_url(image_data_url)
     async with span("image.continue", model=model, instr_len=len(instruction)) as ctx:
         result = await _fal_subscribe(
-            model, _edit_args_for(model, instruction, image_url)
+            model, _edit_args_for(model, instruction, image_url), require_images=True
         )
         image_info = _first_image(result)
         jpeg_bytes, mime = await _fetch_image_bytes(image_info)
@@ -323,7 +324,7 @@ async def expand_image(
     image_url = await to_fal_url(image_data_url)
     async with span("image.expand", model=model, direction=direction, w=w, h=h) as ctx:
         result = await _fal_subscribe(
-            model, _expand_args_for(image_url, direction, w, h)
+            model, _expand_args_for(image_url, direction, w, h), require_images=True
         )
         image_info = _expand_first_image(result)
         jpeg_bytes, mime = await _fetch_image_bytes(image_info)
@@ -400,7 +401,9 @@ async def expand_image_zoomout(
     w, h = _dims_from_data_url(image_data_url) or (width, height)
     image_url = await to_fal_url(image_data_url)
     async with span("image.zoomout", model=model, factor=f, w=w, h=h) as ctx:
-        result = await _fal_subscribe(model, _zoomout_args_for(image_url, f, w, h, prompt))
+        result = await _fal_subscribe(
+            model, _zoomout_args_for(image_url, f, w, h, prompt), require_images=True
+        )
         image_info = _expand_first_image(result)
         jpeg_bytes, mime = await _fetch_image_bytes(image_info)
         ctx["bytes"] = len(jpeg_bytes)

--- a/apps/modal-backend/providers/inpaint.py
+++ b/apps/modal-backend/providers/inpaint.py
@@ -65,7 +65,9 @@ async def inpaint_image(
     mask_url = await to_fal_url(mask_data_url)
     async with span("image.inpaint", model=model, instr_len=len(instruction)) as ctx:
         result = await _fal_subscribe(
-            model, _inpaint_args_for(model, instruction, image_url, mask_url)
+            model,
+            _inpaint_args_for(model, instruction, image_url, mask_url),
+            require_images=True,
         )
         image_info = _first_image(result)
         jpeg_bytes, mime = await _fetch_image_bytes(image_info)

--- a/apps/modal-backend/tests/conftest.py
+++ b/apps/modal-backend/tests/conftest.py
@@ -55,6 +55,8 @@ _SCRUB = (
     "TAP_ZOOM_CONTINUE",
     "TAP_ZOOM_JUDGE",
     "TAP_ZOOM_ACCEPT",
+    # Stochastic-failure retry (default ON — scrub for hermeticity).
+    "RETRY_NO_MEDIA",
     # View grammar (default ON — same hermeticity reasoning).
     "VIEW_GRAMMAR",
     "FAL_ENTER_MODEL",

--- a/apps/modal-backend/tests/test_image_continue.py
+++ b/apps/modal-backend/tests/test_image_continue.py
@@ -18,7 +18,7 @@ async def test_continue_image_defaults_to_kontext(
     async def fake_to_fal(data_url: str) -> str:
         return "fal://region"
 
-    async def fake_sub(model: str, args: dict) -> dict:
+    async def fake_sub(model: str, args: dict, **kw: object) -> dict:
         captured["model"] = model
         captured["args"] = args
         return {"images": [{"url": "http://x"}], "requestId": "r1"}
@@ -120,7 +120,7 @@ async def test_continue_image_respects_env_override(
     async def fake_to_fal(data_url: str) -> str:
         return "fal://region"
 
-    async def fake_sub(model: str, args: dict) -> dict:
+    async def fake_sub(model: str, args: dict, **kw: object) -> dict:
         captured["model"] = model
         return {"images": [{"url": "http://x"}]}
 

--- a/apps/modal-backend/tests/test_image_edit_provider.py
+++ b/apps/modal-backend/tests/test_image_edit_provider.py
@@ -121,7 +121,7 @@ async def test_expand_image_parses_bria_and_uses_real_dims(
     async def fake_to_fal(data_url: str) -> str:
         return "fal://parent"
 
-    async def fake_sub(model: str, args: dict) -> dict:
+    async def fake_sub(model: str, args: dict, **kw: object) -> dict:
         captured["model"] = model
         captured["args"] = args
         # BRIA Expand's real shape: a singular `image`, not `images: [...]`.
@@ -156,7 +156,7 @@ async def test_expand_image_zoomout_centers_and_uses_real_dims(
     async def fake_to_fal(data_url: str) -> str:
         return "fal://parent"
 
-    async def fake_sub(model: str, args: dict) -> dict:
+    async def fake_sub(model: str, args: dict, **kw: object) -> dict:
         captured["model"] = model
         captured["args"] = args
         return {"image": {"url": "http://x", "content_type": "image/png"}}

--- a/apps/modal-backend/tests/test_image_provider.py
+++ b/apps/modal-backend/tests/test_image_provider.py
@@ -134,7 +134,7 @@ async def test_generate_image_ignores_reference_urls_on_fresh_gen(
         uploaded.append(data_url)
         return f"fal://{data_url[-1]}"
 
-    async def fake_sub(model: str, args: dict) -> dict:
+    async def fake_sub(model: str, args: dict, **kw: object) -> dict:
         captured["args"] = args
         return {"images": [{"url": "http://x"}], "requestId": "r1"}
 
@@ -218,14 +218,17 @@ def test_ensure_fal_key_passes_when_set(monkeypatch: pytest.MonkeyPatch) -> None
 # ---------- _is_retryable -----------------------------------------------
 
 
-def _fal_http_error(status: int) -> fal_client.FalClientHTTPError:
+def _fal_http_error(
+    status: int, message: str = "boom", error_type: str | None = None
+) -> fal_client.FalClientHTTPError:
     req = httpx.Request("POST", "https://fal.run/x")
     resp = httpx.Response(status, request=req)
     return fal_client.FalClientHTTPError(
-        "boom",
+        message,
         status_code=status,
         response_headers={},
         response=resp,
+        error_type=error_type,
     )
 
 
@@ -416,7 +419,7 @@ async def test_generate_image_stays_on_fal_by_default(
 ) -> None:
     monkeypatch.setenv("FAL_KEY", "fk")
 
-    async def fake_sub(model: str, args: dict) -> dict:
+    async def fake_sub(model: str, args: dict, **kw: object) -> dict:
         return {"images": [{"url": "http://x"}], "requestId": "r1"}
 
     async def fake_fetch(info: dict) -> tuple[bytes, str]:
@@ -607,3 +610,97 @@ async def test_openrouter_image_failure_falls_back_to_fal_by_default(
     assert seen[0].startswith(image.OPENROUTER_IMAGE_PREFIX)  # tried riverflow first
     assert result.model == "fal-ai/nano-banana-pro"  # …then fell over to fal
 
+
+
+# ---------- stochastic no-media retries (RETRY_NO_MEDIA, default ON) ---------
+#
+# fal sometimes fails a render stochastically: a 422 tagged no_media_generated,
+# or a 200 whose images array is empty. The SAME request usually succeeds on
+# the next attempt (verified live), so both classes are retried in place.
+# Plain 4xx stays fail-fast (pinned above by test_not_retryable_fal_4xx_other).
+
+
+def test_retryable_fal_no_media_generated_error_type() -> None:
+    err = _fal_http_error(422, error_type="no_media_generated")
+    assert image._is_retryable(err) is True
+
+
+def test_retryable_fal_no_media_generated_in_message() -> None:
+    # The detail-list repr case: the marker rides the stringified body.
+    err = _fal_http_error(
+        422,
+        message="[{'loc': ['body'], 'msg': '...', 'type': 'no_media_generated'}]",
+    )
+    assert image._is_retryable(err) is True
+
+
+def test_no_media_retry_kill_switch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RETRY_NO_MEDIA", "false")
+    assert (
+        image._is_retryable(_fal_http_error(422, error_type="no_media_generated"))
+        is False
+    )
+    assert image._is_retryable(image._EmptyFalResult("fal returned no images")) is False
+
+
+def test_retryable_empty_fal_result() -> None:
+    assert image._is_retryable(image._EmptyFalResult("fal returned no images")) is True
+
+
+async def test_fal_subscribe_retries_no_media_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The stochastic evidence, pinned: first attempt raises the tagged 422,
+    # the identical retry succeeds.
+    calls = {"n": 0}
+
+    async def fake_subscribe(model: str, arguments: dict, with_logs: bool) -> dict:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _fal_http_error(422, error_type="no_media_generated")
+        return {"images": [{"url": "https://cdn/x.jpg"}]}
+
+    monkeypatch.setattr(image.fal_client, "subscribe_async", fake_subscribe)
+    result = await image._fal_subscribe("fal-ai/nano-banana", {}, require_images=True)
+    assert calls["n"] == 2
+    assert result["images"]
+
+
+async def test_fal_subscribe_require_images_retries_empty_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"n": 0}
+
+    async def fake_subscribe(model: str, arguments: dict, with_logs: bool) -> dict:
+        calls["n"] += 1
+        return {"images": []} if calls["n"] == 1 else {"images": [{"url": "u"}]}
+
+    monkeypatch.setattr(image.fal_client, "subscribe_async", fake_subscribe)
+    result = await image._fal_subscribe("fal-ai/nano-banana", {}, require_images=True)
+    assert calls["n"] == 2
+    assert result["images"]
+
+
+async def test_fal_subscribe_require_images_accepts_bria_singular_image(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # BRIA Expand answers with a singular `image` object, not `images: [...]` —
+    # a successful outpaint must NOT be mistaken for an empty result.
+    async def fake_subscribe(model: str, arguments: dict, with_logs: bool) -> dict:
+        return {"image": {"url": "https://cdn/expanded.jpg"}}
+
+    monkeypatch.setattr(image.fal_client, "subscribe_async", fake_subscribe)
+    result = await image._fal_subscribe("fal-ai/bria/expand", {}, require_images=True)
+    assert result["image"]["url"].endswith("expanded.jpg")
+
+
+async def test_fal_subscribe_default_ignores_empty_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Non-image callers (segmenter masks, video) keep byte-identical behaviour.
+    async def fake_subscribe(model: str, arguments: dict, with_logs: bool) -> dict:
+        return {"masks": []}
+
+    monkeypatch.setattr(image.fal_client, "subscribe_async", fake_subscribe)
+    result = await image._fal_subscribe("fal-ai/sam-3", {})
+    assert result == {"masks": []}


### PR DESCRIPTION
First of the overnight reliability PRs (plan-approved). Two fal failure classes are empirically **stochastic** — the identical request usually succeeds on retry (verified live: a wander tap failed `422 no_media_generated`, then rendered on retry):

1. a 422 tagged `no_media_generated` — previously fail-fast like any 4xx;
2. a 200 with an **empty images array** — previously raised by `_first_image` *after* the retry loop returned, unreachable by tenacity.

## Fix (one shared seam → covers fresh + edit + continue + expand + zoomout + inpaint)

- `_is_retryable`: the tagged 422 (via the `error_type` attr or the marker in `str(exc)`) is retryable under **`RETRY_NO_MEDIA` (default ON, kill-switch)**. Plain 4xx stays fail-fast (pinned by the existing test).
- `_fal_subscribe(require_images=True)`: empty results raise `_EmptyFalResult` **inside** the retried block. Accepts **both** success shapes — `images: [...]` and BRIA Expand's singular `image` object — a hole caught during implementation that would otherwise have broken every successful outpaint.
- OpenRouter's `_EmptyImageResponse` fail-fast-to-failover untouched (deliberate).

## Tests
8 new (error_type + message-marker retryability, kill-switch, retry-then-succeed pinning the live evidence, empty-result retry, BRIA singular-image acceptance, non-image shapes ignored). Full backend pytest exit 0, ruff + mypy clean.

Tradeoff (stated): a deterministic decliner costs up to 3 attempts (~+30-60s) before erroring; `RETRY_NO_MEDIA=false` reverts to fail-fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)