### PR TITLE
fix(web): reveal timer stops banking backgrounded-tab idle as "reveal"

### DIFF
--- a/apps/web/components/waterfall-hud.tsx
+++ b/apps/web/components/waterfall-hud.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { on, type HudEventName } from "@/lib/trace";
 import {
   buildSegments,
   marksForEndReportedStage,
+  marksForRevealEnd,
+  type HiddenRange,
   type WaterfallMark as Mark,
   type WaterfallStage as StageKey,
 } from "@/lib/waterfall-segments";
@@ -48,6 +50,10 @@ export default function WaterfallHUD() {
   const [run, setRun] = useState<RunState>(EMPTY);
   const [hasShown, setHasShown] = useState(false);
   const [now, setNow] = useState(0);
+  // Document-hidden spans on the trace clock. The reveal's transitionend is
+  // compositor-gated and pauses while hidden — morph:end subtracts these so
+  // idle time renders as `idle`, not a 90s+ "reveal" bar.
+  const hiddenRangesRef = useRef<HiddenRange[]>([]);
 
   useEffect(() => {
     const offs: Array<() => void> = [];
@@ -55,9 +61,29 @@ export default function WaterfallHUD() {
       offs.push(on(name, cb));
     };
 
+    const onVisibility = () => {
+      const ranges = hiddenRangesRef.current;
+      if (document.visibilityState === "hidden") {
+        ranges.push({ start: performanceNow() });
+      } else {
+        const open = ranges[ranges.length - 1];
+        if (open && open.end == null) open.end = performanceNow();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    offs.push(() =>
+      document.removeEventListener("visibilitychange", onVisibility),
+    );
+
     sub("trace:set", (p: unknown) => {
       const id = (p as { id?: string; ts?: number })?.id ?? null;
       const ts = (p as { ts?: number })?.ts ?? 0;
+      // A run can start while hidden (#185 auto-retry fires on return): keep
+      // an open hidden span so the fresh run still knows it's backgrounded.
+      hiddenRangesRef.current =
+        document.visibilityState === "hidden"
+          ? [{ start: performanceNow() }]
+          : [];
       setRun({
         traceId: id,
         startedAt: ts || null,
@@ -131,18 +157,22 @@ export default function WaterfallHUD() {
     sub("morph:end", (p: unknown) => {
       // The reveal runs from the decode's end to this event's arrival; the
       // legacy duration_ms (measured since CLICK) is ignored for the bar.
+      // Hidden spans inside that window render as `idle`, not `reveal` — the
+      // transitionend pauses while backgrounded (the 91724ms incident).
       const v = p as { t?: number; duration_ms?: number };
       setRun((prev) => {
         const last = prev.marks[prev.marks.length - 1];
         const lastEnd = last == null ? 0 : (last.end ?? last.t);
         const endT = typeof v?.t === "number" ? v.t : lastEnd;
+        const marks = marksForRevealEnd(
+          prev.marks,
+          endT,
+          hiddenRangesRef.current,
+        );
         return {
           ...prev,
-          marks: [
-            ...prev.marks,
-            { stage: "morph", t: lastEnd, end: Math.max(endT, lastEnd) },
-          ],
-          endedAt: Math.max(endT, lastEnd),
+          marks,
+          endedAt: marks[marks.length - 1]?.end ?? Math.max(endT, lastEnd),
           active: null,
         };
       });

--- a/apps/web/lib/waterfall-segments.test.ts
+++ b/apps/web/lib/waterfall-segments.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildSegments,
   marksForEndReportedStage,
+  marksForRevealEnd,
   type WaterfallMark,
 } from "./waterfall-segments";
 
@@ -71,5 +72,42 @@ describe("marksForEndReportedStage", () => {
     expect(out.map((m) => m.stage)).toEqual(["final", "idle", "decode"]);
     expect(out[1]).toEqual({ stage: "idle", t: 2000, end: 186_813 });
     expect(out[2]).toEqual({ stage: "decode", t: 186_813, end: 187_003 });
+  });
+});
+
+describe("marksForRevealEnd", () => {
+  it("no hidden time -> a single reveal mark spanning the window (unchanged behavior)", () => {
+    const prev: WaterfallMark[] = [{ stage: "decode", t: 2000, end: 2100 }];
+    const out = marksForRevealEnd(prev, 2600, []);
+    expect(out[out.length - 1]).toEqual({ stage: "morph", t: 2100, end: 2600 });
+    expect(out).toHaveLength(2);
+  });
+
+  it("the 91724ms incident: hidden time banks as idle, reveal shows only visible ms", () => {
+    // The reveal's CSS transitionend is compositor-gated and pauses while the
+    // tab is hidden — a backgrounded tab banked 90.9s of idle into "reveal".
+    const prev: WaterfallMark[] = [{ stage: "decode", t: 2000, end: 2100 }];
+    const hidden = [{ start: 2200, end: 93_000 }];
+    const out = marksForRevealEnd(prev, 93_400, hidden);
+    expect(out.map((m) => m.stage)).toEqual(["decode", "idle", "morph"]);
+    expect(out[1]).toEqual({ stage: "idle", t: 2100, end: 92_900 });
+    expect(out[2]).toEqual({ stage: "morph", t: 92_900, end: 93_400 });
+  });
+
+  it("hidden spans are clipped to the reveal window; sub-gap overlap adds no idle", () => {
+    // Hidden mostly BEFORE the reveal window (during gen, decode already
+    // handles that) — only the 50ms overlap counts, under IDLE_GAP_MS.
+    const prev: WaterfallMark[] = [{ stage: "decode", t: 2000, end: 2100 }];
+    const out = marksForRevealEnd(prev, 2600, [{ start: 0, end: 2150 }]);
+    expect(out.map((m) => m.stage)).toEqual(["decode", "morph"]);
+    expect(out[1]).toEqual({ stage: "morph", t: 2100, end: 2600 });
+  });
+
+  it("a still-open hidden range (no end yet) is clipped at the event's arrival", () => {
+    const prev: WaterfallMark[] = [{ stage: "decode", t: 2000, end: 2100 }];
+    const out = marksForRevealEnd(prev, 93_400, [{ start: 2200 }]);
+    expect(out.map((m) => m.stage)).toEqual(["decode", "idle", "morph"]);
+    expect(out[1]).toEqual({ stage: "idle", t: 2100, end: 93_300 });
+    expect(out[2]).toEqual({ stage: "morph", t: 93_300, end: 93_400 });
   });
 });

--- a/apps/web/lib/waterfall-segments.ts
+++ b/apps/web/lib/waterfall-segments.ts
@@ -73,6 +73,43 @@ export function buildSegments(
   return segments;
 }
 
+/** A document-hidden interval on the trace clock; `end` absent while the tab
+ * is still hidden when the closing event fires. */
+export interface HiddenRange {
+  start: number;
+  end?: number;
+}
+
+/** Insert-point helper for the reveal's end (`morph:end`): the reveal's CSS
+ * transitionend is compositor-gated and PAUSES while the tab is hidden, so a
+ * backgrounded tab banks its idle wall-clock into "reveal" (the 91724ms
+ * incident — same hazard `marksForEndReportedStage` fixed for decode).
+ * Hidden time inside the [previous end, endT] window renders as `idle`; the
+ * reveal bar keeps only the visible remainder. */
+export function marksForRevealEnd(
+  prev: readonly WaterfallMark[],
+  endT: number,
+  hiddenRanges: readonly HiddenRange[],
+): WaterfallMark[] {
+  const last = prev[prev.length - 1];
+  const windowStart = last == null ? endT : (last.end ?? last.t);
+  const windowEnd = Math.max(endT, windowStart);
+  let hiddenMs = 0;
+  for (const r of hiddenRanges) {
+    const s = Math.max(r.start, windowStart);
+    const e = Math.min(r.end ?? windowEnd, windowEnd);
+    if (e > s) hiddenMs += e - s;
+  }
+  const out = [...prev];
+  if (hiddenMs > IDLE_GAP_MS) {
+    out.push({ stage: "idle", t: windowStart, end: windowStart + hiddenMs });
+    out.push({ stage: "morph", t: windowStart + hiddenMs, end: windowEnd });
+  } else {
+    out.push({ stage: "morph", t: windowStart, end: windowEnd });
+  }
+  return out;
+}
+
 /** Insert-point helper for end-reported events (decode): the event arrives at
  * its END carrying a measured duration; reconstruct the start, and surface a
  * leading idle gap when the stage began long after the previous mark ended. */


### PR DESCRIPTION
Campaign thread 1 (F3 from the 08-03 play-through ledger).

## Bug
The waterfall's reveal segment measures wall-clock from decode-end to `morph:end`. The reveal's CSS `transitionend` is compositor-gated and **pauses while the tab is hidden**, so a backgrounded tab banked its idle wall-clock into "reveal" — observed **91,724ms "reveal"** for a ~60ms mock gen. Same hazard class as the decode's 184,813ms incident, which `marksForEndReportedStage` already fixed.

## Fix
Same pure library, same pattern: `marksForRevealEnd` clips document-hidden spans to the `[decode-end, morph:end]` window and renders them as the existing `idle` stage; the reveal bar keeps only visible time. The HUD tracks hidden spans via a `visibilitychange` listener on the trace clock, reset per `trace:set` — seeded with an open span when a run starts while hidden (the #185 auto-retry path).

## Verified
- 4 new unit tests incl. the exact 91,724ms scenario (hidden span → `idle`, reveal keeps the visible 500ms); clipping and open-range edges covered. 9/9 in the file, **819 web tests**, `tsc` clean.
- Live on the mock stack: normal visible-path waterfall renders honestly (44ms total, no spurious idle).

## Found while verifying (separate, pre-existing — follow-up PR)
`morph:end` is currently **unreliable on its own**: `useImageMorph` flips `nextImg` + `phase:"reveal"` in one state update, so the new `<img>` mounts already at the reveal mask-size — no painted start state → the wipe transition often never runs (verified live: zero `transitionend` document-wide across a full tap gen). Product animation timing, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)