### PR TITLE
feat(llm): strict json_schema rung atop the structured-output ladder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -147,6 +147,13 @@ FAL_EDIT_TIER=balanced
 # Kontext path; TAP_ZOOM_DETAIL_ACCEPT is the 0-10 floor.
 # TAP_ZOOM_DETAIL=true
 # TAP_ZOOM_DETAIL_ACCEPT=6.0
+# Strict structured output: LLM/VLM JSON calls that carry a schema ask the
+# provider to ENFORCE it (response_format json_schema, strict) as the top rung
+# of the capability ladder — malformed-JSON and wrong-scale coordinate dice die
+# at the source instead of in downstream salvage. A model whose provider 400s
+# the strict shape degrades to json_object and is remembered for the process.
+# `false` = the old json_object-first ladder, byte-identical.
+# LLM_JSON_SCHEMA=true
 
 # --- Web (apps/web/.env.local) ---
 # Cloudflare R2 (S3-compatible)

--- a/apps/modal-backend/providers/llm/__init__.py
+++ b/apps/modal-backend/providers/llm/__init__.py
@@ -32,6 +32,7 @@ from .click import (
 from .client import (
     _JSON_ONLY_HINT,
     _JSON_REPAIR_HINT,
+    _JSON_SCHEMA_DEMOTED,
     _LLM_BASE_URLS,
     _STRUCTURED_OUTPUT_FAMILIES,
     _TIER_LADDER,
@@ -60,6 +61,8 @@ from .client import (
     _rung_kwargs,
     _safe_json,
     _safe_log,
+    _schema_strictifiable,
+    _strictify_schema,
     _supports_online_suffix,
     _supports_structured_output,
     _system_message,

--- a/apps/modal-backend/providers/llm/click.py
+++ b/apps/modal-backend/providers/llm/click.py
@@ -149,7 +149,21 @@ CANDIDATES_SCHEMA: dict[str, Any] = {
                         "enum": ["interior", "complex", "landscape", "generic"],
                     },
                 },
-                "required": ["x_pct", "y_pct", "subject"],
+                # Deliberately ALL SEVEN fields: each is prompt-mandated and
+                # enum/number-constrained, and _validate_candidates stays
+                # defensive about absence — all-required is what makes this
+                # schema strict-rung eligible (_schema_strictifiable rejects
+                # partial `required`), and CANDIDATES is the coordinate-dice
+                # killer the strict rung exists for.
+                "required": [
+                    "x_pct",
+                    "y_pct",
+                    "subject",
+                    "style",
+                    "salience",
+                    "enter_as",
+                    "place_form",
+                ],
             },
         }
     },

--- a/apps/modal-backend/providers/llm/client.py
+++ b/apps/modal-backend/providers/llm/client.py
@@ -349,9 +349,10 @@ def _safe_log(level: str, event: str, **kv: Any) -> None:
 def _tier_attempts(tier: str) -> list[str]:
     """The ordered rungs to try for a starting tier (degrade-on-error path).
 
-    `json_schema` is not implemented yet, so it maps to `json_object` (the
-    closest structured rung); an unknown override starts at the top so it still
-    walks the full ladder.
+    The strict `json_schema` rung lives ABOVE this ladder: `_complete_json`
+    prepends it (it needs the caller's schema + the LLM_JSON_SCHEMA gate), so
+    a `json_schema` override maps to `json_object` here; an unknown override
+    starts at the top so it still walks the full ladder.
     """
     start = "json_object" if tier == "json_schema" else tier
     if start not in _TIER_LADDER:
@@ -360,10 +361,76 @@ def _tier_attempts(tier: str) -> list[str]:
     return list(_TIER_LADDER[idx:])
 
 
+# Models whose provider 400'd the strict json_schema shape. Remembered for the
+# process lifetime so the failed round-trip is paid once per model, not per
+# call — the same degrade the in-call ladder does, made sticky.
+_JSON_SCHEMA_DEMOTED: set[str] = set()
+
+
+def _strictify_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """A deep-copied, strict-mode-compatible variant of a caller schema.
+
+    Strict `json_schema` (OpenAI wire shape, forwarded by OpenRouter and
+    enforced server-side) demands every object node carry
+    ``additionalProperties: false`` and a ``required`` listing EVERY declared
+    property. Our callers express optionality as union types, never by
+    omission, so requiring everything declared is faithful — no optionality is
+    invented. Arrays/enums/numbers pass through untouched; nested defs are
+    walked like any other node. Pure: the input schema is never mutated.
+    """
+
+    def walk(node: Any) -> Any:
+        if isinstance(node, list):
+            return [walk(item) for item in node]
+        if not isinstance(node, dict):
+            return node
+        out = {key: walk(value) for key, value in node.items()}
+        if out.get("type") == "object":
+            out.setdefault("additionalProperties", False)
+            out["required"] = list((out.get("properties") or {}).keys())
+        return out
+
+    return cast(dict[str, Any], walk(schema))
+
+
+def _schema_strictifiable(schema: dict[str, Any]) -> bool:
+    """Whether strict mode can express this schema faithfully.
+
+    An OPEN object node — ``{"type": "object"}`` with no declared properties,
+    like EXTRACTION_SCHEMA's items — has no strict translation: closing it
+    would enforce EMPTY objects (silent data loss) or 400, and a 400 here
+    would demote the whole MODEL in `_JSON_SCHEMA_DEMOTED`, robbing the
+    fully-typed schemas of the strict rung too. Such schemas skip the rung
+    per-call and keep today's json_object behavior.
+    """
+
+    def ok(node: Any) -> bool:
+        if isinstance(node, list):
+            return all(ok(item) for item in node)
+        if not isinstance(node, dict):
+            return True
+        if node.get("type") == "object" and not node.get("properties"):
+            return False
+        return all(ok(value) for value in node.values())
+
+    return ok(schema)
+
+
 def _rung_kwargs(rung: str, schema: dict[str, Any] | None, schema_name: str) -> dict[str, Any]:
     """The create() kwargs specific to a rung. Spread by the caller so the
     structured params bypass the SDK's strict per-arg typing, matching the
     existing `**_maybe_response_format(...)` pattern."""
+    if rung == "json_schema":
+        return {
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": schema_name or "reply",
+                    "strict": True,
+                    "schema": _strictify_schema(schema or {"type": "object"}),
+                },
+            }
+        }
     if rung == "json_object":
         return {"response_format": {"type": "json_object"}}
     if rung == "tool":
@@ -577,12 +644,18 @@ async def _complete_json(
     """Issue a chat completion and return parsed JSON, degrading gracefully.
 
     Picks a structured-output strategy via `_resolve_structured_tier`, then
-    walks DOWN the ladder (json_object -> tool -> prompt) if a provider rejects
-    the chosen mechanism with a 400. The prompt rung adds a JSON-only hint and
-    one repair retry. The caller's existing `_build_*` / `_parse_*` coercers
-    stay the source of truth, so a weak model degrades to "thinner but valid"
-    rather than crashing. On the default OpenRouter path this issues the exact
-    same json_object request as before.
+    walks DOWN the ladder (json_schema -> json_object -> tool -> prompt) if a
+    provider rejects the chosen mechanism with a 400. The strict top rung is
+    attempted only with a caller `schema` that strict mode can express, an
+    LLM_JSON_SCHEMA=true gate (default), and a json_object-capable start — it
+    enforces the schema at the provider, killing malformed/wrong-scale replies
+    at the source; a 400 on it is remembered per-model in
+    `_JSON_SCHEMA_DEMOTED`. The prompt rung adds a
+    JSON-only hint and one repair retry. The caller's existing `_build_*` /
+    `_parse_*` coercers stay the source of truth, so a weak model degrades to
+    "thinner but valid" rather than crashing. With the gate off (or no schema)
+    the default OpenRouter path issues the exact same json_object request as
+    before.
 
     `response_sink`, when provided, receives the final raw response object so a
     caller that needs more than the parsed JSON (e.g. the planner reading
@@ -591,9 +664,18 @@ async def _complete_json(
     client = _llm._client()
     provider = _llm_provider()
     tier = _resolve_structured_tier(provider, model)
+    attempts = _tier_attempts(tier)
+    if (
+        schema is not None
+        and attempts[0] == "json_object"
+        and model not in _JSON_SCHEMA_DEMOTED
+        and env_flag("LLM_JSON_SCHEMA", "true")
+        and _schema_strictifiable(schema)
+    ):
+        attempts.insert(0, "json_schema")
+        tier = "json_schema"
     if span_ctx is not None:
         span_ctx["structured_tier"] = tier
-    attempts = _tier_attempts(tier)
     eb = extra_body or None
     last_error: BadRequestError | None = None
 
@@ -639,6 +721,12 @@ async def _complete_json(
         except BadRequestError as err:
             last_error = err
             next_tier = attempts[i + 1] if i + 1 < len(attempts) else None
+            if rung == "json_schema":
+                # Sticky per-model demotion: the next call starts straight at
+                # json_object instead of re-paying the failed round-trip.
+                _JSON_SCHEMA_DEMOTED.add(model)
+                if span_ctx is not None:
+                    span_ctx["structured_tier"] = "json_object"
             _llm._safe_log(
                 "warn",
                 "llm.tier_downgrade",

--- a/apps/modal-backend/providers/llm/client.py
+++ b/apps/modal-backend/providers/llm/client.py
@@ -373,10 +373,16 @@ def _strictify_schema(schema: dict[str, Any]) -> dict[str, Any]:
     Strict `json_schema` (OpenAI wire shape, forwarded by OpenRouter and
     enforced server-side) demands every object node carry
     ``additionalProperties: false`` and a ``required`` listing EVERY declared
-    property. Our callers express optionality as union types, never by
-    omission, so requiring everything declared is faithful — no optionality is
-    invented. Arrays/enums/numbers pass through untouched; nested defs are
-    walked like any other node. Pure: the input schema is never mutated.
+    property. An object node with NO ``required`` means the author intended
+    all-required, so one is ADDED; an existing ``required`` is NEVER
+    overwritten — a partial one expresses genuine optionality (e.g.
+    CLICK_SCHEMA's "omit bbox if you can't give a tight box"), and silently
+    forcing those fields would make strict generation FABRICATE data, the
+    exact #127 failure. Such schemas are rejected by `_schema_strictifiable`
+    before this helper is ever consulted; preserving them here keeps the
+    helper honest regardless. Arrays/enums/numbers pass through untouched;
+    nested defs are walked like any other node. Pure: the input schema is
+    never mutated.
     """
 
     def walk(node: Any) -> Any:
@@ -387,7 +393,7 @@ def _strictify_schema(schema: dict[str, Any]) -> dict[str, Any]:
         out = {key: walk(value) for key, value in node.items()}
         if out.get("type") == "object":
             out.setdefault("additionalProperties", False)
-            out["required"] = list((out.get("properties") or {}).keys())
+            out.setdefault("required", list((out.get("properties") or {}).keys()))
         return out
 
     return cast(dict[str, Any], walk(schema))
@@ -400,8 +406,17 @@ def _schema_strictifiable(schema: dict[str, Any]) -> bool:
     like EXTRACTION_SCHEMA's items — has no strict translation: closing it
     would enforce EMPTY objects (silent data loss) or 400, and a 400 here
     would demote the whole MODEL in `_JSON_SCHEMA_DEMOTED`, robbing the
-    fully-typed schemas of the strict rung too. Such schemas skip the rung
-    per-call and keep today's json_object behavior.
+    fully-typed schemas of the strict rung too.
+
+    A PARTIAL ``required`` (a proper subset of the declared properties, like
+    CLICK_SCHEMA's ``["subject"]``) is equally inexpressible: strict mode
+    demands required == ALL properties, and a partial required is the author
+    saying the other fields are genuinely optional ("omit bbox if you can't
+    give a tight box") — forcing them required would make the model FABRICATE
+    values, the exact failure #127 was built to kill.
+
+    Either way such schemas skip the rung per-call (no cache write) and keep
+    today's json_object behavior.
     """
 
     def ok(node: Any) -> bool:
@@ -409,8 +424,13 @@ def _schema_strictifiable(schema: dict[str, Any]) -> bool:
             return all(ok(item) for item in node)
         if not isinstance(node, dict):
             return True
-        if node.get("type") == "object" and not node.get("properties"):
-            return False
+        if node.get("type") == "object":
+            props = node.get("properties")
+            if not props:
+                return False
+            required = node.get("required")
+            if required is not None and set(required) != set(props.keys()):
+                return False
         return all(ok(value) for value in node.values())
 
     return ok(schema)

--- a/apps/modal-backend/tests/conftest.py
+++ b/apps/modal-backend/tests/conftest.py
@@ -33,6 +33,9 @@ _SCRUB = (
     "LLM_VLM_MODEL",
     "LLM_TEXT_MODEL",
     "LLM_STRUCTURED_OUTPUT",
+    # Strict json_schema rung (default ON — scrub so a host kill-switch can't
+    # flip the ladder tests).
+    "LLM_JSON_SCHEMA",
     "FAL_IMAGE_TIER",
     "FAL_IMAGE_MODEL",
     "FAL_IMAGE_MODEL_FAST",

--- a/apps/modal-backend/tests/test_llm_provider.py
+++ b/apps/modal-backend/tests/test_llm_provider.py
@@ -721,19 +721,21 @@ def _bad_request() -> Exception:
 
 async def test_complete_json_json_object_rung_parses(monkeypatch: pytest.MonkeyPatch) -> None:
     # Kill-switch pin: LLM_JSON_SCHEMA=false must reproduce the pre-rung
-    # ladder byte-identically — json_object first, no strict rung.
+    # ladder byte-identically — json_object first, no strict rung. Uses
+    # CANDIDATES_SCHEMA (strict-rung eligible) so the FLAG is what keeps the
+    # rung off, not CLICK_SCHEMA's partial `required`.
     monkeypatch.setenv("LLM_JSON_SCHEMA", "false")
-    fake = _FakeClient([_fake_response(content='{"subject": "Boiler"}')])
+    fake = _FakeClient([_fake_response(content='{"candidates": []}')])
     monkeypatch.setattr(llm, "_client", lambda: fake)
     parsed = await llm._complete_json(
         model="google/gemini-3-flash-preview",
         messages=[{"role": "user", "content": "x"}],
         max_tokens=100,
         temperature=0.2,
-        schema=llm.CLICK_SCHEMA,
-        schema_name="click",
+        schema=llm.CANDIDATES_SCHEMA,
+        schema_name="candidates",
     )
-    assert parsed == {"subject": "Boiler"}
+    assert parsed == {"candidates": []}
     call = fake.chat.completions.calls[0]
     assert call["response_format"] == {"type": "json_object"}
 
@@ -875,8 +877,9 @@ def test_strictify_schema_nested_arrays_no_mutation_idempotent() -> None:
     # Root object node: closed + all-required.
     assert strict["additionalProperties"] is False
     assert strict["required"] == ["candidates"]
-    # Nested array-of-objects: the item node is covered too, and its partial
-    # `required` (3 keys) is replaced by ALL declared properties.
+    # Nested array-of-objects: the item node is covered too. Its `required`
+    # is declared ALL SEVEN fields at the source (the deliberate promotion
+    # that makes CANDIDATES strict-rung eligible) and preserved as-is.
     item = strict["properties"]["candidates"]["items"]
     assert item["additionalProperties"] is False
     assert item["required"] == [
@@ -897,10 +900,42 @@ def test_strictify_schema_nested_arrays_no_mutation_idempotent() -> None:
 
 def test_strictify_schema_covers_object_in_object() -> None:
     strict = llm._strictify_schema(llm.CLICK_SCHEMA)
+    # Nested nodes WITHOUT a `required` get one added (author intent =
+    # all-required)…
     point = strict["properties"]["point"]
     assert point["additionalProperties"] is False
     assert point["required"] == ["x", "y"]
-    assert strict["required"] == list(llm.CLICK_SCHEMA["properties"].keys())
+    # …while the root's declared partial `required` is preserved, never
+    # overwritten (see test_strictify_schema_preserves_partial_required).
+    assert strict["required"] == ["subject"]
+
+
+def test_strictify_schema_preserves_partial_required() -> None:
+    # A partial `required` (CLICK_SCHEMA root: bbox is genuinely optional —
+    # "omit bbox if you can't give a tight box") must survive UNTOUCHED.
+    # Overwriting it with all-properties is how strict generation would
+    # FABRICATE boxes, the #127 failure. Such schemas skip the strict rung
+    # via _schema_strictifiable, but the helper must stay honest regardless.
+    strict = llm._strictify_schema(llm.CLICK_SCHEMA)
+    assert strict["required"] == llm.CLICK_SCHEMA["required"] == ["subject"]
+    # The input is not mutated either.
+    assert llm.CLICK_SCHEMA["required"] == ["subject"]
+
+
+def test_schema_strictifiable_rejects_partial_required() -> None:
+    # Strict json_schema demands required == ALL properties, so a schema
+    # declaring a partial `required` is NOT strict-expressible: the partial
+    # required expresses genuine optionality, and forcing the rest required
+    # would make the model fabricate data (#127). CLICK_SCHEMA keeps the
+    # json_object ladder BY DESIGN.
+    assert not llm._schema_strictifiable(llm.CLICK_SCHEMA)
+
+
+def test_schema_strictifiable_accepts_candidates() -> None:
+    # CANDIDATES is the coordinate-dice killer the strict rung exists for;
+    # its item `required` is deliberately promoted to ALL SEVEN fields. If
+    # someone re-adds a partial required there, this fails loudly.
+    assert llm._schema_strictifiable(llm.CANDIDATES_SCHEMA)
 
 
 async def test_complete_json_schema_rung_first_and_span(
@@ -933,11 +968,13 @@ async def test_complete_json_schema_rung_demotes_and_caches_on_400(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     llm._JSON_SCHEMA_DEMOTED.clear()
+    # CANDIDATES_SCHEMA here: it's the strict-rung-eligible one (CLICK_SCHEMA's
+    # partial `required` keeps it off the rung by design).
     fake = _FakeClient(
         [
             _bad_request(),
-            _fake_response(content='{"subject": "A"}'),
-            _fake_response(content='{"subject": "B"}'),
+            _fake_response(content='{"candidates": ["A"]}'),
+            _fake_response(content='{"candidates": ["B"]}'),
         ]
     )
     monkeypatch.setattr(llm, "_client", lambda: fake)
@@ -947,12 +984,12 @@ async def test_complete_json_schema_rung_demotes_and_caches_on_400(
         messages=[{"role": "user", "content": "x"}],
         max_tokens=100,
         temperature=0.2,
-        schema=llm.CLICK_SCHEMA,
-        schema_name="click",
+        schema=llm.CANDIDATES_SCHEMA,
+        schema_name="candidates",
         span_ctx=span,
     )
     # The 400 on the strict rung degrades to json_object WITHIN the same call.
-    assert first == {"subject": "A"}
+    assert first == {"candidates": ["A"]}
     calls = fake.chat.completions.calls
     assert len(calls) == 2
     assert calls[0]["response_format"]["type"] == "json_schema"
@@ -966,10 +1003,10 @@ async def test_complete_json_schema_rung_demotes_and_caches_on_400(
         messages=[{"role": "user", "content": "x"}],
         max_tokens=100,
         temperature=0.2,
-        schema=llm.CLICK_SCHEMA,
-        schema_name="click",
+        schema=llm.CANDIDATES_SCHEMA,
+        schema_name="candidates",
     )
-    assert second == {"subject": "B"}
+    assert second == {"candidates": ["B"]}
     assert len(calls) == 3
     assert calls[2]["response_format"] == {"type": "json_object"}
     llm._JSON_SCHEMA_DEMOTED.clear()
@@ -1005,7 +1042,9 @@ async def test_complete_json_flag_off_no_schema_rung(
 ) -> None:
     llm._JSON_SCHEMA_DEMOTED.clear()
     monkeypatch.setenv("LLM_JSON_SCHEMA", "false")
-    fake = _FakeClient([_fake_response(content='{"subject": "Z"}')])
+    # CANDIDATES_SCHEMA (strict-rung eligible) so the flag is the only thing
+    # keeping the rung off here.
+    fake = _FakeClient([_fake_response(content='{"candidates": []}')])
     monkeypatch.setattr(llm, "_client", lambda: fake)
     span: dict[str, Any] = {}
     parsed = await llm._complete_json(
@@ -1013,10 +1052,10 @@ async def test_complete_json_flag_off_no_schema_rung(
         messages=[{"role": "user", "content": "x"}],
         max_tokens=100,
         temperature=0.2,
-        schema=llm.CLICK_SCHEMA,
+        schema=llm.CANDIDATES_SCHEMA,
         span_ctx=span,
     )
-    assert parsed == {"subject": "Z"}
+    assert parsed == {"candidates": []}
     assert len(fake.chat.completions.calls) == 1
     assert fake.chat.completions.calls[0]["response_format"] == {"type": "json_object"}
     assert span["structured_tier"] == "json_object"
@@ -1068,7 +1107,11 @@ def test_with_json_hint_appends_text_block_to_multimodal_user_turn() -> None:
 
 
 async def test_complete_json_two_step_downgrade(monkeypatch: pytest.MonkeyPatch) -> None:
-    # gemini starts at json_object; json_object 400 -> tool 400 -> prompt succeeds.
+    # Written for the 3-rung ladder, so the strict rung is pinned OFF (and the
+    # demotion cache cleared) to stay hermetic: gemini starts at json_object;
+    # json_object 400 -> tool 400 -> prompt succeeds.
+    llm._JSON_SCHEMA_DEMOTED.clear()
+    monkeypatch.setenv("LLM_JSON_SCHEMA", "false")
     fake = _FakeClient(
         [_bad_request(), _bad_request(), _fake_response(content='{"subject": "Z"}')]
     )
@@ -1082,6 +1125,7 @@ async def test_complete_json_two_step_downgrade(monkeypatch: pytest.MonkeyPatch)
     )
     assert parsed == {"subject": "Z"}
     assert len(fake.chat.completions.calls) == 3
+    llm._JSON_SCHEMA_DEMOTED.clear()
 
 
 async def test_complete_json_reraises_when_all_rungs_400(
@@ -1089,6 +1133,10 @@ async def test_complete_json_reraises_when_all_rungs_400(
 ) -> None:
     from openai import BadRequestError
 
+    # Written for the 3-rung ladder: pin the strict rung off + clear the
+    # demotion cache so this test never depends on which test ran before it.
+    llm._JSON_SCHEMA_DEMOTED.clear()
+    monkeypatch.setenv("LLM_JSON_SCHEMA", "false")
     fake = _FakeClient([_bad_request(), _bad_request(), _bad_request()])
     monkeypatch.setattr(llm, "_client", lambda: fake)
     with pytest.raises(BadRequestError):

--- a/apps/modal-backend/tests/test_llm_provider.py
+++ b/apps/modal-backend/tests/test_llm_provider.py
@@ -720,6 +720,9 @@ def _bad_request() -> Exception:
 
 
 async def test_complete_json_json_object_rung_parses(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Kill-switch pin: LLM_JSON_SCHEMA=false must reproduce the pre-rung
+    # ladder byte-identically — json_object first, no strict rung.
+    monkeypatch.setenv("LLM_JSON_SCHEMA", "false")
     fake = _FakeClient([_fake_response(content='{"subject": "Boiler"}')])
     monkeypatch.setattr(llm, "_client", lambda: fake)
     parsed = await llm._complete_json(
@@ -825,8 +828,10 @@ async def test_complete_json_downgrades_on_bad_request(
     monkeypatch.setattr(
         llm, "_safe_log", lambda level, event, **kv: events.append((event, kv))
     )
-    # gemini on openrouter starts at json_object; a 400 must drop a rung and the
-    # next rung (tool) succeeds within the same call.
+    # gemini on openrouter starts at json_object (strict rung switched off); a
+    # 400 must drop a rung and the next rung (tool) succeeds within the same
+    # call.
+    monkeypatch.setenv("LLM_JSON_SCHEMA", "false")
     fake = _FakeClient([_bad_request(), _fake_response(tool_args='{"subject": "Y"}')])
     monkeypatch.setattr(llm, "_client", lambda: fake)
     parsed = await llm._complete_json(
@@ -855,6 +860,183 @@ async def test_complete_json_empty_choices_returns_empty(
         schema=llm.CLICK_SCHEMA,
     )
     assert parsed == {}
+
+
+# ---------- strict json_schema rung (LLM_JSON_SCHEMA, default ON) ---------
+
+
+def test_strictify_schema_nested_arrays_no_mutation_idempotent() -> None:
+    import copy
+
+    before = copy.deepcopy(llm.CANDIDATES_SCHEMA)
+    strict = llm._strictify_schema(llm.CANDIDATES_SCHEMA)
+    # The input schema object is NOT mutated.
+    assert before == llm.CANDIDATES_SCHEMA
+    # Root object node: closed + all-required.
+    assert strict["additionalProperties"] is False
+    assert strict["required"] == ["candidates"]
+    # Nested array-of-objects: the item node is covered too, and its partial
+    # `required` (3 keys) is replaced by ALL declared properties.
+    item = strict["properties"]["candidates"]["items"]
+    assert item["additionalProperties"] is False
+    assert item["required"] == [
+        "x_pct",
+        "y_pct",
+        "subject",
+        "style",
+        "salience",
+        "enter_as",
+        "place_form",
+    ]
+    # Enums/numbers untouched.
+    assert item["properties"]["enter_as"]["enum"] == ["scene", "submap", "explainer"]
+    assert item["properties"]["x_pct"] == {"type": "number"}
+    # Idempotent.
+    assert llm._strictify_schema(strict) == strict
+
+
+def test_strictify_schema_covers_object_in_object() -> None:
+    strict = llm._strictify_schema(llm.CLICK_SCHEMA)
+    point = strict["properties"]["point"]
+    assert point["additionalProperties"] is False
+    assert point["required"] == ["x", "y"]
+    assert strict["required"] == list(llm.CLICK_SCHEMA["properties"].keys())
+
+
+async def test_complete_json_schema_rung_first_and_span(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    llm._JSON_SCHEMA_DEMOTED.clear()
+    fake = _FakeClient([_fake_response(content='{"candidates": []}')])
+    monkeypatch.setattr(llm, "_client", lambda: fake)
+    span: dict[str, Any] = {}
+    parsed = await llm._complete_json(
+        model="google/gemini-3-flash-preview",
+        messages=[{"role": "user", "content": "x"}],
+        max_tokens=100,
+        temperature=0.2,
+        schema=llm.CANDIDATES_SCHEMA,
+        schema_name="candidates",
+        span_ctx=span,
+    )
+    assert parsed == {"candidates": []}
+    assert len(fake.chat.completions.calls) == 1
+    rf = fake.chat.completions.calls[0]["response_format"]
+    assert rf["type"] == "json_schema"
+    assert rf["json_schema"]["name"] == "candidates"
+    assert rf["json_schema"]["strict"] is True
+    assert rf["json_schema"]["schema"] == llm._strictify_schema(llm.CANDIDATES_SCHEMA)
+    assert span["structured_tier"] == "json_schema"
+
+
+async def test_complete_json_schema_rung_demotes_and_caches_on_400(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    llm._JSON_SCHEMA_DEMOTED.clear()
+    fake = _FakeClient(
+        [
+            _bad_request(),
+            _fake_response(content='{"subject": "A"}'),
+            _fake_response(content='{"subject": "B"}'),
+        ]
+    )
+    monkeypatch.setattr(llm, "_client", lambda: fake)
+    span: dict[str, Any] = {}
+    first = await llm._complete_json(
+        model="google/gemini-3-flash-preview",
+        messages=[{"role": "user", "content": "x"}],
+        max_tokens=100,
+        temperature=0.2,
+        schema=llm.CLICK_SCHEMA,
+        schema_name="click",
+        span_ctx=span,
+    )
+    # The 400 on the strict rung degrades to json_object WITHIN the same call.
+    assert first == {"subject": "A"}
+    calls = fake.chat.completions.calls
+    assert len(calls) == 2
+    assert calls[0]["response_format"]["type"] == "json_schema"
+    assert calls[1]["response_format"] == {"type": "json_object"}
+    assert span["structured_tier"] == "json_object"
+    assert "google/gemini-3-flash-preview" in llm._JSON_SCHEMA_DEMOTED
+    # The demotion is remembered: the next call goes straight to json_object —
+    # exactly one attempt, no strict round-trip re-paid.
+    second = await llm._complete_json(
+        model="google/gemini-3-flash-preview",
+        messages=[{"role": "user", "content": "x"}],
+        max_tokens=100,
+        temperature=0.2,
+        schema=llm.CLICK_SCHEMA,
+        schema_name="click",
+    )
+    assert second == {"subject": "B"}
+    assert len(calls) == 3
+    assert calls[2]["response_format"] == {"type": "json_object"}
+    llm._JSON_SCHEMA_DEMOTED.clear()
+
+
+async def test_complete_json_open_object_schema_skips_strict_rung(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # EXTRACTION_SCHEMA's items are OPEN objects ({"type": "object"}, no
+    # properties) — strict mode can't express that (closing them would enforce
+    # EMPTY objects). Such schemas keep json_object per-call, WITHOUT demoting
+    # the model for the fully-typed schemas.
+    llm._JSON_SCHEMA_DEMOTED.clear()
+    assert not llm._schema_strictifiable(llm.EXTRACTION_SCHEMA)
+    assert llm._schema_strictifiable(llm.CANDIDATES_SCHEMA)
+    fake = _FakeClient([_fake_response(content='{"added": [], "updated": []}')])
+    monkeypatch.setattr(llm, "_client", lambda: fake)
+    parsed = await llm._complete_json(
+        model="google/gemini-3-flash-preview",
+        messages=[{"role": "user", "content": "x"}],
+        max_tokens=100,
+        temperature=0.2,
+        schema=llm.EXTRACTION_SCHEMA,
+        schema_name="extraction",
+    )
+    assert parsed == {"added": [], "updated": []}
+    assert fake.chat.completions.calls[0]["response_format"] == {"type": "json_object"}
+    assert "google/gemini-3-flash-preview" not in llm._JSON_SCHEMA_DEMOTED
+
+
+async def test_complete_json_flag_off_no_schema_rung(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    llm._JSON_SCHEMA_DEMOTED.clear()
+    monkeypatch.setenv("LLM_JSON_SCHEMA", "false")
+    fake = _FakeClient([_fake_response(content='{"subject": "Z"}')])
+    monkeypatch.setattr(llm, "_client", lambda: fake)
+    span: dict[str, Any] = {}
+    parsed = await llm._complete_json(
+        model="google/gemini-3-flash-preview",
+        messages=[{"role": "user", "content": "x"}],
+        max_tokens=100,
+        temperature=0.2,
+        schema=llm.CLICK_SCHEMA,
+        span_ctx=span,
+    )
+    assert parsed == {"subject": "Z"}
+    assert len(fake.chat.completions.calls) == 1
+    assert fake.chat.completions.calls[0]["response_format"] == {"type": "json_object"}
+    assert span["structured_tier"] == "json_object"
+
+
+async def test_complete_json_no_schema_unchanged_by_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    llm._JSON_SCHEMA_DEMOTED.clear()
+    monkeypatch.setenv("LLM_JSON_SCHEMA", "true")
+    fake = _FakeClient([_fake_response(content='{"k": 1}')])
+    monkeypatch.setattr(llm, "_client", lambda: fake)
+    parsed = await llm._complete_json(
+        model="google/gemini-3-flash-preview",
+        messages=[{"role": "user", "content": "x"}],
+        max_tokens=100,
+        temperature=0.2,
+    )
+    assert parsed == {"k": 1}
+    assert fake.chat.completions.calls[0]["response_format"] == {"type": "json_object"}
 
 
 # ---------- _with_json_hint + multi-step downgrade -----------------------


### PR DESCRIPTION
Kills the VLM dice at the source: when a caller passes a schema and `LLM_JSON_SCHEMA` (default ON), the ladder attempts OpenRouter `response_format {type: json_schema, strict: true}` before json_object — the provider enforces types/enums/bounds at generation, so coordinate-scale rolls (#158/#159) and shape drift can't happen on the strict rung. Downstream salvages stay as seatbelts.

Design points (review-hardened, verdict was FIX-FIRST → fixed):
- `_strictify_schema` deep-copies; adds `additionalProperties: false` + `required` **only where the author declared none** — an existing partial `required` is never overwritten (forcing optional fields required makes strict generation FABRICATE them — the #127 sin; CLICK's `bbox` says "omit if you can't give a tight box" on purpose).
- `_schema_strictifiable`: open-object schemas AND partial-required schemas skip the rung per-call (no demotion-cache write). CANDIDATES_SCHEMA is deliberately promoted to all-required (every field prompt-mandated + constrained; it's the dice-killer schema) — the final rung roster is **CANDIDATES only**, by design; CLICK/PLAN/NEIGHBORS keep genuine optionality on json_object.
- 400 on the strict attempt → same-call fallthrough to json_object + per-model demotion cache (`_JSON_SCHEMA_DEMOTED`) so the failed round-trip is paid once; transient errors never demote. `structured_tier` spans report truthfully.
- Kill-switch → byte-identical old ladder (pinned); hermetic tests (cache cleared, no order-coupling).

920 backend tests + ruff + mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)