### PR TITLE
test(descent-bench): add a real non-degenerate golden chain (Grand Canyon of the Yellowstone) + verify Yellowstone desc

### DIFF
--- a/apps/modal-backend/tests/map_corpus/descriptions/forest-yellowstone-1904.json
+++ b/apps/modal-backend/tests/map_corpus/descriptions/forest-yellowstone-1904.json
@@ -17,7 +17,7 @@
    "visual": "Large, pale blue body of water in the far upper background.",
    "pos": {
     "x": 31.0,
-    "y": 60.0
+    "y": 14.0
    },
    "footprint": {
     "w": 25.0,
@@ -412,8 +412,8 @@
   }
  ],
  "review": {
-  "status": "vlm_draft",
-  "by": "",
-  "date": ""
+  "status": "verified",
+  "by": "claude (image-inspected via overlay; yellowstone-lake pos corrected to its border centroid; grand-canyon anchor confirmed on-feature for descent chain); eren spot-check welcome",
+  "date": "2026-08-02"
  }
 }

--- a/apps/modal-backend/tests/map_corpus/manifest.json
+++ b/apps/modal-backend/tests/map_corpus/manifest.json
@@ -110,6 +110,19 @@
       "attribution": "Joanbanjo, via Wikimedia Commons, CC BY-SA 3.0",
       "sha256": "12f7f44988fc21a2168ea5406db32edb63ac731c446d711d216bb577873d71ec",
       "filename": "wm-sala-del-maggior-consiglio-palau-ducal-de-ven-ci.jpg"
+    },
+    {
+      "id": "wm-grand-canyon-of-yellowstone-and-lower-falls-wyom",
+      "tier": "closeup",
+      "genre": "closeup",
+      "source_url": "https://commons.wikimedia.org/wiki/Special:FilePath/Grand%20Canyon%20of%20Yellowstone%20and%20Lower%20falls%2C%20Wyoming%2C%20United%20States.jpg?width=1600",
+      "license_note": "CC BY-SA 4.0 (via Wikimedia Commons)",
+      "attribution": "Erik Whalen, via Wikimedia Commons, CC BY-SA 4.0",
+      "sha256": "752c1ffda0b68535a5548b00230523387580ec37df872cc76a0328eff1277480",
+      "filename": "wm-grand-canyon-of-yellowstone-and-lower-falls-wyom.jpg",
+      "parent_id": "forest-yellowstone-1904",
+      "parent_ref": "grand-canyon-yellowstone",
+      "view": "exterior"
     }
   ]
 }


### PR DESCRIPTION
Follow-up to #188. That PR fixed the descent bench's with-arm seam but its only golden chain (`manor::church` glyph → Chester Cathedral photo) was **degenerate** — the map never depicted the cathedral, so `place_lift` floored at 0. This adds a chain with genuine parent↔child place correspondence and re-benches live.

## What's added
- **New exterior-closeup chain:** `forest-yellowstone-1904 :: 'Grand Canyon of the Yellowstone' → wm-grand-canyon-of-yellowstone-and-lower-falls-wyom` (`view:exterior`). Child = a sourced CC-BY-SA 4.0 Artist-Point photo of the same canyon (Erik Whalen, via Wikimedia Commons; sha-pinned in the manifest, fetched by `make corpus-fetch`). The 1904 Northern Pacific panorama draws the canyon as a distinctive yellow gorge, so the region crop carries real identity.
- **Verified `forest-yellowstone-1904.json`** (was `vlm_draft`): corrected `yellowstone-lake` pos, which pointed at the bottom title edge instead of its own border centroid; other entity positions image-inspected via `overlay.py`.

## Live re-bench (n=2, ~\$0.61) — an instructive null
```
Church (glyph → cathedral)      place with=2.0  without=2.0   lift +0.0   (both FLOOR)
Grand Canyon (gorge → canyon)   place with=10.0 without=10.0  lift +0.0   (both CEILING)
```
Both chains yield `place_lift ≈ 0`, but for **opposite** reasons — which characterizes the metric:
- **Chester floors:** the glyph has no identity to transfer and the child isn't the mapped place.
- **Grand Canyon ceilings:** verified by pixels — the *text-only baseline* is a photoreal dead-ringer of the real canyon. The model renders "Grand Canyon of the Yellowstone" perfectly from the **name alone**, so region-conditioning has no headroom.

**`place_lift` only moves when the place NAME is uninformative but the CROP is distinctive** — the product's fantasy/generated-map regime, which a real-photo corpus can't represent. Famous real landmarks always ceiling the baseline. The signal that *did* move is the **absolute `place_match_with`: 2.0 → 10.0**, proving the edit-seam pipeline (from #188) carries a real place to ceiling when correspondence exists. So `place_lift` is best read as a **guardrail** (`with ≥ without`), not a positive-on-famous-places headline.

## Notes
- Grand Canyon run logged `continuity_with=0.0` from a transient `judge.unparseable` (empty judge response scored 0, not retried — bench judge-retry only fires on exceptions, not empty-parse). Visually the Kontext with-arm clearly continues the crop; a separate robustness gap, not fixed here.
- Corpus images are sha-pinned + re-fetched, not git-tracked — the manifest row is the artifact.
- 67 corpus + bench tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)