### PR TITLE
feat(web): always-on Gallery link so the published-worlds feed is discoverable

### DIFF
--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -3343,8 +3343,22 @@ export default function PlayPage() {
         setDomLabels={setWorldDomLabels}
       />
 
-      {worldEnabled && (
-        <div className="-mt-2 flex justify-end">
+      <div className="-mt-2 flex justify-end gap-2">
+        {/* Always-on gallery entrance: the published-worlds feed at /gallery
+            was only reachable AFTER you publish (window.open on success), so a
+            first-time visitor could never discover other people's worlds — the
+            reach loop (explore others → make your own → share) had no front
+            door. Opens in a new tab so an in-progress session isn't lost. */}
+        <a
+          href="/gallery"
+          target="_blank"
+          rel="noopener noreferrer"
+          title="Browse worlds other people have published"
+          className="rounded-full border border-[var(--color-ink)]/25 bg-[var(--color-paper)]/70 px-3 py-1 text-xs font-medium text-[var(--color-ink)]/80 transition hover:bg-[var(--color-ink)]/10"
+        >
+          🖼️ Gallery
+        </a>
+        {worldEnabled && (
           <button
             type="button"
             onClick={() => void planWorld()}
@@ -3354,8 +3368,8 @@ export default function PlayPage() {
           >
             ✍ Describe a place
           </button>
-        </div>
-      )}
+        )}
+      </div>
 
       {isDraggingFile && <DragDropOverlay />}
 


### PR DESCRIPTION
Bigger-bet round, reach axis. The `/gallery` feed (opt-in published sessions — poster grid, links into each world) **already existed and works**, but it was **orphaned**: the only path to it was `window.open("/gallery")` in the publish-success handler, so you could only reach the gallery *after* publishing your own session. A first-time visitor could never discover other people's worlds — the reach loop (explore others → make your own → share) had **no front door**.

## Change
An always-visible **🖼️ Gallery** link in the `/play` top-right (folded into the existing right-aligned row; the World-Mode-only "Describe a place" button is unchanged). Opens in a new tab so an in-progress session isn't lost. One `<a>`, additive — nothing moved or removed.

## Verified live (rebuilt real-gen stack)
- The link renders in the top-right and is present on the **first-run landing** (`onEmptyLanding: true`) — so a brand-new visitor sees it. `href="/gallery"`, `target="_blank"`.
- `/gallery` loads (HTTP 200) and renders — empty-state now ("Nothing published yet…"), the poster grid once sessions are published.
- `tsc` clean; **819 web tests pass**.

Pairs with #197 (the Share button): share makes a world *shareable*, this makes shared worlds *discoverable*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)