### PR TITLE
feat(prefetch): candidate budget split + hover upgrades the hottest spots

### DIFF
--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -138,6 +138,8 @@ import {
 } from "@/lib/session-pages";
 import { useImageMorph } from "@/hooks/useImageMorph";
 import {
+  isHoverResolved,
+  PRECOMPUTE_PER_PAGE,
   PREFETCH_LRU_MAX,
   PREFETCH_PER_PAGE,
   usePrefetchCache,
@@ -817,6 +819,7 @@ export default function PlayPage() {
     timerRef: prefetchTimerRef,
     currentKeyRef: prefetchCurrentKeyRef,
     perPageCountRef: prefetchPerPageCountRef,
+    candidateCountRef: prefetchCandidateCountRef,
     bucketKey,
   } = usePrefetchCache();
 
@@ -2032,10 +2035,13 @@ export default function PlayPage() {
         };
         if (!Array.isArray(data.candidates)) return;
         const cache = prefetchCacheRef.current;
-        const counts = prefetchPerPageCountRef.current;
+        // Candidates count against their OWN allowance — one cheap batched
+        // call must not exhaust the hover budget and starve every other
+        // bucket of a full resolve (nudge/dive verdicts).
+        const counts = prefetchCandidateCountRef.current;
         const scope = nodeId;
         for (const c of data.candidates) {
-          if ((counts.get(scope) ?? 0) >= PREFETCH_PER_PAGE) break;
+          if ((counts.get(scope) ?? 0) >= PRECOMPUTE_PER_PAGE) break;
           const key = bucketKey(nodeId, c.x_pct, c.y_pct);
           if (cache.has(key)) continue;
           cache.set(key, {
@@ -2088,7 +2094,10 @@ export default function PlayPage() {
       const key = bucketKey(currentNodeId, xPct, yPct);
       if (prefetchCurrentKeyRef.current === key) return;
       prefetchCurrentKeyRef.current = key;
-      if (cache.has(key)) return;
+      // Skip only FULLY resolved buckets. A candidate-only entry (precompute:
+      // subject/style/enter_as, no groundable verdict) is upgrade-eligible —
+      // hovering the hottest spots earns them blank-tap + confidence data.
+      if (isHoverResolved(cache.get(key))) return;
       if ((pageBucketCounts.get(pageScope) ?? 0) >= PREFETCH_PER_PAGE) return;
       // Serial: cancel any prior in-flight prefetch — only the latest hover
       // is interesting, and parallel multi-MB POSTs are the cost we're
@@ -2128,7 +2137,12 @@ export default function PlayPage() {
             enter_as?: string;
           };
           if (data.subject) {
+            // Merge over any candidate-only entry so its fields (e.g. a
+            // precompute enter_as) survive when the resolve omits them; the
+            // fresh hover resolve wins on every field it carries.
+            const prior = cache.get(key);
             cache.set(key, {
+              ...(prior ?? {}),
               subject: data.subject,
               style: data.style ?? "",
               subject_context: data.subject_context ?? "",

--- a/apps/web/hooks/usePrefetchCache.test.tsx
+++ b/apps/web/hooks/usePrefetchCache.test.tsx
@@ -2,7 +2,13 @@ import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { PrefetchEntry } from "./usePrefetchCache";
-import { PREFETCH_LRU_MAX, PREFETCH_PER_PAGE, usePrefetchCache } from "./usePrefetchCache";
+import {
+  isHoverResolved,
+  PRECOMPUTE_PER_PAGE,
+  PREFETCH_LRU_MAX,
+  PREFETCH_PER_PAGE,
+  usePrefetchCache,
+} from "./usePrefetchCache";
 
 describe("usePrefetchCache constants", () => {
   it("exports the per-page bucket cap and LRU ceiling", () => {
@@ -100,5 +106,36 @@ describe("PrefetchEntry shape", () => {
     expect(blocked.groundable).toBe(false);
     // Consumers should suppress page-gen on this entry.
     expect(blocked.groundable === false && (blocked.confidence ?? 1) < 0.5).toBe(true);
+  });
+
+  it("exposes an independent candidate budget map", () => {
+    const { result } = renderHook(() => usePrefetchCache());
+    expect(result.current.candidateCountRef.current).not.toBe(
+      result.current.perPageCountRef.current
+    );
+    result.current.candidateCountRef.current.set("n1", 8);
+    expect(result.current.perPageCountRef.current.get("n1")).toBeUndefined();
+  });
+
+  it("PRECOMPUTE_PER_PAGE covers the whole 8-candidate precompute", () => {
+    expect(PRECOMPUTE_PER_PAGE).toBe(8);
+    expect(PRECOMPUTE_PER_PAGE).toBeGreaterThanOrEqual(PREFETCH_PER_PAGE);
+  });
+
+  it("isHoverResolved: candidate-only entries are upgrade-eligible", () => {
+    expect(isHoverResolved(undefined)).toBe(false);
+    // precompute writes: subject/style(/enter_as) only — upgradeable
+    expect(isHoverResolved({ subject: "castle", style: "" })).toBe(false);
+    expect(
+      isHoverResolved({ subject: "castle", style: "", enter_as: "scene" })
+    ).toBe(false);
+    // a full hover resolve is complete
+    expect(
+      isHoverResolved({ subject: "castle", style: "", groundable: true })
+    ).toBe(true);
+    // a RESOLVED blank is complete too (a known nothing, not re-fetchable)
+    expect(
+      isHoverResolved({ subject: "sky", style: "", groundable: false })
+    ).toBe(true);
   });
 });

--- a/apps/web/hooks/usePrefetchCache.ts
+++ b/apps/web/hooks/usePrefetchCache.ts
@@ -36,6 +36,24 @@ export interface PrefetchEntry {
 
 export const PREFETCH_PER_PAGE = 6;
 export const PREFETCH_LRU_MAX = 200;
+/** Per-page allowance for PRECOMPUTE candidate writes — its own budget, so
+ *  one cheap batched VLM call (8 spots) no longer exhausts the hover budget
+ *  and starve every other bucket of a resolve. Matches the precompute
+ *  request's max_candidates. */
+export const PRECOMPUTE_PER_PAGE = 8;
+
+/**
+ * Is this cache entry a FULL hover/click resolve (vs a precompute candidate)?
+ * Hover resolves always carry the groundability verdict; candidate writes
+ * never do (subject/style/enter_as only). Candidate-only entries are
+ * upgrade-eligible: a hover on that bucket re-resolves and merges, giving the
+ * hottest spots blank-tap verdicts + confidence. A resolved `groundable:
+ * false` is COMPLETE (a known blank), not re-fetchable. The cache is
+ * in-memory only, so pre-field legacy entries can't survive a deploy.
+ */
+export function isHoverResolved(entry: PrefetchEntry | undefined): boolean {
+  return !!entry && entry.groundable !== undefined;
+}
 
 /**
  * Owns the in-memory hover/click prefetch cache plus the discipline knobs
@@ -53,6 +71,9 @@ export function usePrefetchCache() {
   const timerRef = useRef<number | null>(null);
   const currentKeyRef = useRef<string | null>(null);
   const perPageCountRef = useRef<Map<string, number>>(new Map());
+  // Precompute candidates count HERE, not against the hover budget above —
+  // two writers, two allowances (see PRECOMPUTE_PER_PAGE).
+  const candidateCountRef = useRef<Map<string, number>>(new Map());
 
   // 3% grid — tighter than the original 5% so the 8 precomputed candidates
   // map to distinct buckets, but still loose enough that nearby hovers reuse
@@ -87,6 +108,7 @@ export function usePrefetchCache() {
     timerRef,
     currentKeyRef,
     perPageCountRef,
+    candidateCountRef,
     bucketKey,
     clearTimer,
     reset,


### PR DESCRIPTION
Overnight PR 5/5. Two writers shared one per-page budget and hover skipped any cached bucket — so precompute's 6 entries exhausted the page, non-candidate spots never warmed, and the hottest (candidate) spots never earned a `groundable` verdict: **no blank-tap nudge and no dive on exactly the spots people tap most**.

- **Own allowance for candidates** (`PRECOMPUTE_PER_PAGE = 8`, matching `max_candidates`) — the hover budget (6 resolves/page) is hover's again.
- **Hover upgrade**: skip only *fully resolved* buckets (`isHoverResolved` — hover resolves always carry `groundable`, candidate writes never do); the write merges over the candidate entry (resolve wins per-field, candidate `enter_as` survives).
- **Cost ceiling unchanged**: same 6 hover resolves/page, serial in-flight, 450ms debounce, same-bucket dedup — only *eligibility* widens.

Client-only. Tests: independent budget maps, constant pins, the `isHoverResolved` matrix (incl. `groundable:false` = complete). Web 685 vitest + tsc + circular green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)