### PR TITLE
feat(recon-bench): §4 phase 1 — leave-one-out pose probe (does the register generalize?)

### DIFF
--- a/apps/modal-backend/tests/recon_bench/_align.py
+++ b/apps/modal-backend/tests/recon_bench/_align.py
@@ -36,6 +36,13 @@ class Alignment:
         x = (FRAME_W - p[0]) if self.flip_x else p[0]
         return (self.scale * x + self.tx, self.scale * p[1] + self.ty)
 
+    def invert(self, p: Point) -> Point:
+        """Observed frame -> expected (metric) frame — the read-side register:
+        what a recovered coordinate for a fresh detection would be."""
+        x = (p[0] - self.tx) / self.scale
+        y = (p[1] - self.ty) / self.scale
+        return ((FRAME_W - x) if self.flip_x else x, y)
+
 
 def fit_alignment(pairs: list[tuple[Point, Point]]) -> Alignment | None:
     """Least-squares uniform scale + translation over (expected, observed)
@@ -77,6 +84,41 @@ def fit_alignment(pairs: list[tuple[Point, Point]]) -> Alignment | None:
 def _pos_score(dist: float) -> float:
     tol = _POS_TOLERANCE_FRAC * hypot(FRAME_W, FRAME_H)
     return max(0.0, 1.0 - dist / tol)
+
+
+def pose_probe_loo(pairs: list[tuple[Point, Point]]) -> dict[str, float] | None:
+    """§4 phase-1 probe: does the similarity register GENERALIZE?
+
+    pos_aligned fits and scores on the SAME pairs, so it forgives drift but
+    cannot say whether the register would correctly place an entity it was
+    not fitted on — the metric-pose-recovery question (turn a fresh detection
+    into a trustworthy metric coordinate). Leave-one-out: fit on N-1 matched
+    pairs, invert-register the held-out observation into the expected frame,
+    compare that error to the raw error. recovery_gain > 0 (frame units) ⇒
+    read-side recovery is real, not circular. None when <3 pairs (each LOO
+    fit needs the fitter's 2-pair minimum)."""
+    if len(pairs) < 3:
+        return None
+    raw_errs: list[float] = []
+    rec_errs: list[float] = []
+    for i, (e, o) in enumerate(pairs):
+        fit = fit_alignment(pairs[:i] + pairs[i + 1 :])
+        if fit is None:
+            continue
+        r = fit.invert(o)
+        raw_errs.append(hypot(e[0] - o[0], e[1] - o[1]))
+        rec_errs.append(hypot(e[0] - r[0], e[1] - r[1]))
+    if not raw_errs:
+        return None
+    n = len(raw_errs)
+    err_raw = sum(raw_errs) / n
+    err_rec = sum(rec_errs) / n
+    return {
+        "n": float(n),
+        "err_raw": round(err_raw, 2),
+        "err_recovered": round(err_rec, 2),
+        "recovery_gain": round(err_raw - err_rec, 2),
+    }
 
 
 def geo_scores(
@@ -128,6 +170,9 @@ def geo_scores(
         "pos_raw": pos_raw,
         "pos_aligned": pos_aligned,
         "size": size,
+        # §4 diagnostic: leave-one-out generalization of the register (None
+        # when <3 matches). Zero composite weight, like `alignment`.
+        "pose_probe": pose_probe_loo(pairs),
         "alignment": (
             {
                 "scale": round(align.scale, 3),

--- a/apps/modal-backend/tests/recon_bench/runner.py
+++ b/apps/modal-backend/tests/recon_bench/runner.py
@@ -316,6 +316,16 @@ def recon_fns(sweep: dict[str, Any]) -> dict[str, Any]:
             scores["align_ty"] = round(float(align["ty"]), 1)
             scores["align_flip"] = 1.0 if align["flip_x"] else 0.0
         scores["unalignable"] = 1.0 if geo.get("unalignable") else 0.0
+        # §4 phase-1 diagnostic (zero weight): does the fitted register
+        # GENERALIZE to a held-out entity? recovery_gain > 0 (frame units)
+        # means a read-side inverse register would place fresh detections
+        # closer to metric truth than the raw detector output.
+        probe = geo.get("pose_probe")
+        if probe is not None:
+            scores["pose_n"] = probe["n"]
+            scores["pose_err_raw"] = probe["err_raw"]
+            scores["pose_err_recovered"] = probe["err_recovered"]
+            scores["pose_gain"] = probe["recovery_gain"]
         used = {k: w for k, w in weights.items() if k in scores and w > 0}
         if used:
             total = sum(used.values())

--- a/apps/modal-backend/tests/recon_bench/test_recon.py
+++ b/apps/modal-backend/tests/recon_bench/test_recon.py
@@ -8,7 +8,12 @@ from typing import Any
 
 import pytest
 
-from tests.recon_bench._align import Alignment, fit_alignment, geo_scores
+from tests.recon_bench._align import (
+    Alignment,
+    fit_alignment,
+    geo_scores,
+    pose_probe_loo,
+)
 from tests.recon_bench.runner import _expected_layout, corpus_scenarios
 
 # --- alignment fit -----------------------------------------------------------
@@ -47,6 +52,52 @@ def test_fit_clamps_scale_and_needs_two_points() -> None:
 def test_alignment_apply_round_trips() -> None:
     a = Alignment(scale=1.5, tx=-10.0, ty=5.0, flip_x=False, residual=0.0, matched=4)
     assert a.apply((10.0, 10.0)) == (pytest.approx(5.0), pytest.approx(20.0))
+
+
+def test_alignment_invert_undoes_apply_including_flip() -> None:
+    for flip in (False, True):
+        a = Alignment(scale=0.65, tx=12.0, ty=-4.0, flip_x=flip, residual=0.0, matched=4)
+        for p in PTS:
+            x, y = a.invert(a.apply(p))
+            assert (x, y) == (pytest.approx(p[0]), pytest.approx(p[1]))
+
+
+# --- pose probe (§4 phase 1: does the register GENERALIZE?) ------------------
+#
+# pos_aligned fits and scores on the SAME pairs — it forgives drift but can't
+# say whether the register would place an entity it was NOT fitted on (the
+# metric-pose-recovery question). The leave-one-out probe answers that: fit on
+# N-1 matches, invert-register the held-out observation, compare its error to
+# the raw error. recovery_gain > 0 ⇒ read-side recovery is real, not circular.
+
+
+def test_pose_probe_register_drift_recovers() -> None:
+    # The wild drift signature: whole layout rescaled 0.65 + shifted. Raw
+    # errors are huge; the register generalizes so LOO recovery is ~exact.
+    pairs = _pairs(lambda p: (0.65 * p[0] + 12, 0.65 * p[1] + 8), PTS)
+    probe = pose_probe_loo(pairs)
+    assert probe is not None and probe["n"] == 4
+    assert probe["err_raw"] > 10
+    assert probe["err_recovered"] == pytest.approx(0.0, abs=0.1)
+    assert probe["recovery_gain"] > 10
+
+
+def test_pose_probe_scatter_does_not_fake_recovery() -> None:
+    # Unstructured error (each entity off in a different direction) — no
+    # shared register exists, so LOO must NOT report a healthy gain.
+    scatter = [
+        ((10.0, 10.0), (30.0, 50.0)),
+        ((50.0, 30.0), (20.0, 10.0)),
+        ((90.0, 50.0), (60.0, 5.0)),
+        ((30.0, 45.0), (85.0, 20.0)),
+    ]
+    probe = pose_probe_loo(scatter)
+    assert probe is not None
+    assert probe["recovery_gain"] < 5  # no drift structure to exploit
+
+
+def test_pose_probe_needs_three_pairs() -> None:
+    assert pose_probe_loo(_pairs(lambda p: p, PTS[:2])) is None
 
 
 # --- geometric scorecard -----------------------------------------------------


### PR DESCRIPTION
Campaign thread 4, phase 1 of AUDIT_BOX §4 ("metric pose recovery from arbitrary generated images — treat as research").

## The question
`pos_aligned` fits its similarity transform and scores on the **same** label-matched pairs — it *forgives* drift but can't say whether the register would place an entity it was **not** fitted on. That generalization is the actual §4 question: can a read-side inverse register turn a fresh detection into a trustworthy metric coordinate?

## The probe
`Alignment.invert` (observed → expected/metric frame) + `pose_probe_loo`: fit on N−1 matched pairs, invert-register the held-out observation, compare its error to the raw error. Per-cell zero-weight diagnostics (`pose_n/err_raw/err_recovered/gain`), following the `align_*` pattern. 3 new golden tests (invert round-trip incl. flip; clean drift recovers ~exactly; unstructured scatter must NOT fake recovery) + the <3-pairs guard.

## Live phase-1 numbers (`make eval-recon`, $1.02)
Note: the make target hardcodes `RECON_BENCH_RUN=1` (live, not dry — flagging the unplanned spend); cached cells keep stored scores, so probe fields ride only the 4 freshly-billed yellowstone cells:

| fit health | n | mean pose_gain |
|---|---|---|
| clamped (`align_scale=0.5`) | 2 | **−35.0** |
| healthy (~1.1) | 2 | **+0.5** |

**Phase-1 conclusion:** a naive product-side inverse register is *unsafe* on exactly the drift-y cells it would target — inverting a clamp-saturated fit **doubles** the error (÷0.5). Any `POSE_REGISTER_FIX` must gate on fit health (unclamped scale + residual + match count), and even the healthy regime's gain is marginal (~1 frame unit). **Written next step:** richer transform than 2-DOF similarity (rotation/perspective) before any product write — that's phase 2, if wanted.

## Side observation (not this change)
The same run's sweep gate flagged `height_order 0.650 < 0.67` (band floor) — first live `eval-recon` since #189 verified the Yellowstone description into the corpus. Likely needs a corpus-change re-baseline (the #133 precedent); left for a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)