### PR TITLE
chore(ci): the coverage ratchet — measured floors that CI enforces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,10 @@ jobs:
           cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Vitest
-        run: pnpm --filter @openflipbook/web test
+      - name: Vitest (with the coverage ratchet — thresholds in vitest.config)
+        run: pnpm --filter @openflipbook/web test -- --coverage
+      - name: Config package tests
+        run: pnpm --filter @openflipbook/config test
 
   build:
     runs-on: ubuntu-latest
@@ -105,11 +107,11 @@ jobs:
         run: |
           source .venv/bin/activate
           mypy providers obs.py generate.py
-      - name: Pytest
+      - name: Pytest (with the coverage ratchet — fail_under in pyproject)
         working-directory: apps/modal-backend
         run: |
           source .venv/bin/activate
-          pytest
+          pytest --cov=providers --cov=generate --cov-report=term
 
   e2e-mock:
     # Zero-key boot proof, every PR: the whole compose stack comes up under

--- a/apps/modal-backend/pyproject.toml
+++ b/apps/modal-backend/pyproject.toml
@@ -49,6 +49,13 @@ markers = [
     "paid: spends fal/openrouter; skipped unless its *_BENCH_RUN flag is set",
 ]
 
+# The RATCHET: floor pinned just under the measured baseline (2026-07-18:
+# 84.68% over providers/ + generate.py). CI's pytest runs with --cov so a
+# PR that drops the total below this FAILS; a PR that raises coverage bumps
+# the floor. Never lower it to make a PR pass — that defeats the ratchet.
+[tool.coverage.report]
+fail_under = 83
+
 [tool.mypy]
 python_version = "3.12"
 # Start permissive on the whole tree; tighten module-by-module below.

--- a/apps/modal-backend/requirements-dev.txt
+++ b/apps/modal-backend/requirements-dev.txt
@@ -3,3 +3,4 @@ ruff>=0.7
 mypy>=1.13
 pytest>=8.3
 pytest-asyncio>=0.24
+pytest-cov>=6

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -30,6 +30,17 @@ export default defineConfig({
       reporter: ["text", "json-summary"],
       include: ["lib/**/*.{ts,tsx}", "hooks/**/*.{ts,tsx}", "components/**/*.{ts,tsx}"],
       exclude: ["**/*.test.{ts,tsx}"],
+      // The RATCHET: floors pinned just under the measured baseline
+      // (2026-07-18: lines/stmts 66.0, functions 70.7, branches 85.3). CI
+      // runs vitest with --coverage so a PR that drops below any floor
+      // FAILS; a PR that raises coverage bumps the floor to the new number.
+      // Never lower these to make a PR pass — that defeats the ratchet.
+      thresholds: {
+        lines: 65,
+        statements: 65,
+        functions: 69,
+        branches: 84,
+      },
     },
   },
 });

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -20,9 +20,11 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "devDependencies": {
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.8"
   }
 }

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -1,0 +1,107 @@
+// The scale ladder is the ONE axis every zoom feature (OUTWARD/AROUND/DEEPER,
+// interiors' "room" stamp, the geo frames) hangs off — these invariants are
+// the contract both the TS and Python sides assume. 969 lines of wire types
+// had zero tests until the 2026-07-18 coverage pass.
+import { describe, expect, it } from "vitest";
+
+import {
+  finerTier,
+  SCALE_LADDER,
+  SCALE_TIER_METERS,
+  type ScaleTier,
+  tierIndex,
+  tierMetricMultiplier,
+  tierStep,
+  tierTransitionValid,
+} from "./index";
+
+describe("SCALE_LADDER invariants", () => {
+  it("has exactly 11 unique rungs, universe→object", () => {
+    expect(SCALE_LADDER).toHaveLength(11);
+    expect(new Set(SCALE_LADDER).size).toBe(11);
+    expect(SCALE_LADDER[0]).toBe("universe");
+    expect(SCALE_LADDER[SCALE_LADDER.length - 1]).toBe("object");
+  });
+
+  it("metric anchors are monotonically non-increasing along the ladder", () => {
+    for (let i = 1; i < SCALE_LADDER.length; i++) {
+      const coarser = SCALE_TIER_METERS[SCALE_LADDER[i - 1] as ScaleTier];
+      const finer = SCALE_TIER_METERS[SCALE_LADDER[i] as ScaleTier];
+      expect(finer).toBeLessThanOrEqual(coarser);
+    }
+  });
+
+  it("world and planet share an anchor BY DESIGN (a world is a planet-surface framing)", () => {
+    expect(SCALE_TIER_METERS.world).toBe(SCALE_TIER_METERS.planet);
+  });
+
+  it("every rung has a positive metric anchor", () => {
+    for (const t of SCALE_LADDER) {
+      expect(SCALE_TIER_METERS[t]).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("tierIndex / tierStep", () => {
+  it("tierIndex matches ladder position for every rung", () => {
+    SCALE_LADDER.forEach((t, i) => expect(tierIndex(t)).toBe(i));
+  });
+
+  it("tierStep is signed: DEEPER (toward object) is +, OUTWARD is −, and antisymmetric", () => {
+    expect(tierStep("city", "district")).toBe(1);
+    expect(tierStep("district", "city")).toBe(-1);
+    expect(tierStep("place", "place")).toBe(0);
+    for (const a of SCALE_LADDER) {
+      for (const b of SCALE_LADDER) {
+        // sum form dodges the Object.is(-0, 0) trap on the diagonal
+        expect(tierStep(a, b) + tierStep(b, a)).toBe(0);
+      }
+    }
+  });
+});
+
+describe("tierMetricMultiplier", () => {
+  it("OUTWARD grows (>1), DEEPER shrinks (<1), reciprocal both ways", () => {
+    expect(tierMetricMultiplier("city", "region")).toBeGreaterThan(1);
+    expect(tierMetricMultiplier("city", "district")).toBeLessThan(1);
+    for (const a of SCALE_LADDER) {
+      for (const b of SCALE_LADDER) {
+        expect(tierMetricMultiplier(a, b) * tierMetricMultiplier(b, a)).toBeCloseTo(1, 9);
+      }
+    }
+  });
+});
+
+describe("tierTransitionValid (INV-2: metric moves with the rung step)", () => {
+  it("holds for every adjacent pair on the real ladder, both directions", () => {
+    for (let i = 1; i < SCALE_LADDER.length; i++) {
+      const coarser = SCALE_LADDER[i - 1] as ScaleTier;
+      const finer = SCALE_LADDER[i] as ScaleTier;
+      expect(tierTransitionValid(coarser, finer)).toBe(true); // DEEPER
+      expect(tierTransitionValid(finer, coarser)).toBe(true); // OUTWARD
+    }
+  });
+
+  it("same-rung transitions are trivially valid", () => {
+    for (const t of SCALE_LADDER) expect(tierTransitionValid(t, t)).toBe(true);
+  });
+
+  it("the deliberately-equal world/planet hop is valid in both directions (the ==1 carve-out)", () => {
+    expect(tierTransitionValid("planet", "world")).toBe(true);
+    expect(tierTransitionValid("world", "planet")).toBe(true);
+  });
+});
+
+describe("finerTier", () => {
+  it("steps one rung toward object and clamps at object", () => {
+    expect(finerTier("city")).toBe("district");
+    expect(finerTier("room")).toBe("object");
+    expect(finerTier("object")).toBe("object"); // the clamp
+  });
+
+  it("round-trips with tierStep(+1) everywhere except the clamp", () => {
+    for (const t of SCALE_LADDER.slice(0, -1)) {
+      expect(tierStep(t, finerTier(t))).toBe(1);
+    }
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.17)(happy-dom@15.11.7)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.47.1)
 
 packages:
 


### PR DESCRIPTION
Coverage tooling existed on both sides; nothing enforced it. Measured baselines (2026-07-18): **backend 84.68%**, **web 66.0 lines / 70.7 functions / 85.3 branches**.

- Backend: `fail_under = 83` in pyproject + CI pytest now runs `--cov` — floors just under measured, headroom for the transition; the quick-win test PRs bump it right back.
- Web: vitest `coverage.thresholds` 65/65/69/84 + CI runs `--coverage`.
- **Both gates proof-fired locally**: impossible floor → observed FAIL (`Required test coverage of 95.0% not reached. Total coverage: 84.68%` / `Coverage for lines (66.01%) does not meet global threshold (90%)`) → restored.
- `packages/config` — 969 lines of wire contract, zero tests until now — gets its first suite (12 tests: ladder invariants, INV-2 across all rungs, multiplier reciprocity, finerTier clamp) + a CI step.

The rule, written into both configs: a PR that raises coverage bumps the floor; never lower a floor to make a PR pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)