### PR TITLE
feat(wander): a spend seatbelt + loud stops

### DIFF
--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -74,7 +74,11 @@ import { MorphImagePair } from "@/components/PlayPage/MorphImagePair";
 import { StrokeOverlay } from "@/components/PlayPage/StrokeOverlay";
 import { ClickRipple } from "@/components/PlayPage/ClickRipple";
 import { BlankTapNudge } from "@/components/PlayPage/BlankTapNudge";
-import { useWander } from "@/hooks/useWander";
+import {
+  useWander,
+  WANDER_MAX_PAGES,
+  type WanderStopReason,
+} from "@/hooks/useWander";
 import { BranchBeacons } from "@/components/PlayPage/BranchBeacons";
 import { GeneratingBanner } from "@/components/PlayPage/GeneratingBanner";
 import { Quickbar } from "@/components/PlayPage/Quickbar";
@@ -442,6 +446,14 @@ export default function PlayPage() {
   }, [blankTap]);
   // Wander (auto-explore): the world explores itself, hands-free. See useWander.
   const [wandering, setWandering] = useState(false);
+  // Why the last wander run stopped — a small transient pill by the ▶ button,
+  // so an auto-stop (page cap, failure, dead end) never reads as a silent bug.
+  const [wanderNote, setWanderNote] = useState<string | null>(null);
+  useEffect(() => {
+    if (!wanderNote) return;
+    const t = setTimeout(() => setWanderNote(null), 6000);
+    return () => clearTimeout(t);
+  }, [wanderNote]);
   // The click handler closes over state at dispatch time; Wander's synthetic
   // taps must read the LIVE value (withhold zoom routing mid-wander), so
   // mirror it into a ref.
@@ -1597,7 +1609,16 @@ export default function PlayPage() {
 
   // Wander (auto-explore): reuse the ranked precompute candidates + the tap flow
   // to let the world explore itself, hands-free. Toggled by the ▶ button.
-  const stopWander = useCallback(() => setWandering(false), []);
+  const stopWander = useCallback((reason?: WanderStopReason) => {
+    setWandering(false);
+    setWanderNote(
+      reason === "max-pages"
+        ? `Wander: explored ${WANDER_MAX_PAGES} pages — ▶ to continue`
+        : reason
+          ? "Wander stopped: nothing tappable here"
+          : null,
+    );
+  }, []);
   useWander({
     active: wandering,
     phase,
@@ -1609,6 +1630,14 @@ export default function PlayPage() {
     dispatchTapAt,
     onExhausted: stopWander,
   });
+  // A failed generation mid-wander used to stall the run silently (the tap
+  // never advances the node, so the hook never re-arms). Stop loudly instead.
+  useEffect(() => {
+    if (wandering && phase === "error") {
+      setWandering(false);
+      setWanderNote("Wander stopped: generation failed");
+    }
+  }, [wandering, phase]);
 
   // The geo-aware section of the right-click menu (E2): target-aware actions
   // routed to the primitives that already exist — runEdit (E1 mask path),
@@ -3696,9 +3725,17 @@ export default function PlayPage() {
                 the World pill so, on any residual overlap at narrow widths,
                 this later-in-DOM toolbar wins the stack and stays tappable. */}
             <div className="absolute right-3 top-3 z-10 flex max-w-[calc(100%-1.5rem)] flex-wrap justify-end gap-2">
+              {wanderNote && (
+                <span className="flex items-center rounded-full bg-black/70 px-2.5 py-1 text-xs text-white/95">
+                  {wanderNote}
+                </span>
+              )}
               <button
                 type="button"
-                onClick={() => setWandering((w) => !w)}
+                onClick={() => {
+                  setWanderNote(null);
+                  setWandering((w) => !w);
+                }}
                 aria-pressed={wandering}
                 disabled={!page?.imageDataUrl}
                 className={
@@ -3707,7 +3744,7 @@ export default function PlayPage() {
                     ? "animate-pulse bg-fuchsia-600"
                     : "bg-fuchsia-600/85 hover:bg-fuchsia-600")
                 }
-                title="Wander — let the world explore itself, tapping the most interesting spot each page. Tap again to stop."
+                title="Wander — let the world explore itself, tapping the most interesting spot each page (stops itself after 8). Tap again to stop."
               >
                 <span aria-hidden>{wandering ? "⏸" : "▶"}</span>
                 {wandering ? "Wandering…" : "Wander"}

--- a/apps/web/hooks/useWander.test.tsx
+++ b/apps/web/hooks/useWander.test.tsx
@@ -1,0 +1,120 @@
+// Wander safety: the page cap (a forgotten ▶ can't wander off with the
+// wallet), the stop reasons, and the re-arm reset. Real timers + tiny lingers
+// keep these deterministic without fake-timer/microtask juggling.
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useWander, WANDER_MAX_PAGES, type WanderStopReason } from "./useWander";
+
+const CANDIDATES = {
+  candidates: [
+    { x_pct: 0.5, y_pct: 0.4, salience: 0.9 },
+    { x_pct: 0.2, y_pct: 0.7, salience: 0.5 },
+  ],
+};
+
+function stubFetch(payload: unknown = CANDIDATES, ok = true) {
+  const fn = vi.fn(async () => ({ ok, json: async () => payload }));
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+const tick = (ms = 60) => new Promise((r) => setTimeout(r, ms));
+
+interface HookProps {
+  active: boolean;
+  nodeId: string;
+}
+
+function mount(
+  tap: (x: number, y: number) => void,
+  exhausted: (reason: WanderStopReason) => void,
+  maxPages: number,
+  initial: HookProps = { active: true, nodeId: "a" },
+) {
+  return renderHook(
+    ({ active, nodeId }: HookProps) =>
+      useWander({
+        active,
+        phase: "ready",
+        nodeId,
+        imageDataUrl: "data:image/jpeg;base64,xxx",
+        title: "t",
+        query: "q",
+        outputLocale: null,
+        dispatchTapAt: tap,
+        onExhausted: exhausted,
+        lingerMs: 5,
+        maxPages,
+      }),
+    { initialProps: initial },
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useWander safety", () => {
+  it("auto-taps a top candidate after the linger", async () => {
+    stubFetch();
+    const tap = vi.fn();
+    mount(tap, vi.fn(), 8);
+    await tick();
+    expect(tap).toHaveBeenCalledTimes(1);
+    const [x, y] = tap.mock.calls[0]!;
+    // random among top-3 — both stubbed candidates are acceptable picks
+    expect([0.5, 0.2]).toContain(x);
+    expect([0.4, 0.7]).toContain(y);
+  });
+
+  it("stops with max-pages after maxPages taps and fires no further tap", async () => {
+    stubFetch();
+    const tap = vi.fn();
+    const exhausted = vi.fn();
+    const { rerender } = mount(tap, exhausted, 2);
+    await tick();
+    rerender({ active: true, nodeId: "b" });
+    await tick();
+    expect(tap).toHaveBeenCalledTimes(2);
+    rerender({ active: true, nodeId: "c" });
+    await tick();
+    expect(tap).toHaveBeenCalledTimes(2); // the cap held
+    expect(exhausted).toHaveBeenCalledWith("max-pages");
+  });
+
+  it("reports no-candidates and resolver-error", async () => {
+    stubFetch({ candidates: [] });
+    const exhausted = vi.fn();
+    mount(vi.fn(), exhausted, 8);
+    await tick();
+    expect(exhausted).toHaveBeenCalledWith("no-candidates");
+
+    stubFetch({}, false);
+    const exhausted2 = vi.fn();
+    mount(vi.fn(), exhausted2, 8);
+    await tick();
+    expect(exhausted2).toHaveBeenCalledWith("resolver-error");
+  });
+
+  it("re-arming wander resets the page counter", async () => {
+    stubFetch();
+    const tap = vi.fn();
+    const exhausted = vi.fn();
+    const { rerender } = mount(tap, exhausted, 1);
+    await tick();
+    expect(tap).toHaveBeenCalledTimes(1);
+    rerender({ active: true, nodeId: "b" });
+    await tick();
+    expect(exhausted).toHaveBeenCalledWith("max-pages"); // capped at 1
+    // toggle off (resets the counter), then a fresh run on a new node
+    rerender({ active: false, nodeId: "b" });
+    rerender({ active: true, nodeId: "c" });
+    await tick();
+    expect(tap).toHaveBeenCalledTimes(2);
+  });
+
+  it("the default cap is the documented seatbelt", () => {
+    expect(WANDER_MAX_PAGES).toBe(8);
+  });
+});

--- a/apps/web/hooks/useWander.ts
+++ b/apps/web/hooks/useWander.ts
@@ -8,6 +8,13 @@ interface WanderCandidate {
   salience?: number;
 }
 
+/** Why a wander run ended on its own (the caller surfaces it). */
+export type WanderStopReason = "max-pages" | "no-candidates" | "resolver-error";
+
+/** Auto-explore spends real money per page — cap a run so a forgotten ▶
+ *  can't wander away with the wallet. One more ▶ starts a fresh run. */
+export const WANDER_MAX_PAGES = 8;
+
 interface Options {
   /** Whether wander is currently on. */
   active: boolean;
@@ -23,11 +30,14 @@ interface Options {
   outputLocale: string | null;
   /** Fire the existing tap flow at a normalized point (reuses everything). */
   dispatchTapAt: (xPct: number, yPct: number) => void;
-  /** Called when wander can't continue (no candidates / error) so the caller
-   *  can toggle it off. */
-  onExhausted: () => void;
+  /** Called when wander can't continue — max pages reached, a page with no
+   *  candidates, or the resolver erroring — so the caller can toggle it off
+   *  and say why. */
+  onExhausted: (reason: WanderStopReason) => void;
   /** ms to linger on a freshly-arrived page before the next auto-tap. */
   lingerMs?: number;
+  /** Auto-taps per activation before wander stops itself. */
+  maxPages?: number;
 }
 
 /**
@@ -50,10 +60,14 @@ export function useWander({
   dispatchTapAt,
   onExhausted,
   lingerMs = 2600,
+  maxPages = WANDER_MAX_PAGES,
 }: Options): void {
   // The last node we auto-tapped FROM, so a page is only wandered once even as
   // the effect re-runs.
   const tappedFrom = useRef<string | null>(null);
+  // Auto-taps this activation — reset on toggle-off so one more ▶ starts a
+  // fresh run.
+  const tapCount = useRef(0);
   // The page's non-identity fields ride a ref, NOT the effect deps: the image
   // data-URL string is re-minted after a page settles (the change-stream
   // reconcile), and if the effect depended on it, that re-run would clear the
@@ -65,6 +79,7 @@ export function useWander({
   useEffect(() => {
     if (!active) {
       tappedFrom.current = null;
+      tapCount.current = 0;
       return;
     }
     // Only auto-tap from a settled page whose pixels we can resolve, and only
@@ -75,6 +90,11 @@ export function useWander({
       !latest.current.imageDataUrl?.startsWith("data:") ||
       tappedFrom.current === nodeId
     ) {
+      return;
+    }
+    // The spend seatbelt: a forgotten ▶ stops itself after maxPages taps.
+    if (tapCount.current >= maxPages) {
+      onExhausted("max-pages");
       return;
     }
     tappedFrom.current = nodeId;
@@ -97,7 +117,7 @@ export function useWander({
           signal: ac.signal,
         });
         if (!res.ok) {
-          onExhausted();
+          onExhausted("resolver-error");
           return;
         }
         const data = (await res.json()) as { candidates?: WanderCandidate[] };
@@ -105,7 +125,7 @@ export function useWander({
           (c) => typeof c?.x_pct === "number" && typeof c?.y_pct === "number"
         );
         if (cands.length === 0) {
-          onExhausted();
+          onExhausted("no-candidates");
           return;
         }
         cands.sort((a, b) => (b.salience ?? 0) - (a.salience ?? 0));
@@ -114,7 +134,10 @@ export function useWander({
         const pool = cands.slice(0, Math.min(3, cands.length));
         const pick = pool[Math.floor(Math.random() * pool.length)]!;
         timer = setTimeout(() => {
-          if (!ac.signal.aborted) dispatchTapAt(pick.x_pct, pick.y_pct);
+          if (!ac.signal.aborted) {
+            tapCount.current += 1;
+            dispatchTapAt(pick.x_pct, pick.y_pct);
+          }
         }, lingerMs);
       } catch {
         // Aborted (page changed / toggled off) or network error — the next
@@ -130,5 +153,5 @@ export function useWander({
     // (image, title, query, locale) ride `latest` so a re-mint of the data URL
     // can't cancel the in-flight linger timer.
      
-  }, [active, phase, nodeId, dispatchTapAt, onExhausted, lingerMs]);
+  }, [active, phase, nodeId, dispatchTapAt, onExhausted, lingerMs, maxPages]);
 }


### PR DESCRIPTION
Overnight PR 4/5. Wander ran until toggled off — a forgotten ▶ kept generating pages (~$0.05–0.16 each) indefinitely, and a failed generation mid-run **stalled it silently** (the tap never advances the node, so the hook never re-arms; the button still said "Wandering…").

- **Page cap**: 8 auto-taps per activation (`WANDER_MAX_PAGES`, per-run counter resets on toggle-off — one more ▶ starts a fresh run). `onExhausted` now carries **why**: `max-pages | no-candidates | resolver-error`.
- **Loud stops**: a small transient pill by the ▶ button ("Wander: explored 8 pages — ▶ to continue" / "Wander stopped: generation failed" / "nothing tappable here"), and a failure-stop effect turns wander off when a generation errors instead of the silent stall.

Client-only. 5 new hook tests. Web 682 vitest + tsc + circular green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)