### PR TITLE
feat(taps): tap = enter, everywhere — the closeup rung moves to right-click

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -184,6 +184,12 @@ NEXT_PUBLIC_LTX_WS_URL=
 # debugging tap routing (build-time; rebuild web after change).
 # NEXT_PUBLIC_WORLD_TAP_DEGRADE=1
 
+# Tap = ENTER, everywhere (default ON): geo-mapped places skip the descent
+# ladder's closeup-zoom rung and enter on the FIRST tap, same as unmapped
+# spots. The optical zoom stays on right-click ("Zoom in here"). =0 restores
+# the closeup-then-enter ladder (build-time; rebuild web after change).
+# NEXT_PUBLIC_TAP_ENTER_DIRECT=1
+
 # Dev-only scenario bench gallery at /dev/bench (build-time; rebuild web after change).
 # NEXT_PUBLIC_BENCH_UI=1
 # BENCH_REPORTS_DIR=apps/modal-backend/tests/scenario_lab/reports

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -167,6 +167,14 @@ const EDIT_REGION_ENABLED = ["1", "true", "yes"].includes(
 const WORLD_TAP_DEGRADE_ENABLED = !["0", "false", "no"].includes(
   (process.env.NEXT_PUBLIC_WORLD_TAP_DEGRADE ?? "").toLowerCase()
 );
+// Tap = ENTER, everywhere (default ON): geo-mapped places skip the descent
+// ladder's closeup rung and enter on the FIRST tap — the same one-hop promise
+// as unmapped spots ("that too must enter by default"). The optical zoom
+// stays reachable via right-click → "🔍 Zoom in here". =false restores the
+// closeup-then-enter ladder exactly.
+const TAP_ENTER_DIRECT_ENABLED = !["0", "false", "no"].includes(
+  (process.env.NEXT_PUBLIC_TAP_ENTER_DIRECT ?? "").toLowerCase()
+);
 // On-ramp coach: pre-first-page hint + existing post-first-page chip (default OFF).
 const ON_RAMP_COACH_ENABLED = ["1", "true", "yes"].includes(
   (process.env.NEXT_PUBLIC_ON_RAMP_COACH ?? "").toLowerCase(),
@@ -2567,6 +2575,7 @@ export default function PlayPage() {
               // map; INSIDE a place it's that place's children, so the tap nests
               // one level deeper instead of resolving to a city landmark.
               page.sceneView,
+              { enterDirect: TAP_ENTER_DIRECT_ENABLED },
             )
           : null;
       // W1/W2 fallback chain: the geometric route fell through on a map frame
@@ -2617,6 +2626,7 @@ export default function PlayPage() {
               page.nodeId,
               { x_pct: click.x_pct, y_pct: click.y_pct },
               page.sceneView,
+              TAP_ENTER_DIRECT_ENABLED,
             )
           : null;
       // Conditioning refs are built AFTER routing so the region crop can BE

--- a/apps/web/lib/click-route.test.ts
+++ b/apps/web/lib/click-route.test.ts
@@ -171,7 +171,48 @@ describe("routeToFocus (enter a place resolved by NAME)", () => {
   });
 });
 
-describe("the descent ladder (closeup rung)", () => {
+describe("enterDirect (tap = enter; the rung is right-click territory)", () => {
+  it("first tap on a place → SCENE, no closeup rung", () => {
+    const map = {
+      entities: [geo("palace", 50, 50, { footprint: { w: 10, d: 8 }, height: 18 })],
+      bounds: CROP,
+    };
+    const r = routeClick(map, mapView(CROP), { x_pct: 0.5, y_pct: 0.5 }, ASPECT, {
+      enterDirect: true,
+    });
+    expect(r.kind).toBe("scene");
+    if (r.kind === "scene") expect(r.focus_id).toBe("palace");
+  });
+
+  it("empty-area cluster taps still submap (areas keep the map ladder)", () => {
+    const map = { entities: [geo("a", 20, 20), geo("b", 30, 25)], bounds: CROP };
+    const r = routeClick(map, mapView(CROP), { x_pct: 0.25, y_pct: 0.225 }, ASPECT, {
+      enterDirect: true,
+    });
+    expect(r.kind).toBe("submap");
+  });
+
+  it("legacy closeup frames still transition (reopen-compat)", () => {
+    const map = {
+      entities: [geo("palace", 50, 50, { footprint: { w: 10, d: 8 }, height: 18 })],
+      bounds: CROP,
+    };
+    const closeupView: SceneView = {
+      node_id: "n-close",
+      level: "map",
+      observer: null,
+      map_crop: { x: 41, y: 41, w: 18, h: 18 },
+      focus_id: "palace",
+      closeup: true,
+    };
+    const r = routeClick(map, closeupView, { x_pct: 0.5, y_pct: 0.5 }, ASPECT, {
+      enterDirect: true,
+    });
+    expect(r.kind).toBe("scene");
+  });
+});
+
+describe("the descent ladder (closeup rung — the enterDirect:false kill-switch path)", () => {
   it("first tap on a place → closeup crop, not enter", () => {
     const map = { entities: [geo("palace", 50, 50, { footprint: { w: 10, d: 8 }, height: 18 })], bounds: CROP };
     const r = routeClick(map, mapView(CROP), { x_pct: 0.5, y_pct: 0.5 }, ASPECT);

--- a/apps/web/lib/click-route.ts
+++ b/apps/web/lib/click-route.ts
@@ -183,7 +183,11 @@ export function routeClick(
   view: SceneView,
   click: ClickPoint,
   aspect: number,
-  opts?: { minSubmapEntities?: number },
+  // enterDirect (the page passes NEXT_PUBLIC_TAP_ENTER_DIRECT, default ON):
+  // a tapped place ENTERS on the first tap — the closeup rung is right-click
+  // territory ("Zoom in here"), not the tap default. Absent = the ladder,
+  // so the pure function's default stays the historical behavior.
+  opts?: { minSubmapEntities?: number; enterDirect?: boolean },
 ): ClickRoute {
   const { entities } = map;
   const focus = view.observer
@@ -196,8 +200,9 @@ export function routeClick(
   // faithful Kontext zoom), and only the tap on the place whose closeup you
   // are already on TRANSITIONS into it (enter). Scene frames (observer set)
   // keep entering directly — scene-level closeups are a later rung.
+  // Under enterDirect the rung is skipped outright: tap = enter, one hop.
   if (focus && focus.kind === "place") {
-    if (view.map_crop && !view.observer) {
+    if (!opts?.enterDirect && view.map_crop && !view.observer) {
       const alreadyCloseup =
         view.closeup === true && view.focus_id === focus.id;
       if (!alreadyCloseup) {

--- a/apps/web/lib/geo-tap.test.ts
+++ b/apps/web/lib/geo-tap.test.ts
@@ -257,6 +257,25 @@ describe("geoTapRequest (close the geometric tap loop)", () => {
     expect(second!.kind).toBe("scene");
   });
 
+  it("enterDirect: the FIRST place tap already enters — no closeup rung", () => {
+    const map = {
+      entities: [geo("clock", "clock tower", 60, 30, { height: 18 })],
+      bounds: CROP,
+    };
+    const t = geoTapRequest(
+      map,
+      "n1",
+      { x_pct: 60 / 100, y_pct: 30 / 60 },
+      16 / 9,
+      undefined,
+      undefined,
+      { enterDirect: true },
+    );
+    expect(t!.kind).toBe("scene");
+    expect(t!.focus_id).toBe("clock");
+    expect(t!.focus_label).toBe("clock tower");
+  });
+
   it("routes a tap through the image frame, not the entities' tight bounds (live-bug regression)", () => {
     // Entities cluster in a sub-range of the 100×60 image frame, so their tight
     // bounding box differs from the frame the tap maps through. Tapping a place's

--- a/apps/web/lib/geo-tap.ts
+++ b/apps/web/lib/geo-tap.ts
@@ -210,6 +210,9 @@ export function geoTapRequest(
   // landmark. Every frame — city or interior — is a top-down map in the SAME
   // MAP_IMAGE_FRAME; the per-frame `scale` composes them to absolute coords.
   currentView?: SceneView | null,
+  // Threaded to routeClick: tap = enter (skip the closeup rung). See
+  // routeClick's enterDirect note; absent = the historical ladder.
+  opts?: { enterDirect?: boolean },
 ): GeoTap | null {
   if (map.entities.length === 0) return null;
   const insideId =
@@ -249,7 +252,11 @@ export function geoTapRequest(
     ...(currentView?.focus_id ? { focus_id: currentView.focus_id } : {}),
     ...(currentView?.closeup ? { closeup: true } : {}),
   };
-  const route = routeClick(candidates, mapView, click, aspect);
+  const route = routeClick(candidates, mapView, click, aspect, {
+    ...(opts?.enterDirect !== undefined
+      ? { enterDirect: opts.enterDirect }
+      : {}),
+  });
   if (route.kind === "explainer") return null;
   const byId = new Map(map.entities.map((e) => [e.id, e]));
 

--- a/apps/web/lib/scene-closeup.test.ts
+++ b/apps/web/lib/scene-closeup.test.ts
@@ -48,6 +48,23 @@ describe("sceneCloseupSpec (the ladder inside entered scenes)", () => {
     h_pct: 0.25,
   });
 
+  it("enterDirect: a tap on a localized entity → transition (tap = enter; the rung is right-click territory)", () => {
+    const spec = sceneCloseupSpec(
+      [hall],
+      "n1",
+      { x_pct: 0.5, y_pct: 0.4 },
+      sceneView(),
+      true,
+    );
+    expect(spec).toEqual({ kind: "transition", name: "The Great Hall" });
+  });
+
+  it("enterDirect: missed taps still null (nothing under the finger)", () => {
+    expect(
+      sceneCloseupSpec([hall], "n1", { x_pct: 0.95, y_pct: 0.95 }, sceneView(), true),
+    ).toBeNull();
+  });
+
   it("a tap on a localized entity → closeup with a padded, clamped box", () => {
     const spec = sceneCloseupSpec([hall], "n1", { x_pct: 0.5, y_pct: 0.4 }, sceneView());
     expect(spec).not.toBeNull();

--- a/apps/web/lib/scene-closeup.ts
+++ b/apps/web/lib/scene-closeup.ts
@@ -29,6 +29,10 @@ export function sceneCloseupSpec(
   nodeId: string | null,
   click: { x_pct: number; y_pct: number },
   currentView: SceneView | null | undefined,
+  // enterDirect (NEXT_PUBLIC_TAP_ENTER_DIRECT, default ON at the page): a
+  // localized entity ENTERS on the first tap; the closeup zoom is right-click
+  // territory. Absent = the historical ladder (closeup, then transition).
+  enterDirect = false,
 ): SceneCloseupSpec | null {
   // Map frames have their own (geometry-registered) ladder.
   if (!currentView || currentView.level === "map") return null;
@@ -38,6 +42,9 @@ export function sceneCloseupSpec(
   // (deriveGeoFromExtraction), so the closeup's focus links up once the
   // entity's geometry lands.
   const geoId = `geo_${hit.entity.id}`;
+  if (enterDirect) {
+    return { kind: "transition", name: hit.entity.name };
+  }
   if (currentView.closeup === true && currentView.focus_id === geoId) {
     return { kind: "transition", name: hit.entity.name };
   }


### PR DESCRIPTION
Eren's call, closing the original complaint end to end: geo-mapped places rode the descent ladder (first tap = closeup zoom rung, second tap = enter) while unmapped spots entered directly — "first tap zooms, next tap enters" depending on whether the thing happened to be geo-mapped.

`NEXT_PUBLIC_TAP_ENTER_DIRECT` (default ON): a tapped place **enters on the first tap** in every frame:
- `routeClick` (map frames): the closeup rung is skipped for place hits; empty-area cluster taps still submap (areas keep the map ladder per the earlier decision) and legacy closeup frames still transition (reopen-compat).
- `sceneCloseupSpec` (inside entered scenes): localized-entity taps transition immediately.

The optical zoom stays one right-click away ("🔍 Zoom in here", #162). `=0` restores the ladder exactly — both branches pinned by tests; the pure routing functions default to the historical ladder, only the page passes the flag.

703 web tests (+6) + tsc + lint + circular green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)