### PR TITLE
fix(mock): the classifier steers on the user query ONLY — titles leaked triggers

### DIFF
--- a/apps/modal-backend/providers/mock.py
+++ b/apps/modal-backend/providers/mock.py
@@ -65,19 +65,22 @@ def _classify(text: str) -> tuple[str, str]:
     every mock classification scene/interior, "district" submap/complex, etc.
 
     When the text carries the prompts' embedded `titled '…' (user query:
-    '…')` template, ONLY the title+query are matched: the candidates/world-
-    mode prompts' static instructions themselves name "a tower, house,
-    temple … harbor, market square … valley, coastline, forest" as EXAMPLES
-    and would otherwise classify every single request as scene/interior.
+    '…')` template, ONLY the user-query group is matched. The TITLE is
+    excluded on purpose (live-caught by the first spec run): mock page
+    titles are hash-picked from _SUBJECTS ("The Harbor Gate", "The River
+    Quarter"…) and leak trigger words of their OWN — a "market district"
+    query rolled interior because its mock-minted title carried an
+    interior word. The query is the ONE channel a spec controls; nothing
+    else may steer. The prompts' static instruction text is excluded for
+    the same reason (it names "a tower, house, temple … harbor, market
+    square" as EXAMPLES and would classify every request scene/interior).
 
-    Precedence: title and query are joined ("<title> <query>") and the rule
-    ladder runs top-down, first match wins — so an interior word in EITHER
-    field beats a district word (title 'X tower' + query 'Y district' →
-    scene/interior)."""
+    Precedence: the rule ladder runs top-down on the query, first match
+    wins (interior-first)."""
     t = text.lower()
     m = _TEMPLATE_RE.search(t)
     if m:
-        t = m.group(1) + " " + m.group(2)
+        t = m.group(2)
     for keys, result in _CLASSIFY_RULES:
         if any(k in t for k in keys):
             return result

--- a/apps/modal-backend/providers/mock.py
+++ b/apps/modal-backend/providers/mock.py
@@ -46,7 +46,11 @@ _STYLE = "hand-inked map, sepia, fine linework"
 # mis-steers e2e specs. Lazy `(.*?)` would stop at the same inner apostrophe;
 # greedy is safe because neither classified prompt contains a later "')" for
 # the tail group to overshoot to.
-_TEMPLATE_RE = re.compile(r"titled '(.*)' \(user query: '(.*)'\)")
+# DOTALL: mock page titles for TAP pages embed the composed planner text —
+# newlines included — and a template that dies on a newline sent _classify
+# into the full-prompt fallback, where the static instruction examples
+# ("a tower, house…") classified EVERYTHING interior (live-caught twice).
+_TEMPLATE_RE = re.compile(r"titled '(.*)' \(user query: '(.*)'\)", re.DOTALL)
 
 _CLASSIFY_RULES: tuple[tuple[tuple[str, ...], tuple[str, str]], ...] = (
     (
@@ -79,8 +83,12 @@ def _classify(text: str) -> tuple[str, str]:
     wins (interior-first)."""
     t = text.lower()
     m = _TEMPLATE_RE.search(t)
-    if m:
-        t = m.group(2)
+    if m is None:
+        # No parsed query = no steering. Scanning the raw prompt here is the
+        # false-positive machine (its static examples name towers/markets),
+        # so an unparseable prompt gets the neutral default, full stop.
+        return ("explainer", "")
+    t = m.group(2)
     for keys, result in _CLASSIFY_RULES:
         if any(k in t for k in keys):
             return result

--- a/apps/modal-backend/tests/test_mock_providers.py
+++ b/apps/modal-backend/tests/test_mock_providers.py
@@ -150,14 +150,21 @@ async def test_world_routes_deterministic() -> None:
     assert n1 == n2
 
 
+def _q(query: str) -> str:
+    """Wrap a query in the prompts' template — since the no-template default
+    landed, ONLY a parsed user query can steer, so the matrix goes through
+    the same channel the specs use."""
+    return f"page titled 'X' (user query: '{query}'). tail"
+
+
 def test_classifier_matrix() -> None:
-    assert mock._classify("The Clock Tower") == ("scene", "interior")
-    assert mock._classify("a smoky tavern by the docks") == ("scene", "interior")
-    assert mock._classify("a market district") == ("submap", "complex")
-    assert mock._classify("the harbor gate") == ("submap", "complex")
-    assert mock._classify("a wooded valley") == ("scene", "landscape")
-    assert mock._classify("the palace garden") == ("scene", "landscape")
-    assert mock._classify("photosynthesis") == ("explainer", "")
+    assert mock._classify(_q("The Clock Tower")) == ("scene", "interior")
+    assert mock._classify(_q("a smoky tavern by the docks")) == ("scene", "interior")
+    assert mock._classify(_q("a market district")) == ("submap", "complex")
+    assert mock._classify(_q("the harbor gate")) == ("submap", "complex")
+    assert mock._classify(_q("a wooded valley")) == ("scene", "landscape")
+    assert mock._classify(_q("the palace garden")) == ("scene", "landscape")
+    assert mock._classify(_q("photosynthesis")) == ("explainer", "")
     # Embedded-quote narrowing: the real prompts' STATIC text names tower /
     # harbor / forest as examples — only the quoted title/query may steer.
     assert mock._classify(
@@ -246,6 +253,22 @@ def test_classifier_steers_on_the_query_ONLY() -> None:
         "page titled 'The Smith's Tavern' (user query: 'the smith's tavern'). "
         "Examples: a market district."
     ) == ("scene", "interior")
+
+
+def test_classifier_multiline_title_and_no_template() -> None:
+    """Live-caught (second spec run): TAP pages get mock titles embedding the
+    composed planner text — newlines included — and a non-DOTALL template
+    died on the newline, sending _classify into a full-prompt scan where the
+    static examples classified everything interior. Pins: (a) multiline
+    titles still parse and the QUERY steers; (b) with NO template at all the
+    result is the neutral default, never a raw-prompt scan."""
+    assert mock._classify(
+        "page titled 'Mock page: Query: The Harbor Gate\n\nParent page "
+        "(anchor)' (user query: 'a market district'). Examples: a tower."
+    ) == ("submap", "complex")
+    assert mock._classify(
+        "no template here at all. Examples: a tower, house, temple."
+    ) == ("explainer", "")
 
 
 async def test_mock_error_lever_raises() -> None:

--- a/apps/modal-backend/tests/test_mock_providers.py
+++ b/apps/modal-backend/tests/test_mock_providers.py
@@ -227,20 +227,23 @@ async def test_apostrophes_survive_template_extraction() -> None:
     assert district[0].place_form == "complex"
 
 
-def test_classifier_template_precedence() -> None:
-    """Title and query are JOINED before the rule ladder runs, so both can
-    steer; first-match precedence means an interior word in either field
-    outranks a district word in the other."""
+def test_classifier_steers_on_the_query_ONLY() -> None:
+    """The user query is the ONE channel a spec controls, so it is the only
+    text that steers — live-caught: mock-minted page titles are hash-picked
+    from _SUBJECTS and leak trigger words of their own (a "market district"
+    query rolled interior off its own title). Title words must NOT steer."""
+    # Title carries an interior word; the query says district → the QUERY wins.
     assert mock._classify(
         "page titled 'The Bell Tower' (user query: 'the old district'). x"
-    ) == ("scene", "interior")
+    ) == ("submap", "complex")
+    # And the reverse: a district-ish title cannot demote a tower query.
     assert mock._classify(
         "page titled 'The Old District' (user query: 'the bell tower'). x"
     ) == ("scene", "interior")
-    # Inner apostrophes in BOTH groups survive extraction; the static tail
-    # after the template (naming a district) is still excluded.
+    # Inner apostrophes in the query survive extraction; the static tail
+    # after the template (naming a market district) is still excluded.
     assert mock._classify(
-        "page titled 'The Smith's Tavern' (user query: 'the smith's home'). "
+        "page titled 'The Smith's Tavern' (user query: 'the smith's tavern'). "
         "Examples: a market district."
     ) == ("scene", "interior")
 


### PR DESCRIPTION
Live-caught by the first full spec run (10/11 green): the world-submap spec's "a market district" tap classified **interior** — the mock's hash-minted page title ("The Harbor Gate"-class strings from `_SUBJECTS`) leaked its own trigger words into the classify join. The user query is the one channel a spec controls; it's now the only steering text. Precedence pins updated. 954 backend tests + ruff + mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)