### PR TITLE
fix(mock): gate BRIA expand ops behind MOCK_PROVIDERS — mock stacks were billing real fal

### DIFF
--- a/apps/modal-backend/providers/image_edit.py
+++ b/apps/modal-backend/providers/image_edit.py
@@ -319,7 +319,14 @@ async def expand_image(
     south) so 'expand' extends the same place seamlessly rather than blooming
     new subjects. Default BRIA Expand (bakeoff winner); FAL_EXPAND_MODEL override."""
     from obs import span
+    from providers import mock
 
+    # Live-caught 2026-07-20: this was the ONE image op without the gate, so
+    # "mock" stacks with EXPAND_MAP_PAN=1 quietly billed real BRIA calls per
+    # Around click — until the fal balance ran dry and the tray went empty.
+    if mock.on():
+        m = mock.mock_image(f"pan {direction}", op="expand")
+        return GeneratedImage(m.jpeg_bytes, m.mime_type, m.model, m.request_id)
     _ensure_fal_key()
     model = (
         model_override
@@ -397,7 +404,11 @@ async def expand_image_zoomout(
     the canvas is centered, not edge-pinned. `factor` is clamped to ~1.5-4x. This is
     the opt-in (SCALE_OUTWARD_OUTPAINT) path; the seamless default is `scale_parent`."""
     from obs import span
+    from providers import mock
 
+    if mock.on():
+        m = mock.mock_image(prompt or f"zoomout {factor}x", op="zoomout")
+        return GeneratedImage(m.jpeg_bytes, m.mime_type, m.model, m.request_id)
     _ensure_fal_key()
     model = (
         model_override

--- a/apps/modal-backend/tests/test_mock_providers.py
+++ b/apps/modal-backend/tests/test_mock_providers.py
@@ -299,3 +299,22 @@ async def test_mock_error_reaches_sse_error_frame(
     assert ("MOCK_ERROR" in err.get("detail", "")) or (
         "MOCK_ERROR" in err.get("message", "")
     )
+
+
+async def test_expand_pan_and_zoomout_are_gated() -> None:
+    """Live-caught 2026-07-20: expand_image was the one image op WITHOUT the
+    mock gate, so EXPAND_MAP_PAN "mock" stacks billed real BRIA calls per
+    Around click. The fixture deletes FAL_KEY, so any regression re-raises
+    the key-missing error here instead of billing anyone."""
+    from providers.image_edit import expand_image, expand_image_zoomout
+
+    src = mock.mock_image("seed", op="fresh")
+    data_url = "data:image/jpeg;base64," + base64.b64encode(src.jpeg_bytes).decode()
+
+    pan = await expand_image(data_url, "west")
+    assert pan.model == "mock/expand"
+    Image.open(io.BytesIO(pan.jpeg_bytes)).verify()
+
+    out = await expand_image_zoomout(data_url, factor=3.0, prompt="ink map")
+    assert out.model == "mock/zoomout"
+    Image.open(io.BytesIO(out.jpeg_bytes)).verify()


### PR DESCRIPTION
## The find

Self-play follow-through (2026-07-20): the local mock stack's expand-tray spec went red with an empty tray. Backend log:

```
FalClientHTTPError: User is locked. Reason: Exhausted balance.
```

A stack booted `MOCK_PROVIDERS=1` was calling **real fal**. `expand_image` (BRIA map-pan) was the one image op without the `mock.on()` gate, and `.env` sets `EXPAND_MAP_PAN=1` — so every Around click in "mock" dev billed four real BRIA outpaints. Nobody noticed while they succeeded; today the balance ran dry and it became a hard failure.

CI never caught it because CI's zero-key mock job doesn't set the pan flag — meaning the pan path was also never exercised under mock at all.

## The fix

- `expand_image` + `expand_image_zoomout` get the exact gate `edit_image`/`continue_image` already have: `mock.on()` → deterministic parchment card, before any key check or upload.
- New test runs under the suite's FAL_KEY-deleted fixture, so a regression re-raises the key-missing error instead of billing anyone.

## Receipts

- expand-tray spec: red (90s timeout, 0 tiles) → green in 5.7s against the rebuilt container.
- Backend log for the passing run: **zero** `fal.ai` / `pan_failed` / upload lines.
- Full 11-spec suite: green in 1.0m (was 2.5m when pans hit the live API).
- Gates: ruff clean, mypy (gate scope) clean, pytest 86.33% ≥ 85 floor.

## Known hole left open (deliberate)

`video.py` (Animate) also has no mock gate — mock.py has no video helper and no spec exercises it. Ledgered rather than scope-crept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
