### PR TITLE
fix(candidates): scene clause + one hotter retry on empty VLM rolls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,6 +119,11 @@ FAL_EDIT_TIER=balanced
 # body echoes the WHOLE prompt back — it must not render in the UI). Full
 # exception stays in logs + the additive `detail` field. `false` = raw again.
 # FRIENDLY_ERRORS=true
+# The candidate VLM sometimes returns a well-formed EMPTY list for scenic
+# (non-diagram) pages — that starves tap-prefetch warmup and stops Wander
+# runs. One hotter retry (temp 0.5) flips almost all empty rolls; +1 VLM call
+# (~$0.003) only when the first roll is empty. `false` = single roll.
+# PRECOMPUTE_EMPTY_RETRY=true
 
 # --- Web (apps/web/.env.local) ---
 # Cloudflare R2 (S3-compatible)

--- a/apps/modal-backend/providers/llm/click.py
+++ b/apps/modal-backend/providers/llm/click.py
@@ -494,7 +494,10 @@ async def precompute_click_candidates(
         "CLOSER to; \"submap\" = the page reads as a map/plan and this is a "
         "sub-area best shown as a closer map; \"explainer\" = an abstract "
         "concept, mechanism, or diagram element best served by a fresh "
-        "labelled diagram. Coordinates are 0..1 with origin at the "
+        "labelled diagram. If the page is a scenic illustration or a map "
+        "rather than an annotated diagram, treat its distinct objects, "
+        "buildings, creatures, and landmarks as the clickable subjects — a "
+        "rich scene is never empty. Coordinates are 0..1 with origin at the "
         "top-left of the image. Sort by salience descending."
         + locale_clause
     )
@@ -502,31 +505,44 @@ async def precompute_click_candidates(
         "List the most click-worthy regions on this illustration. Return "
         f"at most {max_candidates}; fewer is fine if the page is sparse."
     )
+    from _env import env_flag
     from obs import span
 
-    async with span("vlm.precompute_candidates", model=_vlm_model()) as ctx:
-        parsed = await _llm._complete_json(
-            model=_vlm_model(),
-            messages=[
-                _system_message(system),
-                {
-                    "role": "user",
-                    "content": [
-                        {"type": "text", "text": user_text},
-                        {
-                            "type": "image_url",
-                            "image_url": {"url": image_data_url, "detail": "high"},
-                        },
-                    ],
-                },
-            ],
-            schema=CANDIDATES_SCHEMA,
-            schema_name="click_candidates",
-            temperature=0.2,
-            max_tokens=900,
-            span_ctx=ctx,
-        )
-    items = parsed.get("candidates", [])
+    # gemini-flash occasionally reads a scenic (non-diagram) page as having no
+    # "annotated subjects" and returns a well-formed empty list — which
+    # silently starves candidate warmup and stops Wander runs mid-flight. One
+    # hotter retry flips almost all of those empty rolls; a genuinely sparse
+    # page just comes back empty twice.
+    attempts = 2 if env_flag("PRECOMPUTE_EMPTY_RETRY", "true") else 1
+    items: Any = []
+    for attempt in range(attempts):
+        async with span("vlm.precompute_candidates", model=_vlm_model()) as ctx:
+            parsed = await _llm._complete_json(
+                model=_vlm_model(),
+                messages=[
+                    _system_message(system),
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": user_text},
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": image_data_url, "detail": "high"},
+                            },
+                        ],
+                    },
+                ],
+                schema=CANDIDATES_SCHEMA,
+                schema_name="click_candidates",
+                temperature=0.2 if attempt == 0 else 0.5,
+                max_tokens=900,
+                span_ctx=ctx,
+            )
+        items = parsed.get("candidates", [])
+        if isinstance(items, list) and items:
+            break
+        if attempt + 1 < attempts:
+            _llm._safe_log("warn", "vlm.precompute_candidates.empty_retry")
     out: list[ClickCandidate] = []
     if not isinstance(items, list):
         return out

--- a/apps/modal-backend/tests/conftest.py
+++ b/apps/modal-backend/tests/conftest.py
@@ -59,6 +59,8 @@ _SCRUB = (
     # for hermeticity).
     "RETRY_NO_MEDIA",
     "FRIENDLY_ERRORS",
+    # Candidate empty-roll retry (default ON — same reasoning).
+    "PRECOMPUTE_EMPTY_RETRY",
     # View grammar (default ON — same hermeticity reasoning).
     "VIEW_GRAMMAR",
     "FAL_ENTER_MODEL",

--- a/apps/modal-backend/tests/test_click_resolution.py
+++ b/apps/modal-backend/tests/test_click_resolution.py
@@ -353,3 +353,70 @@ def test_precompute_candidates_parse_enter_as(monkeypatch) -> None:
     assert by_subject["legend box"].enter_as == "explainer"
     # absent → default
     assert by_subject["harbor"].enter_as == "explainer"
+
+
+# ---------- empty-roll retry (gemini-flash sometimes returns a well-formed
+# ---------- empty list for scenic pages; one hotter retry flips it) -------
+
+
+def _precompute(click_mod):
+    import asyncio
+
+    return asyncio.run(
+        click_mod.precompute_click_candidates(
+            image_data_url="data:image/jpeg;base64,x",
+            parent_title="T",
+            parent_query="q",
+        )
+    )
+
+
+def test_precompute_empty_roll_retries_once_hotter(monkeypatch) -> None:
+    from unittest.mock import AsyncMock
+
+    from providers.llm import click as click_mod
+
+    replies = [
+        {"candidates": []},
+        {"candidates": [{"x_pct": 0.2, "y_pct": 0.3, "subject": "castle", "salience": 0.9}]},
+    ]
+    mock = AsyncMock(side_effect=lambda **kw: replies[mock.await_count - 1])
+    monkeypatch.setattr(click_mod._llm, "_complete_json", mock)
+    cands = _precompute(click_mod)
+    assert [c.subject for c in cands] == ["castle"]
+    assert mock.await_count == 2
+    # the retry runs hotter than the first roll
+    temps = [kw.kwargs["temperature"] for kw in mock.await_args_list]
+    assert temps == [0.2, 0.5]
+    # the scene clause that removes the model's "not an explainer → empty" out
+    system = str(mock.await_args_list[0].kwargs["messages"][0])
+    assert "a rich scene is never empty" in system
+
+
+def test_precompute_nonempty_first_roll_calls_once(monkeypatch) -> None:
+    from unittest.mock import AsyncMock
+
+    from providers.llm import click as click_mod
+
+    mock = AsyncMock(
+        return_value={
+            "candidates": [{"x_pct": 0.5, "y_pct": 0.5, "subject": "boat", "salience": 0.7}]
+        }
+    )
+    monkeypatch.setattr(click_mod._llm, "_complete_json", mock)
+    cands = _precompute(click_mod)
+    assert len(cands) == 1
+    assert mock.await_count == 1  # no double VLM spend on good rolls
+
+
+def test_precompute_empty_retry_kill_switch(monkeypatch) -> None:
+    from unittest.mock import AsyncMock
+
+    from providers.llm import click as click_mod
+
+    monkeypatch.setenv("PRECOMPUTE_EMPTY_RETRY", "false")
+    mock = AsyncMock(return_value={"candidates": []})
+    monkeypatch.setattr(click_mod._llm, "_complete_json", mock)
+    cands = _precompute(click_mod)
+    assert cands == []
+    assert mock.await_count == 1


### PR DESCRIPTION
Overnight follow-up (live-caught during the receipt pass for #152–#156). `/precompute-candidates` returned a well-formed `{"candidates": []}` for a rich cliffside-village scene on **3 of 6 identical calls** — loud-parse clean, the model genuinely said "nothing here". The prompt's "illustrated explainer / annotated regions" framing gives scenic world-mode pages a legitimate-empty out.

An empty roll starves tap-prefetch warmup and stops a Wander run mid-flight with "nothing tappable here" (#155 made the stop visible; the cause predates tonight).

Fixed once where every consumer routes through:
- **Prompt scene clause** — scenic/map pages: objects, buildings, creatures, landmarks ARE the clickable subjects; "a rich scene is never empty". Diagram behaviour untouched ("fewer is fine if sparse" stays).
- **One hotter retry** (temp 0.5) on a raw-empty roll, behind `PRECOMPUTE_EMPTY_RETRY` (default ON, conftest-scrubbed). +1 VLM call (~$0.003) only on empty rolls; a warn marks each flip.

Tests: empty→retry-hotter (2 calls, temps 0.2→0.5, clause pinned), non-empty→one call, kill-switch→one roll. Backend suite + ruff + mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)