### PR TITLE
test(web): cover the untested hooks + components — ratchet moves up

### DIFF
--- a/apps/web/components/PlayPage/HintPrompt.test.tsx
+++ b/apps/web/components/PlayPage/HintPrompt.test.tsx
@@ -1,0 +1,82 @@
+// The ⌘-click hint bubble: anchored at the click point, focused on open,
+// Enter/↵ submits trimmed+capped text, Esc (key or button) cancels.
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { HintPrompt } from "./HintPrompt";
+
+type Props = Parameters<typeof HintPrompt>[0];
+
+function mount(over: Partial<Pick<Props, "xPx" | "yPx" | "placeholder">> = {}) {
+  const props = {
+    xPx: 120,
+    yPx: 80,
+    onSubmit: vi.fn(),
+    onCancel: vi.fn(),
+    ...over,
+  };
+  const view = render(<HintPrompt {...props} />);
+  return {
+    props,
+    view,
+    input: within(view.container).getByLabelText("Click hint") as HTMLInputElement,
+  };
+}
+
+describe("HintPrompt", () => {
+  it("anchors above the click point and focuses the input on open", () => {
+    const { view, input } = mount();
+    const bubble = view.container.firstElementChild as HTMLElement;
+    expect(bubble.style.left).toBe("120px");
+    expect(bubble.style.top).toBe("68px"); // yPx - 12
+    expect(document.activeElement).toBe(input);
+  });
+
+  it("clamps the anchor to the top edge (no off-screen bubble)", () => {
+    const { view } = mount({ yPx: 4 });
+    const bubble = view.container.firstElementChild as HTMLElement;
+    expect(bubble.style.top).toBe("0px");
+  });
+
+  it("submits the trimmed text on Enter (form submit)", () => {
+    const { props, input } = mount();
+    fireEvent.change(input, { target: { value: "  cross-section  " } });
+    fireEvent.submit(input.closest("form")!);
+    expect(props.onSubmit).toHaveBeenCalledWith("cross-section");
+    expect(props.onCancel).not.toHaveBeenCalled();
+  });
+
+  it("the ↵ button is a submit control, and overlong hints are capped at 240 chars", () => {
+    const { props, input } = mount();
+    // happy-dom doesn't synthesize implicit form submission from a button
+    // click, so pin the wiring (type=submit) and drive the same path.
+    const enter = screen.getByRole("button", { name: "Submit hint" });
+    expect(enter.getAttribute("type")).toBe("submit");
+    fireEvent.change(input, { target: { value: "x".repeat(300) } });
+    fireEvent.submit(input.closest("form")!);
+    expect(props.onSubmit).toHaveBeenCalledTimes(1);
+    expect((props.onSubmit.mock.calls[0]![0] as string).length).toBe(240);
+  });
+
+  it("Escape cancels without submitting", () => {
+    const { props, input } = mount();
+    fireEvent.change(input, { target: { value: "half a thought" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(props.onCancel).toHaveBeenCalledTimes(1);
+    expect(props.onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("the esc button cancels", () => {
+    const { props } = mount();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(props.onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the resolver's clarifying question as placeholder when given", () => {
+    const { input } = mount({ placeholder: "Enter the lighthouse?" });
+    expect(input.placeholder).toBe("Enter the lighthouse?");
+    // …and the default placeholder otherwise.
+    const { input: plain } = mount();
+    expect(plain.placeholder).toContain("add a note");
+  });
+});

--- a/apps/web/components/PlayPage/MapLabelOverlay.test.tsx
+++ b/apps/web/components/PlayPage/MapLabelOverlay.test.tsx
@@ -1,0 +1,163 @@
+// DOM place-name labels: bbox-centred anchors beat geo fallback, map-frames
+// only, pointer-events pass through, and %-positioning when no measured
+// content rect exists (no imgRef here, so the percent fallback path).
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { Entity, SceneView, WorldEntityGeo } from "@openflipbook/config";
+
+import { MapLabelOverlay } from "./MapLabelOverlay";
+
+function entity(over: Partial<Entity> = {}): Entity {
+  return {
+    id: "e1",
+    kind: "place",
+    name: "Harbour",
+    aliases: [],
+    appearance: "stone harbour",
+    reference_image_url: null,
+    facts: [],
+    state: {},
+    first_seen_node_id: "n1",
+    last_seen_node_id: "n1",
+    appears_on_node_ids: ["n1"],
+    appearance_bboxes: {
+      n1: { x_pct: 0.2, y_pct: 0.3, w_pct: 0.2, h_pct: 0.2 },
+    },
+    pinned_by_user: false,
+    confidence: 0.9,
+    updated_at: "2026-01-01T00:00:00.000Z",
+    ...over,
+  };
+}
+
+function geo(over: Partial<WorldEntityGeo> = {}): WorldEntityGeo {
+  return {
+    id: "g1",
+    entity_id: "e1",
+    kind: "place",
+    label: "Fort",
+    pos: { x: 50, y: 30 },
+    height: 5,
+    footprint: { w: 4, d: 4 },
+    visual: "star fort",
+    state: {},
+    confidence: 0.9,
+    source: "extracted",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    ...over,
+  };
+}
+
+const mapView: SceneView = {
+  node_id: "n1",
+  level: "map",
+  observer: null,
+  map_crop: { x: 0, y: 0, w: 100, h: 60 },
+};
+
+describe("MapLabelOverlay", () => {
+  it("labels codex entities at their bbox centres (percent fallback, click-through)", () => {
+    const { container } = render(
+      <MapLabelOverlay
+        nodeId="n1"
+        entities={[entity()]}
+        geoEntities={[]}
+        currentView={mapView}
+      />,
+    );
+    const label = screen.getByText("Harbour");
+    // Anchored from the bbox centre (0.3, 0.4): horizontally centred on 30%,
+    // vertically just above 40% — positions come from props, not layout.
+    const left = parseFloat(label.style.left);
+    const top = parseFloat(label.style.top);
+    expect(label.style.left.endsWith("%")).toBe(true);
+    expect(left).toBeGreaterThan(20);
+    expect(left).toBeLessThan(30);
+    expect(top).toBeGreaterThan(30);
+    expect(top).toBeLessThan(40);
+    // The layer never eats a map click.
+    const layer = container.firstElementChild as HTMLElement;
+    expect(layer.className).toContain("pointer-events-none");
+    expect(layer.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("bbox anchors win over the geo fallback when both exist", () => {
+    render(
+      <MapLabelOverlay
+        nodeId="n1"
+        entities={[entity()]}
+        geoEntities={[geo()]}
+        currentView={mapView}
+      />,
+    );
+    expect(screen.getByText("Harbour")).toBeTruthy();
+    expect(screen.queryByText("Fort")).toBeNull();
+  });
+
+  it("falls back to geo anchors mapped through the map frame", () => {
+    render(
+      <MapLabelOverlay
+        nodeId="n1"
+        entities={[]}
+        geoEntities={[geo(), geo({ id: "g2", label: "", pos: { x: 10, y: 10 } })]}
+        currentView={mapView}
+      />,
+    );
+    // pos (50,30) in a 100×60 frame → mid-map label; the blank-label geo is culled.
+    const label = screen.getByText("Fort");
+    expect(parseFloat(label.style.left)).toBeGreaterThan(40);
+    expect(parseFloat(label.style.left)).toBeLessThan(50);
+    expect(document.querySelectorAll("[data-label-id]").length).toBe(1);
+  });
+
+  it("culls geo anchors that land outside the visible frame", () => {
+    const { container } = render(
+      <MapLabelOverlay
+        nodeId="n1"
+        entities={[]}
+        geoEntities={[geo({ pos: { x: 500, y: 30 } })]}
+        currentView={mapView}
+      />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing on non-map frames (an entered scene keeps its pixels)", () => {
+    const { container } = render(
+      <MapLabelOverlay
+        nodeId="n1"
+        entities={[entity()]}
+        geoEntities={[geo()]}
+        currentView={{ ...mapView, level: "eye" }}
+      />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("a null view is treated as a map (the classic top frame)", () => {
+    render(
+      <MapLabelOverlay
+        nodeId="n1"
+        entities={[entity()]}
+        geoEntities={[]}
+        currentView={null}
+      />,
+    );
+    expect(screen.getByText("Harbour")).toBeTruthy();
+  });
+
+  it("skips entities without a bbox on THIS node or without a name", () => {
+    const { container } = render(
+      <MapLabelOverlay
+        nodeId="other-node"
+        entities={[entity(), entity({ id: "e2", name: "   " })]}
+        geoEntities={[]}
+        currentView={mapView}
+      />,
+    );
+    // e1's bbox is keyed to n1, not other-node; e2 has no usable name; no geo
+    // fallback data → nothing renders at all.
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/apps/web/components/PlayPage/MorphImagePair.test.tsx
+++ b/apps/web/components/PlayPage/MorphImagePair.test.tsx
@@ -1,0 +1,123 @@
+// Two-layer morph rendering: single-img rest state, the dive vs shimmer wait
+// classes, the --ec-dive-scale contract (motion end == zoom-continuation
+// start), the reduce-motion opacity branch, and the event wiring.
+import { createRef } from "react";
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { MorphFx } from "@/hooks/useImageMorph";
+import { DIVE_END_SCALE } from "@/lib/morph-style";
+
+import { MorphImagePair } from "./MorphImagePair";
+
+function fx(over: Partial<MorphFx> = {}): MorphFx {
+  return {
+    ox: 40,
+    oy: 30,
+    prevImg: "data:image/jpeg;base64,prev",
+    nextImg: "data:image/jpeg;base64,next",
+    phase: "wait",
+    isFinal: false,
+    startedAt: 0,
+    reduceMotion: false,
+    ...over,
+  };
+}
+
+function mount(morphFx: MorphFx | null, over: Partial<Parameters<typeof MorphImagePair>[0]> = {}) {
+  const props = {
+    imgRef: createRef<HTMLImageElement | null>(),
+    imageDataUrl: "data:image/jpeg;base64,current",
+    alt: "the page",
+    morphFx,
+    onError: vi.fn(),
+    onMorphTransitionEnd: vi.fn(),
+    newImageClassName: "the-new-image",
+    ...over,
+  };
+  const view = render(<MorphImagePair {...props} />);
+  const imgs = Array.from(view.container.querySelectorAll("img"));
+  return { props, view, imgs };
+}
+
+describe("MorphImagePair", () => {
+  it("rest state: one image, no morph style, ref attached", () => {
+    const { props, imgs } = mount(null);
+    expect(imgs.length).toBe(1);
+    expect(imgs[0]!.getAttribute("src")).toBe("data:image/jpeg;base64,current");
+    expect(imgs[0]!.getAttribute("alt")).toBe("the page");
+    expect(imgs[0]!.getAttribute("style")).toBeFalsy();
+    expect(props.imgRef.current).toBe(imgs[0]);
+  });
+
+  it("morphing renders old (prevImg, decorative) under new (nextImg)", () => {
+    const { imgs } = mount(fx());
+    expect(imgs.length).toBe(2);
+    const [oldImg, newImg] = imgs as [HTMLImageElement, HTMLImageElement];
+    expect(oldImg.getAttribute("src")).toBe("data:image/jpeg;base64,prev");
+    expect(oldImg.getAttribute("aria-hidden")).toBe("true");
+    expect(oldImg.getAttribute("alt")).toBe("");
+    expect(newImg.getAttribute("src")).toBe("data:image/jpeg;base64,next");
+    expect(newImg.className).toBe("the-new-image");
+  });
+
+  it("dive-wait: old layer gets the dive class, origin at the tap, scale var = 1/REGION_FRAC", () => {
+    const { imgs } = mount(fx({ dive: true }));
+    const oldImg = imgs[0]!;
+    expect(oldImg.className).toContain("ec-morph-old");
+    expect(oldImg.className).not.toContain("ec-morph-shimmer");
+    expect(oldImg.style.transformOrigin).toBe("40px 30px");
+    // The single TS source of truth for the dive's end scale.
+    expect(oldImg.style.getPropertyValue("--ec-dive-scale")).toBe(String(DIVE_END_SCALE));
+  });
+
+  it("non-dive wait shimmers instead — the motion never promises a zoom", () => {
+    const { imgs } = mount(fx({ dive: false }));
+    expect(imgs[0]!.className).toContain("ec-morph-shimmer");
+    expect(imgs[0]!.className).not.toContain("ec-morph-old");
+  });
+
+  it("reveal phase fades the old layer out", () => {
+    const { imgs } = mount(fx({ phase: "reveal", dive: true }));
+    const oldImg = imgs[0]!;
+    expect(oldImg.style.opacity).toBe("0");
+    // Reveal is past the wait: no dive/shimmer class riding along.
+    expect(oldImg.className).not.toContain("ec-morph-old");
+  });
+
+  it("reduce-motion: no dive/shimmer, new image gets the plain opacity fade", () => {
+    const { imgs } = mount(fx({ dive: true, reduceMotion: true }));
+    const [oldImg, newImg] = imgs as [HTMLImageElement, HTMLImageElement];
+    expect(oldImg.className).not.toContain("ec-morph-old");
+    expect(oldImg.className).not.toContain("ec-morph-shimmer");
+    expect(newImg.style.transition).toBe("opacity 200ms linear");
+  });
+
+  it("full motion animates the mask, not opacity, on the new image", () => {
+    // happy-dom drops mask-* declarations from inline style, so pin the branch
+    // through what it keeps: the transition targets mask-size (the ink bloom).
+    // The mask geometry itself is covered by lib/morph-style.test.ts.
+    const { imgs } = mount(fx());
+    expect(imgs[1]!.style.transition).toContain("mask-size");
+    expect(imgs[1]!.style.transition).not.toContain("opacity");
+  });
+
+  it("centre-origin fallback when the fx has no numeric origin", () => {
+    const { imgs } = mount(fx({ ox: undefined as unknown as number, dive: true }));
+    expect(imgs[0]!.style.transformOrigin).toBe("center");
+  });
+
+  it("wires onError and onTransitionEnd to the live image", () => {
+    const { props, imgs } = mount(fx());
+    fireEvent.error(imgs[1]!);
+    expect(props.onError).toHaveBeenCalledTimes(1);
+    fireEvent.transitionEnd(imgs[1]!);
+    expect(props.onMorphTransitionEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("missing prev/next fall back to the current page image", () => {
+    const { imgs } = mount(fx({ prevImg: null, nextImg: null }));
+    expect(imgs[0]!.getAttribute("src")).toBe("data:image/jpeg;base64,current");
+    expect(imgs[1]!.getAttribute("src")).toBe("data:image/jpeg;base64,current");
+  });
+});

--- a/apps/web/components/PlayPage/QueryToolbar.test.tsx
+++ b/apps/web/components/PlayPage/QueryToolbar.test.tsx
@@ -1,0 +1,128 @@
+// The main toolbar: submit gating, the upload proxy click, and the setter
+// wiring for locale / theme / tier / world-mode cluster. Renders with the
+// real English strings so labels match what users see.
+import { createRef } from "react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { getStrings } from "@/lib/i18n";
+
+import { QueryToolbar } from "./QueryToolbar";
+
+const t = getStrings("en");
+
+type Props = Parameters<typeof QueryToolbar>[0];
+
+function makeProps(over: Partial<Props> = {}): Props {
+  return {
+    t,
+    input: "",
+    onInputChange: vi.fn(),
+    onSubmit: vi.fn((e) => e.preventDefault()),
+    fileInputRef: createRef<HTMLInputElement | null>(),
+    onFileInputChange: vi.fn(),
+    busy: false,
+    outputLocale: "auto",
+    setOutputLocale: vi.fn(),
+    theme: "light",
+    setTheme: vi.fn(),
+    imageTier: "balanced",
+    setImageTier: vi.fn(),
+    loopKnobs: { maxAttempts: 2, verify: true },
+    setLoopKnobs: vi.fn(),
+    sessionSpend: null,
+    devModel: null,
+    setDevModel: undefined,
+    worldMode: false,
+    setWorldMode: vi.fn(),
+    autonomy: "auto",
+    setAutonomy: vi.fn(),
+    domLabels: false,
+    setDomLabels: vi.fn(),
+    ...over,
+  };
+}
+
+describe("QueryToolbar", () => {
+  it("types into the query box and submits", () => {
+    const props = makeProps({ input: "volcanoes" });
+    render(<QueryToolbar {...props} />);
+    fireEvent.change(screen.getByPlaceholderText(t.placeholder), {
+      target: { value: "volcanoes!" },
+    });
+    expect(props.onInputChange).toHaveBeenCalledWith("volcanoes!");
+    fireEvent.click(screen.getByRole("button", { name: t.go }));
+    expect(props.onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("gates Go on non-blank input and busy", () => {
+    const { rerender } = render(<QueryToolbar {...makeProps({ input: "   " })} />);
+    const go = () => screen.getByRole("button", { name: t.go }) as HTMLButtonElement;
+    expect(go().disabled).toBe(true); // whitespace-only doesn't count
+
+    rerender(<QueryToolbar {...makeProps({ input: "ok" })} />);
+    expect(go().disabled).toBe(false);
+
+    rerender(<QueryToolbar {...makeProps({ input: "ok", busy: true })} />);
+    // Busy: the submit shows the generating glyph and stays disabled.
+    const busyBtn = screen.getByRole("button", { name: t.generating }) as HTMLButtonElement;
+    expect(busyBtn.disabled).toBe(true);
+  });
+
+  it("the upload button proxies a click to the hidden file input", () => {
+    const props = makeProps();
+    render(<QueryToolbar {...props} />);
+    const fileInput = props.fileInputRef.current!;
+    const click = vi.spyOn(fileInput, "click");
+    fireEvent.click(screen.getByRole("button", { name: t.upload }));
+    expect(click).toHaveBeenCalledTimes(1);
+    fireEvent.change(fileInput);
+    expect(props.onFileInputChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("changes the output locale", () => {
+    const props = makeProps();
+    render(<QueryToolbar {...props} />);
+    fireEvent.change(screen.getByRole("combobox", { name: t.langLabel }), {
+      target: { value: "fr" },
+    });
+    expect(props.setOutputLocale).toHaveBeenCalledWith("fr");
+  });
+
+  it("theme + tier segmented controls report presses and mark the active one", () => {
+    const props = makeProps();
+    render(<QueryToolbar {...props} />);
+    fireEvent.click(screen.getByRole("button", { name: t.themeSepia }));
+    expect(props.setTheme).toHaveBeenCalledWith("sepia");
+    const light = screen.getByRole("button", { name: t.themeLight });
+    expect(light.getAttribute("aria-pressed")).toBe("true");
+
+    // Scoped: SpeedPreset renders its own tier words elsewhere in the bar.
+    const tierGroup = within(screen.getByRole("group", { name: "Image quality tier" }));
+    fireEvent.click(tierGroup.getByRole("button", { name: "pro" }));
+    expect(props.setImageTier).toHaveBeenCalledWith("pro");
+    const balanced = tierGroup.getByRole("button", { name: "balanced" });
+    expect(balanced.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("world mode OFF hides the autonomy + labels sub-toggles", () => {
+    const props = makeProps();
+    render(<QueryToolbar {...props} />);
+    expect(screen.queryByRole("button", { name: "semi" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "labels" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "world" }));
+    expect(props.setWorldMode).toHaveBeenCalledWith(true);
+  });
+
+  it("world mode ON exposes autonomy + DOM-labels toggles and flips them", () => {
+    const props = makeProps({ worldMode: true, autonomy: "auto", domLabels: false });
+    render(<QueryToolbar {...props} />);
+    fireEvent.click(screen.getByRole("button", { name: "semi" }));
+    expect(props.setAutonomy).toHaveBeenCalledWith("semi");
+    fireEvent.click(screen.getByRole("button", { name: "labels" }));
+    expect(props.setDomLabels).toHaveBeenCalledWith(true);
+    // The world button toggles back off from the same cluster.
+    fireEvent.click(screen.getByRole("button", { name: "world" }));
+    expect(props.setWorldMode).toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/web/hooks/useAscend.test.tsx
+++ b/apps/web/hooks/useAscend.test.tsx
@@ -1,0 +1,232 @@
+// OUTWARD nav: the two-fetch contract (backend synthesize → web persist),
+// the optional body fields (style anchor / label suppression), the callback
+// payload the page re-roots from, error surfacing, and re-start abort.
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { MAP_IMAGE_FRAME } from "@/lib/geo-tap";
+
+import { useAscend, type AscendRoot } from "./useAscend";
+
+const READY = {
+  type: "ascend_ready",
+  page_title: "The Valley",
+  image_data_url: "data:image/jpeg;base64,container",
+  image_model: "m",
+  prompt_author_model: "p",
+  final_prompt: "fp",
+  scale_tier: "region",
+  from_tier: "city",
+  session_id: "s1",
+};
+
+function sseBody(events: unknown[]): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const e of events) {
+        controller.enqueue(enc.encode(`data: ${JSON.stringify(e)}\n\n`));
+      }
+      controller.close();
+    },
+  });
+}
+
+interface StubOptions {
+  events?: unknown[];
+  generateOk?: boolean;
+  saveOk?: boolean;
+  saveJson?: unknown;
+}
+
+function stubFetch({
+  events = [READY],
+  generateOk = true,
+  saveOk = true,
+  saveJson = { parent_node_id: "parent-1" },
+}: StubOptions = {}) {
+  const fn = vi.fn(async (url: RequestInfo | URL) => {
+    if (String(url) === "/api/generate-page") {
+      return { ok: generateOk, status: generateOk ? 200 : 500, body: sseBody(events) };
+    }
+    return {
+      ok: saveOk,
+      status: saveOk ? 200 : 500,
+      json: async () => saveJson,
+    };
+  });
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+function root(over: Partial<AscendRoot> = {}): AscendRoot {
+  return {
+    nodeId: "child-1",
+    query: "the town",
+    imageDataUrl: "data:image/jpeg;base64,child",
+    aspectRatio: "16:9",
+    ...over,
+  };
+}
+
+const bodyOf = (call: unknown[]): Record<string, unknown> =>
+  JSON.parse((call[1] as RequestInit).body as string) as Record<string, unknown>;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useAscend", () => {
+  it("synthesizes, persists, then hands the reparent to onAscended", async () => {
+    const fn = stubFetch();
+    const onAscended = vi.fn();
+    const { result } = renderHook(() => useAscend(onAscended));
+
+    act(() => result.current.start("s1", root()));
+    expect(result.current.pending).toBe(true);
+
+    await waitFor(() => expect(onAscended).toHaveBeenCalledTimes(1));
+    expect(result.current.pending).toBe(false);
+    expect(result.current.error).toBeNull();
+
+    // Fetch 1: the backend ascend branch.
+    expect(String(fn.mock.calls[0]![0])).toBe("/api/generate-page");
+    const gen = bodyOf(fn.mock.calls[0]!);
+    expect(gen.mode).toBe("ascend");
+    expect(gen.session_id).toBe("s1");
+    expect(gen.current_node_id).toBe("child-1");
+    expect(gen.image).toBe("data:image/jpeg;base64,child");
+    expect(gen.aspect_ratio).toBe("16:9");
+    expect(gen.web_search).toBe(false);
+
+    // Fetch 2: the atomic reparent route, fed from ascend_ready.
+    expect(String(fn.mock.calls[1]![0])).toBe("/api/world/s1/ascend");
+    const save = bodyOf(fn.mock.calls[1]!);
+    expect(save.child_node_id).toBe("child-1");
+    expect(save.image_data_url).toBe(READY.image_data_url);
+    expect(save.parent_tier).toBe("region");
+    expect(save.page_title).toBe("The Valley");
+    expect(save.query).toBe("The Valley");
+
+    // The callback contract the page re-roots the session from.
+    expect(onAscended).toHaveBeenCalledWith({
+      parentNodeId: "parent-1",
+      childNodeId: "child-1",
+      pageTitle: "The Valley",
+      imageDataUrl: READY.image_data_url,
+      scaleTier: "region",
+      renderUnjudged: false,
+      sceneView: {
+        node_id: "parent-1",
+        level: "map",
+        observer: null,
+        map_crop: MAP_IMAGE_FRAME,
+        focus_id: null,
+        scale_tier: "region",
+      },
+    });
+  });
+
+  it("omits style anchor + label suppression unless armed, sends them when set", async () => {
+    const fn = stubFetch();
+    const onAscended = vi.fn();
+    const { result } = renderHook(() => useAscend(onAscended));
+
+    act(() => result.current.start("s1", root()));
+    await waitFor(() => expect(onAscended).toHaveBeenCalledTimes(1));
+    const bare = bodyOf(fn.mock.calls[0]!);
+    expect("session_style_anchor" in bare).toBe(false);
+    expect("suppress_map_labels" in bare).toBe(false);
+
+    act(() =>
+      result.current.start(
+        "s1",
+        root({ styleAnchor: "woodcut, sepia", suppressMapLabels: true }),
+      ),
+    );
+    await waitFor(() => expect(onAscended).toHaveBeenCalledTimes(2));
+    const armed = bodyOf(fn.mock.calls[2]!);
+    expect(armed.session_style_anchor).toBe("woodcut, sepia");
+    expect(armed.suppress_map_labels).toBe(true);
+  });
+
+  it("surfaces render_unjudged=true through the callback", async () => {
+    stubFetch({ events: [{ ...READY, render_unjudged: true }] });
+    const onAscended = vi.fn();
+    const { result } = renderHook(() => useAscend(onAscended));
+    act(() => result.current.start("s1", root()));
+    await waitFor(() => expect(onAscended).toHaveBeenCalledTimes(1));
+    expect(onAscended.mock.calls[0]![0].renderUnjudged).toBe(true);
+  });
+
+  it("reports an HTTP failure from the synthesize fetch", async () => {
+    stubFetch({ generateOk: false });
+    const onAscended = vi.fn();
+    const { result } = renderHook(() => useAscend(onAscended));
+    act(() => result.current.start("s1", root()));
+    await waitFor(() => expect(result.current.error).toBe("ascend failed: HTTP 500"));
+    expect(result.current.pending).toBe(false);
+    expect(onAscended).not.toHaveBeenCalled();
+  });
+
+  it("propagates a stream error event's message", async () => {
+    stubFetch({ events: [{ type: "error", message: "the judge quit" }] });
+    const { result } = renderHook(() => useAscend(vi.fn()));
+    act(() => result.current.start("s1", root()));
+    await waitFor(() => expect(result.current.error).toBe("the judge quit"));
+  });
+
+  it("errors when the stream ends without ascend_ready", async () => {
+    stubFetch({ events: [{ type: "status", message: "warming" }] });
+    const { result } = renderHook(() => useAscend(vi.fn()));
+    act(() => result.current.start("s1", root()));
+    await waitFor(() =>
+      expect(result.current.error).toBe("no container was produced"),
+    );
+  });
+
+  it("surfaces the persist route's error body (no silent half-reparent)", async () => {
+    stubFetch({ saveOk: false, saveJson: { error: "geo store said no" } });
+    const onAscended = vi.fn();
+    const { result } = renderHook(() => useAscend(onAscended));
+    act(() => result.current.start("s1", root()));
+    await waitFor(() => expect(result.current.error).toBe("geo store said no"));
+    expect(onAscended).not.toHaveBeenCalled();
+  });
+
+  it("re-start aborts the in-flight ascend; only the new one lands", async () => {
+    const onAscended = vi.fn();
+    let generateCalls = 0;
+    const fn = vi.fn((url: RequestInfo | URL, init?: RequestInit) => {
+      if (String(url) === "/api/generate-page") {
+        generateCalls += 1;
+        if (generateCalls === 1) {
+          // First ascend hangs like a slow backend; abort rejects it the way
+          // real fetch does.
+          return new Promise((_, reject) => {
+            init?.signal?.addEventListener("abort", () =>
+              reject(new DOMException("Aborted", "AbortError")),
+            );
+          });
+        }
+        return Promise.resolve({ ok: true, status: 200, body: sseBody([READY]) });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({ parent_node_id: "parent-2" }),
+      });
+    });
+    vi.stubGlobal("fetch", fn);
+
+    const { result } = renderHook(() => useAscend(onAscended));
+    act(() => result.current.start("s1", root({ nodeId: "first" })));
+    act(() => result.current.start("s1", root({ nodeId: "second" })));
+
+    await waitFor(() => expect(onAscended).toHaveBeenCalledTimes(1));
+    expect(onAscended.mock.calls[0]![0].childNodeId).toBe("second");
+    // The aborted run must not leak an error into the fresh one.
+    expect(result.current.error).toBeNull();
+    expect(result.current.pending).toBe(false);
+  });
+});

--- a/apps/web/hooks/useContainRect.test.tsx
+++ b/apps/web/hooks/useContainRect.test.tsx
@@ -1,0 +1,179 @@
+// The contain-rect measurer, incl. THE #48 REGRESSION PIN: callers mount
+// BEFORE the conditional <figure> exists (permalink / continue hydration), so
+// the effect must POLL until the img appears and then attach — a one-shot
+// bail was the invisible-marquee / maskless-edit bug. happy-dom has no
+// ResizeObserver, so a fake records observe/disconnect and lets tests fire
+// resize callbacks by hand.
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRef } from "react";
+
+import { useContainRect } from "./useContainRect";
+
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = [];
+  observed: Element[] = [];
+  disconnected = false;
+  constructor(public cb: () => void) {
+    FakeResizeObserver.instances.push(this);
+  }
+  observe(el: Element) {
+    this.observed.push(el);
+  }
+  unobserve() {}
+  disconnect() {
+    this.disconnected = true;
+  }
+}
+
+interface Dims {
+  clientWidth: number;
+  clientHeight: number;
+  naturalWidth: number;
+  naturalHeight: number;
+}
+
+function makeImg(dims: Dims): { img: HTMLImageElement; dims: Dims } {
+  const img = document.createElement("img");
+  for (const prop of Object.keys(dims) as (keyof Dims)[]) {
+    Object.defineProperty(img, prop, { get: () => dims[prop], configurable: true });
+  }
+  return { img, dims };
+}
+
+beforeEach(() => {
+  FakeResizeObserver.instances = [];
+  vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("useContainRect", () => {
+  it("measures an already-mounted img and observes it for resize", () => {
+    const { img } = makeImg({
+      clientWidth: 160,
+      clientHeight: 90,
+      naturalWidth: 320,
+      naturalHeight: 180,
+    });
+    const ref = createRef<HTMLImageElement | null>();
+    ref.current = img;
+    const { result } = renderHook(() => useContainRect(ref));
+    // Same aspect: content fills the box, no letterbox offsets.
+    expect(result.current).toEqual({ width: 160, height: 90, offsetX: 0, offsetY: 0 });
+    expect(FakeResizeObserver.instances[0]!.observed).toEqual([img]);
+  });
+
+  it("letterboxes a portrait image inside a wide box (the overlay-alignment math)", () => {
+    const { img } = makeImg({
+      clientWidth: 160,
+      clientHeight: 90,
+      naturalWidth: 90,
+      naturalHeight: 90,
+    });
+    const ref = createRef<HTMLImageElement | null>();
+    ref.current = img;
+    const { result } = renderHook(() => useContainRect(ref));
+    // 1:1 content in a 16:9 box → pillarboxed: 90px wide, centred.
+    expect(result.current).toEqual({ width: 90, height: 90, offsetX: 35, offsetY: 0 });
+  });
+
+  it("#48 pin: a ref that's null at mount polls until the img appears, then attaches", () => {
+    const ref = createRef<HTMLImageElement | null>();
+    const { result } = renderHook(() => useContainRect(ref));
+    expect(result.current).toBeNull();
+
+    // Nothing to attach yet — polling, not bailing.
+    act(() => void vi.advanceTimersByTime(600));
+    expect(result.current).toBeNull();
+    expect(FakeResizeObserver.instances.length).toBe(0);
+
+    // The figure mounts late (permalink / continue hydration)…
+    const { img } = makeImg({
+      clientWidth: 160,
+      clientHeight: 90,
+      naturalWidth: 320,
+      naturalHeight: 180,
+    });
+    ref.current = img;
+    act(() => void vi.advanceTimersByTime(300));
+
+    // …and the hook attached for real: measured + ResizeObserver wired.
+    expect(result.current).toEqual({ width: 160, height: 90, offsetX: 0, offsetY: 0 });
+    expect(FakeResizeObserver.instances.length).toBe(1);
+    expect(FakeResizeObserver.instances[0]!.observed).toEqual([img]);
+
+    // The poll stopped — more time creates no duplicate observers.
+    act(() => void vi.advanceTimersByTime(1200));
+    expect(FakeResizeObserver.instances.length).toBe(1);
+  });
+
+  it("returns null until the image has natural dimensions, re-measures on load", () => {
+    const { img, dims } = makeImg({
+      clientWidth: 160,
+      clientHeight: 90,
+      naturalWidth: 0, // not decoded yet
+      naturalHeight: 0,
+    });
+    const ref = createRef<HTMLImageElement | null>();
+    ref.current = img;
+    const { result } = renderHook(() => useContainRect(ref));
+    expect(result.current).toBeNull();
+
+    dims.naturalWidth = 320;
+    dims.naturalHeight = 180;
+    act(() => void img.dispatchEvent(new Event("load")));
+    expect(result.current).toEqual({ width: 160, height: 90, offsetX: 0, offsetY: 0 });
+  });
+
+  it("re-measures when the ResizeObserver fires", () => {
+    const { img, dims } = makeImg({
+      clientWidth: 160,
+      clientHeight: 90,
+      naturalWidth: 320,
+      naturalHeight: 180,
+    });
+    const ref = createRef<HTMLImageElement | null>();
+    ref.current = img;
+    const { result } = renderHook(() => useContainRect(ref));
+    expect(result.current?.width).toBe(160);
+
+    dims.clientWidth = 320;
+    dims.clientHeight = 180;
+    act(() => FakeResizeObserver.instances[0]!.cb());
+    expect(result.current).toEqual({ width: 320, height: 180, offsetX: 0, offsetY: 0 });
+  });
+
+  it("cleans up: unmount stops the poll and disconnects the observer", () => {
+    // Attached case → observer disconnected.
+    const { img } = makeImg({
+      clientWidth: 160,
+      clientHeight: 90,
+      naturalWidth: 320,
+      naturalHeight: 180,
+    });
+    const attachedRef = createRef<HTMLImageElement | null>();
+    attachedRef.current = img;
+    const attached = renderHook(() => useContainRect(attachedRef));
+    attached.unmount();
+    expect(FakeResizeObserver.instances[0]!.disconnected).toBe(true);
+
+    // Still-polling case → no late attach after unmount.
+    const lateRef = createRef<HTMLImageElement | null>();
+    const polling = renderHook(() => useContainRect(lateRef));
+    polling.unmount();
+    lateRef.current = img;
+    act(() => void vi.advanceTimersByTime(900));
+    expect(FakeResizeObserver.instances.length).toBe(1); // only the first test's
+  });
+
+  it("no ref at all stays null (callers fall back to wrapper-relative %)", () => {
+    const { result } = renderHook(() => useContainRect(undefined));
+    act(() => void vi.advanceTimersByTime(600));
+    expect(result.current).toBeNull();
+  });
+});

--- a/apps/web/hooks/useSharedSession.test.tsx
+++ b/apps/web/hooks/useSharedSession.test.tsx
@@ -1,0 +1,150 @@
+// Read-along shared sessions: presence heartbeat → viewer count, the feed's
+// node_added → incoming chip (own pages filtered out), the standalone-Mongo
+// `unsupported` degrade, and teardown. EventSource is faked so tests drive
+// the feed by hand.
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useSharedSession } from "./useSharedSession";
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  url: string;
+  onmessage: ((msg: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  closed = false;
+  constructor(url: string) {
+    this.url = url;
+    FakeEventSource.instances.push(this);
+  }
+  close() {
+    this.closed = true;
+  }
+  emit(evt: unknown) {
+    this.onmessage?.({ data: JSON.stringify(evt) });
+  }
+  emitRaw(data: string) {
+    this.onmessage?.({ data });
+  }
+}
+
+function stubFetch(viewers: number | null = 1) {
+  const fn = vi.fn(async (_url: RequestInfo | URL, _init?: RequestInit) => ({
+    ok: viewers !== null,
+    json: async () => ({ viewers }),
+  }));
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+const tick = (ms = 20) => new Promise((r) => setTimeout(r, ms));
+const feed = () => FakeEventSource.instances.at(-1)!;
+
+beforeEach(() => {
+  FakeEventSource.instances = [];
+  vi.stubGlobal("EventSource", FakeEventSource);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useSharedSession", () => {
+  it("does nothing without a session id", async () => {
+    const fn = stubFetch();
+    const { result } = renderHook(() => useSharedSession(null, new Set<string>()));
+    await tick();
+    expect(fn).not.toHaveBeenCalled();
+    expect(FakeEventSource.instances.length).toBe(0);
+    expect(result.current.viewers).toBeNull();
+  });
+
+  it("heartbeats presence with a stable viewer_id and reads the count back", async () => {
+    const fn = stubFetch(3);
+    const { result } = renderHook(() => useSharedSession("s 1", new Set<string>()));
+    await waitFor(() => expect(result.current.viewers).toBe(3));
+    expect(String(fn.mock.calls[0]![0])).toBe("/api/session/s%201/presence");
+    const body = JSON.parse(
+      (fn.mock.calls[0]![1] as RequestInit).body as string,
+    ) as { viewer_id: string };
+    expect(body.viewer_id.length).toBeGreaterThan(0);
+    // ...and the feed subscription targets the same (encoded) session.
+    expect(feed().url).toBe("/api/session/s%201/events");
+  });
+
+  it("updates viewers from hello/presence feed frames", async () => {
+    stubFetch(null); // heartbeat degraded; the feed carries the count
+    const { result } = renderHook(() => useSharedSession("s1", new Set<string>()));
+    act(() => feed().emit({ type: "hello", viewers: 2 }));
+    expect(result.current.viewers).toBe(2);
+    act(() => feed().emit({ type: "presence", viewers: 5 }));
+    expect(result.current.viewers).toBe(5);
+  });
+
+  it("surfaces another viewer's node as incoming, and clearIncoming resets it", () => {
+    stubFetch();
+    const { result } = renderHook(() =>
+      useSharedSession("s1", new Set<string>(["mine"])),
+    );
+    const node = { id: "theirs", parent_id: null, title: "Their page" };
+    act(() => feed().emit({ type: "node_added", node }));
+    expect(result.current.incoming).toEqual(node);
+    act(() => result.current.clearIncoming());
+    expect(result.current.incoming).toBeNull();
+  });
+
+  it("never echoes this tab's own pages back as incoming", () => {
+    stubFetch();
+    const known = new Set<string>(["mine"]);
+    const { result, rerender } = renderHook(
+      ({ ids }) => useSharedSession("s1", ids),
+      { initialProps: { ids: known } },
+    );
+    act(() =>
+      feed().emit({
+        type: "node_added",
+        node: { id: "mine", parent_id: null, title: "Mine" },
+      }),
+    );
+    expect(result.current.incoming).toBeNull();
+
+    // knownNodeIds is read through a live ref: a page added AFTER mount is
+    // filtered too, without resubscribing.
+    rerender({ ids: new Set<string>(["mine", "fresh"]) });
+    expect(FakeEventSource.instances.length).toBe(1);
+    act(() =>
+      feed().emit({
+        type: "node_added",
+        node: { id: "fresh", parent_id: null, title: "Fresh" },
+      }),
+    );
+    expect(result.current.incoming).toBeNull();
+  });
+
+  it("closes the feed on `unsupported` (standalone Mongo) and stays silent", () => {
+    stubFetch();
+    const { result } = renderHook(() => useSharedSession("s1", new Set<string>()));
+    act(() => feed().emit({ type: "unsupported" }));
+    expect(feed().closed).toBe(true);
+    expect(result.current.viewers).toBeNull();
+  });
+
+  it("skips malformed frames without dying", () => {
+    stubFetch();
+    const { result } = renderHook(() => useSharedSession("s1", new Set<string>()));
+    act(() => feed().emitRaw("not json{{"));
+    act(() => feed().emit({ type: "presence", viewers: 4 }));
+    expect(result.current.viewers).toBe(4);
+  });
+
+  it("tears down the feed and heartbeat on unmount", () => {
+    stubFetch();
+    const clearSpy = vi.spyOn(window, "clearInterval");
+    const { unmount } = renderHook(() => useSharedSession("s1", new Set<string>()));
+    const es = feed();
+    unmount();
+    expect(es.closed).toBe(true);
+    expect(clearSpy).toHaveBeenCalled();
+    clearSpy.mockRestore();
+  });
+});

--- a/apps/web/hooks/useWorldMap.test.tsx
+++ b/apps/web/hooks/useWorldMap.test.tsx
@@ -1,0 +1,117 @@
+// World-map hydration: fetch-on-mount, the empty-map fallback (never a null
+// snapshot while a session exists), best-effort error handling, and refetch.
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { WorldMapSnapshot } from "@openflipbook/config";
+
+import { useWorldMap } from "./useWorldMap";
+
+const SNAP: WorldMapSnapshot = {
+  session_id: "s1",
+  entities: [
+    {
+      id: "g1",
+      entity_id: "e1",
+      kind: "place",
+      label: "Fort",
+      pos: { x: 10, y: 20 },
+      height: 5,
+      footprint: { w: 4, d: 4 },
+      visual: "stone fort",
+      state: {},
+      confidence: 0.9,
+      source: "extracted",
+      updated_at: "2026-01-01T00:00:00.000Z",
+    },
+  ],
+  bounds: { x: 0, y: 0, w: 100, h: 60 },
+  schema_version: 1,
+  updated_at: "2026-01-01T00:00:00.000Z",
+};
+
+function stubFetch(payload: unknown = SNAP, ok = true) {
+  const fn = vi.fn(async (_url: RequestInfo | URL) => ({
+    ok,
+    json: async () => payload,
+  }));
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+const tick = (ms = 20) => new Promise((r) => setTimeout(r, ms));
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useWorldMap", () => {
+  it("hydrates the snapshot from /api/world/{sid}/map", async () => {
+    const fn = stubFetch();
+    const { result } = renderHook(() => useWorldMap("s1"));
+    await waitFor(() => expect(result.current.snapshot).toEqual(SNAP));
+    expect(String(fn.mock.calls[0]![0])).toBe("/api/world/s1/map");
+    expect(result.current.entities).toEqual(SNAP.entities);
+    expect(result.current.bounds).toEqual(SNAP.bounds);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("null session: no fetch, null snapshot, empty derived state", async () => {
+    const fn = stubFetch();
+    const { result } = renderHook(() => useWorldMap(null));
+    await tick();
+    expect(fn).not.toHaveBeenCalled();
+    expect(result.current.snapshot).toBeNull();
+    expect(result.current.entities).toEqual([]);
+    expect(result.current.bounds).toEqual({ x: 0, y: 0, w: 0, h: 0 });
+  });
+
+  it("serves the empty-map fallback (not null) while the route says no", async () => {
+    stubFetch({}, false);
+    const { result } = renderHook(() => useWorldMap("s1"));
+    await tick();
+    expect(result.current.snapshot).toMatchObject({
+      session_id: "s1",
+      entities: [],
+      bounds: { x: 0, y: 0, w: 0, h: 0 },
+    });
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("a network error keeps the prior snapshot (best-effort refetch)", async () => {
+    stubFetch();
+    const { result } = renderHook(() => useWorldMap("s1"));
+    await waitFor(() => expect(result.current.entities.length).toBe(1));
+
+    const boom = vi.fn(async () => {
+      throw new Error("offline");
+    });
+    vi.stubGlobal("fetch", boom);
+    await act(() => result.current.refetch());
+    expect(boom).toHaveBeenCalled();
+    expect(result.current.entities.length).toBe(1); // prior snapshot survives
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("refetch pulls fresh geometry after a generation", async () => {
+    const fn = stubFetch();
+    const { result } = renderHook(() => useWorldMap("s1"));
+    await waitFor(() => expect(result.current.entities.length).toBe(1));
+
+    stubFetch({ ...SNAP, entities: [], updated_at: "2026-01-02T00:00:00.000Z" });
+    await act(() => result.current.refetch());
+    expect(result.current.entities).toEqual([]);
+    expect(result.current.snapshot?.updated_at).toBe("2026-01-02T00:00:00.000Z");
+    expect(fn).toHaveBeenCalledTimes(1); // the first stub saw only the mount fetch
+  });
+
+  it("clearing the session resets the snapshot to null via refetch", async () => {
+    stubFetch();
+    const { result, rerender } = renderHook(({ sid }) => useWorldMap(sid), {
+      initialProps: { sid: "s1" as string | null },
+    });
+    await waitFor(() => expect(result.current.entities.length).toBe(1));
+    rerender({ sid: null });
+    await waitFor(() => expect(result.current.snapshot).toBeNull());
+  });
+});

--- a/apps/web/hooks/useWorldMode.test.tsx
+++ b/apps/web/hooks/useWorldMode.test.tsx
@@ -1,0 +1,106 @@
+// Per-session World Mode preference: the build-time NEXT_PUBLIC seed, the
+// per-session localStorage persistence, and the hydrate-on-session-change
+// coercion of stored garbage. MemoryStorage comes from tests/setup.ts.
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useWorldMode } from "./useWorldMode";
+
+const key = (sid: string) => `openflipbook.worldMode.${sid}`;
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe("useWorldMode", () => {
+  it("defaults off / auto / no DOM labels when nothing is stored or seeded", () => {
+    const { result } = renderHook(() => useWorldMode("s1"));
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.autonomy).toBe("auto");
+    expect(result.current.domLabels).toBe(false);
+  });
+
+  it("persists toggles per session and re-hydrates them on remount", () => {
+    const { result, unmount } = renderHook(() => useWorldMode("s1"));
+    act(() => result.current.setEnabled(true));
+    act(() => result.current.setAutonomy("semi"));
+    act(() => result.current.setDomLabels(true));
+    expect(JSON.parse(window.localStorage.getItem(key("s1"))!)).toEqual({
+      enabled: true,
+      autonomy: "semi",
+      domLabels: true,
+    });
+    unmount();
+
+    const { result: again } = renderHook(() => useWorldMode("s1"));
+    expect(again.current.enabled).toBe(true);
+    expect(again.current.autonomy).toBe("semi");
+    expect(again.current.domLabels).toBe(true);
+  });
+
+  it("keeps sessions independent: switching sessionId hydrates THAT session's pref", () => {
+    const { result, rerender } = renderHook(({ sid }) => useWorldMode(sid), {
+      initialProps: { sid: "s1" },
+    });
+    act(() => result.current.setEnabled(true));
+
+    rerender({ sid: "s2" });
+    expect(result.current.enabled).toBe(false); // fresh session, fresh default
+
+    rerender({ sid: "s1" });
+    expect(result.current.enabled).toBe(true); // s1's own toggle survives
+  });
+
+  it("coerces stored garbage back to safe values", () => {
+    window.localStorage.setItem(
+      key("s1"),
+      JSON.stringify({ enabled: "yes", autonomy: "yolo", domLabels: 1 }),
+    );
+    const { result } = renderHook(() => useWorldMode("s1"));
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.autonomy).toBe("auto");
+    expect(result.current.domLabels).toBe(false);
+  });
+
+  it("falls back to the default on unparseable storage", () => {
+    window.localStorage.setItem(key("s1"), "{not json");
+    const { result } = renderHook(() => useWorldMode("s1"));
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.autonomy).toBe("auto");
+  });
+
+  it("NEXT_PUBLIC_WORLD_MODE / _DOM_LABELS seed new sessions ON", async () => {
+    vi.stubEnv("NEXT_PUBLIC_WORLD_MODE", "1");
+    vi.stubEnv("NEXT_PUBLIC_DOM_LABELS", "true");
+    vi.resetModules(); // the seeds are read at module import
+    const fresh = await import("./useWorldMode");
+    const { result } = renderHook(() => fresh.useWorldMode("seeded"));
+    expect(result.current.enabled).toBe(true);
+    expect(result.current.domLabels).toBe(true);
+  });
+
+  it("a session's stored OFF beats the env seed (the toggle wins)", async () => {
+    vi.stubEnv("NEXT_PUBLIC_WORLD_MODE", "yes");
+    vi.resetModules();
+    const fresh = await import("./useWorldMode");
+    window.localStorage.setItem(
+      key("opted-out"),
+      JSON.stringify({ enabled: false, autonomy: "auto", domLabels: false }),
+    );
+    const { result } = renderHook(() => fresh.useWorldMode("opted-out"));
+    expect(result.current.enabled).toBe(false);
+  });
+
+  it("an unrecognized env value seeds OFF", async () => {
+    vi.stubEnv("NEXT_PUBLIC_WORLD_MODE", "on"); // not in the 1/true/yes set
+    vi.resetModules();
+    const fresh = await import("./useWorldMode");
+    const { result } = renderHook(() => fresh.useWorldMode("s1"));
+    expect(result.current.enabled).toBe(false);
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -31,15 +31,15 @@ export default defineConfig({
       include: ["lib/**/*.{ts,tsx}", "hooks/**/*.{ts,tsx}", "components/**/*.{ts,tsx}"],
       exclude: ["**/*.test.{ts,tsx}"],
       // The RATCHET: floors pinned just under the measured baseline
-      // (2026-07-18: lines/stmts 66.0, functions 70.7, branches 85.3). CI
+      // (2026-07-19: lines/stmts 71.9, functions 73.4, branches 86.2). CI
       // runs vitest with --coverage so a PR that drops below any floor
       // FAILS; a PR that raises coverage bumps the floor to the new number.
       // Never lower these to make a PR pass — that defeats the ratchet.
       thresholds: {
-        lines: 65,
-        statements: 65,
-        functions: 69,
-        branches: 84,
+        lines: 70,
+        statements: 70,
+        functions: 72,
+        branches: 85,
       },
     },
   },


### PR DESCRIPTION
PR D of the coverage campaign — 68 new tests across the five untested hooks and four untested components:

- **useAscend** (critical nav): two-fetch contract, full `onAscended` payload, all four error surfaces, re-start abort semantics.
- **useContainRect**: **the #48 late-mount regression is now pinned** — a null-at-mount ref polls instead of bailing, attaches ResizeObserver when the img appears.
- **useWorldMode** (env seed vs stored state), **useSharedSession** (SSE presence feed via a hand-driven FakeEventSource), **useWorldMap** (hydrate/fallback/refetch).
- **QueryToolbar**, **MapLabelOverlay** (bbox-beats-geo + frame culls), **HintPrompt**, **MorphImagePair** (dive-scale var, shimmer, reduce-motion).

**Ratchet: lines 66.0 → 71.9, functions 70.7 → 73.4, branches 85.3 → 86.2; thresholds bumped 65/65/69/84 → 70/70/72/85.** 772 web tests + tsc + lint + circular green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)