### PR TITLE
feat(zoom): classic submap zooms redraw too — the #164 follow-up

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -131,8 +131,8 @@ FAL_EDIT_TIER=balanced
 # byte-identical. INTERIOR_ACCEPT is the 0-10 acceptance floor.
 # INTERIOR_ENTERS=true
 # INTERIOR_ACCEPT=6.0
-# Real map zoom: world-mode map zooms (place_submap) are RE-DRAWN at the
-# closer scale — the region crop rides the EDIT/continue seam with a
+# Real map zoom: map zooms (place_submap, world AND classic) are RE-DRAWN at
+# the closer scale — the region crop rides the EDIT/continue seam with a
 # loose-refs model, instead of Kontext's crop-upscale. Kontext magnifies
 # pixels without new detail, so dense city maps arrive as blurry illegible
 # mush. `false` = the old Kontext path, byte-identical.

--- a/apps/modal-backend/providers/generate_modes/tap.py
+++ b/apps/modal-backend/providers/generate_modes/tap.py
@@ -385,10 +385,12 @@ async def stream_tap(
     # reference-frozen — it magnifies the crop's pixels without synthesizing
     # new detail, so dense city maps arrive as blurry illegible mush (live
     # screenshots). `false` is the kill-switch: today's continue_image bytes.
-    # Classic (non-world) submap zooms keep Kontext on purpose (blast radius).
+    # Classic mode included since the world-only debut (#164's noted
+    # follow-up): classic submap zooms mush identically; without world
+    # entities the layout/topdown clauses are simply empty and the redraw is
+    # prompt + region ref + the same two judges.
     submap_redraw = (
         use_continuation
-        and effective_world_mode
         and render_mode == "place_submap"
         and env_flag("SUBMAP_REDRAW", "true")
     )

--- a/apps/modal-backend/tests/test_generate_enter.py
+++ b/apps/modal-backend/tests/test_generate_enter.py
@@ -965,11 +965,12 @@ async def test_submap_redraw_kill_switch_is_todays_kontext(
     assert final["image_op"] == "zoom_continue"
 
 
-async def test_classic_submap_keeps_kontext_regardless_of_flag(
+async def test_classic_submap_redraws_too(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # World mode NOT effective (env off) → the redraw never arms, whatever the
-    # flag says. Blast-radius choice: classic submap zooms stay Kontext.
+    # Classic (world env off) submap zooms mush exactly like world ones —
+    # since the follow-up to #164 the redraw arms in classic mode as well:
+    # empty layout/topdown clauses, same loose-refs model, same judges.
     monkeypatch.setenv("SUBMAP_REDRAW", "true")
     _mock_plan(monkeypatch)
     _mock_edit(monkeypatch)
@@ -980,6 +981,24 @@ async def test_classic_submap_keeps_kontext_regardless_of_flag(
 
     cont.assert_awaited_once()
     gen.assert_not_awaited()
+    assert (
+        cont.await_args.kwargs["model_override"] == "fal-ai/nano-banana-pro/edit"
+    )
+    final = next(e for e in events if e["type"] == "final")
+    assert final["image_op"] == "map_redraw"
+
+
+async def test_classic_submap_kill_switch_restores_kontext(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SUBMAP_REDRAW", "false")
+    _mock_plan(monkeypatch)
+    _mock_edit(monkeypatch)
+    cont = _mock_continue(monkeypatch)
+
+    events = await _collect(_event_stream(_world_submap_body(), "t1"))
+
+    cont.assert_awaited_once()
     assert cont.await_args.kwargs["model_override"] is None  # default Kontext
     final = next(e for e in events if e["type"] == "final")
     assert final["image_op"] == "zoom_continue"


### PR DESCRIPTION
Classic map zooms mushed exactly like world ones; world-only was #164's stated blast-radius choice. The gate drops `effective_world_mode` — with no world entities the layout/topdown clauses are empty and the redraw is prompt + region ref + the same two judges. Kill-switch unchanged; classic on/off both pinned. 922 backend tests + ruff + mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)