### PR TITLE
feat(web): prominent Share button (copy-permalink was a silent right-click action)

### DIFF
--- a/apps/modal-backend/tests/continuity_bench/test_view.py
+++ b/apps/modal-backend/tests/continuity_bench/test_view.py
@@ -17,8 +17,23 @@ from tests.continuity_bench.view_runner import (
     ArmResult,
     CaseResult,
     _bench_loop_config,
+    _run_tag,
     summarize,
 )
+
+
+def test_run_tag_suffixes_arm_frames_and_sanitizes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Unset = historic untagged names (so VIEW_BENCH_REUSE_ARTIFACTS keeps
+    # working); set = a leading-underscore suffix with path-unsafe chars scrubbed
+    # so an off/on A/B doesn't clobber view_<case>_<arm>_a<i>.jpg.
+    monkeypatch.delenv("VIEW_BENCH_RUN_TAG", raising=False)
+    assert _run_tag() == ""
+    monkeypatch.setenv("VIEW_BENCH_RUN_TAG", "swap off")
+    assert _run_tag() == "_swap-off"
+    monkeypatch.setenv("VIEW_BENCH_RUN_TAG", "a/b.2")
+    assert _run_tag() == "_a-b.2"  # '.', '-' kept; '/' scrubbed
 
 
 def _case(name: str, conf: dict[str, float], same: dict[str, float]) -> CaseResult:

--- a/apps/modal-backend/tests/continuity_bench/view_runner.py
+++ b/apps/modal-backend/tests/continuity_bench/view_runner.py
@@ -184,6 +184,20 @@ def _positioning_probe_on() -> bool:
     )
 
 
+def _run_tag() -> str:
+    """Per-run suffix for ARM output frames (VIEW_BENCH_RUN_TAG) so an off/on
+    A/B keeps both sets instead of the second run clobbering the first
+    (e.g. the ENTER_RETRY_MODEL_SWAP A/B, where both runs wrote
+    view_<case>_<arm>_a<i>.jpg). Empty = the historic untagged names. The base
+    map/region/probe frames stay UNtagged so VIEW_BENCH_REUSE_ARTIFACTS still
+    finds them across runs."""
+    raw = os.environ.get("VIEW_BENCH_RUN_TAG", "").strip()
+    if not raw:
+        return ""
+    safe = "".join(c if (c.isalnum() or c in "._-") else "-" for c in raw)
+    return f"_{safe}"
+
+
 @dataclass(frozen=True)
 class ArmResult:
     arm: str
@@ -335,7 +349,7 @@ async def _run_case(case: Case, aspect: str) -> CaseResult:
                 render_for_attempt=_render_attempt,
             )
             for i, att in enumerate(loop_result.attempts):
-                (_REPORTS / f"view_{case.name}_{arm}_a{i}.jpg").write_bytes(
+                (_REPORTS / f"view_{case.name}_{arm}{_run_tag()}_a{i}.jpg").write_bytes(
                     att.image.jpeg_bytes
                 )
             best = max(
@@ -345,7 +359,7 @@ async def _run_case(case: Case, aspect: str) -> CaseResult:
                     a.same_place.score if a.same_place else -1.0,
                 ),
             )
-            (_REPORTS / f"view_{case.name}_{arm}.jpg").write_bytes(
+            (_REPORTS / f"view_{case.name}_{arm}{_run_tag()}.jpg").write_bytes(
                 loop_result.image.jpeg_bytes
             )
             arms.append(
@@ -498,6 +512,7 @@ async def run_bench() -> dict[str, Any]:
         "loop": bool(os.environ.get("VIEW_BENCH_LOOP")),
         "arms_filter": os.environ.get("VIEW_BENCH_ARMS"),
         "cases_filter": os.environ.get("VIEW_BENCH_CASES"),
+        "run_tag": os.environ.get("VIEW_BENCH_RUN_TAG"),
         # Receipts: which accept floors this run actually used (A/B lever).
         "accept_env": {
             k: os.environ[k] for k in _BENCH_ACCEPT_ENVS if k in os.environ

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -478,6 +478,18 @@ export default function PlayPage() {
     const t = setTimeout(() => setWanderNote(null), 6000);
     return () => clearTimeout(t);
   }, [wanderNote]);
+  // Share: copying a permalink used to be a silent right-click-menu action, so
+  // sharing (each /n/ link is a whole explorable world) never happened. A
+  // top-level Share button + this transient confirmation surface it. The copy
+  // itself is inlined at the button + the context-menu (both read the live
+  // `page`, in JSX scope) so there's no cross-scope handler to thread.
+  const [shareNote, setShareNote] = useState<string | null>(null);
+  useEffect(() => {
+    if (!shareNote) return;
+    const t = setTimeout(() => setShareNote(null), 2500);
+    return () => clearTimeout(t);
+  }, [shareNote]);
+  const SHARE_COPIED_NOTE = "Link copied — anyone can open it to explore this world";
   // The click handler closes over state at dispatch time; Wander's synthetic
   // taps must read the LIVE value (withhold zoom routing mid-wander), so
   // mirror it into a ref.
@@ -4071,9 +4083,32 @@ export default function PlayPage() {
       )}
 
       {page?.nodeId && (
-        <p className="text-center text-xs opacity-60">
-          Permalink: <code>/n/{page.nodeId}</code>
-        </p>
+        <div className="flex flex-col items-center gap-1 text-xs">
+          <div className="flex items-center gap-2 opacity-60">
+            <span>
+              Permalink: <code>/n/{page.nodeId}</code>
+            </span>
+            <button
+              type="button"
+              onClick={() => {
+                if (!page?.nodeId) return;
+                void navigator.clipboard?.writeText(
+                  `${window.location.origin}/n/${page.nodeId}`,
+                );
+                setShareNote(SHARE_COPIED_NOTE);
+              }}
+              title="Copy a link anyone can open to explore this world"
+              className="rounded-full border border-[var(--color-ink)]/30 px-2.5 py-0.5 font-medium opacity-100 transition hover:bg-[var(--color-ink)]/10"
+            >
+              🔗 Share
+            </button>
+          </div>
+          {shareNote && (
+            <span role="status" className="text-[var(--color-ink)]/80">
+              {shareNote}
+            </span>
+          )}
+        </div>
       )}
 
       {quickbarOpen && (
@@ -4180,6 +4215,7 @@ export default function PlayPage() {
             if (page?.nodeId) {
               const link = `${window.location.origin}/n/${page.nodeId}`;
               void navigator.clipboard?.writeText(link);
+              setShareNote(SHARE_COPIED_NOTE);
             }
             setContextMenu(null);
           }}


### PR DESCRIPTION
Roadmap I2 (reach). Every `/n/` page **is** a shareable, explorable world — but the only way to share was "Copy permalink" buried in the right-click menu, and it copied **silently** (no confirmation), so sharing basically never happened.

## Change
A top-level **🔗 Share** button next to the permalink line: copies `${origin}/n/${nodeId}` and shows a transient toast — "Link copied — anyone can open it to explore this world" (mirrors the existing `wanderNote` toast pattern). The right-click **Copy permalink** now shows the same toast too. **Additive** — nothing moved or removed (respects the keep-UX-intact rule).

## Verified
- `tsc` clean; **819 web tests pass**.
- **Live on the real-gen stack** (reopened a persisted session via `/play?continue=`): the button renders in the right spot, and clicking it shows the toast (confirmed via DOM). Screenshot placement: `Permalink: /n/… · 🔗 Share`.
- Note: the clipboard *write* can't be read back on the automated (hidden) tab — clipboard read/write is blocked without focus — but `writeText` succeeds on a real focused click (standard secure-context behavior).

## Not included (deliberately)
- No GIF/postcard bundling here — export (GIF/PDF/ZIP), postcard, and publish-to-gallery already exist in the right-click menu; this PR is just about making the cheapest, most-instant share (the permalink) a discoverable one-click with feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)