### PR TITLE
feat(zoom): redraw map zooms instead of upscaling — SUBMAP_REDRAW + legibility judge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -132,11 +132,15 @@ FAL_EDIT_TIER=balanced
 # INTERIOR_ENTERS=true
 # INTERIOR_ACCEPT=6.0
 # Real map zoom: world-mode map zooms (place_submap) are RE-DRAWN at the
-# closer scale by a fresh tier-model render conditioned on the region crop,
-# instead of Kontext's crop-upscale — Kontext magnifies pixels without new
-# detail, so dense city maps arrive as blurry illegible mush. `false` = the
-# old Kontext path, byte-identical.
+# closer scale — the region crop rides the EDIT/continue seam with a
+# loose-refs model, instead of Kontext's crop-upscale. Kontext magnifies
+# pixels without new detail, so dense city maps arrive as blurry illegible
+# mush. `false` = the old Kontext path, byte-identical.
 # SUBMAP_REDRAW=true
+# The redraw's edit model. Must be a LOOSE-refs edit slug (re-synthesizes
+# with the crop as context); pointing this at kontext defeats the purpose —
+# it freezes the pixels, which is the original mush.
+# SUBMAP_REDRAW_MODEL=fal-ai/nano-banana-pro/edit
 # Zoom legibility judge: map zooms must ALSO pass a craft/legibility check
 # (crisp linework, fine detail, readable lettering) besides the step-in
 # judge — mush retries once, keep-best. Applies to both the redraw and the

--- a/.env.example
+++ b/.env.example
@@ -131,6 +131,18 @@ FAL_EDIT_TIER=balanced
 # byte-identical. INTERIOR_ACCEPT is the 0-10 acceptance floor.
 # INTERIOR_ENTERS=true
 # INTERIOR_ACCEPT=6.0
+# Real map zoom: world-mode map zooms (place_submap) are RE-DRAWN at the
+# closer scale by a fresh tier-model render conditioned on the region crop,
+# instead of Kontext's crop-upscale — Kontext magnifies pixels without new
+# detail, so dense city maps arrive as blurry illegible mush. `false` = the
+# old Kontext path, byte-identical.
+# SUBMAP_REDRAW=true
+# Zoom legibility judge: map zooms must ALSO pass a craft/legibility check
+# (crisp linework, fine detail, readable lettering) besides the step-in
+# judge — mush retries once, keep-best. Applies to both the redraw and the
+# Kontext path; TAP_ZOOM_DETAIL_ACCEPT is the 0-10 floor.
+# TAP_ZOOM_DETAIL=true
+# TAP_ZOOM_DETAIL_ACCEPT=6.0
 
 # --- Web (apps/web/.env.local) ---
 # Cloudflare R2 (S3-compatible)

--- a/apps/modal-backend/.venv
+++ b/apps/modal-backend/.venv
@@ -1,0 +1,1 @@
+/Users/eren/Documents/AI/openflipbook/apps/modal-backend/.venv

--- a/apps/modal-backend/.venv
+++ b/apps/modal-backend/.venv
@@ -1,1 +1,0 @@
-/Users/eren/Documents/AI/openflipbook/apps/modal-backend/.venv

--- a/apps/modal-backend/providers/generate_modes/tap.py
+++ b/apps/modal-backend/providers/generate_modes/tap.py
@@ -636,9 +636,7 @@ async def stream_tap(
         # Kontext must NOT be this model — it freezes the pixels, which is the
         # original mush. The kill-switched path is today's Kontext continue,
         # byte-identical.
-        redraw_model = (
-            os.environ.get("SUBMAP_REDRAW_MODEL") or "fal-ai/nano-banana-pro/edit"
-        )
+        redraw_model = model_router.resolve_model("submap_redraw")
 
         async def _render_zoom(instr: str) -> Any:
             return await image_edit_provider.continue_image(
@@ -698,9 +696,13 @@ async def stream_tap(
                 return v.score >= accept and (d is None or d.score >= detail_accept)
 
             def _total(v: JudgeResult, d: JudgeResult | None) -> float:
-                # Keep-best over BOTH axes; degrades to the old single-score
-                # comparison when the detail judge is off.
-                return v.score + (d.score if d is not None else 0.0)
+                # Keep-best = the attempt whose WORST axis is best (min-floor).
+                # A sum could crown a retry that regressed legibility on a
+                # step_in swing — the exact mush the detail axis exists to
+                # block. Detail off degrades to the old single-score compare.
+                if d is None:
+                    return v.score
+                return min(v.score, d.score)
 
             try:
                 verdict, detail = await _verdicts(first)

--- a/apps/modal-backend/providers/generate_modes/tap.py
+++ b/apps/modal-backend/providers/generate_modes/tap.py
@@ -372,6 +372,19 @@ async def stream_tap(
     # edit endpoint; everything else is a fresh gen.
     image_op = model_router.select_operation(render_mode, region_ref is not None)
     use_continuation = image_op == "zoom_continue"
+    # SUBMAP REDRAW (SUBMAP_REDRAW, default ON): a world-mode map zoom is
+    # RE-DRAWN at the closer scale by a fresh tier-model render conditioned on
+    # the region crop, instead of Kontext's crop-upscale. Kontext is
+    # reference-frozen — it magnifies the crop's pixels without synthesizing
+    # new detail, so dense city maps arrive as blurry illegible mush (live
+    # screenshots). `false` is the kill-switch: today's continue_image bytes.
+    # Classic (non-world) submap zooms keep Kontext on purpose (blast radius).
+    submap_redraw = (
+        use_continuation
+        and effective_world_mode
+        and render_mode == "place_submap"
+        and env_flag("SUBMAP_REDRAW", "true")
+    )
     # Spend accounting (providers/spend.py): how many images this
     # generation billed — judged loops overwrite with their attempt count,
     # the draft records itself at emission.
@@ -470,6 +483,10 @@ async def stream_tap(
     # it through the world model and geometry.
     from providers.prompt_library import camera as camera_lib
 
+    # place_closeup zooms into a PERSPECTIVE scene — the cartographic wording
+    # would fight the reference pixels. The register also gates the legibility
+    # judge below (map zooms only).
+    zoom_register = "view" if render_mode == "place_closeup" else "map"
     zoom_instruction = image_edit_provider.build_zoom_instruction(
         plan.page_title,
         plan.facts,
@@ -480,14 +497,19 @@ async def stream_tap(
             body.image_model or model_router.resolve_model("zoom_continue")
         ),
         label_free=body.suppress_map_labels,
-        # place_closeup zooms into a PERSPECTIVE scene — the cartographic
-        # wording would fight the reference pixels.
-        register="view" if render_mode == "place_closeup" else "map",
+        register=zoom_register,
         # The closeup rung magnifies faithfully: no planner facts, no
         # "elaborate" — the facts channel is how city-wide context leaked
         # into closeups (the invented-riverside-palace failure).
         faithful=bool(body.scene_view and body.scene_view.closeup),
+        redraw=submap_redraw,
     )
+    if submap_redraw:
+        # The fresh path's top-down map lever rides the redraw too
+        # (WORLD_TOPDOWN_MAPS; flag-gated → "").
+        _redraw_topdown = _topdown_clause_for(body)
+        if _redraw_topdown:
+            zoom_instruction += "\n\n" + _redraw_topdown
     # The enter edit is a view CHANGE on the SAME place: the region crop
     # carries the look, this text carries the move inside + everything the
     # system knows (identity, neighbours-by-bearing, medium, geometry) —
@@ -605,20 +627,46 @@ async def stream_tap(
     result: Any = None
     main_task: _asyncio.Task | None = None
     if use_continuation and region_ref is not None:
+        # SUBMAP_REDRAW rides the fresh-gen conditioning mechanics: the region
+        # crop as the (sole) reference + the same conditioning preamble the
+        # fresh branch composes — the redraw prompt names it "the reference
+        # image". The kill-switched path is today's Kontext continue, byte-
+        # identical.
+        redraw_preamble = (
+            image_provider.conditioning_preamble(["region"], body.mode)
+            if submap_redraw
+            else ""
+        )
+
+        async def _render_zoom(instr: str) -> Any:
+            if submap_redraw:
+                return await image_provider.generate_image(
+                    prompt=redraw_preamble + instr,
+                    aspect_ratio=body.aspect_ratio,
+                    tier=body.image_tier,
+                    model_override=body.image_model,
+                    reference_urls=[region_ref],
+                )
+            return await image_edit_provider.continue_image(
+                region_ref, instr, model_override=body.image_model
+            )
 
         async def _judged_zoom() -> Any:
-            """Kontext zoom with a step-in judge + one keep-best retry.
+            """Judged zoom (redraw or Kontext) + one keep-best retry.
 
             Every zoom flavour funnels here (classic scene/closeup + submap,
-            world submap, wideRegionCut), so one gate covers them all: the
-            arrival must be the tapped region seen CLOSER (score_step_in — a
-            wider redraw or an unrelated scene fails), else retry once with
-            the critic's rationale folded in and keep the better attempt.
-            TAP_ZOOM_JUDGE default ON; judge failures never block the tap.
+            world submap + redraw, wideRegionCut), so one gate covers them
+            all: the arrival must be the tapped region seen CLOSER
+            (score_step_in — a wider redraw or an unrelated scene fails) AND,
+            on map-register zooms with TAP_ZOOM_DETAIL on, actually LEGIBLE
+            at the new scale (score_map_legibility — a crop-upscale's blurry
+            mush is the same region closer, so step-in alone passes it). On a
+            fail, retry once with every failed axis's rationale folded in and
+            keep the better attempt. TAP_ZOOM_JUDGE default ON; judge
+            failures never block the tap. view-register zooms
+            (place_closeup) skip the legibility axis.
             """
-            first = await image_edit_provider.continue_image(
-                region_ref, zoom_instruction, model_override=body.image_model
-            )
+            first = await _render_zoom(zoom_instruction)
             if not env_flag("TAP_ZOOM_JUDGE", "true") or body.verify is False:
                 return first
             from providers import judge, render_loop
@@ -630,9 +678,36 @@ async def stream_tap(
                 accept = float(os.environ.get("TAP_ZOOM_ACCEPT", "6.0"))
             except ValueError:
                 accept = 6.0
-            step_in = _same_place_judge(judge)
             try:
-                verdict = await step_in(region_bytes, first.jpeg_bytes)
+                detail_accept = float(
+                    os.environ.get("TAP_ZOOM_DETAIL_ACCEPT", "6.0")
+                )
+            except ValueError:
+                detail_accept = 6.0
+            step_in = _same_place_judge(judge)
+            detail_on = zoom_register == "map" and env_flag(
+                "TAP_ZOOM_DETAIL", "true"
+            )
+
+            async def _verdicts(img: Any) -> tuple[JudgeResult, JudgeResult | None]:
+                if not detail_on:
+                    return await step_in(region_bytes, img.jpeg_bytes), None
+                got = await _asyncio.gather(
+                    step_in(region_bytes, img.jpeg_bytes),
+                    judge.score_map_legibility(img.jpeg_bytes),
+                )
+                return got[0], got[1]
+
+            def _accepted(v: JudgeResult, d: JudgeResult | None) -> bool:
+                return v.score >= accept and (d is None or d.score >= detail_accept)
+
+            def _total(v: JudgeResult, d: JudgeResult | None) -> float:
+                # Keep-best over BOTH axes; degrades to the old single-score
+                # comparison when the detail judge is off.
+                return v.score + (d.score if d is not None else 0.0)
+
+            try:
+                verdict, detail = await _verdicts(first)
             except Exception:
                 return first
             log(
@@ -640,27 +715,35 @@ async def stream_tap(
                 "tap.zoom_judge",
                 attempt=1,
                 score=verdict.score,
-                accepted=verdict.score >= accept,
+                legibility=detail.score if detail is not None else None,
+                accepted=_accepted(verdict, detail),
             )
-            if verdict.score >= accept:
+            if _accepted(verdict, detail):
                 return first
             # One deadline-aware retry (same margin discipline as the render
             # loop: never start an attempt the ingress window can't fit).
             remaining = ingress_timeout_s - 120.0 - (_time.perf_counter() - started)
             if remaining < 45.0:
                 return first
+            reasons: list[str] = []
+            if verdict.score < accept:
+                reasons.append(
+                    (verdict.rationale or "not recognisably the same region, closer")[:200]
+                )
+            if detail is not None and detail.score < detail_accept:
+                reasons.append(
+                    (detail.rationale or "blurry upscale mush, no fine detail")[:200]
+                )
             retry_instruction = (
                 zoom_instruction
                 + " A previous attempt was rejected by a reviewer: \""
-                + (verdict.rationale or "not recognisably the same region, closer")[:200]
+                + "; ".join(reasons)
                 + "\". Render the SAME tapped region again — identical structures,"
                 " palette and line work — just seen closer."
             )
             try:
-                second = await image_edit_provider.continue_image(
-                    region_ref, retry_instruction, model_override=body.image_model
-                )
-                verdict2 = await step_in(region_bytes, second.jpeg_bytes)
+                second = await _render_zoom(retry_instruction)
+                verdict2, detail2 = await _verdicts(second)
             except Exception:
                 return first
             log(
@@ -668,9 +751,10 @@ async def stream_tap(
                 "tap.zoom_judge",
                 attempt=2,
                 score=verdict2.score,
-                accepted=verdict2.score >= accept,
+                legibility=detail2.score if detail2 is not None else None,
+                accepted=_accepted(verdict2, detail2),
             )
-            return second if verdict2.score >= verdict.score else first
+            return second if _total(verdict2, detail2) >= _total(verdict, detail) else first
 
         main_task = _asyncio.create_task(_judged_zoom())
     elif use_enter_edit and enter_source is not None:
@@ -946,7 +1030,9 @@ async def stream_tap(
     # the fresh path (unchanged wire shape). Lets the demo trace / A-B
     # drivers machine-check the route instead of inferring from the model.
     executed_op = (
-        "zoom_continue"
+        "map_redraw"
+        if use_continuation and submap_redraw
+        else "zoom_continue"
         if use_continuation
         else "enter_scene"
         if use_enter_edit

--- a/apps/modal-backend/providers/generate_modes/tap.py
+++ b/apps/modal-backend/providers/generate_modes/tap.py
@@ -373,7 +373,7 @@ async def stream_tap(
     image_op = model_router.select_operation(render_mode, region_ref is not None)
     use_continuation = image_op == "zoom_continue"
     # SUBMAP REDRAW (SUBMAP_REDRAW, default ON): a world-mode map zoom is
-    # RE-DRAWN at the closer scale by a fresh tier-model render conditioned on
+    # RE-DRAWN at the closer scale by a LOOSE-refs edit model conditioned on
     # the region crop, instead of Kontext's crop-upscale. Kontext is
     # reference-frozen — it magnifies the crop's pixels without synthesizing
     # new detail, so dense city maps arrive as blurry illegible mush (live
@@ -627,28 +627,24 @@ async def stream_tap(
     result: Any = None
     main_task: _asyncio.Task | None = None
     if use_continuation and region_ref is not None:
-        # SUBMAP_REDRAW rides the fresh-gen conditioning mechanics: the region
-        # crop as the (sole) reference + the same conditioning preamble the
-        # fresh branch composes — the redraw prompt names it "the reference
-        # image". The kill-switched path is today's Kontext continue, byte-
-        # identical.
-        redraw_preamble = (
-            image_provider.conditioning_preamble(["region"], body.mode)
-            if submap_redraw
-            else ""
+        # SUBMAP_REDRAW rides the pixel-honoring EDIT seam with a LOOSE-refs
+        # model. The fresh path is NOT an option: fal's text-to-image endpoints
+        # accept-but-ignore reference images (supports_refs=False, #109 removed
+        # the inert upload), so a "fresh render conditioned on the crop" is
+        # text-anchored only — a nice new map of somewhere else. The nano EDIT
+        # slug re-synthesizes WITH the crop's pixels (the enter path's slug);
+        # Kontext must NOT be this model — it freezes the pixels, which is the
+        # original mush. The kill-switched path is today's Kontext continue,
+        # byte-identical.
+        redraw_model = (
+            os.environ.get("SUBMAP_REDRAW_MODEL") or "fal-ai/nano-banana-pro/edit"
         )
 
         async def _render_zoom(instr: str) -> Any:
-            if submap_redraw:
-                return await image_provider.generate_image(
-                    prompt=redraw_preamble + instr,
-                    aspect_ratio=body.aspect_ratio,
-                    tier=body.image_tier,
-                    model_override=body.image_model,
-                    reference_urls=[region_ref],
-                )
             return await image_edit_provider.continue_image(
-                region_ref, instr, model_override=body.image_model
+                region_ref,
+                instr,
+                model_override=redraw_model if submap_redraw else body.image_model,
             )
 
         async def _judged_zoom() -> Any:

--- a/apps/modal-backend/providers/image_edit.py
+++ b/apps/modal-backend/providers/image_edit.py
@@ -129,11 +129,13 @@ def build_zoom_instruction(
     label_free: bool = False,
     register: str = "map",
     faithful: bool = False,
+    redraw: bool = False,
 ) -> str:
     """Delegates to prompt_library.instructions (the body moved verbatim;
     view=None is byte-identical to the pre-grammar string — pinned by
     tests/test_image_continue.py + the frozen goldens). With a view, the
-    keep-camera fragment is spelled per projection in PRESERVE form."""
+    keep-camera fragment is spelled per projection in PRESERVE form. redraw
+    (SUBMAP_REDRAW) switches to the fresh re-render wording."""
     from typing import cast
 
     from providers.prompt_library import instructions as _instructions
@@ -149,6 +151,7 @@ def build_zoom_instruction(
         label_free=label_free,
         register=register,
         faithful=faithful,
+        redraw=redraw,
     )
 
 

--- a/apps/modal-backend/providers/judge.py
+++ b/apps/modal-backend/providers/judge.py
@@ -247,6 +247,23 @@ async def score_step_in(region_crop: bytes, candidate: bytes) -> JudgeResult:
     )
 
 
+async def score_map_legibility(arrival: bytes) -> JudgeResult:
+    """The zoom gate's second axis (TAP_ZOOM_DETAIL): is the arrived MAP
+    actually DRAWN at this scale — crisp linework, fine architectural detail —
+    or a crop-upscale's smeared mush? score_step_in can't catch mush: an
+    upscaled blur IS the same region seen closer, so it sails through.
+    Single-image by design — blur is visible without the reference crop."""
+    system = (
+        "Score this MAP image's craft 0-10. 10 = crisp linework, fine "
+        "architectural detail (individual buildings, streets), any lettering "
+        "legible. 4-6 = soft but readable. 0-2 = blurry upscale mush: smeared "
+        "texture, illegible or garbled lettering, no fine detail."
+        ' Return JSON exactly: {"score": <0-10 number>, "rationale": "<one short sentence>"}.'
+    )
+    user_text = "Score this map image's craft and legibility on a 0-10 scale."
+    return await _ask_judge(system, user_text, [_image_block(arrival)])
+
+
 async def score_interior(region_or_parent: bytes, arrival: bytes) -> JudgeResult:
     """INTERIOR ENTERS' gate: is the arrival actually INDOORS, and does that
     interior plausibly belong to the tapped building? Replaces the step-in

--- a/apps/modal-backend/providers/model_router.py
+++ b/apps/modal-backend/providers/model_router.py
@@ -24,6 +24,10 @@ MODEL_SLOTS: dict[str, tuple[str | None, str | None]] = {
     # and tolerate a view change, where Kontext strict-zooms. The enter eval
     # (tests/continuity_bench/enter_runner.py) A/Bs the candidates.
     "enter_scene": ("fal-ai/nano-banana-pro/edit", "FAL_ENTER_MODEL"),
+    # World-mode map-zoom REDRAW (SUBMAP_REDRAW): same loose-refs pedigree as
+    # enter_scene — honours the region crop, re-synthesizes detail, keeps map
+    # lettering legible. Kontext here would defeat the purpose (pixel-freeze).
+    "submap_redraw": ("fal-ai/nano-banana-pro/edit", "SUBMAP_REDRAW_MODEL"),
     # B2 OUTWARD: a centered BRIA outpaint paints the container around the
     # source; the medium-flip hop is a tier-based fresh gen.
     "outpaint_zoomout": ("fal-ai/bria/expand", "FAL_OUTPAINT_MODEL"),

--- a/apps/modal-backend/providers/prompt_library/instructions.py
+++ b/apps/modal-backend/providers/prompt_library/instructions.py
@@ -667,6 +667,37 @@ def _faithful_zoom_instruction(
     return text.strip()
 
 
+def _redraw_zoom_instruction(
+    page_title: str,
+    facts: list[str],
+    layout_clause: str = "",
+    *,
+    style_anchor: str | None = None,
+) -> str:
+    """The SUBMAP_REDRAW variant of the map-register zoom: a fresh cartographic
+    re-render at the closer scale instead of a Kontext crop-upscale. Kontext is
+    reference-frozen — it magnifies the crop's pixels without synthesizing new
+    detail, so dense city maps arrive as blurry illegible mush. This wording
+    asks a fresh model to DRAW the closer map (finer architectural/street
+    detail) while keeping the reference's landmarks in place; medium_lock
+    carries the style anchor and the lettering guard rides inside it."""
+    title = page_title.strip() or "this place"
+    text = (
+        f'Draw a closer, richer, MORE DETAILED map of "{title}" — the area '
+        "the reference image shows. Redraw it at this larger scale with finer "
+        "architectural and street detail (individual buildings, lanes, "
+        "courtyards), keeping every named landmark, wall and waterway the "
+        "reference shows in the same positions"
+    )
+    named = [f.strip() for f in facts if f and f.strip()]
+    if named:
+        text += ", working in the features that belong here: " + "; ".join(named[:8])
+    text += ". " + medium_lock(style_anchor)
+    if layout_clause.strip():
+        text += "\n\n" + layout_clause.strip()
+    return text.strip()
+
+
 def build_zoom_instruction(
     page_title: str,
     facts: list[str],
@@ -678,6 +709,7 @@ def build_zoom_instruction(
     label_free: bool = False,
     register: str = "map",
     faithful: bool = False,
+    redraw: bool = False,
 ) -> str:
     """Zoom-continue: same place, SAME camera, finer detail. view=None ->
     today's exact string. With a view, the keep-camera fragment is spelled per
@@ -687,7 +719,10 @@ def build_zoom_instruction(
     directive. register="view" (place_closeup: the source is a perspective
     SCENE, not a map) swaps the cartographic words on the legacy skeleton.
     faithful (closeup rung) switches to pure magnification — no facts, no
-    elaboration. Defaults keep every instruction byte-identical."""
+    elaboration. redraw (SUBMAP_REDRAW: world-mode map zooms rendered fresh
+    instead of crop-upscaled) switches to the re-render wording — map register
+    by construction, so view/family/register don't apply. Defaults keep every
+    instruction byte-identical."""
     if label_free:
         text = build_zoom_instruction(
             page_title,
@@ -698,10 +733,15 @@ def build_zoom_instruction(
             family=family,
             register=register,
             faithful=faithful,
+            redraw=redraw,
         )
         if LETTERING_GUARD in text:
             return text.replace(LETTERING_GUARD, NO_LETTERING)
         return f"{text} {NO_LETTERING}"
+    if redraw:
+        return _redraw_zoom_instruction(
+            page_title, facts, layout_clause, style_anchor=style_anchor
+        )
     if faithful:
         # The closeup rung ignores the view-aware variants too — the
         # reference pixels carry the camera, and facts never ride a

--- a/apps/modal-backend/tests/conftest.py
+++ b/apps/modal-backend/tests/conftest.py
@@ -55,9 +55,11 @@ _SCRUB = (
     "TAP_ZOOM_CONTINUE",
     "TAP_ZOOM_JUDGE",
     "TAP_ZOOM_ACCEPT",
-    # Real map zoom (default ON: world submap zooms are redrawn fresh) + the
-    # legibility judge axis — scrub for the same hermeticity.
+    # Real map zoom (default ON: world submap zooms are redrawn via the
+    # loose-refs edit seam) + the legibility judge axis — scrub for the same
+    # hermeticity.
     "SUBMAP_REDRAW",
+    "SUBMAP_REDRAW_MODEL",
     "TAP_ZOOM_DETAIL",
     "TAP_ZOOM_DETAIL_ACCEPT",
     # Stochastic-failure retry + friendly error frames (default ON — scrub

--- a/apps/modal-backend/tests/conftest.py
+++ b/apps/modal-backend/tests/conftest.py
@@ -55,6 +55,11 @@ _SCRUB = (
     "TAP_ZOOM_CONTINUE",
     "TAP_ZOOM_JUDGE",
     "TAP_ZOOM_ACCEPT",
+    # Real map zoom (default ON: world submap zooms are redrawn fresh) + the
+    # legibility judge axis — scrub for the same hermeticity.
+    "SUBMAP_REDRAW",
+    "TAP_ZOOM_DETAIL",
+    "TAP_ZOOM_DETAIL_ACCEPT",
     # Stochastic-failure retry + friendly error frames (default ON — scrub
     # for hermeticity).
     "RETRY_NO_MEDIA",

--- a/apps/modal-backend/tests/test_generate_enter.py
+++ b/apps/modal-backend/tests/test_generate_enter.py
@@ -459,7 +459,28 @@ def _mock_step_in(monkeypatch: pytest.MonkeyPatch, scores: list[float]) -> Async
         side_effect=[JudgeResult(s, f"verdict {s}", "raw") for s in scores]
     )
     monkeypatch.setattr(judge_mod, "score_step_in", step)
+    # The legibility axis (TAP_ZOOM_DETAIL, default ON) rides alongside on
+    # map-register zooms — pin it PASSING so these tests keep exercising the
+    # step-in axis alone; the detail-gate tests below own the legibility axis.
+    _mock_legibility(monkeypatch, [9.0] * max(2, len(scores)))
     return step
+
+
+def _mock_legibility(
+    monkeypatch: pytest.MonkeyPatch, scores: list[tuple[float, str] | float]
+) -> AsyncMock:
+    from providers import judge as judge_mod
+    from providers.judge import JudgeResult
+
+    results = [
+        JudgeResult(s, "ok", "raw")
+        if isinstance(s, (int, float))
+        else JudgeResult(s[0], s[1], "raw")
+        for s in scores
+    ]
+    leg = AsyncMock(side_effect=results)
+    monkeypatch.setattr(judge_mod, "score_map_legibility", leg)
+    return leg
 
 
 async def test_zoom_judge_pass_is_single_attempt(
@@ -579,6 +600,7 @@ async def test_zoom_judge_error_never_blocks_the_tap(
     monkeypatch.setattr(
         judge_mod, "score_step_in", AsyncMock(side_effect=RuntimeError("judge down"))
     )
+    _mock_legibility(monkeypatch, [9.0, 9.0])  # only step_in is down
 
     events = await _collect(
         _event_stream(
@@ -803,3 +825,349 @@ async def test_interior_accept_env_floor_is_honored(
 
     edit.assert_awaited_once()  # accepted on the first attempt — no retry
     interior.assert_awaited_once()
+
+
+# ---------- real map zoom (SUBMAP_REDRAW, default ON) --------------------------
+#
+# Kontext is reference-frozen: a world-mode submap "zoom" crop-UPSCALED the
+# region without re-synthesizing detail — dense city maps arrived as blurry
+# illegible mush. Default ON, the zoom is a FRESH cartographic re-render
+# (tier model) conditioned on the region crop; `false` is a strict kill-switch
+# back to the Kontext continue, and classic (non-world) submaps keep Kontext
+# regardless.
+
+
+def _world_submap_body(**over: Any) -> GenerateBody:
+    defaults: dict[str, Any] = {
+        "render_mode": "place_submap",
+        "world_mode": True,
+    }
+    defaults.update(over)
+    return _tap_body(**defaults)
+
+
+async def test_world_submap_redraw_routes_fresh_with_region_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Default (flag unset = ON): the world submap zoom is a fresh tier-model
+    # render — the region crop rides as the reference + conditioning preamble,
+    # continue_image is never called, and the wire says map_redraw.
+    monkeypatch.setenv("WORLD_MODE", "true")
+    _mock_plan(monkeypatch)
+    edit = _mock_edit(monkeypatch)
+    cont = _mock_continue(monkeypatch)
+    gen = _mock_fresh(monkeypatch)
+
+    events = await _collect(_event_stream(_world_submap_body(), "t1"))
+
+    gen.assert_awaited_once()
+    cont.assert_not_awaited()
+    edit.assert_not_awaited()
+    assert gen.await_args.kwargs["reference_urls"] == ["data:r"]  # the region crop
+    assert gen.await_args.kwargs["tier"] is None  # the fresh path's tier resolve
+    assert gen.await_args.kwargs["model_override"] is None  # no hardcoded model
+    prompt = gen.await_args.kwargs["prompt"]
+    assert prompt.startswith("Use the reference images as visual grounding")
+    assert "MORE DETAILED map" in prompt
+    final = next(e for e in events if e["type"] == "final")
+    assert final["image_op"] == "map_redraw"
+    assert final["image_model"] == "fal-ai/nano-banana-pro"
+
+
+async def test_submap_redraw_kill_switch_is_todays_kontext(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("WORLD_MODE", "true")
+    monkeypatch.setenv("SUBMAP_REDRAW", "false")
+    _mock_plan(monkeypatch)
+    _mock_edit(monkeypatch)
+    cont = _mock_continue(monkeypatch)
+    gen = _mock_fresh(monkeypatch)
+
+    events = await _collect(_event_stream(_world_submap_body(), "t1"))
+
+    cont.assert_awaited_once()
+    gen.assert_not_awaited()
+    assert cont.await_args.args[0] == "data:r"
+    assert cont.await_args.args[1].startswith("Zoom into")  # the legacy wording
+    final = next(e for e in events if e["type"] == "final")
+    assert final["image_op"] == "zoom_continue"
+
+
+async def test_classic_submap_keeps_kontext_regardless_of_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # World mode NOT effective (env off) → the redraw never arms, whatever the
+    # flag says. Blast-radius choice: classic submap zooms stay Kontext.
+    monkeypatch.setenv("SUBMAP_REDRAW", "true")
+    _mock_plan(monkeypatch)
+    _mock_edit(monkeypatch)
+    cont = _mock_continue(monkeypatch)
+    gen = _mock_fresh(monkeypatch)
+
+    events = await _collect(_event_stream(_world_submap_body(), "t1"))
+
+    cont.assert_awaited_once()
+    gen.assert_not_awaited()
+    final = next(e for e in events if e["type"] == "final")
+    assert final["image_op"] == "zoom_continue"
+
+
+async def test_redraw_prompt_carries_clauses_and_style(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The redraw instruction = closer-richer wording + medium/style lock +
+    # lettering guard (+ the top-down map lever when armed), and it is also
+    # the reported final_prompt.
+    monkeypatch.setenv("WORLD_MODE", "true")
+    monkeypatch.setenv("WORLD_TOPDOWN_MAPS", "true")
+    _mock_plan(monkeypatch)
+    _mock_edit(monkeypatch)
+    _mock_continue(monkeypatch)
+    gen = _mock_fresh(monkeypatch)
+
+    events = await _collect(_event_stream(_world_submap_body(), "t1"))
+
+    prompt = gen.await_args.kwargs["prompt"]
+    assert 'Draw a closer, richer, MORE DETAILED map of "The Stone Castle"' in prompt
+    assert "individual buildings, lanes, courtyards" in prompt
+    assert "The Inner Bailey" in prompt  # the planner's facts ride in
+    assert "hand-drawn engraving, sepia ink" in prompt  # the medium lock
+    assert "garbled" in prompt  # the lettering guard
+    assert "FLAT TOP-DOWN" in prompt  # the map lever rides the redraw
+    final = next(e for e in events if e["type"] == "final")
+    assert "MORE DETAILED map" in final["final_prompt"]
+
+
+# ---------- the zoom legibility gate (TAP_ZOOM_DETAIL, default ON) -------------
+#
+# score_step_in alone cannot catch upscale mush — a blurry magnification IS the
+# same region seen closer. Map-register zooms (submap, either op) must ALSO
+# pass score_map_legibility; a fail folds its rationale into the ONE existing
+# keep-best retry. view-register zooms (place_closeup) are exempt.
+
+
+async def test_zoom_detail_both_pass_accepts_first(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_plan(monkeypatch)
+    _mock_edit(monkeypatch)
+    cont = _mock_continue(monkeypatch)
+    _mock_fresh(monkeypatch)
+    _mock_step_in(monkeypatch, [8.0])
+    leg = _mock_legibility(monkeypatch, [7.0])
+
+    await _collect(
+        _event_stream(
+            _classic_body(
+                condition_image_urls=[_region_data_url(), "data:p"],
+                condition_roles=["region", "parent"],
+            ),
+            "t1",
+        )
+    )
+
+    cont.assert_awaited_once()
+    leg.assert_awaited_once()
+    assert leg.await_args.args[0] == b"jpeg"  # judged on the ARRIVAL bytes
+
+
+async def test_zoom_detail_fail_retries_with_legibility_rationale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Step-in passes, legibility fails → the retry fires carrying the
+    # legibility rationale ONLY (the passing axis does not pollute it), and
+    # keep-best prefers the crisper second attempt.
+    _mock_plan(monkeypatch)
+    _mock_edit(monkeypatch)
+    first = GeneratedImage(b"jpeg-first", "image/jpeg", "fal-ai/flux-pro/kontext", "r1")
+    second = GeneratedImage(b"jpeg-second", "image/jpeg", "fal-ai/flux-pro/kontext", "r2")
+    cont = AsyncMock(side_effect=[first, second])
+    monkeypatch.setattr(image_edit_mod, "continue_image", cont)
+    _mock_fresh(monkeypatch)
+    _mock_step_in(monkeypatch, [9.0, 9.0])
+    _mock_legibility(monkeypatch, [(2.0, "smeared upscale mush"), (8.0, "crisp")])
+
+    events = await _collect(
+        _event_stream(
+            _classic_body(
+                condition_image_urls=[_region_data_url(), "data:p"],
+                condition_roles=["region", "parent"],
+            ),
+            "t1",
+        )
+    )
+
+    assert cont.await_count == 2
+    retry_instruction = cont.await_args_list[1].args[1]
+    assert "rejected by a reviewer" in retry_instruction
+    assert "smeared upscale mush" in retry_instruction
+    assert "verdict 9.0" not in retry_instruction  # the passing axis stays out
+    final = next(e for e in events if e["type"] == "final")
+    assert _b64.b64encode(b"jpeg-second").decode() in final["image_data_url"]
+
+
+async def test_zoom_detail_both_axes_fail_folds_both_rationales(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_plan(monkeypatch)
+    _mock_edit(monkeypatch)
+    first = GeneratedImage(b"jpeg-first", "image/jpeg", "fal-ai/flux-pro/kontext", "r1")
+    second = GeneratedImage(b"jpeg-second", "image/jpeg", "fal-ai/flux-pro/kontext", "r2")
+    cont = AsyncMock(side_effect=[first, second])
+    monkeypatch.setattr(image_edit_mod, "continue_image", cont)
+    _mock_fresh(monkeypatch)
+    _mock_step_in(monkeypatch, [4.0, 8.0])
+    _mock_legibility(monkeypatch, [(2.0, "smeared mush"), (8.0, "crisp")])
+
+    await _collect(
+        _event_stream(
+            _classic_body(
+                condition_image_urls=[_region_data_url(), "data:p"],
+                condition_roles=["region", "parent"],
+            ),
+            "t1",
+        )
+    )
+
+    retry_instruction = cont.await_args_list[1].args[1]
+    assert "verdict 4.0" in retry_instruction  # step-in's rationale
+    assert "smeared mush" in retry_instruction  # + legibility's
+
+
+async def test_zoom_detail_keep_best_spans_both_axes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Retry passes neither; totals decide (first 9+2=11 vs second 8+1=9) →
+    # keep the first attempt.
+    _mock_plan(monkeypatch)
+    _mock_edit(monkeypatch)
+    first = GeneratedImage(b"jpeg-first", "image/jpeg", "fal-ai/flux-pro/kontext", "r1")
+    second = GeneratedImage(b"jpeg-second", "image/jpeg", "fal-ai/flux-pro/kontext", "r2")
+    cont = AsyncMock(side_effect=[first, second])
+    monkeypatch.setattr(image_edit_mod, "continue_image", cont)
+    _mock_fresh(monkeypatch)
+    _mock_step_in(monkeypatch, [9.0, 8.0])
+    _mock_legibility(monkeypatch, [(2.0, "mush"), (1.0, "worse mush")])
+
+    events = await _collect(
+        _event_stream(
+            _classic_body(
+                condition_image_urls=[_region_data_url(), "data:p"],
+                condition_roles=["region", "parent"],
+            ),
+            "t1",
+        )
+    )
+
+    assert cont.await_count == 2
+    final = next(e for e in events if e["type"] == "final")
+    assert _b64.b64encode(b"jpeg-first").decode() in final["image_data_url"]
+
+
+async def test_zoom_detail_kill_switch_never_calls_legibility(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TAP_ZOOM_DETAIL", "false")
+    _mock_plan(monkeypatch)
+    _mock_edit(monkeypatch)
+    cont = _mock_continue(monkeypatch)
+    _mock_fresh(monkeypatch)
+    _mock_step_in(monkeypatch, [9.0])
+    leg = _mock_legibility(monkeypatch, [9.0])  # would pass — must not be asked
+
+    await _collect(
+        _event_stream(
+            _classic_body(
+                condition_image_urls=[_region_data_url(), "data:p"],
+                condition_roles=["region", "parent"],
+            ),
+            "t1",
+        )
+    )
+
+    cont.assert_awaited_once()
+    leg.assert_not_awaited()
+
+
+async def test_zoom_detail_skips_view_register_closeups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # place_closeup zooms ride the "view" register — no map-craft judging.
+    _mock_plan(monkeypatch)
+    _mock_edit(monkeypatch)
+    cont = _mock_continue(monkeypatch)
+    _mock_fresh(monkeypatch)
+    _mock_step_in(monkeypatch, [9.0])
+    leg = _mock_legibility(monkeypatch, [9.0])
+
+    await _collect(
+        _event_stream(
+            _classic_body(
+                prefetched_enter_as="scene",  # → place_closeup
+                condition_image_urls=[_region_data_url(), "data:p"],
+                condition_roles=["region", "parent"],
+            ),
+            "t1",
+        )
+    )
+
+    cont.assert_awaited_once()
+    leg.assert_not_awaited()
+
+
+async def test_zoom_detail_accept_env_floor_is_honored(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # TAP_ZOOM_DETAIL_ACCEPT lowers the floor: a 5.0 passes at 4.0.
+    monkeypatch.setenv("TAP_ZOOM_DETAIL_ACCEPT", "4.0")
+    _mock_plan(monkeypatch)
+    _mock_edit(monkeypatch)
+    cont = _mock_continue(monkeypatch)
+    _mock_fresh(monkeypatch)
+    _mock_step_in(monkeypatch, [9.0])
+    _mock_legibility(monkeypatch, [5.0])
+
+    await _collect(
+        _event_stream(
+            _classic_body(
+                condition_image_urls=[_region_data_url(), "data:p"],
+                condition_roles=["region", "parent"],
+            ),
+            "t1",
+        )
+    )
+
+    cont.assert_awaited_once()  # accepted — no retry
+
+
+async def test_zoom_detail_gates_the_redraw_op_too(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The legibility gate covers BOTH ops: a mushy redraw retries on the
+    # FRESH path (never Kontext), rationale folded in.
+    monkeypatch.setenv("WORLD_MODE", "true")
+    _mock_plan(monkeypatch)
+    _mock_edit(monkeypatch)
+    cont = _mock_continue(monkeypatch)
+    gen = _mock_fresh(monkeypatch)
+    _mock_step_in(monkeypatch, [9.0, 9.0])
+    _mock_legibility(monkeypatch, [(2.0, "smeared mush"), (8.0, "crisp")])
+
+    events = await _collect(
+        _event_stream(
+            _world_submap_body(
+                condition_image_urls=[_region_data_url(), "data:p"],
+                condition_roles=["region", "parent"],
+            ),
+            "t1",
+        )
+    )
+
+    assert gen.await_count == 2
+    cont.assert_not_awaited()
+    retry_prompt = gen.await_args_list[1].kwargs["prompt"]
+    assert "smeared mush" in retry_prompt
+    assert "MORE DETAILED map" in retry_prompt  # still the redraw instruction
+    final = next(e for e in events if e["type"] == "final")
+    assert final["image_op"] == "map_redraw"

--- a/apps/modal-backend/tests/test_generate_enter.py
+++ b/apps/modal-backend/tests/test_generate_enter.py
@@ -831,10 +831,11 @@ async def test_interior_accept_env_floor_is_honored(
 #
 # Kontext is reference-frozen: a world-mode submap "zoom" crop-UPSCALED the
 # region without re-synthesizing detail — dense city maps arrived as blurry
-# illegible mush. Default ON, the zoom is a FRESH cartographic re-render
-# (tier model) conditioned on the region crop; `false` is a strict kill-switch
-# back to the Kontext continue, and classic (non-world) submaps keep Kontext
-# regardless.
+# illegible mush. Default ON, the zoom rides the pixel-honoring EDIT seam with
+# a LOOSE-refs model (fal's fresh path DROPS reference images at dispatch, so
+# a "fresh conditioned redraw" would be text-anchored only); `false` is a
+# strict kill-switch back to the plain Kontext continue, and classic
+# (non-world) submaps keep Kontext regardless.
 
 
 def _world_submap_body(**over: Any) -> GenerateBody:
@@ -846,12 +847,13 @@ def _world_submap_body(**over: Any) -> GenerateBody:
     return _tap_body(**defaults)
 
 
-async def test_world_submap_redraw_routes_fresh_with_region_ref(
+async def test_world_submap_redraw_rides_edit_seam_with_loose_refs_model(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Default (flag unset = ON): the world submap zoom is a fresh tier-model
-    # render — the region crop rides as the reference + conditioning preamble,
-    # continue_image is never called, and the wire says map_redraw.
+    # Default (flag unset = ON): the world submap zoom is a continue_image of
+    # the region crop with the LOOSE-refs nano EDIT slug (NOT Kontext, NOT the
+    # ref-dropping fresh path), carrying the redraw wording; the wire says
+    # map_redraw.
     monkeypatch.setenv("WORLD_MODE", "true")
     _mock_plan(monkeypatch)
     edit = _mock_edit(monkeypatch)
@@ -860,18 +862,31 @@ async def test_world_submap_redraw_routes_fresh_with_region_ref(
 
     events = await _collect(_event_stream(_world_submap_body(), "t1"))
 
-    gen.assert_awaited_once()
-    cont.assert_not_awaited()
+    cont.assert_awaited_once()
+    gen.assert_not_awaited()
     edit.assert_not_awaited()
-    assert gen.await_args.kwargs["reference_urls"] == ["data:r"]  # the region crop
-    assert gen.await_args.kwargs["tier"] is None  # the fresh path's tier resolve
-    assert gen.await_args.kwargs["model_override"] is None  # no hardcoded model
-    prompt = gen.await_args.kwargs["prompt"]
-    assert prompt.startswith("Use the reference images as visual grounding")
-    assert "MORE DETAILED map" in prompt
+    assert cont.await_args.args[0] == "data:r"  # the region crop is the source
+    assert "MORE DETAILED map" in cont.await_args.args[1]
+    assert (
+        cont.await_args.kwargs["model_override"] == "fal-ai/nano-banana-pro/edit"
+    )
     final = next(e for e in events if e["type"] == "final")
     assert final["image_op"] == "map_redraw"
-    assert final["image_model"] == "fal-ai/nano-banana-pro"
+
+
+async def test_submap_redraw_model_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("WORLD_MODE", "true")
+    monkeypatch.setenv("SUBMAP_REDRAW_MODEL", "fal-ai/nano-banana-2/edit")
+    _mock_plan(monkeypatch)
+    _mock_edit(monkeypatch)
+    cont = _mock_continue(monkeypatch)
+    _mock_fresh(monkeypatch)
+
+    await _collect(_event_stream(_world_submap_body(), "t1"))
+
+    assert cont.await_args.kwargs["model_override"] == "fal-ai/nano-banana-2/edit"
 
 
 async def test_submap_redraw_kill_switch_is_todays_kontext(
@@ -890,6 +905,7 @@ async def test_submap_redraw_kill_switch_is_todays_kontext(
     gen.assert_not_awaited()
     assert cont.await_args.args[0] == "data:r"
     assert cont.await_args.args[1].startswith("Zoom into")  # the legacy wording
+    assert cont.await_args.kwargs["model_override"] is None  # default Kontext
     final = next(e for e in events if e["type"] == "final")
     assert final["image_op"] == "zoom_continue"
 
@@ -909,6 +925,7 @@ async def test_classic_submap_keeps_kontext_regardless_of_flag(
 
     cont.assert_awaited_once()
     gen.assert_not_awaited()
+    assert cont.await_args.kwargs["model_override"] is None  # default Kontext
     final = next(e for e in events if e["type"] == "final")
     assert final["image_op"] == "zoom_continue"
 
@@ -923,12 +940,12 @@ async def test_redraw_prompt_carries_clauses_and_style(
     monkeypatch.setenv("WORLD_TOPDOWN_MAPS", "true")
     _mock_plan(monkeypatch)
     _mock_edit(monkeypatch)
-    _mock_continue(monkeypatch)
-    gen = _mock_fresh(monkeypatch)
+    cont = _mock_continue(monkeypatch)
+    _mock_fresh(monkeypatch)
 
     events = await _collect(_event_stream(_world_submap_body(), "t1"))
 
-    prompt = gen.await_args.kwargs["prompt"]
+    prompt = cont.await_args.args[1]
     assert 'Draw a closer, richer, MORE DETAILED map of "The Stone Castle"' in prompt
     assert "individual buildings, lanes, courtyards" in prompt
     assert "The Inner Bailey" in prompt  # the planner's facts ride in
@@ -1144,8 +1161,9 @@ async def test_zoom_detail_accept_env_floor_is_honored(
 async def test_zoom_detail_gates_the_redraw_op_too(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # The legibility gate covers BOTH ops: a mushy redraw retries on the
-    # FRESH path (never Kontext), rationale folded in.
+    # The legibility gate covers BOTH flavours: a mushy redraw retries on the
+    # SAME loose-refs edit seam (never plain Kontext, never the ref-dropping
+    # fresh path), rationale folded in.
     monkeypatch.setenv("WORLD_MODE", "true")
     _mock_plan(monkeypatch)
     _mock_edit(monkeypatch)
@@ -1164,10 +1182,14 @@ async def test_zoom_detail_gates_the_redraw_op_too(
         )
     )
 
-    assert gen.await_count == 2
-    cont.assert_not_awaited()
-    retry_prompt = gen.await_args_list[1].kwargs["prompt"]
+    assert cont.await_count == 2
+    gen.assert_not_awaited()
+    retry_prompt = cont.await_args_list[1].args[1]
     assert "smeared mush" in retry_prompt
     assert "MORE DETAILED map" in retry_prompt  # still the redraw instruction
+    assert [c.kwargs["model_override"] for c in cont.await_args_list] == [
+        "fal-ai/nano-banana-pro/edit",
+        "fal-ai/nano-banana-pro/edit",
+    ]
     final = next(e for e in events if e["type"] == "final")
     assert final["image_op"] == "map_redraw"

--- a/apps/modal-backend/tests/test_judge_place_match.py
+++ b/apps/modal-backend/tests/test_judge_place_match.py
@@ -51,6 +51,38 @@ async def test_score_place_match_is_medium_agnostic_and_passes_both_images(
     assert b64 in blocks[1]["image_url"]["url"]
 
 
+@pytest.mark.asyncio
+async def test_score_map_legibility_is_single_image_craft_judge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The zoom gate's second axis: single-image (the arrival only), and the
+    # prompt must pin the contract — crisp fine detail high, blurry upscale
+    # mush low, lettering legibility in scope.
+    captured: dict[str, Any] = {}
+
+    async def fake_ask(system: str, user_text: str, image_blocks: list[dict[str, object]]):
+        captured["system"] = system
+        captured["user_text"] = user_text
+        captured["blocks"] = image_blocks
+        return JudgeResult(2.0, "smeared texture", "raw")
+
+    monkeypatch.setattr(judge, "_ask_judge", fake_ask)
+
+    result = await judge.score_map_legibility(b"ARRIVAL")
+
+    assert result.score == 2.0
+    prompt = (captured["system"] + " " + captured["user_text"]).lower()
+    assert "crisp" in prompt
+    assert "blurry" in prompt and "mush" in prompt
+    assert "legible" in prompt or "illegible" in prompt
+    assert "0-10" in captured["system"]
+
+    # exactly ONE image travels: the arrival
+    blocks = captured["blocks"]
+    assert len(blocks) == 1
+    assert base64.b64encode(b"ARRIVAL").decode("ascii") in blocks[0]["image_url"]["url"]
+
+
 # --- _parse_judgement robustness (the silent-zero bug, pure) ---------------
 #
 # gemini-3-flash (the default judge) prepends a "thought" reasoning preamble on

--- a/apps/modal-backend/tests/test_prompt_library.py
+++ b/apps/modal-backend/tests/test_prompt_library.py
@@ -105,6 +105,50 @@ def test_golden_zoom_view_none_both_paths() -> None:
         )
         == GOLDEN_ZOOM_RICH
     )
+    # redraw=False (the SUBMAP_REDRAW kill-switch value) is byte-identical.
+    assert (
+        image_edit.build_zoom_instruction(
+            "The Unseen University",
+            ["The Tower of Art", "The Library", "Great Hall"],
+            "Place the Tower of Art toward the upper-left.",
+            redraw=False,
+        )
+        == GOLDEN_ZOOM_RICH
+    )
+
+
+def test_redraw_zoom_is_fresh_rerender_wording() -> None:
+    # SUBMAP_REDRAW's instruction: a fresh cartographic re-render at the
+    # closer scale — closer/richer wording + medium lock + lettering guard +
+    # the layout clause — NOT the Kontext keep-pixels zoom skeleton.
+    s = image_edit.build_zoom_instruction(
+        "Ankh-Morpork",
+        ["The Shades", "Unseen University"],
+        "Place the Shades toward the lower-left.",
+        style_anchor="hand-drawn engraving, sepia ink",
+        redraw=True,
+    )
+    assert 'Draw a closer, richer, MORE DETAILED map of "Ankh-Morpork"' in s
+    assert "the area the reference image shows" in s
+    assert "individual buildings, lanes, courtyards" in s
+    assert "in the same positions" in s
+    assert "The Shades" in s and "Unseen University" in s
+    assert "hand-drawn engraving, sepia ink" in s  # the medium lock
+    assert "photograph" in s.lower()  # the photoreal guard rides the lock
+    assert "garbled" in s.lower()  # the lettering guard
+    assert "Place the Shades toward the lower-left." in s  # layout clause
+    assert "Zoom into" not in s  # not the Kontext skeleton
+
+
+def test_redraw_zoom_label_free_swaps_lettering_guard() -> None:
+    from providers.prompt_library.style import LETTERING_GUARD, NO_LETTERING
+
+    s = image_edit.build_zoom_instruction(
+        "The Keep", [], "", redraw=True, label_free=True
+    )
+    assert LETTERING_GUARD not in s
+    assert NO_LETTERING in s
+    assert "MORE DETAILED map" in s
 
 
 def test_golden_layout_default_call() -> None:


### PR DESCRIPTION
The step-8 screenshot: a world-mode map zoom that's blurry upscale mush. Kontext is reference-frozen — the "elaborate finer detail" clause was a no-op — and the zoom judge only scored same-region-closer, so mush passed.

- **SUBMAP_REDRAW (default ON)**: world-mode `place_submap`+region zooms now run `continue_image(region_crop, redraw_instruction, model_override=resolve_model("submap_redraw"))` — default `fal-ai/nano-banana-pro/edit` (same loose-refs pedigree as enter_scene: honours the crop, re-synthesizes detail, `legible_text=True`). Redraw instruction = closer-richer-map wording + layout clause + topdown clause + medium lock + lettering guard. Ground-truth note: the fresh path DROPS reference images (nano-pro `supports_refs=False`, #109), so the edit seam is the only place pixels actually bite.
- **Legibility axis**: `score_map_legibility` (mush scores 0–2) required alongside `score_step_in` for map-register zooms, gated `TAP_ZOOM_DETAIL` (default ON, `TAP_ZOOM_DETAIL_ACCEPT=6.0`), on BOTH ops. Keep-best = **min-floor across axes** (a sum could crown a retry that regressed legibility on a step_in swing); degrades exactly to the old compare when detail is off. Both rationales fold into the one deadline-aware retry.
- Wire: `image_op: "map_redraw"` (additive). Kill-switch → today's Kontext byte-identical (golden-pinned). Classic (non-world) submaps keep Kontext — follow-up noted.

Adversarially reviewed → fixes applied (min-floor keep-best, MODEL_SLOTS routing; the ".env.example missing" finding was the backend-local decoy — root has all four vars). 906 backend tests + ruff + mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)