### PR TITLE
feat(menu): right-click "Zoom in here" — explicit optical zoom at the pointer

### DIFF
--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -2272,11 +2272,11 @@ export default function PlayPage() {
       // saved place instead of generating a new one — the persistence that
       // makes the atlas read as one continuous world.
       if (worldEnabled && !evt.metaKey && !evt.ctrlKey) {
-        const revisitId = findRevisitTarget(
-          history.items,
-          currentNodeId,
-          click
-        );
+        // An explicit "Zoom in here" outranks the revisit shortcut — the
+        // user said closer, not back.
+        const revisitId = pinnedRenderMode
+          ? null
+          : findRevisitTarget(history.items, currentNodeId, click);
         if (revisitId) {
           clickInFlightRef.current = false;
           selectFromMap(revisitId);

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -58,7 +58,11 @@ import {
   orderedRefs,
   REGION_FRAC,
 } from "@/lib/image-condition";
-import { enterAsToRenderMode, findRevisitTarget } from "@/lib/world-mode";
+import {
+  enterAsToRenderMode,
+  findRevisitTarget,
+  zoomModeForLevel,
+} from "@/lib/world-mode";
 import { usePersistedLocale } from "@/hooks/usePersistedLocale";
 import { usePersistedTheme } from "@/hooks/usePersistedTheme";
 import { useStyleAnchor } from "@/hooks/useStyleAnchor";
@@ -635,6 +639,13 @@ export default function PlayPage() {
   // double-click can pass the `phase === "generating"` check twice and start
   // two overlapping generates.
   const clickInFlightRef = useRef(false);
+  // One-shot render_mode pin from the context menu's "🔍 Zoom in here": set
+  // just before its synthetic dispatchTapAt, consumed (and cleared) at the
+  // top of the tap handler — so wander and normal taps can never inherit it,
+  // even when the pinned tap aborts before reaching generate.
+  const pinnedRenderModeRef = useRef<"place_submap" | "place_closeup" | null>(
+    null
+  );
   const [hoverPos, setHoverPos] = useState<{
     xPx: number;
     yPx: number;
@@ -1720,6 +1731,27 @@ export default function PlayPage() {
         },
       });
     }
+    // Explicit optical zoom (same image, closer — the Kontext zoom path).
+    // Taps ENTER places in world mode, so "closer, not inside" needs its own
+    // affordance. Not entity-gated: any point on the image content zooms
+    // (clickPct is null only on the letterbox, where "here" means nothing).
+    if (contextMenu.clickPct) {
+      const { x_pct, y_pct } = contextMenu.clickPct;
+      items.push({
+        label: "🔍 Zoom in here",
+        onClick: () => {
+          close();
+          // Map-ness heuristic: no scene_view (classic/root frames) or an
+          // explicit map level ⇒ aligned submap cut; any observer level
+          // (building/street/eye) ⇒ closeup. Consumed one-shot by the tap
+          // handler the synthetic click below runs through.
+          pinnedRenderModeRef.current = zoomModeForLevel(
+            page?.sceneView?.level
+          );
+          dispatchTapAt(x_pct, y_pct);
+        },
+      });
+    }
     // Export the root→here path as a shareable artifact (Wave 6). Server
     // route walks the chain; these just open the download.
     if (page?.nodeId) {
@@ -2215,6 +2247,12 @@ export default function PlayPage() {
     };
 
     const handler = async (evt: MouseEvent) => {
+      // "🔍 Zoom in here" pin: read + clear FIRST, whatever happens next — a
+      // guard return, a cancelled hint, or a failed generate must never leak
+      // the pinned mode into the NEXT tap. dispatchEvent runs this handler
+      // synchronously inside dispatchTapAt, so set-then-dispatch can't race.
+      const pinnedRenderMode = pinnedRenderModeRef.current;
+      pinnedRenderModeRef.current = null;
       if (phase === "generating") return;
       if (editMode) return;
       if (clickInFlightRef.current) return;
@@ -2762,6 +2800,10 @@ export default function PlayPage() {
                 : {}),
             }
           : {}),
+        // The context menu's explicit optical zoom: the user SAID "closer,
+        // not inside", so this one-shot pin outranks every heuristic
+        // render_mode above (worldTap / sceneCloseup / wideCut) — spread last.
+        ...(pinnedRenderMode ? { render_mode: pinnedRenderMode } : {}),
         ...(styleAnchor ? { session_style_anchor: styleAnchor.style } : {}),
       });
     };

--- a/apps/web/components/PlayPage/ContextMenu.test.tsx
+++ b/apps/web/components/PlayPage/ContextMenu.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
+
+const base = {
+  x: 12,
+  y: 34,
+  beaconsHidden: false,
+  canCopy: true,
+  canPrune: true,
+  canSavePostcard: true,
+  onCopyPermalink: () => {},
+  onPrune: () => {},
+  onToggleBeacons: () => {},
+  onSavePostcard: () => {},
+  onClose: () => {},
+};
+
+describe("ContextMenu extraItems (parent-injected actions)", () => {
+  it("renders injected items — e.g. 🔍 Zoom in here — and fires their onClick", () => {
+    const onZoom = vi.fn();
+    const extraItems: ContextMenuItem[] = [
+      { label: "🔍 Zoom in here", onClick: onZoom },
+    ];
+    render(<ContextMenu {...base} extraItems={extraItems} />);
+    fireEvent.click(screen.getByText("🔍 Zoom in here"));
+    expect(onZoom).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the page-level actions below the injected section", () => {
+    render(
+      <ContextMenu
+        {...base}
+        extraItems={[{ label: "🔍 Zoom in here", onClick: () => {} }]}
+      />
+    );
+    const labels = screen
+      .getAllByRole("button")
+      .map((b) => b.textContent ?? "");
+    expect(labels.indexOf("🔍 Zoom in here")).toBeLessThan(
+      labels.indexOf("Copy permalink")
+    );
+  });
+
+  it("renders no injected section when extraItems is empty", () => {
+    render(<ContextMenu {...base} extraItems={[]} />);
+    expect(screen.queryByText("🔍 Zoom in here")).toBeNull();
+    expect(screen.getByText("Copy permalink")).toBeTruthy();
+  });
+});

--- a/apps/web/lib/world-mode.test.ts
+++ b/apps/web/lib/world-mode.test.ts
@@ -4,6 +4,7 @@ import {
   REVISIT_RADIUS,
   enterAsToRenderMode,
   findRevisitTarget,
+  zoomModeForLevel,
 } from "./world-mode";
 
 describe("enterAsToRenderMode", () => {
@@ -13,6 +14,23 @@ describe("enterAsToRenderMode", () => {
     expect(enterAsToRenderMode("explainer")).toBe("explainer");
     expect(enterAsToRenderMode(undefined)).toBe("explainer");
     expect(enterAsToRenderMode("bogus")).toBe("explainer");
+  });
+});
+
+describe("zoomModeForLevel (context menu's 🔍 Zoom in here)", () => {
+  it("a map frame zooms as an aligned submap cut", () => {
+    expect(zoomModeForLevel("map")).toBe("place_submap");
+  });
+
+  it("no scene_view (classic/root pages) counts as a map frame", () => {
+    expect(zoomModeForLevel(undefined)).toBe("place_submap");
+    expect(zoomModeForLevel(null)).toBe("place_submap");
+  });
+
+  it("observer levels zoom as a closeup", () => {
+    expect(zoomModeForLevel("eye")).toBe("place_closeup");
+    expect(zoomModeForLevel("street")).toBe("place_closeup");
+    expect(zoomModeForLevel("building")).toBe("place_closeup");
   });
 });
 

--- a/apps/web/lib/world-mode.ts
+++ b/apps/web/lib/world-mode.ts
@@ -17,6 +17,16 @@ export function enterAsToRenderMode(
   return "explainer";
 }
 
+// The context menu's "🔍 Zoom in here": which optical-zoom render mode fits
+// the CURRENT frame. Map frames — no scene_view yet (classic/root pages) or
+// an explicit map level — zoom as an aligned submap cut; any observer level
+// (building/street/eye) zooms as a closeup of what's under the pointer.
+export function zoomModeForLevel(
+  level: string | null | undefined,
+): "place_submap" | "place_closeup" {
+  return !level || level === "map" ? "place_submap" : "place_closeup";
+}
+
 export interface RevisitCandidate {
   nodeId: string | null;
   parentId?: string | null;


### PR DESCRIPTION
Taps ENTER places in world mode; "closer, not inside" gets its own affordance. New context-menu item at the pointer: one-shot `pinnedRenderModeRef` (consumed+cleared at the very top of the tap handler — wander/normal taps can never inherit it) → `dispatchTapAt` → spread **last** in the generate body so it outranks every heuristic render_mode. Map frames (`zoomModeForLevel`: no scene_view or level=map) zoom as `place_submap`; observer levels as `place_closeup`. An explicit zoom also bypasses the revisit shortcut (the user said closer, not back). No backend change — the explicit `render_mode` override is already honored server-side.

Tests: ContextMenu extraItems render/click/order + `zoomModeForLevel` matrix. 691 web tests, tsc, lint, circular green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)