### PR TITLE
feat(errors): friendly failure frames + a Try-again banner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,6 +115,10 @@ FAL_EDIT_TIER=balanced
 # next try, so those are retried in place (3 attempts total). `false` reverts
 # to fail-fast. A deterministic decliner costs up to 3 attempts before erroring.
 # RETRY_NO_MEDIA=true
+# Errors reaching the browser are mapped to short human messages (the raw fal
+# body echoes the WHOLE prompt back — it must not render in the UI). Full
+# exception stays in logs + the additive `detail` field. `false` = raw again.
+# FRIENDLY_ERRORS=true
 
 # --- Web (apps/web/.env.local) ---
 # Cloudflare R2 (S3-compatible)

--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -885,6 +885,42 @@ def _note_duplicate_generate(body: GenerateBody) -> bool:
     return seen is not None and (now - seen) < _RECENT_GENERATE_TTL_S
 
 
+def _friendly_error(exc: BaseException) -> tuple[str, str]:
+    """(short human message, detail ≤300 chars) for the SSE error frame.
+
+    The raw exception used to reach the browser verbatim — for fal failures
+    that includes the ENTIRE prompt echoed back in the validation body, which
+    rendered as a wall of leaked internals. The mapping keeps the user-facing
+    message short and actionable; the capped `detail` plus the untouched
+    log/record_error calls keep full diagnosability server-side. String/attr
+    matching on purpose (no fal imports here); the error_type attr is the
+    stable half, wording matches are best-effort.
+    """
+    s = str(exc).lower()
+    name = type(exc).__name__
+    detail = f"{name}: {exc}"[:300]
+    if (
+        getattr(exc, "error_type", None) == "no_media_generated"
+        or "no_media_generated" in s
+        or "returned no images" in s
+        or name == "_EmptyImageResponse"
+    ):
+        return (
+            "The image model declined this one — hit retry or tap somewhere else.",
+            detail,
+        )
+    if isinstance(exc, TimeoutError) or "timed out" in s or "timeout" in name.lower():
+        return ("That page took too long to draw — hit retry.", detail)
+    if getattr(exc, "status_code", None) == 429 or "rate limit" in s:
+        return ("The image service is busy right now — retry in a moment.", detail)
+    if "content_policy" in s or "moderation" in s:
+        return (
+            "Blocked by the image model's safety filter — try a different spot or wording.",
+            detail,
+        )
+    return ("Generation failed — hit retry.", detail)
+
+
 async def _event_stream(
     body: GenerateBody,
     trace_id: str,
@@ -1074,7 +1110,13 @@ async def _event_stream(
             error=f"{type(exc).__name__}: {exc}",
         )
         record_error("sse_generate", exc)
-        yield _sse({"type": "error", "message": str(exc)}, trace_id)
+        if env_flag("FRIENDLY_ERRORS", "true"):
+            msg, detail = _friendly_error(exc)
+            yield _sse(
+                {"type": "error", "message": msg, "detail": detail}, trace_id
+            )
+        else:
+            yield _sse({"type": "error", "message": str(exc)}, trace_id)
 
 
 @fastapi_app.post("/sse/generate")

--- a/apps/modal-backend/providers/generate_modes/ascend.py
+++ b/apps/modal-backend/providers/generate_modes/ascend.py
@@ -219,7 +219,19 @@ async def stream_ascend(
     except Exception as exc:
         log("warn", "ascend.failed", error=f"{type(exc).__name__}: {exc}")
         record_error("ascend", exc)
-        yield _sse({"type": "error", "message": f"ascend failed: {exc}"}, trace_id)
+        # Same friendly mapping as the main funnel — the raw fal body echoes
+        # the whole prompt back, which must not reach the browser. Function-
+        # local import: generate imports this module at call time, so a
+        # module-level import would be circular.
+        from generate import _friendly_error
+
+        if env_flag("FRIENDLY_ERRORS", "true"):
+            msg, detail = _friendly_error(exc)
+            yield _sse({"type": "error", "message": msg, "detail": detail}, trace_id)
+        else:
+            yield _sse(
+                {"type": "error", "message": f"ascend failed: {exc}"}, trace_id
+            )
         return
     data_url = await _asyncio.to_thread(
         image_provider.encode_data_url, img.jpeg_bytes, img.mime_type

--- a/apps/modal-backend/tests/conftest.py
+++ b/apps/modal-backend/tests/conftest.py
@@ -55,8 +55,10 @@ _SCRUB = (
     "TAP_ZOOM_CONTINUE",
     "TAP_ZOOM_JUDGE",
     "TAP_ZOOM_ACCEPT",
-    # Stochastic-failure retry (default ON — scrub for hermeticity).
+    # Stochastic-failure retry + friendly error frames (default ON — scrub
+    # for hermeticity).
     "RETRY_NO_MEDIA",
+    "FRIENDLY_ERRORS",
     # View grammar (default ON — same hermeticity reasoning).
     "VIEW_GRAMMAR",
     "FAL_ENTER_MODEL",

--- a/apps/modal-backend/tests/test_friendly_errors.py
+++ b/apps/modal-backend/tests/test_friendly_errors.py
@@ -1,0 +1,100 @@
+"""_friendly_error — the SSE error frame mapping (FRIENDLY_ERRORS, default ON).
+
+The raw exception used to reach the browser verbatim; for fal failures that
+includes the ENTIRE prompt echoed back in the validation body. These pin the
+mapping AND the leakage regression: prompt text never rides `message`.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.modules.setdefault("modal", MagicMock())
+
+from generate import _friendly_error  # noqa: E402
+
+
+class _FalLikeError(Exception):
+    def __init__(self, message: str, error_type: str | None = None, status_code: int | None = None):
+        super().__init__(message)
+        if error_type is not None:
+            self.error_type = error_type
+        if status_code is not None:
+            self.status_code = status_code
+
+
+def test_no_media_by_error_type_attr() -> None:
+    msg, detail = _friendly_error(_FalLikeError("boom", error_type="no_media_generated"))
+    assert msg == "The image model declined this one — hit retry or tap somewhere else."
+    assert "boom" in detail
+
+
+def test_no_media_by_message_marker() -> None:
+    msg, _ = _friendly_error(RuntimeError("[{'type': 'no_media_generated', ...}]"))
+    assert "declined" in msg
+
+
+def test_returned_no_images_marker() -> None:
+    msg, _ = _friendly_error(RuntimeError("fal returned no images"))
+    assert "declined" in msg
+
+
+def test_timeout_class_and_wording() -> None:
+    msg, _ = _friendly_error(TimeoutError("deadline"))
+    assert "too long" in msg
+    msg2, _ = _friendly_error(RuntimeError("request timed out after 300s"))
+    assert "too long" in msg2
+
+
+def test_rate_limit_by_status_and_wording() -> None:
+    msg, _ = _friendly_error(_FalLikeError("slow down", status_code=429))
+    assert "busy" in msg
+    msg2, _ = _friendly_error(RuntimeError("openai rate limit exceeded"))
+    assert "busy" in msg2
+
+
+def test_safety_block() -> None:
+    msg, _ = _friendly_error(RuntimeError("rejected by content_policy check"))
+    assert "safety filter" in msg
+
+
+def test_default_is_generic_retry() -> None:
+    msg, _ = _friendly_error(ValueError("weird internal thing"))
+    assert msg == "Generation failed — hit retry."
+
+
+def test_detail_is_capped_at_300() -> None:
+    _, detail = _friendly_error(RuntimeError("x" * 2000))
+    assert len(detail) <= 300
+
+
+def test_prompt_never_leaks_into_message() -> None:
+    # THE regression this exists for: fal echoes the whole prompt back in the
+    # error body — none of it may reach the user-facing message.
+    prompt = (
+        "Style: early-20th-century lithograph plate, muted pastel ink, "
+        "cross-hatching, aged paper. A sprawling aerial map of a medieval "
+        "fantasy city nestled in a river bend with SECRET INTERNAL WORDING."
+    )
+    exc = _FalLikeError(
+        f"[{{'loc': ['body'], 'msg': 'bad', 'type': 'no_media_generated', "
+        f"'input': {{'prompt': \"{prompt}\"}}}}]"
+    )
+    msg, detail = _friendly_error(exc)
+    assert "lithograph" not in msg
+    assert "SECRET INTERNAL WORDING" not in msg
+    assert msg == "The image model declined this one — hit retry or tap somewhere else."
+    assert len(detail) <= 300  # even the diagnostic tail is capped
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [RuntimeError("anything"), _FalLikeError("boom", error_type="no_media_generated")],
+)
+def test_always_returns_two_strings(exc: BaseException) -> None:
+    msg, detail = _friendly_error(exc)
+    assert isinstance(msg, str) and msg
+    assert isinstance(detail, str)

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -643,6 +643,8 @@ export default function PlayPage() {
   const imgRef = useRef<HTMLImageElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
   const abortRef = useRef<AbortController | null>(null);
+  // The last generate body, any kind — powers the error banner's "Try again".
+  const lastGenerateRef = useRef<GenerateRequestBody | null>(null);
   const streamRef = useRef<StreamClient | null>(null);
   const [streamStatus, setStreamStatus] = useState<StreamStatus | "off">("off");
   const [fallbackVideoUrl, setFallbackVideoUrl] = useState<string | null>(null);
@@ -808,6 +810,11 @@ export default function PlayPage() {
 
   const generate = useCallback(
     async (body: GenerateRequestBody) => {
+      // Every generation kind (query/tap/edit/expand/ascend) funnels through
+      // here — keep the last body so the error banner's "Try again" can
+      // replay it verbatim (minus trace_id: the API route claims the
+      // Idempotency-Key per trace, so a same-trace replay would 409).
+      lastGenerateRef.current = body;
       abortRef.current?.abort();
       const ac = new AbortController();
       abortRef.current = ac;
@@ -1063,6 +1070,9 @@ export default function PlayPage() {
             } else if (evt.type === "error") {
               hudEmit("sse:error", {
                 message: evt.message,
+                // Capped diagnostic tail (FRIENDLY_ERRORS) — HUD/logs only,
+                // never the banner.
+                detail: evt.detail,
                 trace_id: traceId,
                 t: nowMs(),
               });
@@ -1102,6 +1112,16 @@ export default function PlayPage() {
     },
     []
   );
+
+  // The error banner's "Try again": replay the exact failed request with the
+  // trace_id stripped — the API route claims the Idempotency-Key per trace,
+  // so a fresh trace is what makes the retry actually run.
+  const retryLast = useCallback(() => {
+    const last = lastGenerateRef.current;
+    if (!last) return;
+    const { trace_id: _dropped, ...rest } = last;
+    void generate(rest);
+  }, [generate]);
 
   // Build the expand body from the current page + session state and hand it to
   // the bloom hook (which owns the SSE loop, tray state, persistence + abort).
@@ -1259,6 +1279,9 @@ export default function PlayPage() {
           }
         });
       } catch (err) {
+        // An upload failure isn't a generation — "Try again" must not replay
+        // an unrelated earlier generate body.
+        lastGenerateRef.current = null;
         setError((err as Error).message);
         setPhase("error");
       }
@@ -3153,8 +3176,19 @@ export default function PlayPage() {
       {isDraggingFile && <DragDropOverlay />}
 
       {phase === "error" && (
-        <div className="rounded-lg border border-red-500 bg-red-50 px-4 py-3 text-sm text-red-900">
-          {error}
+        <div className="flex items-center justify-between gap-3 rounded-lg border border-red-300 bg-red-50 px-4 py-2.5 text-sm text-red-900">
+          <span className="min-w-0 break-words">
+            {(error ?? "Generation failed.").slice(0, 220)}
+          </span>
+          {lastGenerateRef.current && (
+            <button
+              type="button"
+              onClick={retryLast}
+              className="shrink-0 rounded-full border border-red-300 bg-white px-3 py-1 text-xs font-medium text-red-900 hover:bg-red-100"
+            >
+              ↻ Try again
+            </button>
+          )}
         </div>
       )}
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -354,7 +354,12 @@ export interface GenerateFinalEvent {
 
 export interface GenerateErrorEvent {
   type: "error";
+  // Short, human, safe-to-render message (FRIENDLY_ERRORS maps known failure
+  // classes; the raw exception never reaches the browser).
   message: string;
+  // Capped (~300 chars) diagnostic tail — debug HUD / logs surface, not the
+  // banner. Additive; absent on older backends or with FRIENDLY_ERRORS=false.
+  detail?: string;
   trace_id?: string;
 }
 


### PR DESCRIPTION
Overnight PR 2/5. The raw exception reached the browser verbatim — for fal failures that includes the **entire prompt echoed back** in the validation body, rendering as a wall of leaked internals in a giant red banner with no way forward.

## Backend
- `_friendly_error(exc) → (message, detail≤300)`: declined / timeout / busy / safety-filter / generic rows; `error_type` attr is the stable detection half. Full exception stays in logs + `record_error` untouched.
- SSE funnel emits `{type:"error", message, detail}` behind **`FRIENDLY_ERRORS` (default ON, kill-switch = raw again)**. ascend's own leaking frame routes through the same helper.

## Web
- `lastGenerateRef` captures every generate body (query/tap/edit/expand/ascend all funnel through `generate()`); the banner gains **↻ Try again**, replaying it with `trace_id` **stripped** — the API route claims the Idempotency-Key per trace, so a fresh trace is what makes the retry run instead of 409 "duplicate".
- Compact banner (flex row, 220-char cap). Upload failures null the ref. `detail` goes to the debug HUD, never the banner.

## Wire
`GenerateErrorEvent.detail?: string` — additive.

## Tests
11 new, including **the leakage regression**: a prompt embedded in the exception never reaches `message`. Full backend + web gates green.

Live receipts (banner + retry idempotency + kill-switch) land in the overnight wrap-up on the rebuilt stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)