### PR TITLE
fix(click): salvage mixed-scale VLM coordinates instead of dropping/clamping

### DIFF
--- a/apps/modal-backend/providers/llm/click.py
+++ b/apps/modal-backend/providers/llm/click.py
@@ -334,29 +334,47 @@ async def click_to_subject(
     return _build_click_resolution(parsed, x_pct=x_pct, y_pct=y_pct, fallback_subject=parent_title)
 
 
-def _coerce_unit(value: Any) -> float | None:
-    """Coerce a JSON value to a clamped [0,1] float, or None if non-numeric."""
+def _coerce_unit(
+    value: Any, *, clamp: bool = True, percent: bool = False
+) -> float | None:
+    """Coerce a JSON value to a [0,1] float, or None if non-numeric.
+
+    ``percent=True`` (COORDINATE fields only): the VLM mixes coordinate
+    scales WITHIN one reply (live-caught: ``{"x_pct": 0.55, "y_pct": 71.3}``
+    — a fraction and a percentage side by side), so values in (2, 100] are
+    read as percentages and rescaled. Values in (1, 2] stay overshot
+    fractions and clamp — a 1.5 is a right-edge overshoot, not "1.5%".
+    Non-coordinate fields (confidence, salience) keep plain clamp semantics:
+    a "5" there is an off-scale score, not 5%.
+
+    ``clamp=True`` (points/bboxes): out-of-range values pin to the nearest
+    edge — a rough position beats none. ``clamp=False`` (tap candidates):
+    still-out-of-range values return None so a garbage pixel coordinate
+    can't mint an edge-of-page auto-tap target.
+    """
     try:
         f = float(value)
     except (TypeError, ValueError):
         return None
     if f != f:  # NaN
         return None
+    if percent and 2.0 < f <= 100.0:
+        f = f / 100.0
     if f < 0.0:
-        return 0.0
+        return 0.0 if clamp else None
     if f > 1.0:
-        return 1.0
+        return 1.0 if clamp else None
     return f
 
 
 def _parse_point(raw: Any) -> tuple[float, float] | None:
     """Accept {"x": .., "y": ..} or [x, y] or null. Out-of-range → clamped."""
     if isinstance(raw, dict):
-        x = _coerce_unit(raw.get("x"))
-        y = _coerce_unit(raw.get("y"))
+        x = _coerce_unit(raw.get("x"), percent=True)
+        y = _coerce_unit(raw.get("y"), percent=True)
     elif isinstance(raw, (list, tuple)) and len(raw) >= 2:
-        x = _coerce_unit(raw[0])
-        y = _coerce_unit(raw[1])
+        x = _coerce_unit(raw[0], percent=True)
+        y = _coerce_unit(raw[1], percent=True)
     else:
         return None
     if x is None or y is None:
@@ -367,15 +385,15 @@ def _parse_point(raw: Any) -> tuple[float, float] | None:
 def _parse_bbox(raw: Any) -> tuple[float, float, float, float] | None:
     """Accept {x,y,w,h} or [x,y,w,h]. Returns None if any component invalid."""
     if isinstance(raw, dict):
-        x = _coerce_unit(raw.get("x"))
-        y = _coerce_unit(raw.get("y"))
-        w = _coerce_unit(raw.get("w") or raw.get("width"))
-        h = _coerce_unit(raw.get("h") or raw.get("height"))
+        x = _coerce_unit(raw.get("x"), percent=True)
+        y = _coerce_unit(raw.get("y"), percent=True)
+        w = _coerce_unit(raw.get("w") or raw.get("width"), percent=True)
+        h = _coerce_unit(raw.get("h") or raw.get("height"), percent=True)
     elif isinstance(raw, (list, tuple)) and len(raw) >= 4:
-        x = _coerce_unit(raw[0])
-        y = _coerce_unit(raw[1])
-        w = _coerce_unit(raw[2])
-        h = _coerce_unit(raw[3])
+        x = _coerce_unit(raw[0], percent=True)
+        y = _coerce_unit(raw[1], percent=True)
+        w = _coerce_unit(raw[2], percent=True)
+        h = _coerce_unit(raw[3], percent=True)
     else:
         return None
     if x is None or y is None or w is None or h is None:
@@ -513,8 +531,11 @@ async def precompute_click_candidates(
     # silently starves candidate warmup and stops Wander runs mid-flight. One
     # hotter retry flips almost all of those empty rolls; a genuinely sparse
     # page just comes back empty twice.
+    # Retry on a VALIDATED-empty roll, not just a raw-empty one: the live
+    # failure was 8 raw items whose mixed-scale coordinates all fell to the
+    # validator, which is the same starvation as a bare [].
     attempts = 2 if env_flag("PRECOMPUTE_EMPTY_RETRY", "true") else 1
-    items: Any = []
+    out: list[ClickCandidate] = []
     for attempt in range(attempts):
         async with span("vlm.precompute_candidates", model=_vlm_model()) as ctx:
             parsed = await _llm._complete_json(
@@ -538,24 +559,35 @@ async def precompute_click_candidates(
                 max_tokens=900,
                 span_ctx=ctx,
             )
-        items = parsed.get("candidates", [])
-        if isinstance(items, list) and items:
+        out = _validate_candidates(parsed.get("candidates", []), max_candidates)
+        if out:
             break
         if attempt + 1 < attempts:
             _llm._safe_log("warn", "vlm.precompute_candidates.empty_retry")
+    return out
+
+
+def _validate_candidates(items: Any, max_candidates: int) -> list[ClickCandidate]:
+    """Validate a raw VLM candidate list into ClickCandidates.
+
+    Coordinates ride ``_coerce_unit(clamp=False)``: percent-scale values
+    ((1, 100], the live-caught mixed-convention reply) rescale to fractions;
+    anything still out of range drops the entry — a clamped garbage
+    coordinate would mint an edge-of-page auto-tap target for Wander.
+    """
     out: list[ClickCandidate] = []
     if not isinstance(items, list):
         return out
     for entry in items:
         if not isinstance(entry, dict):
             continue
+        x = _coerce_unit(entry.get("x_pct"), clamp=False, percent=True)
+        y = _coerce_unit(entry.get("y_pct"), clamp=False, percent=True)
+        if x is None or y is None:
+            continue
         try:
-            x = float(entry.get("x_pct", -1))
-            y = float(entry.get("y_pct", -1))
             sal = float(entry.get("salience", 0.5))
         except (TypeError, ValueError):
-            continue
-        if not (0.0 <= x <= 1.0 and 0.0 <= y <= 1.0):
             continue
         subject = str(entry.get("subject", "")).strip()
         style = str(entry.get("style", "")).strip()

--- a/apps/modal-backend/tests/test_click_resolution.py
+++ b/apps/modal-backend/tests/test_click_resolution.py
@@ -7,6 +7,8 @@ under tests/click_bench (gated behind CLICK_BENCH_RUN=1).
 
 from __future__ import annotations
 
+import pytest
+
 from providers import llm
 
 # ---------- _coerce_unit --------------------------------------------------
@@ -420,3 +422,71 @@ def test_precompute_empty_retry_kill_switch(monkeypatch) -> None:
     cands = _precompute(click_mod)
     assert cands == []
     assert mock.await_count == 1
+
+
+# ---------- mixed-scale coordinate salvage (live-caught: gemini returned
+# ---------- {"x_pct": 0.55, "y_pct": 71.3} — fraction and percent in ONE
+# ---------- entry — and the 0..1 validator dropped all 8 candidates) ------
+
+
+def test_coerce_unit_rescales_percent_values() -> None:
+    from providers.llm.click import _coerce_unit
+
+    assert _coerce_unit(0.55, percent=True) == 0.55
+    assert _coerce_unit(1.0, percent=True) == 1.0  # a fraction, NOT 1%
+    assert _coerce_unit(71.3, percent=True) == pytest.approx(0.713)
+    assert _coerce_unit(100, percent=True) == 1.0
+    assert _coerce_unit("33.1", percent=True) == pytest.approx(0.331)
+    # (1, 2] is an overshot fraction, not a percentage — keeps the historical
+    # clamp reading (1.5 = right-edge overshoot, not 1.5% = left edge)
+    assert _coerce_unit(1.5, percent=True) == 1.0
+    # beyond percent range: clamp for points, drop for candidates
+    assert _coerce_unit(672, percent=True) == 1.0
+    assert _coerce_unit(672, percent=True, clamp=False) is None
+    assert _coerce_unit(-0.2, percent=True) == 0.0
+    assert _coerce_unit(-0.2, percent=True, clamp=False) is None
+    # non-coordinate fields keep plain clamp semantics: a "5" confidence is
+    # an off-scale score, not 5%
+    assert _coerce_unit(5) == 1.0
+    assert _coerce_unit("nope") is None
+    assert _coerce_unit(float("nan")) is None
+
+
+def test_precompute_salvages_mixed_scale_coordinates(monkeypatch) -> None:
+    from unittest.mock import AsyncMock
+
+    from providers.llm import click as click_mod
+
+    mock = AsyncMock(
+        return_value={
+            "candidates": [
+                {"x_pct": 0.55, "y_pct": 71.3, "subject": "boat fleet", "salience": 0.95},
+                {"x_pct": 33.1, "y_pct": 30.5, "subject": "red cottage", "salience": 0.8},
+                # pixel garbage must DROP, not clamp into an edge tap target
+                {"x_pct": 672, "y_pct": 0.4, "subject": "ghost", "salience": 0.9},
+            ]
+        }
+    )
+    monkeypatch.setattr(click_mod._llm, "_complete_json", mock)
+    cands = _precompute(click_mod)
+    assert mock.await_count == 1  # salvage, not a second VLM spend
+    by_subject = {c.subject: c for c in cands}
+    assert set(by_subject) == {"boat fleet", "red cottage"}
+    assert by_subject["boat fleet"].y_pct == pytest.approx(0.713)
+    assert by_subject["red cottage"].x_pct == pytest.approx(0.331)
+
+
+def test_precompute_retries_when_every_entry_fails_validation(monkeypatch) -> None:
+    from unittest.mock import AsyncMock
+
+    from providers.llm import click as click_mod
+
+    replies = [
+        {"candidates": [{"x_pct": 900, "y_pct": 1200, "subject": "junk", "salience": 1}]},
+        {"candidates": [{"x_pct": 0.4, "y_pct": 0.6, "subject": "harbor", "salience": 0.7}]},
+    ]
+    mock = AsyncMock(side_effect=lambda **kw: replies[mock.await_count - 1])
+    monkeypatch.setattr(click_mod._llm, "_complete_json", mock)
+    cands = _precompute(click_mod)
+    assert [c.subject for c in cands] == ["harbor"]
+    assert mock.await_count == 2  # validated-empty counts as an empty roll


### PR DESCRIPTION
Follow-up to #157, live-caught by spying on the running stack: gemini mixes fraction and percentage coordinates **in one entry** — `{"x_pct": 0.55, "y_pct": 71.3}` — on most rolls for scene pages. One convention flip, two silent symptoms:

- **candidates**: the 0..1 range check dropped every such entry → validated `[]` (#157's retry never fired — the raw list wasn't empty) → no tap-prefetch warmup, Wander stops mid-run.
- **resolve points/bboxes**: `_coerce_unit` clamped 71.3 to 1.0 → tap targets silently pinned to the bottom/right edge.

Fixed in the one helper every coordinate parse routes through:
- `_coerce_unit(percent=True)` (coordinate fields only): (2, 100] rescales as a percentage; (1, 2] keeps the historical overshot-fraction clamp (pre-existing tests pin `1.5 → 1.0`). Confidence/salience keep plain clamp semantics (`5` is an off-scale score, not 5%).
- candidates use `clamp=False, percent=True`: pixel garbage (672) still **drops** — a clamped edge coordinate would mint an edge-of-page auto-tap target.
- #157's retry now fires on **validated**-empty (an all-invalid roll = the same starvation as a bare `[]`).

World-mode extraction/detector have the same flip but DROP by design (#127 posture) — untouched tonight, flagged for daylight.

Tests: `_coerce_unit` matrix, mixed-scale salvage (no second VLM spend), all-invalid→retry-hotter. Backend suite + ruff + mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)