### PR TITLE
fix(click): read (100, 1000] coordinates as per-mille — the third live scale

### DIFF
--- a/apps/modal-backend/providers/llm/click.py
+++ b/apps/modal-backend/providers/llm/click.py
@@ -340,17 +340,22 @@ def _coerce_unit(
     """Coerce a JSON value to a [0,1] float, or None if non-numeric.
 
     ``percent=True`` (COORDINATE fields only): the VLM mixes coordinate
-    scales WITHIN one reply (live-caught: ``{"x_pct": 0.55, "y_pct": 71.3}``
-    — a fraction and a percentage side by side), so values in (2, 100] are
-    read as percentages and rescaled. Values in (1, 2] stay overshot
-    fractions and clamp — a 1.5 is a right-edge overshoot, not "1.5%".
-    Non-coordinate fields (confidence, salience) keep plain clamp semantics:
-    a "5" there is an off-scale score, not 5%.
+    scales WITHIN one reply — live-caught flavours include
+    ``{"x_pct": 0.55, "y_pct": 71.3}`` (fraction + percent) and
+    ``{"x_pct": 0.509, "y_pct": 238}`` (fraction + PER-MILLE: the same
+    model's good rolls put the same cathedral at y=0.238). So: (2, 100]
+    reads as a percentage, (100, 1000] as per-mille, and anything beyond
+    is unsalvageable. Values in (1, 2] stay overshot fractions and clamp —
+    a 1.5 is a right-edge overshoot, not "1.5%". Ceiling: a raw PIXEL
+    value in (100, 1000] is indistinguishable from per-mille and lands
+    slightly off; the tap-side judges catch those downstream.
+    Non-coordinate fields (confidence, salience) keep plain clamp
+    semantics: a "5" there is an off-scale score, not 5%.
 
     ``clamp=True`` (points/bboxes): out-of-range values pin to the nearest
     edge — a rough position beats none. ``clamp=False`` (tap candidates):
-    still-out-of-range values return None so a garbage pixel coordinate
-    can't mint an edge-of-page auto-tap target.
+    still-out-of-range values return None so a garbage coordinate can't
+    mint an edge-of-page auto-tap target.
     """
     try:
         f = float(value)
@@ -360,6 +365,8 @@ def _coerce_unit(
         return None
     if percent and 2.0 < f <= 100.0:
         f = f / 100.0
+    elif percent and 100.0 < f <= 1000.0:
+        f = f / 1000.0
     if f < 0.0:
         return 0.0 if clamp else None
     if f > 1.0:

--- a/apps/modal-backend/tests/test_click_resolution.py
+++ b/apps/modal-backend/tests/test_click_resolution.py
@@ -440,9 +440,13 @@ def test_coerce_unit_rescales_percent_values() -> None:
     # (1, 2] is an overshot fraction, not a percentage — keeps the historical
     # clamp reading (1.5 = right-edge overshoot, not 1.5% = left edge)
     assert _coerce_unit(1.5, percent=True) == 1.0
-    # beyond percent range: clamp for points, drop for candidates
-    assert _coerce_unit(672, percent=True) == 1.0
-    assert _coerce_unit(672, percent=True, clamp=False) is None
+    # (100, 1000] reads as per-mille (live-caught: y_pct 238 where the same
+    # model's good rolls said 0.238)
+    assert _coerce_unit(238, percent=True) == pytest.approx(0.238)
+    assert _coerce_unit(672, percent=True, clamp=False) == pytest.approx(0.672)
+    # beyond the ladder: clamp for points, drop for candidates
+    assert _coerce_unit(1344, percent=True) == 1.0
+    assert _coerce_unit(1344, percent=True, clamp=False) is None
     assert _coerce_unit(-0.2, percent=True) == 0.0
     assert _coerce_unit(-0.2, percent=True, clamp=False) is None
     # non-coordinate fields keep plain clamp semantics: a "5" confidence is
@@ -462,8 +466,10 @@ def test_precompute_salvages_mixed_scale_coordinates(monkeypatch) -> None:
             "candidates": [
                 {"x_pct": 0.55, "y_pct": 71.3, "subject": "boat fleet", "salience": 0.95},
                 {"x_pct": 33.1, "y_pct": 30.5, "subject": "red cottage", "salience": 0.8},
-                # pixel garbage must DROP, not clamp into an edge tap target
-                {"x_pct": 672, "y_pct": 0.4, "subject": "ghost", "salience": 0.9},
+                # the live harbor-town flavour: fraction x + per-mille y
+                {"x_pct": 0.509, "y_pct": 238, "subject": "cathedral", "salience": 0.85},
+                # beyond the ladder must DROP, not clamp into an edge target
+                {"x_pct": 1344, "y_pct": 0.4, "subject": "ghost", "salience": 0.9},
             ]
         }
     )
@@ -471,9 +477,10 @@ def test_precompute_salvages_mixed_scale_coordinates(monkeypatch) -> None:
     cands = _precompute(click_mod)
     assert mock.await_count == 1  # salvage, not a second VLM spend
     by_subject = {c.subject: c for c in cands}
-    assert set(by_subject) == {"boat fleet", "red cottage"}
+    assert set(by_subject) == {"boat fleet", "red cottage", "cathedral"}
     assert by_subject["boat fleet"].y_pct == pytest.approx(0.713)
     assert by_subject["red cottage"].x_pct == pytest.approx(0.331)
+    assert by_subject["cathedral"].y_pct == pytest.approx(0.238)
 
 
 def test_precompute_retries_when_every_entry_fails_validation(monkeypatch) -> None:


### PR DESCRIPTION
Ten minutes after #158, the same harbor-town image rolled the next flavour **deterministically on both temperatures**: `{"x_pct": 0.509, "y_pct": 238}` — fraction + per-mille in one entry. Proof it's per-mille, not pixels: the same model's good rolls put the same cathedral at `y=0.238`, and `238/1000 = 0.238` exactly (pixel-y would be 183/768). Every entry dropped → validated `[]` → Wander stopped on page 1.

The coordinate ladder in `_coerce_unit` becomes: **(2, 100] percent · (100, 1000] per-mille · beyond → clamp (points) / drop (candidates)**. Stated ceiling: a raw pixel value inside (100, 1000] is indistinguishable from per-mille and lands slightly off — tap-side judges catch those downstream.

Matrix + mixed-scale tests updated with the live flavour. Suite + ruff + mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)