### PR TITLE
feat(descent-bench): DESCENT_BENCH_BLIND_LABEL — make place_lift measure region-conditioning's contribution

### DIFF
--- a/apps/modal-backend/tests/descent_bench/runner.py
+++ b/apps/modal-backend/tests/descent_bench/runner.py
@@ -59,6 +59,24 @@ def _model() -> str:
     return os.environ.get("FAL_IMAGE_MODEL_BALANCED", "fal-ai/nano-banana-pro")
 
 
+# The label the model can't cheat off. A famous real name (e.g. "Grand Canyon of
+# the Yellowstone") lets the BASELINE render the place from text alone, so both
+# arms ceiling and place_lift reads 0 — even when region-conditioning is doing
+# real work. Blinding the name in BOTH arms isolates the crop's contribution:
+# the fantasy/generated-map regime the product actually serves (a made-up place
+# the model can only render from its DRAWN form). The judge never sees the label
+# — it compares images — so this changes only what the arms are TOLD, not scoring.
+_BLIND_PROMPT_LABEL = "the place marked at this spot on the map"
+
+
+def _blind_label() -> bool:
+    return os.environ.get("DESCENT_BENCH_BLIND_LABEL", "").lower() in ("1", "true", "yes")
+
+
+def _prompt_label(label: str) -> str:
+    return _BLIND_PROMPT_LABEL if _blind_label() else label
+
+
 def resolve_chains() -> list[dict[str, Any]]:
     descs = {d["map_id"]: d for d in load_descriptions(status="verified")}
     return descent_chains(load_manifest(), descs)
@@ -92,7 +110,8 @@ async def _score_chain(chain: dict[str, Any], aspect: str) -> dict[str, Any]:
     # closer OUTSIDE view — the shape that measures place_lift when the parent
     # already draws a distinctive exterior (tests/map_corpus/chains.py docs).
     view = chain.get("view", "interior")
-    base = f"A closer, {view} view of {label}, a place within the parent map."
+    plabel = _prompt_label(label)
+    base = f"A closer, {view} view of {plabel}, a place within the parent map."
 
     # save artifacts for visual inspection (overlays/ is gitignored). A live
     # judge can die after image spend; opt-in reuse lets the rerun finish judges
@@ -117,9 +136,9 @@ async def _score_chain(chain: dict[str, Any], aspect: str) -> dict[str, Any]:
         # so the reference pixels actually bite (generate_image ignores refs).
         if view == "interior":
             instruction = image_edit_provider.build_enter_instruction(
-                label,
+                plabel,
                 [],
-                subject_context=f"{label}, a place within the parent map",
+                subject_context=f"{plabel}, a place within the parent map",
                 interior=True,
             )
             with_gen = await image_edit_provider.edit_image(
@@ -130,7 +149,7 @@ async def _score_chain(chain: dict[str, Any], aspect: str) -> dict[str, Any]:
         else:
             # exterior closeup = the product's zoom_continue rung (Kontext).
             instruction = image_edit_provider.build_zoom_instruction(
-                label, [], register="view", faithful=True
+                plabel, [], register="view", faithful=True
             )
             with_gen = await image_edit_provider.continue_image(
                 region_url,
@@ -186,6 +205,7 @@ def _aggregate(rows: list[dict[str, Any]]) -> dict[str, Any]:
 
     return {
         "run_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "blind_label": _blind_label(),
         "chains": rows,
         "mean_place_lift": _mean("place_lift"),
         "mean_style_lift": _mean("style_lift"),

--- a/apps/modal-backend/tests/descent_bench/test_descent.py
+++ b/apps/modal-backend/tests/descent_bench/test_descent.py
@@ -150,3 +150,58 @@ async def test_exterior_with_arm_rides_zoom_continue(monkeypatch, tmp_path) -> N
 
     assert calls["continue"] == ["data:region"]
     assert calls["edit"] == []
+
+
+def test_prompt_label_blinds_only_when_enabled(monkeypatch) -> None:
+    assert runner._prompt_label("Grand Canyon of the Yellowstone") == (
+        "Grand Canyon of the Yellowstone"
+    )
+    monkeypatch.setenv("DESCENT_BENCH_BLIND_LABEL", "1")
+    blinded = runner._prompt_label("Grand Canyon of the Yellowstone")
+    assert blinded == runner._BLIND_PROMPT_LABEL
+    assert "Grand Canyon" not in blinded
+
+
+async def test_blind_label_strips_the_name_from_both_arms(monkeypatch, tmp_path) -> None:
+    """DESCENT_BENCH_BLIND_LABEL removes the real place name from BOTH the with-arm
+    edit instruction and the without-arm base prompt, so place_lift can isolate
+    the region crop's contribution (the model can't cheat off a famous name)."""
+    monkeypatch.setenv("DESCENT_BENCH_BLIND_LABEL", "1")
+    captured: dict[str, str] = {}
+
+    async def _fake_edit(image_data_url, instruction, **_kw):
+        captured["edit_instr"] = instruction
+        return _StubImage()
+
+    async def _fake_enter(prompt, aspect, model, ref):
+        captured["without_prompt"] = prompt
+        return b"\xff\xd8without"
+
+    async def _fake_judge(*_a, **_k):
+        return _StubJudgement(5.0)
+
+    from tests import map_corpus
+
+    monkeypatch.setattr(map_corpus, "ROOT", tmp_path)
+    monkeypatch.setattr(runner, "image_path", lambda _id: _StubPath())
+    monkeypatch.setattr(coherence_runner, "_region_crop", lambda _b, _a: b"\xff\xd8region")
+    monkeypatch.setattr(coherence_runner, "_enter", _fake_enter)
+    monkeypatch.setattr(image_provider, "encode_data_url", lambda _b: "data:region")
+    monkeypatch.setattr(image_edit_provider, "edit_image", _fake_edit)
+    monkeypatch.setattr(model_router, "resolve_model", lambda slot: f"model:{slot}")
+    for name in ("score_style_pair", "score_place_match", "score_continuation"):
+        monkeypatch.setattr(judge, name, _fake_judge)
+
+    chain = {
+        "parent_id": "p",
+        "child_id": "c",
+        "anchor": {},
+        "label": "The Grand Bazaar of Isfahan",
+        "view": "interior",
+    }
+    await runner._score_chain(chain, "16:9")
+
+    # neither arm is told the real name; both see the blind marker
+    assert "Grand Bazaar" not in captured["edit_instr"]
+    assert "Grand Bazaar" not in captured["without_prompt"]
+    assert "marked at this spot" in captured["without_prompt"]


### PR DESCRIPTION
Follow-up to #189, which showed `place_lift` is structurally ~0 on real-photo chains: a famous name lets the **baseline** render the place from text alone, so both arms ceiling and the metric can't see conditioning working. The regime where region-conditioning actually matters — a made-up place the model can only render from its **drawn form** (the product's fantasy/generated-map use case) — was unrepresentable with real place-names.

## What
`DESCENT_BENCH_BLIND_LABEL=1` strips the real name from **both** arms' generation prompts, substituting a generic `"the place marked at this spot on the map"`. The judge never sees the label (it compares images), so this changes only what the arms are *told*, not scoring — isolating what the **region crop** contributes.

## Live validation (n=2, ~\$0.61) — vs #189's real-name +0.0
```
mean place_lift: +6.000   (was +0.000 with real names)
  Grand Canyon   place with=10.0  without=0.0   lift +10.0   continuity=10.0
  Church         place with=2.0   without=0.0   lift  +2.0   continuity= 9.0
```
Blinded, the baseline generates a random place — **verified by pixels**: a generic "YOU ARE HERE" cottage-on-a-map → `place_match 0`. The crop-conditioned arm reproduces the canyon (10). Region-conditioning contributes the **entire** identity — a +10 lift — proving the #188 edit-seam carries a real place when the name can't. Even the Chester glyph transfers a weak +2.

Cross-confirmation: `continuity_with=10.0`, not the old spurious `0` — the **#190 empty-judge-retry fix is working live**.

## Tests
- `test_prompt_label_blinds_only_when_enabled` — the pure helper (off → real name, on → generic marker).
- `test_blind_label_strips_the_name_from_both_arms` — integration: neither the with-arm edit instruction nor the without-arm base prompt contains the real name under blind mode.

988 backend tests pass. Bench flags stay code-documented (not in `.env.example`, consistent with the other `DESCENT_BENCH_*` knobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)