### PR TITLE
chore: gitignore live-verification scratch at repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,11 @@ ladder-proof-runs/
 # Cursor Composer kickoff prompt — an ephemeral paste-into-chat scratch file,
 # not a durable doc (the project brief lives in .cursor/rules + docs/AUDIT_BOX).
 docs/CURSOR_KICKOFF.md
+
+# Live-verification scratch at repo root: Playwright MCP page snapshots
+# (*-snap.md) + one-off screenshot pairs. Durable receipts live on the
+# Desktop visuals folder; these are session droppings. .polly/ is local
+# tool state (registry.json), not project source.
+/*-snap.md
+/tapzoom-*.png
+/.polly/


### PR DESCRIPTION
Playwright MCP session droppings (`*-snap.md`, `tapzoom-*.png`) + `.polly/` local tool state kept showing as 7 phantom "diffs" in editors. Root-anchored patterns so `docs/` etc. stay unaffected. Durable receipts live in the Desktop visuals folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)