### PR TITLE
fix: 4-agent review follow-ups on PRs #189–#198

### DIFF
--- a/apps/modal-backend/providers/judge.py
+++ b/apps/modal-backend/providers/judge.py
@@ -21,6 +21,10 @@ from dataclasses import dataclass
 from typing import Any
 
 _SCORE_RE = re.compile(r"\"score\"\s*:\s*(\d+(?:\.\d+)?)")
+# The one unparseable sentinel. Emitted by _parse_judgement (and the empty-reply
+# default) and the ONLY thing _ask_judge retries on — with the colon-space so a
+# valid reply whose rationale merely starts with the word can't be retried away.
+_UNPARSEABLE_PREFIX = "UNPARSEABLE: "
 
 
 @dataclass(frozen=True)
@@ -117,7 +121,7 @@ def _parse_judgement(raw: str) -> JudgeResult:
             raw_head=cleaned[:120],
             model=_judge_model(),
         )
-        return JudgeResult(score=0.0, rationale=f"UNPARSEABLE: {cleaned[:200]}", raw=cleaned[:500])
+        return JudgeResult(score=0.0, rationale=f"{_UNPARSEABLE_PREFIX}{cleaned[:200]}", raw=cleaned[:500])
     return JudgeResult(score=score, rationale=rationale, raw=cleaned[:500])
 
 
@@ -147,8 +151,10 @@ async def _ask_judge(
     # without raising, so it slips past that retry AND the benches' own
     # exception-only retry — banking a blank reply as a real 0. Re-issue the
     # call when the reply can't be parsed.
+    # NOTE: this is a total-attempts cap (cost bound), not additional retries —
+    # default 3 = up to 3 calls before banking the loud UNPARSEABLE 0.
     attempts = _bounded_int_env("VLM_JUDGE_EMPTY_RETRIES", 3, floor=1, ceiling=5)
-    result = JudgeResult(score=0.0, rationale="UNPARSEABLE: no judge response", raw="")
+    result = JudgeResult(score=0.0, rationale=f"{_UNPARSEABLE_PREFIX}no judge response", raw="")
     for _ in range(attempts):
         response = await llm._create_with_retry(
             client,
@@ -159,7 +165,7 @@ async def _ask_judge(
         )
         raw = response.choices[0].message.content or ""
         result = _parse_judgement(raw)
-        if not result.rationale.startswith("UNPARSEABLE"):
+        if not result.rationale.startswith(_UNPARSEABLE_PREFIX):
             return result
     return result
 

--- a/apps/modal-backend/tests/descent_bench/runner.py
+++ b/apps/modal-backend/tests/descent_bench/runner.py
@@ -118,9 +118,14 @@ async def _score_chain(chain: dict[str, Any], aspect: str) -> dict[str, Any]:
     # without paying to regenerate the same artifacts.
     art = ROOT / "overlays"
     art.mkdir(parents=True, exist_ok=True)
+    # Blind vs named runs generate DIFFERENT with/without images (the prompt
+    # label differs), so tag the reusable artifacts by blind state — else a
+    # `BLIND_LABEL=1 REUSE_ARTIFACTS=1` run silently judges the prior named
+    # images while the report claims blind_label:true. Region is pure geometry.
+    blind_tag = "-blind" if _blind_label() else ""
     region_path = art / f"descent-{chain['child_id']}-region.jpg"
-    with_path = art / f"descent-{chain['child_id']}-with.jpg"
-    without_path = art / f"descent-{chain['child_id']}-without.jpg"
+    with_path = art / f"descent-{chain['child_id']}-with{blind_tag}.jpg"
+    without_path = art / f"descent-{chain['child_id']}-without{blind_tag}.jpg"
     region_path.write_bytes(region)
 
     if (

--- a/apps/modal-backend/tests/recon_bench/test_recon.py
+++ b/apps/modal-backend/tests/recon_bench/test_recon.py
@@ -96,6 +96,23 @@ def test_pose_probe_scatter_does_not_fake_recovery() -> None:
     assert probe["recovery_gain"] < 5  # no drift structure to exploit
 
 
+def test_pose_probe_out_of_clamp_rescale_leaves_residual() -> None:
+    # A coherent rescale whose TRUE scale (3.0) sits outside fit_alignment's
+    # [0.5, 2.0] clamp. The clamp saturates at 2.0 — never the true 3.0 — so the
+    # register can only PARTIALLY recover: err_recovered stays well above 0,
+    # unlike an in-clamp drift which recovers ~exactly (…register_drift_recovers).
+    # (recovery_gain is still large+positive here — clamped-2.0 beats identity —
+    # so gain alone can't flag this; err_recovered is the honest signal.) Pins the
+    # clamp: widen/remove it and err_recovered collapses to ~0 on this case,
+    # faking read-side recovery the product's clamped register can never deliver.
+    pairs = _pairs(lambda p: (3.0 * p[0] + 5, 3.0 * p[1] + 5), PTS)
+    fit = fit_alignment(pairs)
+    assert fit is not None and fit.scale == 2.0  # clamp bites, not the true 3.0
+    probe = pose_probe_loo(pairs)
+    assert probe is not None
+    assert probe["err_recovered"] > 5.0  # partial only; ≈0 if the clamp were gone
+
+
 def test_pose_probe_needs_three_pairs() -> None:
     assert pose_probe_loo(_pairs(lambda p: p, PTS[:2])) is None
 

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -480,9 +480,10 @@ export default function PlayPage() {
   }, [wanderNote]);
   // Share: copying a permalink used to be a silent right-click-menu action, so
   // sharing (each /n/ link is a whole explorable world) never happened. A
-  // top-level Share button + this transient confirmation surface it. The copy
-  // itself is inlined at the button + the context-menu (both read the live
-  // `page`, in JSX scope) so there's no cross-scope handler to thread.
+  // top-level Share button + this transient confirmation surface it. `copyPermalink`
+  // is the one copy path (button + context-menu both call it) and only claims
+  // success after the write resolves — an insecure context (no `navigator.clipboard`)
+  // or a denied/rejected write shows the failure note instead of lying "copied".
   const [shareNote, setShareNote] = useState<string | null>(null);
   useEffect(() => {
     if (!shareNote) return;
@@ -490,6 +491,17 @@ export default function PlayPage() {
     return () => clearTimeout(t);
   }, [shareNote]);
   const SHARE_COPIED_NOTE = "Link copied — anyone can open it to explore this world";
+  const SHARE_COPY_FAILED_NOTE = "Couldn't copy — long-press the link to copy it";
+  const copyPermalink = async (nodeId: string) => {
+    const link = `${window.location.origin}/n/${nodeId}`;
+    try {
+      if (!navigator.clipboard) throw new Error("clipboard unavailable");
+      await navigator.clipboard.writeText(link);
+      setShareNote(SHARE_COPIED_NOTE);
+    } catch {
+      setShareNote(SHARE_COPY_FAILED_NOTE);
+    }
+  };
   // The click handler closes over state at dispatch time; Wander's synthetic
   // taps must read the LIVE value (withhold zoom routing mid-wander), so
   // mirror it into a ref.
@@ -4105,11 +4117,7 @@ export default function PlayPage() {
             <button
               type="button"
               onClick={() => {
-                if (!page?.nodeId) return;
-                void navigator.clipboard?.writeText(
-                  `${window.location.origin}/n/${page.nodeId}`,
-                );
-                setShareNote(SHARE_COPIED_NOTE);
+                if (page?.nodeId) void copyPermalink(page.nodeId);
               }}
               title="Copy a link anyone can open to explore this world"
               className="rounded-full border border-[var(--color-ink)]/30 px-2.5 py-0.5 font-medium opacity-100 transition hover:bg-[var(--color-ink)]/10"
@@ -4226,11 +4234,7 @@ export default function PlayPage() {
           }
           canSavePostcard={!!page?.nodeId}
           onCopyPermalink={() => {
-            if (page?.nodeId) {
-              const link = `${window.location.origin}/n/${page.nodeId}`;
-              void navigator.clipboard?.writeText(link);
-              setShareNote(SHARE_COPIED_NOTE);
-            }
+            if (page?.nodeId) void copyPermalink(page.nodeId);
             setContextMenu(null);
           }}
           onSavePostcard={() => {


### PR DESCRIPTION
Acting on the confirmed findings from a **2-Codex + 2-Claude** review of the last 10 PRs (`716668f..e9d1748`).

## Fixed
- **web(share): the lying copy toast** — one `copyPermalink()` used by both the Share button and the context-menu (was duplicated inline), and it only claims "Link copied" **after** `clipboard.writeText` resolves. Insecure context / denied permission / rejected write now shows a failure note instead of a false success. *(Codex-web med + Claude-simplifier)*
- **judge: retry predicate** — deduped the `UNPARSEABLE` sentinel into `_UNPARSEABLE_PREFIX` and match it **with** the colon-space, so a valid reply whose rationale merely starts with the word can't be retried away. *(Codex-backend)*
- **descent bench: blind-label artifact reuse** — tag reusable with/without artifacts by blind state, so `DESCENT_BENCH_BLIND_LABEL=1 DESCENT_BENCH_REUSE_ARTIFACTS=1` can't silently judge the prior *named* images while the report claims `blind_label:true`. *(Codex-backend med)*
- **recon bench: pose_probe clamped-fit guard** — added the missing test. A coherent out-of-`[0.5,2.0]` rescale saturates the fit at 2.0, so `err_recovered` stays well above 0 (partial recovery only). Pins the clamp: widen/remove it and the test fails. Corrected the reviewer's suggested assertion — `recovery_gain` is large+positive here (clamped-2.0 beats identity), `err_recovered` is the honest signal. *(Claude-test-coverage)*

## Skipped (with reason)
- retries-vs-attempts env **name** — behavior is a correct, cost-bounded attempts cap (default 3); kept the semantics, clarified the comment. Renaming would break the committed contract for no functional gain.
- `nan` accept-floor + non-exact `"interior"` routing — bench-only, require deliberate misuse / typo'd controlled data.

## Verification
- Backend: 38 tests green (`test_recon`, `test_judge_place_match`, `test_continuity_bench`, `test_descent`).
- Web: `tsc --noEmit` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)