### PR TITLE
feat(mock): world/interior routes + deterministic classifier + MOCK_ERROR lever

### DIFF
--- a/apps/modal-backend/providers/mock.py
+++ b/apps/modal-backend/providers/mock.py
@@ -38,9 +38,15 @@ _SUBJECTS = (
 
 _STYLE = "hand-inked map, sepia, fine linework"
 
-# The real prompts embed the steering text verbatim as `titled '<parent_title>'`
-# and `(user query: '<parent_query>')` — see providers/llm/click.py + world.py.
-_QUOTED_RE = re.compile(r"(?:titled|user query:)\s*'([^']*)'")
+# The real click/candidates prompts embed: titled '<T>' (user query: '<Q>').
+# (providers/llm/click.py — click_to_subject + precompute_click_candidates
+# both use exactly this shape.) GREEDY groups + the literal separators keep
+# inner apostrophes intact: "the smith's tavern" must NOT truncate at the
+# possessive — a truncated extraction loses the trigger word and silently
+# mis-steers e2e specs. Lazy `(.*?)` would stop at the same inner apostrophe;
+# greedy is safe because neither classified prompt contains a later "')" for
+# the tail group to overshoot to.
+_TEMPLATE_RE = re.compile(r"titled '(.*)' \(user query: '(.*)'\)")
 
 _CLASSIFY_RULES: tuple[tuple[tuple[str, ...], tuple[str, str]], ...] = (
     (
@@ -58,15 +64,20 @@ def _classify(text: str) -> tuple[str, str]:
     prompts embed parent_query/parent_title, and "tower" in the query makes
     every mock classification scene/interior, "district" submap/complex, etc.
 
-    When the text carries the prompts' embedded `titled '…'` / `user query:
-    '…'` quotes, ONLY those are matched: the candidates/world-mode prompts'
-    static instructions themselves name "a tower, house, temple … harbor,
-    market square … valley, coastline, forest" as EXAMPLES and would
-    otherwise classify every single request as scene/interior."""
+    When the text carries the prompts' embedded `titled '…' (user query:
+    '…')` template, ONLY the title+query are matched: the candidates/world-
+    mode prompts' static instructions themselves name "a tower, house,
+    temple … harbor, market square … valley, coastline, forest" as EXAMPLES
+    and would otherwise classify every single request as scene/interior.
+
+    Precedence: title and query are joined ("<title> <query>") and the rule
+    ladder runs top-down, first match wins — so an interior word in EITHER
+    field beats a district word (title 'X tower' + query 'Y district' →
+    scene/interior)."""
     t = text.lower()
-    quoted = _QUOTED_RE.findall(t)
-    if quoted:
-        t = " ".join(quoted)
+    m = _TEMPLATE_RE.search(t)
+    if m:
+        t = m.group(1) + " " + m.group(2)
     for keys, result in _CLASSIFY_RULES:
         if any(k in t for k in keys):
             return result

--- a/apps/modal-backend/providers/mock.py
+++ b/apps/modal-backend/providers/mock.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import hashlib
 import io
 import json
+import re
 from dataclasses import dataclass
 from typing import Any
 
@@ -34,6 +35,42 @@ _SUBJECTS = (
     "The Guild Hall",
     "The Harbor Gate",
 )
+
+_STYLE = "hand-inked map, sepia, fine linework"
+
+# The real prompts embed the steering text verbatim as `titled '<parent_title>'`
+# and `(user query: '<parent_query>')` — see providers/llm/click.py + world.py.
+_QUOTED_RE = re.compile(r"(?:titled|user query:)\s*'([^']*)'")
+
+_CLASSIFY_RULES: tuple[tuple[tuple[str, ...], tuple[str, str]], ...] = (
+    (
+        ("tower", "lighthouse", "tavern", "hall", "conservatory", "keep"),
+        ("scene", "interior"),
+    ),
+    (("district", "quarter", "market", "harbor"), ("submap", "complex")),
+    (("valley", "coast", "forest", "garden"), ("scene", "landscape")),
+)
+
+
+def _classify(text: str) -> tuple[str, str]:
+    """Deterministic (enter_as, place_form) keyed on lowercase substrings, so
+    e2e specs steer classification from the OUTSIDE via /play?q=… — the real
+    prompts embed parent_query/parent_title, and "tower" in the query makes
+    every mock classification scene/interior, "district" submap/complex, etc.
+
+    When the text carries the prompts' embedded `titled '…'` / `user query:
+    '…'` quotes, ONLY those are matched: the candidates/world-mode prompts'
+    static instructions themselves name "a tower, house, temple … harbor,
+    market square … valley, coastline, forest" as EXAMPLES and would
+    otherwise classify every single request as scene/interior."""
+    t = text.lower()
+    quoted = _QUOTED_RE.findall(t)
+    if quoted:
+        t = " ".join(quoted)
+    for keys, result in _CLASSIFY_RULES:
+        if any(k in t for k in keys):
+            return result
+    return ("explainer", "")
 
 
 def on() -> bool:
@@ -117,23 +154,76 @@ def _route(system: str, user: str) -> str:
     distinctive phrases in the system prompt; the tolerant parsers upstream
     make near-misses degrade instead of crash."""
     s = system.lower()
+    # Stateless per-request failure switch for e2e: any prompt carrying
+    # "mock_error" fails loudly here and propagates through _complete_json
+    # into generate.py's stream except-handler — exercising the REAL SSE
+    # error path (#153 friendly frames) with zero keys and zero state.
+    if "mock_error" in s or "mock_error" in user.lower():
+        raise RuntimeError("MOCK_ERROR: forced test failure")
     seed = _h(system[:120], user[:200])
     subject = _SUBJECTS[seed % len(_SUBJECTS)]
     if "content reviewer" in s:
         return json.dumps({"allowed": True, "reason": ""})
     if "score" in s and ("judge" in s or "rate" in s or "0-10" in s or "10" in s):
         return json.dumps({"score": 8.5, "rationale": "mock judge: accepted"})
-    if "tapped" in s or "crosshair" in s or "click" in s:
+    # BEFORE the click catch-all: the candidates prompt also contains the word
+    # "click(able)", so it used to fall into the click route — the ClickResolution
+    # -shaped reply then validated to zero candidates and Wander stopped
+    # instantly ("no-candidates"). Match on the prompt's own schema echo.
+    if '"candidates"' in s:
+        enter_as, place_form = _classify(system)
+        spots = (
+            (0.30, 0.30, 0.9),
+            (0.70, 0.35, 0.8),
+            (0.50, 0.70, 0.7),
+            (0.25, 0.60, 0.6),
+        )
         return json.dumps(
             {
-                "subject": subject,
-                "style": "hand-inked map, sepia, fine linework",
-                "subject_context": f"{subject}, a notable place in this scene",
-                "groundable": True,
-                "confidence": 0.9,
-                "enter_as": "explainer",
+                "candidates": [
+                    {
+                        "x_pct": x,
+                        "y_pct": y,
+                        "subject": _SUBJECTS[(seed + i) % len(_SUBJECTS)],
+                        "style": _STYLE,
+                        "salience": sal,
+                        "enter_as": enter_as,
+                        "place_form": place_form,
+                    }
+                    for i, (x, y, sal) in enumerate(spots)
+                ]
             }
         )
+    # The expand-outward neighbour survey (providers/llm/world.py).
+    if "expand outward" in s:
+        scales = ("container", "peer", "peer", "component")
+        return json.dumps(
+            {
+                "neighbors": [
+                    {
+                        "subject": _SUBJECTS[(seed + i) % len(_SUBJECTS)],
+                        "scale": scales[i],
+                        "note": "a nearby subject in the mock world",
+                    }
+                    for i in range(4)
+                ]
+            }
+        )
+    if "tapped" in s or "crosshair" in s or "click" in s:
+        enter_as, place_form = _classify(system)
+        payload: dict[str, Any] = {
+            "subject": subject,
+            "style": _STYLE,
+            "subject_context": f"{subject}, a notable place in this scene",
+            "groundable": True,
+            "confidence": 0.9,
+            "enter_as": enter_as,
+        }
+        # "" is ClickResolution's neutral place_form; omitting the key keeps
+        # the default (non-steered) reply byte-identical to the classic mock.
+        if place_form:
+            payload["place_form"] = place_form
+        return json.dumps(payload)
     if "page_title" in s or ("plan" in s and "image" in s):
         return json.dumps(
             {

--- a/apps/modal-backend/tests/test_mock_providers.py
+++ b/apps/modal-backend/tests/test_mock_providers.py
@@ -196,6 +196,55 @@ async def test_click_route_steers_enter_as_and_place_form() -> None:
     assert res.place_form == "interior"
 
 
+async def test_apostrophes_survive_template_extraction() -> None:
+    """"the smith's tavern": a lazy/char-class quote match truncates at the
+    possessive, drops "tavern", and the spec silently classifies default —
+    the template-anchored regex must keep the trigger word, on BOTH routes."""
+    from providers.llm.click import click_to_subject, precompute_click_candidates
+
+    res = await click_to_subject(
+        _IMG,
+        0.5,
+        0.5,
+        parent_title="The Smith's Tavern",
+        parent_query="the smith's tavern",
+    )
+    assert res.enter_as == "scene"
+    assert res.place_form == "interior"
+
+    cands = await precompute_click_candidates(
+        _IMG, "The Smith's Tavern", "the smith's tavern"
+    )
+    assert cands[0].enter_as == "scene"
+    assert cands[0].place_form == "interior"
+
+    # An apostrophe in the title must not eat the query: the district word
+    # still steers.
+    district = await precompute_click_candidates(
+        _IMG, "The Weaver's Row", "the cloth district"
+    )
+    assert district[0].enter_as == "submap"
+    assert district[0].place_form == "complex"
+
+
+def test_classifier_template_precedence() -> None:
+    """Title and query are JOINED before the rule ladder runs, so both can
+    steer; first-match precedence means an interior word in either field
+    outranks a district word in the other."""
+    assert mock._classify(
+        "page titled 'The Bell Tower' (user query: 'the old district'). x"
+    ) == ("scene", "interior")
+    assert mock._classify(
+        "page titled 'The Old District' (user query: 'the bell tower'). x"
+    ) == ("scene", "interior")
+    # Inner apostrophes in BOTH groups survive extraction; the static tail
+    # after the template (naming a district) is still excluded.
+    assert mock._classify(
+        "page titled 'The Smith's Tavern' (user query: 'the smith's home'). "
+        "Examples: a market district."
+    ) == ("scene", "interior")
+
+
 async def test_mock_error_lever_raises() -> None:
     with pytest.raises(RuntimeError, match="MOCK_ERROR"):
         await mock.mock_llm_client().chat.completions.create(
@@ -203,10 +252,15 @@ async def test_mock_error_lever_raises() -> None:
         )
 
 
-async def test_mock_error_reaches_sse_error_frame() -> None:
+async def test_mock_error_reaches_sse_error_frame(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """The lever's whole point: the forced failure propagates through
     _complete_json into generate.py's except-handler and comes out as the
     REAL friendly SSE error frame (#153)."""
+    # Pin the flag: with FRIENDLY_ERRORS off, the frame carries no `detail`
+    # key, so `err.get("detail", "") == ""` would let ANY error false-pass.
+    monkeypatch.setenv("FRIENDLY_ERRORS", "true")
     events = await _collect(
         _event_stream(
             GenerateBody(query="mock_error town", session_id="s-err", web_search=False),
@@ -214,4 +268,8 @@ async def test_mock_error_reaches_sse_error_frame() -> None:
         )
     )
     err = next(e for e in events if e["type"] == "error")
-    assert "MOCK_ERROR" in err.get("detail", "")
+    # Friendly frames put the exception text in `detail`, raw frames in
+    # `message` — checking both keeps the assertion honest under either shape.
+    assert ("MOCK_ERROR" in err.get("detail", "")) or (
+        "MOCK_ERROR" in err.get("message", "")
+    )

--- a/apps/modal-backend/tests/test_mock_providers.py
+++ b/apps/modal-backend/tests/test_mock_providers.py
@@ -100,3 +100,118 @@ async def test_mock_determinism() -> None:
     c = mock.mock_image("a different prompt", op="fresh")
     assert a.jpeg_bytes == b.jpeg_bytes
     assert a.jpeg_bytes != c.jpeg_bytes
+
+
+# ── World/interior routes: the candidates + neighbors prompts through the
+# REAL provider functions (parsers and validators run for real; only the model
+# reply is canned), steered via the query the prompts embed. ────────────────
+
+_IMG = "data:image/jpeg;base64,AAAA"  # never decoded — the mock ignores images
+
+
+async def test_candidates_route_validates_and_steers() -> None:
+    from providers.llm.click import precompute_click_candidates
+
+    tower = await precompute_click_candidates(_IMG, "A Tall Tower", "a tall stone tower")
+    assert 3 <= len(tower) <= 4
+    assert all(0.0 <= c.x_pct <= 1.0 and 0.0 <= c.y_pct <= 1.0 for c in tower)
+    saliences = [c.salience for c in tower]
+    assert saliences == sorted(saliences, reverse=True)
+    assert all(c.subject and c.style for c in tower)
+    assert tower[0].enter_as == "scene"
+    assert tower[0].place_form == "interior"
+
+    district = await precompute_click_candidates(
+        _IMG, "The Merchant District", "the merchant district"
+    )
+    assert district[0].enter_as == "submap"
+    assert district[0].place_form == "complex"
+
+
+async def test_neighbors_route_via_real_propose() -> None:
+    from providers.llm.world import propose_neighbors
+
+    out = await propose_neighbors(_IMG, "The Old Keep", "the old keep")
+    assert len(out) == 4
+    assert all(n.subject for n in out)
+    assert len({n.subject.lower() for n in out}) == 4  # _build_neighbors dedupes
+    assert all(n.scale in ("component", "peer", "container") for n in out)
+
+
+async def test_world_routes_deterministic() -> None:
+    from providers.llm.click import precompute_click_candidates
+    from providers.llm.world import propose_neighbors
+
+    a = await precompute_click_candidates(_IMG, "A Tall Tower", "a tall stone tower")
+    b = await precompute_click_candidates(_IMG, "A Tall Tower", "a tall stone tower")
+    assert a == b
+    n1 = await propose_neighbors(_IMG, "The Old Keep", "the old keep")
+    n2 = await propose_neighbors(_IMG, "The Old Keep", "the old keep")
+    assert n1 == n2
+
+
+def test_classifier_matrix() -> None:
+    assert mock._classify("The Clock Tower") == ("scene", "interior")
+    assert mock._classify("a smoky tavern by the docks") == ("scene", "interior")
+    assert mock._classify("a market district") == ("submap", "complex")
+    assert mock._classify("the harbor gate") == ("submap", "complex")
+    assert mock._classify("a wooded valley") == ("scene", "landscape")
+    assert mock._classify("the palace garden") == ("scene", "landscape")
+    assert mock._classify("photosynthesis") == ("explainer", "")
+    # Embedded-quote narrowing: the real prompts' STATIC text names tower /
+    # harbor / forest as examples — only the quoted title/query may steer.
+    assert mock._classify(
+        "page titled 'Photosynthesis' (user query: 'how leaves work'). "
+        "Examples: a tower, a harbor, a forest."
+    ) == ("explainer", "")
+
+
+def test_click_route_default_stays_byte_identical() -> None:
+    system = (
+        "You examine a generated illustration of the page titled 'Photosynthesis' "
+        "(user query: 'how leaves work'). A red crosshair marks the click."
+    )
+    user = "Look at the red crosshair marker on the image."
+    subject = mock._SUBJECTS[mock._h(system[:120], user[:200]) % len(mock._SUBJECTS)]
+    # The exact pre-world reply: enter_as explainer, NO place_form key.
+    assert mock._route(system, user) == json.dumps(
+        {
+            "subject": subject,
+            "style": "hand-inked map, sepia, fine linework",
+            "subject_context": f"{subject}, a notable place in this scene",
+            "groundable": True,
+            "confidence": 0.9,
+            "enter_as": "explainer",
+        }
+    )
+
+
+async def test_click_route_steers_enter_as_and_place_form() -> None:
+    from providers.llm.click import click_to_subject
+
+    res = await click_to_subject(
+        _IMG, 0.5, 0.5, parent_title="A Tall Tower", parent_query="a tall stone tower"
+    )
+    assert res.enter_as == "scene"
+    assert res.place_form == "interior"
+
+
+async def test_mock_error_lever_raises() -> None:
+    with pytest.raises(RuntimeError, match="MOCK_ERROR"):
+        await mock.mock_llm_client().chat.completions.create(
+            messages=[{"role": "user", "content": "please mock_error now"}]
+        )
+
+
+async def test_mock_error_reaches_sse_error_frame() -> None:
+    """The lever's whole point: the forced failure propagates through
+    _complete_json into generate.py's except-handler and comes out as the
+    REAL friendly SSE error frame (#153)."""
+    events = await _collect(
+        _event_stream(
+            GenerateBody(query="mock_error town", session_id="s-err", web_search=False),
+            "t-err",
+        )
+    )
+    err = next(e for e in events if e["type"] == "error")
+    assert "MOCK_ERROR" in err.get("detail", "")


### PR DESCRIPTION
Foundation for the required Playwright gate — the mock seam now covers what the specs need, and the mock's replies feed the REAL product code (tap.py routing, judges, SSE):

- **Candidates route** placed before the click catch-all — the candidates prompt contains "click-worthy", so it was being swallowed and validated to `[]` (Wander died instantly under mock). Fixed + shape-valid against `_validate_candidates`.
- **Neighbors route** for the EXPAND OUTWARD prompt (shape verified against `_build_neighbors`).
- **Deterministic classifier** steered by `/play?q=…`: tower/tavern/hall → scene+interior, district/market → submap+complex, valley/coast → scene+landscape, default byte-identical explainer. Template-anchored extraction (`titled '…' (user query: '…')`) with greedy groups so **apostrophes can't truncate** ("the smith's tavern" steers correctly — review-caught false-green, fixed + pinned both orderings).
- **MOCK_ERROR lever**: stateless raise when "mock_error" is in the prompt — propagates through the real `_complete_json` → SSE error frame (#153), end-to-end tested with FRIENDLY_ERRORS pinned and both frame shapes asserted.

Adversarially reviewed (FIX-FIRST → both findings fixed). 8+ new tests via the REAL provider functions; byte-identity of the default click route pinned as an exact string. 930+ backend tests + ruff + mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)