### PR TITLE
fix(web): move localize toast off the Pin-style corner (bottom-left overlap)

### DIFF
--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -3830,7 +3830,12 @@ export default function PlayPage() {
             {phase === "ready" &&
               localizeStatus?.status === "failed" &&
               localizeStatus.nodeId === page?.nodeId && (
-                <div className="pointer-events-auto absolute bottom-3 left-3 flex items-center gap-3 rounded-full bg-amber-700/90 px-4 py-2 text-xs text-white shadow-lg">
+                <div className="pointer-events-auto absolute bottom-3 end-3 z-10 flex items-center gap-3 rounded-full bg-amber-700/90 px-4 py-2 text-xs text-white shadow-lg">
+                  {/* end-3 (not left-3): the bottom-LEFT corner holds the 📌 Pin
+                      style button (z-10) which rendered on top and occluded this
+                      toast's text. Localize belongs on the right per TapHint's
+                      layout contract (Pin-style left / hint centered / localize
+                      right); z-10 keeps "Map it" tappable over the centered hint. */}
                   <span>Couldn’t map this page — taps may miss.</span>
                   <button
                     type="button"


### PR DESCRIPTION
Found during a solo play-through of the mock+world stack (Track 3 findings pass).

## Bug
The "Couldn't map this page — taps may miss / Map it" localize toast was anchored `bottom-3 left-3` with **no z-index**, so it rendered *under* the `bottom-3 start-3 z-10` "📌 Pin style" button — the pill occluded the toast's leading text. This is exactly the collision `TapHint.tsx`'s layout contract documents (Pin-style **left** / hint **centered** / localize **right**), but this inline toast sat on the wrong side.

## Fix
Move it to `bottom-3 end-3 z-10` — the free right corner (logical `end-3` RTL-mirrors Pin-style's `start-3`; `z-10` keeps "Map it" tappable over the centered hint). One-line className change.

## Verified live
Rebuilt the web container and reproduced the toast on a mock map page — the three bottom-of-frame elements now sit left/center/right with **no overlap** (toast rect 777–1123 vs Pin 157–246, `overlaps=false`; class confirmed `bottom-3 end-3 z-10`). `TapHint` tests still 4/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)