### PR TITLE
fix(interiors): mint the eye frame when a frameless enter carries the interior stamp

### DIFF
--- a/apps/web/lib/session-pages.test.ts
+++ b/apps/web/lib/session-pages.test.ts
@@ -68,10 +68,23 @@ describe("foldSceneViewStamp (SSE final's interior arrival stamp)", () => {
     expect(foldSceneViewStamp(undefined, undefined)).toBeNull();
   });
 
-  it("prior null → null even with a stamp (nothing to anchor it to)", () => {
-    expect(
-      foldSceneViewStamp(null, { scale_tier: "room", place_form: "interior" }),
-    ).toBeNull();
+  it("prior null + INTERIOR stamp → mints the minimal eye frame (live-caught: a ladder TRANSITION enter sends no scene_view, and the old null rule dropped the marker from state AND persistence)", () => {
+    const minted = foldSceneViewStamp(null, {
+      scale_tier: "room",
+      place_form: "interior",
+    });
+    expect(minted).toEqual({
+      node_id: "",
+      level: "eye",
+      observer: null,
+      map_crop: null,
+      scale_tier: "room",
+      place_form: "interior",
+    });
+  });
+
+  it("prior null + non-interior stamp → still null (nothing to anchor)", () => {
+    expect(foldSceneViewStamp(null, { scale_tier: "place" })).toBeNull();
   });
 
   it("merges the stamp over the prior — stamp wins per-field, rest survives", () => {

--- a/apps/web/lib/session-pages.ts
+++ b/apps/web/lib/session-pages.ts
@@ -54,15 +54,29 @@ export interface SessionNodeWire {
  * (scale_tier "room" + place_form "interior"); the client persists the
  * REQUEST's scene_view, so without this fold the stamp never reaches page
  * state or the saved node. Stamp absent → prior unchanged (byte-identical
- * to pre-stamp behavior). Prior null → null: a stamp without a frame has
- * nothing to anchor, and the chip this feeds only matters on world pages,
- * which always carry a scene_view. */
+ * to pre-stamp behavior).
+ *
+ * Prior null: live-caught (Oakhaven receipts) — a descent-ladder TRANSITION
+ * enter sends no scene_view, so the old "prior null → null" silently dropped
+ * the interior stamp and the persisted node hydrated unmarked. An interior
+ * arrival is self-describing: mint the minimal eye-level frame from the
+ * stamp instead. Non-interior stamps without a frame still fold to null
+ * (nothing to anchor). node_id is stamped by the callers (post-save). */
 export function foldSceneViewStamp(
   prior: SceneView | null | undefined,
   stamp: Partial<SceneView> | null | undefined,
 ): SceneView | null {
-  if (!prior) return null;
-  if (!stamp) return prior;
+  if (!stamp) return prior ?? null;
+  if (!prior) {
+    if (stamp.place_form !== "interior") return null;
+    return {
+      node_id: stamp.node_id ?? "",
+      level: "eye",
+      observer: null,
+      map_crop: null,
+      ...stamp,
+    };
+  }
   return { ...prior, ...stamp };
 }
 


### PR DESCRIPTION
Live-caught during the receipt pass: a descent-ladder TRANSITION enter (closeup → enter) sends **no scene_view**, so `foldSceneViewStamp`'s "prior null → null" rule dropped the interior stamp — persisted `scene_view: null` (verified in Mongo), unmarked hydration, no chip, and the node read as a map frame afterwards. The indoor render itself was perfect (interior judge **10.0**, first attempt) — only the marker died.

Interior arrivals are self-describing: prior-null + `place_form: "interior"` now mints the minimal eye-level frame from the stamp. Non-interior stamps without a frame still fold to null. 697 web tests + tsc + lint + circular green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)