### PR TITLE
fix(zoom): frameless ENTERED pages aim the right-click zoom as a closeup

### DIFF
--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -1759,12 +1759,14 @@ export default function PlayPage() {
         label: "🔍 Zoom in here",
         onClick: () => {
           close();
-          // Map-ness heuristic: no scene_view (classic/root frames) or an
-          // explicit map level ⇒ aligned submap cut; any observer level
-          // (building/street/eye) ⇒ closeup. Consumed one-shot by the tap
-          // handler the synthetic click below runs through.
+          // Map-ness heuristic: explicit map level, or a frameless ROOT page
+          // (classic/session-start map) ⇒ aligned submap cut; everything else
+          // — including frameless ENTERED pages (a place you're AT, not a map
+          // you're over) ⇒ closeup. Consumed one-shot by the tap handler the
+          // synthetic click below runs through.
           pinnedRenderModeRef.current = zoomModeForLevel(
-            page?.sceneView?.level
+            page?.sceneView?.level,
+            !page?.parentId
           );
           dispatchTapAt(x_pct, y_pct);
         },

--- a/apps/web/lib/world-mode.test.ts
+++ b/apps/web/lib/world-mode.test.ts
@@ -22,9 +22,14 @@ describe("zoomModeForLevel (context menu's 🔍 Zoom in here)", () => {
     expect(zoomModeForLevel("map")).toBe("place_submap");
   });
 
-  it("no scene_view (classic/root pages) counts as a map frame", () => {
-    expect(zoomModeForLevel(undefined)).toBe("place_submap");
-    expect(zoomModeForLevel(null)).toBe("place_submap");
+  it("a frameless ROOT page (classic/session-start map) counts as a map frame", () => {
+    expect(zoomModeForLevel(undefined, true)).toBe("place_submap");
+    expect(zoomModeForLevel(null, true)).toBe("place_submap");
+  });
+
+  it("a frameless ENTERED page is a place you're AT — closeup (video-caught: the Astronomer's Study Desk read as a map and its zoom came back a cartographic redraw)", () => {
+    expect(zoomModeForLevel(undefined, false)).toBe("place_closeup");
+    expect(zoomModeForLevel(null)).toBe("place_closeup");
   });
 
   it("observer levels zoom as a closeup", () => {

--- a/apps/web/lib/world-mode.ts
+++ b/apps/web/lib/world-mode.ts
@@ -18,13 +18,23 @@ export function enterAsToRenderMode(
 }
 
 // The context menu's "🔍 Zoom in here": which optical-zoom render mode fits
-// the CURRENT frame. Map frames — no scene_view yet (classic/root pages) or
-// an explicit map level — zoom as an aligned submap cut; any observer level
-// (building/street/eye) zooms as a closeup of what's under the pointer.
+// the CURRENT frame. An explicit map level — or a ROOT page with no
+// scene_view (the classic/session-start map) — zooms as an aligned submap
+// cut; everything else zooms as a closeup of what's under the pointer.
+//
+// Why root-ness matters (video-caught, the enter-and-interiors clip): entered
+// pages often carry NO scene_view — ladder TRANSITION enters send none, and
+// non-interior arrivals have no stamp to mint one from — so keying on level
+// alone read the Astronomer's Study Desk page as a MAP and its "closer look"
+// came back as a cartographic redraw of somewhere else. A child page without
+// a frame is a place you're AT, not a map you're over.
 export function zoomModeForLevel(
   level: string | null | undefined,
+  isRootPage = false,
 ): "place_submap" | "place_closeup" {
-  return !level || level === "map" ? "place_submap" : "place_closeup";
+  if (level === "map") return "place_submap";
+  if (!level && isRootPage) return "place_submap";
+  return "place_closeup";
 }
 
 export interface RevisitCandidate {


### PR DESCRIPTION
Video-caught in the enter-and-interiors clip: an entered page with no scene_view (ladder TRANSITION enters send none; non-interior arrivals have no stamp to mint one from) read as a **map frame**, so "🔍 Zoom in here" rode `place_submap` and returned a cartographic redraw of somewhere else instead of a closer look at the desk.

`zoomModeForLevel` gains root-ness: explicit map level or a frameless ROOT page → submap cut; everything else — including frameless entered pages (a place you're AT, not a map you're over) → closeup. 704 web tests + tsc + circular green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)