### PR TITLE
feat(interiors): place_form rides the warm path — cache temperature can't flip enter behavior

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -286,6 +286,10 @@ class GenerateBody(BaseModel):
     # warm classic tap route to the faithful zoom (TAP_ZOOM_CONTINUE) without a
     # second resolve. Whitelist-mapped in tap.py; anything else is ignored.
     prefetched_enter_as: str | None = None
+    # The prefetch's place_form (interior|complex|landscape|generic) — lets a
+    # warm tap keep the cold tap's enter behavior (INTERIOR_ENTERS renders the
+    # interior). Whitelist-validated in tap.py; anything else is ignored.
+    prefetched_place_form: str | None = None
     # World Mode semi-autonomy already resolved the tap client-side; this carries
     # the resolver's spatial-anchor note back so the planner can keep the
     # entered place's neighbours where the parent map had them.
@@ -1297,6 +1301,7 @@ async def resolve_click(req: Request, body: ResolveClickBody):
                 else None
             ),
             "enter_as": resolution.enter_as,
+            "place_form": resolution.place_form,
             "clarifiers": resolution.clarifiers,
             "surroundings": resolution.surroundings,
             "trace_id": trace_id,
@@ -1359,6 +1364,7 @@ async def precompute_candidates(req: Request, body: PrecomputeBody):
                     "style": c.style,
                     "salience": c.salience,
                     "enter_as": c.enter_as,
+                    "place_form": c.place_form,
                 }
                 for c in cands
             ],

--- a/apps/modal-backend/providers/generate_modes/tap.py
+++ b/apps/modal-backend/providers/generate_modes/tap.py
@@ -151,6 +151,13 @@ async def stream_tap(
             surroundings_behind_effective = (
                 _sanitize_hint(body.surroundings_behind, 240) or None
             )
+            # Warm place_form parity (#161): without this, the SAME tap
+            # renders the interior cold but the exterior warm — enter
+            # behavior must not depend on cache temperature. Whitelisted;
+            # anything else stays None ("unknown"), never a guess.
+            prefetched_form = (body.prefetched_place_form or "").strip().lower()
+            if prefetched_form in ("interior", "complex", "landscape", "generic"):
+                place_form_resolved = prefetched_form
             # Classic warm tap: the prefetch cache carried the classifier's
             # enter_as — route zoomable taps to the faithful Kontext zoom
             # without a second resolve. Needs a region ref to bite (else

--- a/apps/modal-backend/providers/llm/click.py
+++ b/apps/modal-backend/providers/llm/click.py
@@ -82,6 +82,11 @@ class ClickCandidate:
     # warm tap on a precomputed bucket can route to the faithful zoom without a
     # second resolve (TAP_ZOOM_CONTINUE).
     enter_as: str = "explainer"
+    # The place's FORM ("interior" | "complex" | "landscape" | "generic") —
+    # same classification as ClickResolution.place_form, so a warm tap keeps
+    # the cold tap's enter behavior (INTERIOR_ENTERS). Empty when the VLM
+    # omitted or fumbled it — "unknown", never a guess.
+    place_form: str = ""
 
 
 # JSON Schemas for the structured-output ladder. Used as the `tool` rung's
@@ -138,6 +143,10 @@ CANDIDATES_SCHEMA: dict[str, Any] = {
                     "enter_as": {
                         "type": "string",
                         "enum": ["scene", "submap", "explainer"],
+                    },
+                    "place_form": {
+                        "type": "string",
+                        "enum": ["interior", "complex", "landscape", "generic"],
                     },
                 },
                 "required": ["x_pct", "y_pct", "subject"],
@@ -516,12 +525,26 @@ async def precompute_click_candidates(
         "\"style\": \"<=30 word visual style sentence — same for every "
         "candidate, describing this illustration's medium/palette/line-work\", "
         "\"salience\": 0..1, "
-        "\"enter_as\": \"scene|submap|explainer\"}, ...]}. `enter_as`: "
+        "\"enter_as\": \"scene|submap|explainer\", "
+        "\"place_form\": \"interior|complex|landscape|generic\"}, ...]}. "
+        "`enter_as`: "
         "\"scene\" = a concrete place or physical thing the reader would move "
         "CLOSER to; \"submap\" = the page reads as a map/plan and this is a "
         "sub-area best shown as a closer map; \"explainer\" = an abstract "
         "concept, mechanism, or diagram element best served by a fresh "
-        "labelled diagram. If the page is a scenic illustration or a map "
+        "labelled diagram. "
+        # place_form definition mirrors the click classifier's widened #161
+        # wording so a warm (precomputed) tap classifies EXACTLY like a cold
+        # one — this is what keeps interiors independent of cache temperature.
+        "`place_form` — the subject's FORM, judged from the image (not from "
+        "the words, which may be in any language): \"interior\" = a single "
+        "enclosed volume you'd stand inside (a room, hall, tavern, shop, "
+        "workshop) OR a discrete roofed building you would step into next (a "
+        "tower, house, temple, church, keep, windmill, lighthouse); "
+        "\"complex\" = a multi-structure compound or walkable outdoor area (a "
+        "castle, campus, harbor, market square, village); \"landscape\" = "
+        "open terrain (a valley, coastline, forest); \"generic\" = none of "
+        "these / unclear. If the page is a scenic illustration or a map "
         "rather than an annotated diagram, treat its distinct objects, "
         "buildings, creatures, and landmarks as the clickable subjects — a "
         "rich scene is never empty. Coordinates are 0..1 with origin at the "
@@ -565,7 +588,10 @@ async def precompute_click_candidates(
                 schema=CANDIDATES_SCHEMA,
                 schema_name="click_candidates",
                 temperature=0.2 if attempt == 0 else 0.5,
-                max_tokens=900,
+                # 8 items x (~90 tokens incl. the 30-word style sentence) plus
+                # the new one-word place_form enum — 900 was sized before that
+                # field (#127 right-sizing); 1000 keeps the same headroom.
+                max_tokens=1000,
                 span_ctx=ctx,
             )
         out = _validate_candidates(parsed.get("candidates", []), max_candidates)
@@ -603,6 +629,7 @@ def _validate_candidates(items: Any, max_candidates: int) -> list[ClickCandidate
         if not subject:
             continue
         enter_as_raw = str(entry.get("enter_as", "")).strip().lower()
+        place_form_raw = str(entry.get("place_form", "")).strip().lower()
         out.append(
             ClickCandidate(
                 x_pct=x,
@@ -614,6 +641,14 @@ def _validate_candidates(items: Any, max_candidates: int) -> list[ClickCandidate
                     enter_as_raw
                     if enter_as_raw in ("scene", "submap", "explainer")
                     else "explainer"
+                ),
+                # Same whitelist as the click classifier; "" = unknown (the
+                # warm tap then behaves like no classification), NOT a guess.
+                place_form=(
+                    place_form_raw
+                    if place_form_raw
+                    in ("interior", "complex", "landscape", "generic")
+                    else ""
                 ),
             )
         )

--- a/apps/modal-backend/tests/test_click_resolution.py
+++ b/apps/modal-backend/tests/test_click_resolution.py
@@ -391,6 +391,44 @@ def test_precompute_candidates_parse_enter_as(monkeypatch) -> None:
     assert by_subject["harbor"].enter_as == "explainer"
 
 
+def test_precompute_candidates_parse_place_form(monkeypatch) -> None:
+    # place_form warms the tap cache alongside enter_as so a warm tap keeps
+    # the cold tap's enter behavior (INTERIOR_ENTERS). Bogus/absent → "" —
+    # "unknown", never a guessed form.
+    import asyncio
+    from unittest.mock import AsyncMock
+
+    from providers.llm import click as click_mod
+
+    async def fake_complete_json(**kwargs):
+        return {
+            "candidates": [
+                {"x_pct": 0.2, "y_pct": 0.3, "subject": "castle", "salience": 0.9,
+                 "place_form": "interior"},
+                {"x_pct": 0.6, "y_pct": 0.5, "subject": "legend box", "salience": 0.5,
+                 "place_form": "mansion"},
+                {"x_pct": 0.8, "y_pct": 0.7, "subject": "harbor", "salience": 0.7},
+            ]
+        }
+
+    monkeypatch.setattr(click_mod._llm, "_complete_json", AsyncMock(side_effect=fake_complete_json))
+    cands = asyncio.run(
+        click_mod.precompute_click_candidates(
+            image_data_url="data:image/jpeg;base64,x",
+            parent_title="T",
+            parent_query="q",
+        )
+    )
+    by_subject = {c.subject: c for c in cands}
+    assert by_subject["castle"].place_form == "interior"
+    assert by_subject["legend box"].place_form == ""
+    assert by_subject["harbor"].place_form == ""
+    # the prompt defines the field with the classifier's widened wording
+    system = str(click_mod._llm._complete_json.await_args.kwargs["messages"][0])
+    assert "place_form" in system
+    assert "OR a discrete roofed building you would step into" in system
+
+
 # ---------- empty-roll retry (gemini-flash sometimes returns a well-formed
 # ---------- empty list for scenic pages; one hotter retry flips it) -------
 
@@ -531,3 +569,46 @@ def test_precompute_retries_when_every_entry_fails_validation(monkeypatch) -> No
     cands = _precompute(click_mod)
     assert [c.subject for c in cands] == ["harbor"]
     assert mock.await_count == 2  # validated-empty counts as an empty roll
+
+
+# ---------- /resolve-click route: the response feeds the warm-tap cache ---
+
+
+def test_resolve_click_response_carries_place_form(monkeypatch) -> None:
+    # The hover-prefetch + world-semi clients read place_form off this
+    # response and hand it back as prefetched_place_form — if the route
+    # drops it, warm taps lose interiors (the cache-temperature bug).
+    import sys
+    from unittest.mock import AsyncMock, MagicMock
+
+    sys.modules.setdefault("modal", MagicMock())
+    from fastapi.testclient import TestClient
+
+    from generate import fastapi_app
+    from providers.llm import ClickResolution
+
+    monkeypatch.setattr(
+        llm,
+        "click_to_subject",
+        AsyncMock(
+            return_value=ClickResolution(
+                subject="The Tower of Art",
+                style="hand-drawn engraving",
+                enter_as="scene",
+                place_form="interior",
+            )
+        ),
+    )
+    client = TestClient(fastapi_app)
+    res = client.post(
+        "/resolve-click",
+        json={
+            "image_data_url": "data:image/jpeg;base64,x",
+            "x_pct": 0.5,
+            "y_pct": 0.5,
+        },
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert data["place_form"] == "interior"
+    assert data["enter_as"] == "scene"  # the field it rides beside

--- a/apps/modal-backend/tests/test_generate_enter.py
+++ b/apps/modal-backend/tests/test_generate_enter.py
@@ -720,6 +720,61 @@ async def test_complex_place_form_keeps_exterior_enter(
     assert "scene_view" not in final
 
 
+async def test_warm_prefetched_place_form_enters_interior(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The warm path: prefetched_subject short-circuits the VLM resolve, so
+    # place_form must ride the body — or the SAME tap renders the interior
+    # cold and the exterior warm (cache temperature flipping enter behavior).
+    monkeypatch.setenv("VIEW_LOOP", "false")
+    _mock_plan(monkeypatch)
+    edit = _mock_edit(monkeypatch)
+    _mock_fresh(monkeypatch)
+    resolve = AsyncMock()
+    monkeypatch.setattr(llm_mod, "click_to_subject", resolve)
+    captured = _spy_enter_instruction(monkeypatch)
+
+    await _collect(
+        _event_stream(
+            _interior_body(
+                prefetched_subject="The Tower of Art",
+                prefetched_place_form="interior",
+            ),
+            "t1",
+        )
+    )
+
+    resolve.assert_not_awaited()  # still warm — no second VLM round-trip
+    assert captured["interior"] is True
+    assert "INDOOR" in edit.await_args.args[1]
+
+
+async def test_warm_invalid_prefetched_place_form_is_ignored(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Outside the {interior, complex, landscape, generic} whitelist the hint
+    # is silently dropped — "unknown" (exterior enter), never a guess.
+    monkeypatch.setenv("VIEW_LOOP", "false")
+    _mock_plan(monkeypatch)
+    edit = _mock_edit(monkeypatch)
+    _mock_fresh(monkeypatch)
+    monkeypatch.setattr(llm_mod, "click_to_subject", AsyncMock())
+    captured = _spy_enter_instruction(monkeypatch)
+
+    await _collect(
+        _event_stream(
+            _interior_body(
+                prefetched_subject="The Tower of Art",
+                prefetched_place_form="mansion",
+            ),
+            "t1",
+        )
+    )
+
+    assert captured["interior"] is False
+    assert "INDOOR" not in edit.await_args.args[1]
+
+
 def _mock_loop_judges(
     monkeypatch: pytest.MonkeyPatch, interior_scores: list[tuple[float, str]]
 ) -> tuple[AsyncMock, AsyncMock]:

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -136,6 +136,7 @@ import { viewNeutralAppearance } from "@/lib/appearance";
 // The in-session page graph node — lives in lib/session-pages.ts so the
 // ?continue= hydration mapper (nodeToPage) is a testable pure function.
 import {
+  foldSceneViewStamp,
   nodeToPage,
   type Page,
   type SessionNodeWire,
@@ -982,6 +983,15 @@ export default function PlayPage() {
                 // debug HUD counts how often (UI_AUDIT #11's live half).
                 hudEmit("layout:suppressed", {});
               }
+              // INTERIOR_ENTERS arrivals stamp the final with a scene_view
+              // Partial (scale_tier "room" + place_form "interior") — fold it
+              // over the request's scene_view so page state AND the persisted
+              // node carry the interior marker (the minimap chip + permalink
+              // reloads read it). Stamp absent → body.scene_view unchanged.
+              const foldedSceneView = foldSceneViewStamp(
+                body.scene_view,
+                evt.scene_view
+              );
               void persistNode(
                 {
                   parent_id: body.current_node_id || null,
@@ -1007,7 +1017,7 @@ export default function PlayPage() {
                     url: s.url,
                     title: s.title ?? null,
                   })),
-                  scene_view: body.scene_view ?? null,
+                  scene_view: foldedSceneView,
                 },
                 traceId
               ).then((saved) => {
@@ -1028,8 +1038,8 @@ export default function PlayPage() {
                     // Same relation the persist body sent — so the in-session
                     // map reads this page like the atlas will after a reload.
                     ...(body.mode === "edit" ? { relation: "edit" as const } : {}),
-                    sceneView: body.scene_view
-                      ? { ...body.scene_view, node_id: saved.id }
+                    sceneView: foldedSceneView
+                      ? { ...foldedSceneView, node_id: saved.id }
                       : null,
                     ...(body.mode === "tap" && body.click
                       ? {
@@ -1045,8 +1055,8 @@ export default function PlayPage() {
                       ? {
                           ...prev,
                           nodeId: saved.id,
-                          sceneView: body.scene_view
-                            ? { ...body.scene_view, node_id: saved.id }
+                          sceneView: foldedSceneView
+                            ? { ...foldedSceneView, node_id: saved.id }
                             : null,
                         }
                       : prev
@@ -1077,8 +1087,8 @@ export default function PlayPage() {
                     imageDataUrl: evt.image_data_url,
                     caption: evt.page_title,
                     sceneDescription: evt.final_prompt ?? null,
-                    sceneView: body.scene_view
-                      ? { ...body.scene_view, node_id: saved.id }
+                    sceneView: foldedSceneView
+                      ? { ...foldedSceneView, node_id: saved.id }
                       : null,
                     traceId,
                   }).then((res) => {

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -2063,6 +2063,7 @@ export default function PlayPage() {
             style: string;
             salience: number;
             enter_as?: string;
+            place_form?: string;
           }[];
         };
         if (!Array.isArray(data.candidates)) return;
@@ -2080,6 +2081,9 @@ export default function PlayPage() {
             subject: c.subject,
             style: c.style,
             ...(typeof c.enter_as === "string" ? { enter_as: c.enter_as } : {}),
+            ...(typeof c.place_form === "string" && c.place_form
+              ? { place_form: c.place_form }
+              : {}),
           });
           counts.set(scope, (counts.get(scope) ?? 0) + 1);
           // LRU evict oldest entries when we exceed the global cap.
@@ -2167,6 +2171,7 @@ export default function PlayPage() {
             point?: { x: number; y: number } | null;
             bbox?: { x: number; y: number; w: number; h: number } | null;
             enter_as?: string;
+            place_form?: string;
           };
           if (data.subject) {
             // Merge over any candidate-only entry so its fields (e.g. a
@@ -2188,6 +2193,9 @@ export default function PlayPage() {
               ...(data.bbox ? { bbox: data.bbox } : {}),
               ...(typeof data.enter_as === "string"
                 ? { enter_as: data.enter_as }
+                : {}),
+              ...(typeof data.place_form === "string" && data.place_form
+                ? { place_form: data.place_form }
                 : {}),
             });
             pageBucketCounts.set(
@@ -2221,6 +2229,7 @@ export default function PlayPage() {
       style?: string;
       subject_context?: string;
       enter_as?: string;
+      place_form?: string;
       clarifiers?: string[];
       surroundings?: string;
     } | null> => {
@@ -2298,6 +2307,7 @@ export default function PlayPage() {
             style?: string;
             subject_context?: string;
             enter_as?: string;
+            place_form?: string;
             clarifiers?: string[];
             surroundings?: string;
           }
@@ -2675,6 +2685,12 @@ export default function PlayPage() {
               !wanderingRef.current
                 ? { prefetched_enter_as: cached.enter_as as EnterAs }
                 : {}),
+              // place_form rides under the SAME wander rule as enter_as: a
+              // wander auto-tap withholds every prefetched classification so
+              // the in-band resolve decides everything for that hop.
+              ...(cached.place_form && !wanderingRef.current
+                ? { prefetched_place_form: cached.place_form }
+                : {}),
             }
           : {}),
         // World Mode "semi" already resolved the tap → reuse it (skips the
@@ -2690,6 +2706,13 @@ export default function PlayPage() {
           : {}),
         ...(worldResolved?.surroundings
           ? { prefetched_surroundings: worldResolved.surroundings }
+          : {}),
+        // World "semi" is the OTHER warm path (the blocking client resolve
+        // makes the backend skip its own VLM) — hand its place_form back or
+        // interiors would depend on autonomy mode the same way they depended
+        // on cache temperature.
+        ...(worldResolved?.place_form
+          ? { prefetched_place_form: worldResolved.place_form }
           : {}),
         ...(worldEnabled
           ? {
@@ -3708,6 +3731,9 @@ export default function PlayPage() {
                       ? page.sceneView.map_crop ?? null
                       : null
                   }
+                  // This page IS an interior arrival (#161 stamp) — the
+                  // "no interior mapped yet" complaint would be a lie.
+                  interiorHere={page?.sceneView?.place_form === "interior"}
                 />
               )}
             </div>

--- a/apps/web/components/PlayPage/WorldMiniMap.test.tsx
+++ b/apps/web/components/PlayPage/WorldMiniMap.test.tsx
@@ -136,6 +136,30 @@ describe("WorldMiniMap", () => {
     expect(screen.queryByText(/world coords/i)).toBeNull();
   });
 
+  it("interiorHere: an interior arrival says 'inside X' without the complaint", async () => {
+    // The current page IS the interior (#161 stamp) — "no interior mapped
+    // yet" would be a lie about the very room you're standing in.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        ok(
+          mapPayload([
+            ent("u", "University", 50, 30),
+            ent("b", "Bridge", 80, 40),
+          ]),
+        ),
+      ) as unknown as typeof fetch,
+    );
+    render(
+      <WorldMiniMap sessionId="s1" focusId="u" focusLabel="University" interiorHere />,
+    );
+    await waitFor(() => expect(screen.getByTestId("minimap-empty")).toBeTruthy());
+    expect(screen.getByTestId("minimap-empty").textContent).toBe(
+      "inside University",
+    );
+    expect(screen.queryByText(/no interior mapped yet/i)).toBeNull();
+  });
+
   it("post-ascend: nested former roots still dot the world view with sane bounds", async () => {
     // The OUTWARD reparent shape: P top-level with scale=pScale; old roots at
     // parent-local coords/footprints. Dots resolve to absolutes; the stored

--- a/apps/web/components/PlayPage/WorldMiniMap.tsx
+++ b/apps/web/components/PlayPage/WorldMiniMap.tsx
@@ -20,6 +20,10 @@ interface Props {
   // A submap crop (tap-empty → cropped region): scope the inset to it, in world
   // coords. Mutually exclusive with focusId in practice (scene vs submap).
   crop?: MapCrop | null;
+  // The current page IS an interior arrival (scene_view.place_form ===
+  // "interior", INTERIOR_ENTERS): you're standing inside — "no interior
+  // mapped yet" would be a lie, so the chip drops the complaint.
+  interiorHere?: boolean;
 }
 
 const KIND_COLOR: Record<string, string> = {
@@ -40,6 +44,7 @@ export default function WorldMiniMap({
   focusId,
   focusLabel,
   crop,
+  interiorHere,
 }: Props) {
   const { entities: worldEntities, bounds: worldBounds } = useWorldMap(sessionId);
 
@@ -56,7 +61,8 @@ export default function WorldMiniMap({
         className="pointer-events-none absolute right-2 top-12 rounded-lg border border-black/20 bg-stone-50/95 px-2 py-1.5 text-[10px] text-stone-500 shadow-lg"
         data-testid="minimap-empty"
       >
-        inside {resolvedLabel} · no interior mapped yet
+        inside {resolvedLabel}
+        {interiorHere ? "" : " · no interior mapped yet"}
       </div>
     );
   }

--- a/apps/web/hooks/usePrefetchCache.test.tsx
+++ b/apps/web/hooks/usePrefetchCache.test.tsx
@@ -122,6 +122,22 @@ describe("PrefetchEntry shape", () => {
     expect(PRECOMPUTE_PER_PAGE).toBeGreaterThanOrEqual(PREFETCH_PER_PAGE);
   });
 
+  it("carries place_form through a cache write/read (warm-tap parity)", () => {
+    const { result } = renderHook(() => usePrefetchCache());
+    const cache = result.current.cacheRef.current;
+    const key = result.current.bucketKey("n1", 0.5, 0.5);
+    cache.set(key, {
+      subject: "The Tower of Art",
+      style: "ink",
+      enter_as: "scene",
+      place_form: "interior",
+    });
+    expect(cache.get(key)?.place_form).toBe("interior");
+    // legacy entries without it stay valid — absent means "unknown"
+    const legacy: PrefetchEntry = { subject: "x", style: "" };
+    expect(legacy.place_form).toBeUndefined();
+  });
+
   it("isHoverResolved: candidate-only entries are upgrade-eligible", () => {
     expect(isHoverResolved(undefined)).toBe(false);
     // precompute writes: subject/style(/enter_as) only — upgradeable

--- a/apps/web/hooks/usePrefetchCache.ts
+++ b/apps/web/hooks/usePrefetchCache.ts
@@ -32,6 +32,12 @@ export interface PrefetchEntry {
    * zoom-continuation server-side (TAP_ZOOM_CONTINUE) and dive client-side.
    */
   enter_as?: string;
+  /**
+   * interior | complex | landscape | generic — the resolver's read of the
+   * place's FORM. Rides the tap body (prefetched_place_form) so a warm tap
+   * keeps the cold tap's enter behavior (INTERIOR_ENTERS). Absent = unknown.
+   */
+  place_form?: string;
 }
 
 export const PREFETCH_PER_PAGE = 6;

--- a/apps/web/lib/session-pages.test.ts
+++ b/apps/web/lib/session-pages.test.ts
@@ -1,6 +1,11 @@
+import type { SceneView } from "@openflipbook/config";
 import { describe, expect, it } from "vitest";
 
-import { nodeToPage, type SessionNodeWire } from "./session-pages";
+import {
+  foldSceneViewStamp,
+  nodeToPage,
+  type SessionNodeWire,
+} from "./session-pages";
 
 function wire(overrides: Partial<SessionNodeWire> = {}): SessionNodeWire {
   return {
@@ -45,5 +50,37 @@ describe("nodeToPage (?continue= hydration)", () => {
 
   it("leaves relation absent when a pre-relation server omits it (descend semantics)", () => {
     expect("relation" in nodeToPage(wire())).toBe(false);
+  });
+});
+
+describe("foldSceneViewStamp (SSE final's interior arrival stamp)", () => {
+  const prior: SceneView = {
+    node_id: "n1",
+    level: "street",
+    observer: null,
+    map_crop: null,
+    focus_id: "geo_e1",
+    scale_tier: "place",
+  };
+
+  it("stamp absent → prior unchanged (pre-stamp behavior byte-identical)", () => {
+    expect(foldSceneViewStamp(prior, undefined)).toBe(prior);
+    expect(foldSceneViewStamp(undefined, undefined)).toBeNull();
+  });
+
+  it("prior null → null even with a stamp (nothing to anchor it to)", () => {
+    expect(
+      foldSceneViewStamp(null, { scale_tier: "room", place_form: "interior" }),
+    ).toBeNull();
+  });
+
+  it("merges the stamp over the prior — stamp wins per-field, rest survives", () => {
+    const folded = foldSceneViewStamp(prior, {
+      scale_tier: "room",
+      place_form: "interior",
+    });
+    expect(folded).toEqual({ ...prior, scale_tier: "room", place_form: "interior" });
+    expect(folded?.place_form).toBe("interior");
+    expect(folded?.focus_id).toBe("geo_e1"); // the frame the stamp anchors to
   });
 });

--- a/apps/web/lib/session-pages.ts
+++ b/apps/web/lib/session-pages.ts
@@ -49,6 +49,23 @@ export interface SessionNodeWire {
   relation?: NodeRelation;
 }
 
+/** Fold the SSE final's scene_view stamp over the request's scene_view.
+ * INTERIOR_ENTERS arrivals (#161) stamp the final event with a Partial
+ * (scale_tier "room" + place_form "interior"); the client persists the
+ * REQUEST's scene_view, so without this fold the stamp never reaches page
+ * state or the saved node. Stamp absent → prior unchanged (byte-identical
+ * to pre-stamp behavior). Prior null → null: a stamp without a frame has
+ * nothing to anchor, and the chip this feeds only matters on world pages,
+ * which always carry a scene_view. */
+export function foldSceneViewStamp(
+  prior: SceneView | null | undefined,
+  stamp: Partial<SceneView> | null | undefined,
+): SceneView | null {
+  if (!prior) return null;
+  if (!stamp) return prior;
+  return { ...prior, ...stamp };
+}
+
 /** Server node row → in-session Page, for ?continue= hydration. */
 export function nodeToPage(n: SessionNodeWire): Page {
   return {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -137,6 +137,10 @@ export interface GenerateRequestBody {
   // the faithful zoom-continuation (TAP_ZOOM_CONTINUE) without a second
   // resolve; backend whitelist-maps it, anything else is ignored.
   prefetched_enter_as?: EnterAs;
+  // The prefetch's place_form (interior|complex|landscape|generic). Lets a
+  // warm tap keep the cold tap's enter behavior (INTERIOR_ENTERS); backend
+  // whitelist-validates it, anything else is ignored.
+  prefetched_place_form?: string;
   // World Mode: the resolver's spatial-anchor note ("river to the south, the
   // Citadel NE") carried back so the planner keeps the entered place's
   // neighbours where the parent map had them. Mirrors GenerateBody.
@@ -276,6 +280,11 @@ export interface ResolveClickResponse {
   // mode since TAP_ZOOM_CONTINUE — classic mode uses it to route zoomable taps
   // to the faithful Kontext continuation. Clarifiers: world semi autonomy only.
   enter_as?: EnterAs;
+  // The tapped place's FORM ("interior" | "complex" | "landscape" |
+  // "generic"), judged from the image. Carried so a warm tap can hand it
+  // back (prefetched_place_form) and keep the cold tap's enter behavior
+  // (INTERIOR_ENTERS). Empty/absent = unknown.
+  place_form?: string;
   clarifiers?: string[];
   // World Mode spatial anchor: what sits AROUND the tapped spot and in which
   // direction ("river to the south, timbered houses west, market square NE"),


### PR DESCRIPTION
Follow-up to #161. Warm taps skip the click VLM, and `place_form` wasn't carried anywhere on that path — so the SAME tap entered an interior (cold) or an exterior (warm). Fixed end to end, mirroring `enter_as`'s #150 journey 1:1:

- `/resolve-click` + `/precompute-candidates` responses carry `place_form` (additive); the candidates VLM prompt/schema now classifies it per candidate (same widened definition as #161, whitelist-validated, never guessed; max_tokens 900→1000).
- `GenerateRequestBody.prefetched_place_form` → tap.py warm branch sets `place_form_resolved` (enum-whitelisted), and #161's `interior_enter` formula works warm unchanged. Withheld while Wandering under the exact `prefetched_enter_as` rule.
- The final's `scene_view` stamp is now FOLDED into page state + node persistence (`foldSceneViewStamp`, four consumers) — the interior marker survives permalink reload.
- WorldMiniMap: an interior page shows `inside {label}` without the "no interior mapped yet" complaint.
- Dive-motion audit: world-mode taps can never trigger the crop-promise dive (`willZoom` requires `!worldEnabled`) — verified, no change needed.

Adversarially reviewed → MERGE (whitelists, fold semantics, wire additivity, wander parity, #157–#159 salvage tests untouched all verified). Backend 894 tests + ruff + mypy; web 696 tests + tsc + lint + circular green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)