### PR TITLE
fix(judge): retry a transient empty/unparseable judge reply instead of banking a silent 0

### DIFF
--- a/apps/modal-backend/.env.example
+++ b/apps/modal-backend/.env.example
@@ -13,6 +13,9 @@ OPENROUTER_ENABLE_WEB_SEARCH=true
 # JPEG data URLs; larger inline payloads can make OpenRouter/Gemini reset reads.
 # VLM_JUDGE_MAX_SIDE_PX=512
 # VLM_JUDGE_JPEG_QUALITY=72
+# A judge reply that comes back empty/unparseable (transient 200 with no content)
+# is re-issued this many times before falling back to a loud UNPARSEABLE 0.
+# VLM_JUDGE_EMPTY_RETRIES=3
 
 # --- Use a different LLM provider (advanced; default = OpenRouter above) ---
 # Leave LLM_PROVIDER unset to keep OpenRouter byte-for-byte. Set it to point the

--- a/apps/modal-backend/providers/judge.py
+++ b/apps/modal-backend/providers/judge.py
@@ -142,15 +142,26 @@ async def _ask_judge(
             "content": [{"type": "text", "text": user_text}, *image_blocks],
         },
     ]
-    response = await llm._create_with_retry(
-        client,
-        model=_judge_model(),
-        messages=messages,
-        temperature=0.0,
-        max_tokens=400,
-    )
-    raw = response.choices[0].message.content or ""
-    return _parse_judgement(raw)
+    # _create_with_retry only retries API-level errors; a 200 with EMPTY content
+    # (a transient judge-model failure) parses to a loud UNPARSEABLE score-0
+    # without raising, so it slips past that retry AND the benches' own
+    # exception-only retry — banking a blank reply as a real 0. Re-issue the
+    # call when the reply can't be parsed.
+    attempts = _bounded_int_env("VLM_JUDGE_EMPTY_RETRIES", 3, floor=1, ceiling=5)
+    result = JudgeResult(score=0.0, rationale="UNPARSEABLE: no judge response", raw="")
+    for _ in range(attempts):
+        response = await llm._create_with_retry(
+            client,
+            model=_judge_model(),
+            messages=messages,
+            temperature=0.0,
+            max_tokens=400,
+        )
+        raw = response.choices[0].message.content or ""
+        result = _parse_judgement(raw)
+        if not result.rationale.startswith("UNPARSEABLE"):
+            return result
+    return result
 
 
 async def score_style_pair(image_a: bytes, image_b: bytes) -> JudgeResult:

--- a/apps/modal-backend/tests/test_judge_place_match.py
+++ b/apps/modal-backend/tests/test_judge_place_match.py
@@ -149,3 +149,77 @@ def test_parse_salvages_reasoning_preamble_then_json() -> None:
     # A preamble followed by a COMPLETE json object → salvage recovers the score.
     r = judge._parse_judgement('Let me think. The dome matches.\n{"score": 9, "rationale": "dome"}')
     assert r.score == 9.0
+
+
+# --- _ask_judge retries a transient EMPTY / unparseable response --------------
+#
+# _create_with_retry only retries API-level errors; a 200 with empty content
+# parses to a loud UNPARSEABLE score-0 without raising, so every caller (the
+# view-loop AND the paid benches) used to bank a transient blank reply as a real
+# 0. _ask_judge now re-issues the call when the reply can't be parsed.
+
+
+class _FakeMessage:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class _FakeChoice:
+    def __init__(self, content: str) -> None:
+        self.message = _FakeMessage(content)
+
+
+class _FakeResponse:
+    def __init__(self, content: str) -> None:
+        self.choices = [_FakeChoice(content)]
+
+
+def _stub_replies(monkeypatch: pytest.MonkeyPatch, replies: list[str]) -> dict[str, int]:
+    from providers import llm
+
+    calls = {"n": 0}
+
+    async def _fake_create(_client: Any, **_kw: Any) -> _FakeResponse:
+        content = replies[min(calls["n"], len(replies) - 1)]
+        calls["n"] += 1
+        return _FakeResponse(content)
+
+    monkeypatch.setattr(llm, "_client", lambda: object())
+    monkeypatch.setattr(llm, "_create_with_retry", _fake_create)
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_ask_judge_retries_empty_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    # First call returns an empty body (the observed transient), second is valid.
+    calls = _stub_replies(monkeypatch, ["", '{"score": 7, "rationale": "match"}'])
+
+    r = await judge._ask_judge("sys", "user", [])
+
+    assert calls["n"] == 2  # retried the blank reply
+    assert r.score == 7.0
+    assert "UNPARSEABLE" not in r.rationale
+
+
+@pytest.mark.asyncio
+async def test_ask_judge_gives_up_loudly_after_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Persistent empty replies → bounded retries, then the loud UNPARSEABLE 0.
+    monkeypatch.setenv("VLM_JUDGE_EMPTY_RETRIES", "2")
+    calls = _stub_replies(monkeypatch, [""])
+
+    r = await judge._ask_judge("sys", "user", [])
+
+    assert calls["n"] == 2  # capped, not infinite
+    assert r.score == 0.0
+    assert r.rationale.startswith("UNPARSEABLE")
+
+
+@pytest.mark.asyncio
+async def test_ask_judge_does_not_retry_a_legit_score(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A valid reply (incl. a legit 0) must not burn extra calls.
+    calls = _stub_replies(monkeypatch, ['{"score": 0, "rationale": "unrelated"}'])
+
+    r = await judge._ask_judge("sys", "user", [])
+
+    assert calls["n"] == 1
+    assert r.score == 0.0 and "UNPARSEABLE" not in r.rationale


### PR DESCRIPTION
Fixes the judge-retry gap flagged in #189.

## The bug
`_ask_judge` wraps its API call in `_create_with_retry`, which only retries **API-level errors**. But a `200` response with **empty content** — a transient judge-model failure — flows into `_parse_judgement`, which (correctly, by design) returns a loud `UNPARSEABLE` **score-0** *without raising*. So the empty reply slipped past `_create_with_retry` **and** the benches' exception-only `_judge_with_retry`, banking a blank response as a real `0`.

This is exactly what surfaced as `continuity_with=0.0` (`raw_head:""`) on the #189 descent run — the Kontext with-arm visibly continued the crop, but a transient empty judge reply scored it 0.

## The fix
At the single chokepoint every `score_*` routes through, `_ask_judge` now **re-issues the call while the reply can't be parsed** (rationale `startswith("UNPARSEABLE")`), bounded by `VLM_JUDGE_EMPTY_RETRIES` (default 3, clamped 1–5), then falls back to the loud `UNPARSEABLE` 0. One place → both the production view-loop judges and the paid benches benefit. A legit reply (including a real `0`) never burns an extra call.

## Tests (TDD — added failing first)
- `test_ask_judge_retries_empty_then_succeeds` — empty body → retries → banks the valid score.
- `test_ask_judge_gives_up_loudly_after_retries` — persistent empty → bounded retries → loud UNPARSEABLE 0.
- `test_ask_judge_does_not_retry_a_legit_score` — a valid reply (incl. legit 0) costs exactly one call.

The existing `_parse_judgement` contract tests (legit-0 vs UNPARSEABLE) still pass unchanged. 986 backend tests pass, coverage 86.81%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)