### PR TITLE
feat(view-bench): failing-first oblique case + env-tunable accept floors + per-attempt scores

### DIFF
--- a/apps/modal-backend/tests/continuity_bench/test_view.py
+++ b/apps/modal-backend/tests/continuity_bench/test_view.py
@@ -7,6 +7,8 @@ and the project_top_down port the positioning probe depends on.
 """
 from __future__ import annotations
 
+import pytest
+
 from providers.geometry import project_top_down
 from tests.continuity_bench.view_runner import (
     _ARM_INTENT,
@@ -14,6 +16,7 @@ from tests.continuity_bench.view_runner import (
     _CASES,
     ArmResult,
     CaseResult,
+    _bench_loop_config,
     summarize,
 )
 
@@ -36,6 +39,32 @@ def test_cases_and_arms_are_well_formed() -> None:
         if view is not None:
             assert view["projection"] == arm
             assert view["source"] == "user"
+
+
+def test_bench_loop_config_defaults_match_the_old_literal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Unset env must be byte-identical to the old LoopConfig(max_attempts=3)
+    # literal; VIEW_BENCH_ACCEPT_* raises the floors (the retry-forcing A/B
+    # lever). Production VIEW_LOOP_ACCEPT_* must stay ignored on the bench.
+    for k in (
+        "VIEW_BENCH_ACCEPT_CONFORMANCE",
+        "VIEW_BENCH_ACCEPT_SAME_PLACE",
+        "VIEW_BENCH_ACCEPT_DETAIL",
+        "VIEW_BENCH_ACCEPT_MEDIUM",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    from providers.render_loop import LoopConfig
+
+    assert _bench_loop_config() == LoopConfig(max_attempts=3)
+
+    monkeypatch.setenv("VIEW_LOOP_ACCEPT_CONFORMANCE", "9.9")  # production knob
+    assert _bench_loop_config().accept_conformance == 7.0  # still ignored
+
+    monkeypatch.setenv("VIEW_BENCH_ACCEPT_CONFORMANCE", "8.5")
+    cfg = _bench_loop_config()
+    assert cfg.accept_conformance == 8.5
+    assert cfg.accept_same_place == 6.0  # untouched floors keep defaults
 
 
 def test_summarize_gates() -> None:

--- a/apps/modal-backend/tests/continuity_bench/view_runner.py
+++ b/apps/modal-backend/tests/continuity_bench/view_runner.py
@@ -103,7 +103,66 @@ _CASES: list[Case] = [
         surroundings="just north, the bell tower; south beyond the walls, terraced vineyards",
         facts=["the cloth stalls", "the well"],
     ),
+    # The failing-first case: the 2026-07-21 failure class was oblique enters
+    # into DENSE complex places — the landmark survives but the FRAMING
+    # scatters (wider/sideways) across retries. The two cases above pass on
+    # attempt 0, so the retry path (and ENTER_RETRY_MODEL_SWAP) never runs;
+    # this one crowds the subject so oblique framing is genuinely hard.
+    Case(
+        name="etched_cliff_monastery",
+        map_prompt=(
+            "a fine-lined etched top-down map of a sprawling cliffside "
+            "monastery complex: a great domed library hall at the center, "
+            "twin bell towers flanking it, terraced courtyards stepping down "
+            "the cliff to the south, a covered bridge crossing a gorge to the "
+            "west, and a walled herb garden northeast; dense fine linework, "
+            "muted umber wash, many small annexes and stairways crowding the "
+            "slopes"
+        ),
+        style="fine-lined etching, muted umber wash, dense linework",
+        tap=(0.5, 0.45),
+        place_label="The Great Library Hall",
+        subject_context=(
+            "a great domed library hall at the heart of a crowded cliffside "
+            "monastery complex, hemmed in by towers, annexes and stairways"
+        ),
+        surroundings=(
+            "twin bell towers flanking the hall; terraced courtyards stepping "
+            "down the cliff to the south; the covered gorge bridge to the west"
+        ),
+        facts=["the reading terrace", "the twin bell towers"],
+    ),
 ]
+
+
+# The env names the bench honours for its loop accept floors (A/B lever).
+_BENCH_ACCEPT_ENVS = (
+    "VIEW_BENCH_ACCEPT_CONFORMANCE",
+    "VIEW_BENCH_ACCEPT_SAME_PLACE",
+    "VIEW_BENCH_ACCEPT_DETAIL",
+    "VIEW_BENCH_ACCEPT_MEDIUM",
+)
+
+
+def _bench_loop_config() -> Any:
+    """The bench's LoopConfig. Passing a literal here SHORT-CIRCUITS
+    loop_config_from_env, so the production VIEW_LOOP_ACCEPT_* env never
+    reaches bench runs — accept floors were locked at the dataclass defaults
+    and the two seed cases pass on attempt 0, leaving the retry path (and
+    ENTER_RETRY_MODEL_SWAP) unexercisable. VIEW_BENCH_ACCEPT_* raises the
+    floors for A/Bs that need guaranteed retries; unset env keeps runs
+    byte-identical to the old literal (defaults match the dataclass)."""
+    from providers import render_loop
+
+    return render_loop.LoopConfig(
+        max_attempts=3,
+        accept_conformance=render_loop._env_float(
+            "VIEW_BENCH_ACCEPT_CONFORMANCE", 7.0
+        ),
+        accept_same_place=render_loop._env_float("VIEW_BENCH_ACCEPT_SAME_PLACE", 6.0),
+        accept_detail=render_loop._env_float("VIEW_BENCH_ACCEPT_DETAIL", 6.0),
+        accept_medium=render_loop._env_float("VIEW_BENCH_ACCEPT_MEDIUM", 6.0),
+    )
 
 
 def _selected(name: str, allowed: list[str]) -> list[str]:
@@ -133,6 +192,10 @@ class ArmResult:
     conformance_rationale: str
     # How many loop attempts produced this arm (1 = single-shot, the default).
     attempts: int = 1
+    # Loop mode only: per-attempt judge scores in attempt order, so an A/B can
+    # compare the RETRY attempts (index >= 1) — the only ones a retry-model
+    # swap changes — instead of just the kept-best headline.
+    attempt_scores: list[dict[str, float | None]] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -266,7 +329,7 @@ async def _run_case(case: Case, aspect: str) -> CaseResult:
                 region_bytes=region_bytes,
                 judge_conformance=judge_mod.score_view_conformance,
                 judge_same_place=judge_mod.score_continuation,
-                config=render_loop.LoopConfig(max_attempts=3),
+                config=_bench_loop_config(),
                 judge_detail=_judge_detail,
                 judge_medium=judge_mod.score_style_pair,
                 render_for_attempt=_render_attempt,
@@ -294,6 +357,17 @@ async def _run_case(case: Case, aspect: str) -> CaseResult:
                         best.conformance.rationale if best.conformance else ""
                     ),
                     attempts=len(loop_result.attempts),
+                    attempt_scores=[
+                        {
+                            "conformance": (
+                                att.conformance.score if att.conformance else None
+                            ),
+                            "same_place": (
+                                att.same_place.score if att.same_place else None
+                            ),
+                        }
+                        for att in loop_result.attempts
+                    ],
                 )
             )
             continue
@@ -424,6 +498,10 @@ async def run_bench() -> dict[str, Any]:
         "loop": bool(os.environ.get("VIEW_BENCH_LOOP")),
         "arms_filter": os.environ.get("VIEW_BENCH_ARMS"),
         "cases_filter": os.environ.get("VIEW_BENCH_CASES"),
+        # Receipts: which accept floors this run actually used (A/B lever).
+        "accept_env": {
+            k: os.environ[k] for k in _BENCH_ACCEPT_ENVS if k in os.environ
+        },
         "conform_threshold": _CONFORM_THRESHOLD,
         "same_place_floor": _SAME_PLACE_FLOOR,
         "cases": [asdict(r) for r in results],


### PR DESCRIPTION
Campaign thread 3, part 1 (the free harness half). The 08-03 A/B of `ENTER_RETRY_MODEL_SWAP` came back null: both bench cases pass on attempt 0 (`attempts=1` in every cell), so the retry path — the only thing the swap changes — never ran. Three gaps closed:

1. **Env-tunable accept floors.** The bench passed a literal `LoopConfig(max_attempts=3)` into `run_view_loop`, which short-circuits `loop_config_from_env` — no env could raise the accept floors on bench runs. `_bench_loop_config()` keeps the same defaults (unset env is byte-identical to the old literal) and honours `VIEW_BENCH_ACCEPT_{CONFORMANCE,SAME_PLACE,DETAIL,MEDIUM}` as a deterministic retry-forcing lever. The floors used are stamped into the report (`accept_env`) for receipts. Production `VIEW_LOOP_ACCEPT_*` stays ignored on the bench, as before.
2. **A failing-first case.** `etched_cliff_monastery`: a dense multi-landmark cliffside complex — the 2026-07-21 failure class (oblique enters into *crowded* places scatter framing across retries) — so the retry path has a case that can genuinely fail attempt 0.
3. **Per-attempt scores in the report.** Loop-mode `ArmResult` now carries `attempt_scores` (conformance/same_place per attempt, in order), so an A/B can compare the retry attempts (index ≥ 1) instead of just the kept-best headline.

Free tests pin the config seam: unset env == old literal; production `VIEW_LOOP_ACCEPT_*` still ignored; `VIEW_BENCH_ACCEPT_CONFORMANCE` bites; untouched floors keep defaults. 21 continuity-bench tests green.

The paid off/on A/B runs next from this branch; findings + receipts will land as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)