### PR TITLE
feat(view-bench): VIEW_BENCH_RUN_TAG so A/B runs stop clobbering attempt frames

### DIFF
--- a/apps/modal-backend/tests/continuity_bench/test_view.py
+++ b/apps/modal-backend/tests/continuity_bench/test_view.py
@@ -17,8 +17,23 @@ from tests.continuity_bench.view_runner import (
     ArmResult,
     CaseResult,
     _bench_loop_config,
+    _run_tag,
     summarize,
 )
+
+
+def test_run_tag_suffixes_arm_frames_and_sanitizes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Unset = historic untagged names (so VIEW_BENCH_REUSE_ARTIFACTS keeps
+    # working); set = a leading-underscore suffix with path-unsafe chars scrubbed
+    # so an off/on A/B doesn't clobber view_<case>_<arm>_a<i>.jpg.
+    monkeypatch.delenv("VIEW_BENCH_RUN_TAG", raising=False)
+    assert _run_tag() == ""
+    monkeypatch.setenv("VIEW_BENCH_RUN_TAG", "swap off")
+    assert _run_tag() == "_swap-off"
+    monkeypatch.setenv("VIEW_BENCH_RUN_TAG", "a/b.2")
+    assert _run_tag() == "_a-b.2"  # '.', '-' kept; '/' scrubbed
 
 
 def _case(name: str, conf: dict[str, float], same: dict[str, float]) -> CaseResult:

--- a/apps/modal-backend/tests/continuity_bench/view_runner.py
+++ b/apps/modal-backend/tests/continuity_bench/view_runner.py
@@ -184,6 +184,20 @@ def _positioning_probe_on() -> bool:
     )
 
 
+def _run_tag() -> str:
+    """Per-run suffix for ARM output frames (VIEW_BENCH_RUN_TAG) so an off/on
+    A/B keeps both sets instead of the second run clobbering the first
+    (e.g. the ENTER_RETRY_MODEL_SWAP A/B, where both runs wrote
+    view_<case>_<arm>_a<i>.jpg). Empty = the historic untagged names. The base
+    map/region/probe frames stay UNtagged so VIEW_BENCH_REUSE_ARTIFACTS still
+    finds them across runs."""
+    raw = os.environ.get("VIEW_BENCH_RUN_TAG", "").strip()
+    if not raw:
+        return ""
+    safe = "".join(c if (c.isalnum() or c in "._-") else "-" for c in raw)
+    return f"_{safe}"
+
+
 @dataclass(frozen=True)
 class ArmResult:
     arm: str
@@ -335,7 +349,7 @@ async def _run_case(case: Case, aspect: str) -> CaseResult:
                 render_for_attempt=_render_attempt,
             )
             for i, att in enumerate(loop_result.attempts):
-                (_REPORTS / f"view_{case.name}_{arm}_a{i}.jpg").write_bytes(
+                (_REPORTS / f"view_{case.name}_{arm}{_run_tag()}_a{i}.jpg").write_bytes(
                     att.image.jpeg_bytes
                 )
             best = max(
@@ -345,7 +359,7 @@ async def _run_case(case: Case, aspect: str) -> CaseResult:
                     a.same_place.score if a.same_place else -1.0,
                 ),
             )
-            (_REPORTS / f"view_{case.name}_{arm}.jpg").write_bytes(
+            (_REPORTS / f"view_{case.name}_{arm}{_run_tag()}.jpg").write_bytes(
                 loop_result.image.jpeg_bytes
             )
             arms.append(
@@ -498,6 +512,7 @@ async def run_bench() -> dict[str, Any]:
         "loop": bool(os.environ.get("VIEW_BENCH_LOOP")),
         "arms_filter": os.environ.get("VIEW_BENCH_ARMS"),
         "cases_filter": os.environ.get("VIEW_BENCH_CASES"),
+        "run_tag": os.environ.get("VIEW_BENCH_RUN_TAG"),
         # Receipts: which accept floors this run actually used (A/B lever).
         "accept_env": {
             k: os.environ[k] for k in _BENCH_ACCEPT_ENVS if k in os.environ


### PR DESCRIPTION
Small bench-DX fix from the 08-05 findings backlog. The `ENTER_RETRY_MODEL_SWAP` A/B wrote its off and on runs to the same `view_<case>_<arm>_a<i>.jpg` paths, so run 2 clobbered run 1 (the no-op retry frame could only be eyeballed on the ON run).

`VIEW_BENCH_RUN_TAG` inserts a sanitized suffix into the **arm output frames** (per-attempt + kept-best) so both runs survive. Base map/region/probe frames stay **untagged** so `VIEW_BENCH_REUSE_ARTIFACTS` still finds them across runs. The tag is stamped into the report (`run_tag`) for receipts. Unset = byte-identical historic names.

**Held (not changed):** the `ENTER_RETRY_MODEL_SWAP` default stays **off** — the "judge-equivalent" verdict was n=2 on a bench whose same-place judge is blind to the framing axis, so flipping a production default isn't warranted on that evidence.

5 continuity-bench view tests pass (1 new: `_run_tag` unset/set/sanitize).

🤖 Generated with [Claude Code](https://claude.com/claude-code)