### PR TITLE
perf(enters): steep default flips to nano-banana-pro/edit — 4x faster, re-benched

### DIFF
--- a/apps/modal-backend/providers/model_router.py
+++ b/apps/modal-backend/providers/model_router.py
@@ -117,18 +117,23 @@ def select_outward_op(from_tier: str, to_tier: str) -> str:
 
 
 # Steep view TRANSFORMS (an overhead map crop re-rendered at eye level or as a
-# closer plan) land ~2.5/10 on the nano family — it drifts back to its aerial
-# attractor — but 8/10 on gpt-image-2/edit, at equal same-place fidelity
-# (view-bench A/B, 2026-06-10). Aerial registers (oblique/isometric) are 9-10
-# on BOTH, so the cheaper incumbent keeps those.
+# closer plan): the 2026-06-10 view-bench put the nano family at ~2.5/10 here
+# (aerial-attractor drift) vs 8/10 on gpt-image-2/edit — but the 2026-07-14
+# enter re-bench (3 steep map→scene cases via ENTER_BENCH_MODELS) scored
+# nano-banana-pro/edit 9.0 vs gpt 8.33 on same-place, no rings drift in any
+# rationale, at ~30s/attempt vs ~2min (4x). Two things changed since June:
+# enter instructions gained the view-grammar transform sentences, and every
+# enter now runs the judged VIEW_LOOP (a drifted arrival fails conformance
+# and retries) — the seatbelt the old pin predates. Flipped to nano for
+# speed; FAL_ENTER_MODEL_STEEP restores gpt in one env if rings resurface.
 STEEP_ENTER_PROJECTIONS = frozenset({"eye_level", "top_down"})
-STEEP_ENTER_DEFAULT = "openai/gpt-image-2/edit"
+STEEP_ENTER_DEFAULT = "fal-ai/nano-banana-pro/edit"
 
 
 def select_enter_model(projection: str | None) -> str | None:
     """The enter model for a deliberate camera: steep transforms route to the
-    gpt family (FAL_ENTER_MODEL_STEEP override); everything else — including
-    the legacy no-view enter — keeps the enter_scene slot."""
+    steep default (FAL_ENTER_MODEL_STEEP override); everything else —
+    including the legacy no-view enter — keeps the enter_scene slot."""
     if projection in STEEP_ENTER_PROJECTIONS:
         return os.environ.get("FAL_ENTER_MODEL_STEEP") or STEEP_ENTER_DEFAULT
     return resolve_model("enter_scene")

--- a/apps/modal-backend/tests/test_generate_view.py
+++ b/apps/modal-backend/tests/test_generate_view.py
@@ -297,12 +297,14 @@ async def test_eye_level_enter_keeps_layout_clause(
     assert "SCENE LAYOUT" in instruction  # matching register: clause kept
 
 
-async def test_steep_enter_routes_to_gpt_family(
+async def test_steep_enter_routes_to_steep_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # An interior (eye_level policy) enter must dispatch on the gpt-family
-    # model AND speak its change-first grammar; an establishing (oblique)
-    # enter keeps the nano slot.
+    # An interior (eye_level policy) enter must dispatch on the STEEP default
+    # (nano-banana-pro/edit since the 2026-07-14 re-bench: 9.0 vs gpt 8.33
+    # same-place, no aerial drift, 4x faster; VIEW_LOOP guards every enter)
+    # AND speak that family's grammar; an establishing (oblique) enter keeps
+    # the enter_scene slot.
     _mock_plan(monkeypatch)
     edit = _mock_edit(monkeypatch)
     _mock_fresh(monkeypatch)
@@ -316,8 +318,10 @@ async def test_steep_enter_routes_to_gpt_family(
             "t1",
         )
     )
-    assert edit.await_args.kwargs["model_override"] == "openai/gpt-image-2/edit"
-    assert edit.await_args.args[1].startswith("Change only the camera:")
+    assert edit.await_args.kwargs["model_override"] == "fal-ai/nano-banana-pro/edit"
+    # The instruction family follows the model: nano grammar anchors on the
+    # reference map, not gpt's change-first sentence.
+    assert "the overhead map of" in edit.await_args.args[1]
 
     edit.reset_mock()
     await _collect(_event_stream(_tap_body(), "t1"))  # the castle -> oblique

--- a/apps/modal-backend/tests/test_model_router.py
+++ b/apps/modal-backend/tests/test_model_router.py
@@ -96,12 +96,13 @@ def test_coarser_tier_steps_outward() -> None:
     assert model_router.coarser_tier("bogus") is None  # unknown rung
 
 
-def test_select_enter_model_routes_steep_to_gpt(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Steep view transforms (aerial source -> eye_level/top_down) go to the
-    # gpt family (view-bench A/B: 8.0 vs the nano family's 2.5); aerial
-    # registers + the legacy no-view enter keep the enter_scene slot.
-    assert model_router.select_enter_model("eye_level") == "openai/gpt-image-2/edit"
-    assert model_router.select_enter_model("top_down") == "openai/gpt-image-2/edit"
+def test_select_enter_model_routes_steep_to_nano(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Steep view transforms (aerial source -> eye_level/top_down): re-benched
+    # 2026-07-14 (ENTER_BENCH_MODELS arms) — nano-banana-pro/edit 9.0 vs gpt
+    # 8.33 same-place, no aerial-attractor drift, 4x faster. The judged
+    # VIEW_LOOP now guards every enter, which the old gpt pin predates.
+    assert model_router.select_enter_model("eye_level") == "fal-ai/nano-banana-pro/edit"
+    assert model_router.select_enter_model("top_down") == "fal-ai/nano-banana-pro/edit"
     assert model_router.select_enter_model("oblique") == model_router.resolve_model("enter_scene")
     assert model_router.select_enter_model("isometric") == model_router.resolve_model("enter_scene")
     assert model_router.select_enter_model(None) == model_router.resolve_model("enter_scene")


### PR DESCRIPTION
Item 4 of the queue. The June pin sent steep transforms to `gpt-image-2/edit` (nano scored ~2.5/10 on aerial-attractor drift back then). **Re-benched today** (`ENTER_BENCH_MODELS` arms, 3 steep map→scene cases): **nano-banana-pro/edit 9.0 vs gpt 8.33** on same-place, zero rings mentions in rationales, **~30s vs ~2min per attempt**. Two things changed since June: enter instructions gained the view-grammar transform sentences, and every enter now runs the judged VIEW_LOOP — drifted arrivals fail conformance and retry, a seatbelt the old pin predates.

Net UX: world enters drop from ~2–4 min to ~30–90 s. `FAL_ENTER_MODEL_STEEP` restores gpt in one env if rings resurface. Honest caveat: n=3 — the escape hatch is the risk posture. 921 backend tests + ruff + mypy green; bench baseline PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)