### PR TITLE
feat(expand): report failed neighbours instead of silently dropping them

### DIFF
--- a/apps/modal-backend/providers/generate_modes/expand.py
+++ b/apps/modal-backend/providers/generate_modes/expand.py
@@ -104,7 +104,10 @@ async def stream_expand(
             for pan_task in pan_tasks:
                 if not pan_task.done():
                     pan_task.cancel()
-        yield _sse({"type": "expand_done", "count": emitted}, trace_id)
+        yield _sse(
+            {"type": "expand_done", "count": emitted, "failed": total - emitted},
+            trace_id,
+        )
         return
 
     expand_style_lock = (body.session_style_anchor or "").strip() or None
@@ -122,7 +125,7 @@ async def stream_expand(
     )
     total = len(neighbors)
     if total == 0:
-        yield _sse({"type": "expand_done", "count": 0}, trace_id)
+        yield _sse({"type": "expand_done", "count": 0, "failed": 0}, trace_id)
         return
 
     # Image conditioning: every neighbour shares the parent's world + the
@@ -219,5 +222,8 @@ async def stream_expand(
         for bloom_task in tasks:
             if not bloom_task.done():
                 bloom_task.cancel()
-    yield _sse({"type": "expand_done", "count": emitted}, trace_id)
+    yield _sse(
+        {"type": "expand_done", "count": emitted, "failed": total - emitted},
+        trace_id,
+    )
     return

--- a/apps/modal-backend/tests/test_generate_expand.py
+++ b/apps/modal-backend/tests/test_generate_expand.py
@@ -131,7 +131,12 @@ async def test_expand_zero_neighbours_emits_done(
     _mock_providers(monkeypatch, neighbours=[])
     events = await _collect(_event_stream(_expand_body(), "trace1"))
     assert not [e for e in events if e["type"] == "neighbor"]
-    assert events[-1] == {"type": "expand_done", "count": 0, "trace_id": "trace1"}
+    assert events[-1] == {
+        "type": "expand_done",
+        "count": 0,
+        "failed": 0,
+        "trace_id": "trace1",
+    }
 
 
 async def test_expand_isolates_one_neighbour_failure(
@@ -150,6 +155,9 @@ async def test_expand_isolates_one_neighbour_failure(
     assert len(neighbours) == 1
     assert events[-1]["type"] == "expand_done"
     assert events[-1]["count"] == 1
+    # Expand honesty: the lost neighbour is REPORTED, not silently dropped —
+    # the tray can say "1 failed" instead of pretending nothing was proposed.
+    assert events[-1]["failed"] == 1
 
 
 async def test_expand_requires_an_image(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -3968,6 +3968,7 @@ export default function PlayPage() {
           items={bloom.items}
           total={bloom.total}
           done={bloom.done}
+          failed={bloom.failed}
           onPick={(item) => {
             if (item.nodeId) window.location.href = `/n/${item.nodeId}`;
           }}

--- a/apps/web/components/PlayPage/NeighbourTray.test.tsx
+++ b/apps/web/components/PlayPage/NeighbourTray.test.tsx
@@ -114,4 +114,28 @@ describe("NeighbourTray", () => {
     fireEvent.click(screen.getByRole("button", { name: "Close neighbours" }));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  it("says how many neighbours failed instead of pretending nothing was lost", () => {
+    const ok = item({ subject: "Made it", imageDataUrl: "data:x", nodeId: "n1" });
+    render(
+      <NeighbourTray items={[ok]} total={3} done failed={2} onPick={noop} onClose={noop} />
+    );
+    expect(screen.getByText(/2 failed/)).toBeTruthy();
+  });
+
+  it("all-failed bloom says so, not 'no neighbours found'", () => {
+    render(
+      <NeighbourTray items={[]} total={3} done failed={3} onPick={noop} onClose={noop} />
+    );
+    expect(screen.getByText(/Couldn't draw the neighbours/)).toBeTruthy();
+    expect(screen.queryByText(/No neighbours found nearby/)).toBeNull();
+  });
+
+  it("failed=0 renders the normal done status (byte-compat)", () => {
+    const ok = item({ subject: "Fine", imageDataUrl: "data:x", nodeId: "n1" });
+    render(
+      <NeighbourTray items={[ok]} total={1} done failed={0} onPick={noop} onClose={noop} />
+    );
+    expect(screen.queryByText(/failed/)).toBeNull();
+  });
 });

--- a/apps/web/components/PlayPage/NeighbourTray.tsx
+++ b/apps/web/components/PlayPage/NeighbourTray.tsx
@@ -19,6 +19,9 @@ interface Props {
   total: number;
   /** True once the `expand_done` event lands. */
   done: boolean;
+  /** Proposed neighbours that never rendered (generation failures). The tray
+   *  says so instead of silently pretending nothing was lost. */
+  failed?: number | undefined;
   onPick: (item: NeighbourItem) => void;
   onClose: () => void;
 }
@@ -31,7 +34,14 @@ const SCALE_META: Record<ScaleKind, { label: string; chip: string; width: string
   container: { label: "around", chip: "bg-amber-500", width: "w-28" },
 };
 
-export default function NeighbourTray({ items, total, done, onPick, onClose }: Props) {
+export default function NeighbourTray({
+  items,
+  total,
+  done,
+  failed,
+  onPick,
+  onClose,
+}: Props) {
   const ready = items.filter((i) => i.imageDataUrl).length;
   const pendingCount = Math.max(0, total - items.length);
   // The bloom finished but proposed nothing usable (e.g. a weak VLM whose
@@ -41,10 +51,13 @@ export default function NeighbourTray({ items, total, done, onPick, onClose }: P
   // Bloom started but no neighbours known yet (the VLM is still surveying):
   // show activity rather than nothing while it thinks.
   const proposing = !done && total === 0 && items.length === 0;
+  const failedNote = done && (failed ?? 0) > 0 ? ` · ${failed} failed` : "";
   const status = empty
-    ? "No neighbours found nearby"
+    ? (failed ?? 0) > 0
+      ? "Couldn't draw the neighbours — try again"
+      : "No neighbours found nearby"
     : done
-      ? `Around this page · ${ready} neighbour${ready === 1 ? "" : "s"} — tap one`
+      ? `Around this page · ${ready} neighbour${ready === 1 ? "" : "s"} — tap one${failedNote}`
       : proposing
         ? "Looking around…"
         : `Looking around · ${ready} of ${total}`;

--- a/apps/web/hooks/useExpandBloom.ts
+++ b/apps/web/hooks/useExpandBloom.ts
@@ -18,6 +18,9 @@ export interface BloomState {
   total: number;
   /** True once `expand_done` lands (or the stream errored out). */
   done: boolean;
+  /** Proposed neighbours that never rendered (generation failures) — the tray
+   *  says so instead of pretending nothing was lost. Absent = unknown. */
+  failed?: number;
 }
 
 /** Persists one bloomed neighbour as a relation:"expand" child and returns its
@@ -143,7 +146,17 @@ export function useExpandBloom(persist: PersistNeighbour): {
                   );
                 });
               } else if (evt.type === "expand_done") {
-                setBloom((prev) => (prev ? { ...prev, done: true } : prev));
+                const failed =
+                  typeof evt.failed === "number" ? evt.failed : undefined;
+                setBloom((prev) =>
+                  prev
+                    ? {
+                        ...prev,
+                        done: true,
+                        ...(failed !== undefined ? { failed } : {}),
+                      }
+                    : prev,
+                );
               } else if (evt.type === "error") {
                 throw new Error(evt.message);
               }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -413,6 +413,10 @@ export interface GenerateNeighborEvent {
 export interface GenerateExpandDoneEvent {
   type: "expand_done";
   count: number;
+  // How many proposed neighbours/directions never rendered (generation
+  // failures). Additive; absent on older backends means "unknown", 0 means
+  // everything landed.
+  failed?: number;
   trace_id?: string;
 }
 


### PR DESCRIPTION
Overnight PR 3/5. A failed Around/neighbour generation was logged and skipped — the tray pretended nothing was proposed ("No neighbours found nearby" even when 4 were proposed and all 4 failed at fal, which is exactly what the `no_media_generated` flakiness produced).

- `expand_done` carries **`failed: total - emitted`** on all three emit paths (map-pan, bloom, zero-proposals). Additive wire field.
- The tray says **"· N failed"** when some neighbours were lost, and an all-failed bloom says **"Couldn't draw the neighbours — try again"** instead of the misleading empty message. `failed`=0/absent renders byte-identically.

Tests: backend failing-neighbour case asserts the count + zero-path exact dict; 3 tray render tests. Full gates green. Pairs with #152 (the failures themselves now retry) and #153 (whatever still fails looks human).

🤖 Generated with [Claude Code](https://claude.com/claude-code)