### PR TITLE
feat(recon): §4 Step 1 — fit-health-gated recovery metric

### DIFF
--- a/apps/modal-backend/tests/recon_bench/_align.py
+++ b/apps/modal-backend/tests/recon_bench/_align.py
@@ -86,6 +86,53 @@ def _pos_score(dist: float) -> float:
     return max(0.0, 1.0 - dist / tol)
 
 
+# §4 Step 1 — fit-health-gated recovery. Storing inverse-registered coords is only
+# safe when the fit actually explains the drift; a clamped scale (the fitter
+# saturated at 0.5/2.0) or a high residual means it does NOT, and inverting through
+# such a fit can DOUBLE the error (phase-1 probe measured -35 mean gain on clamped
+# fits). Gate: scale STRICTLY inside the clamp, residual small in the EXPECTED
+# (storage) frame, and enough matches to over-determine the 4-DOF similarity.
+# The residual is measured in the storage frame — residual / scale — because
+# `invert` divides by scale, so a compression fit (scale < 1) AMPLIFIES its
+# observed-frame residual by 1/scale on the way back (the recon corpus caught a
+# scale-0.588 cell whose invert wobbled pos_raw -0.009; expected-frame residual
+# flags exactly those noise-amplifying compressions). Fail ⇒ keep raw.
+_RECOVERY_MIN_MATCHED = 3
+_RECOVERY_RESIDUAL_MAX = 0.10 * hypot(FRAME_W, FRAME_H)  # ~11.7 frame units
+
+
+def _fit_is_healthy(align: Alignment) -> bool:
+    return (
+        align.matched >= _RECOVERY_MIN_MATCHED
+        and 0.5 < align.scale < 2.0  # strictly inside the clamp, not saturated
+        and align.residual / align.scale <= _RECOVERY_RESIDUAL_MAX  # expected frame
+    )
+
+
+def gated_recovery(pairs: list[tuple[Point, Point]]) -> dict[str, Any]:
+    """§4 Step 1: score positions AS IF the stored coord were inverse-registered
+    into the metric frame — but only when the fit is healthy enough to trust.
+
+    Fit the similarity on the matches; for each observed detection recover its
+    metric coordinate via `Alignment.invert` and score that against ground truth
+    like pos_raw. On an unhealthy fit (clamped scale / high residual / too few
+    matches) fall back to the RAW observed coord, so recovery is never worse than
+    storing raw — the phase-1 -35 disaster can't reach a stored coord. Zero
+    composite weight: a diagnostic for whether the register is safe to bake into
+    stored coords, and how much pos_raw it would buy where it is."""
+    if not pairs:
+        return {"pos_recovered": 0.0, "gated_on": False}
+    raw = sum(_pos_score(hypot(e[0] - o[0], e[1] - o[1])) for e, o in pairs) / len(pairs)
+    align = fit_alignment(pairs)
+    if align is None or not _fit_is_healthy(align):
+        return {"pos_recovered": round(raw, 4), "gated_on": False}
+    recovered = sum(
+        _pos_score(hypot(*(a - b for a, b in zip(e, align.invert(o), strict=True))))
+        for e, o in pairs
+    ) / len(pairs)
+    return {"pos_recovered": round(recovered, 4), "gated_on": True}
+
+
 def pose_probe_loo(pairs: list[tuple[Point, Point]]) -> dict[str, float] | None:
     """§4 phase-1 probe: does the similarity register GENERALIZE?
 
@@ -145,6 +192,7 @@ def geo_scores(
     pos_raw = sum(
         _pos_score(hypot(e[0] - o[0], e[1] - o[1])) for e, o in pairs
     ) / len(pairs)
+    recovery = gated_recovery(pairs)
 
     align = fit_alignment(pairs)
     if align is None:
@@ -173,6 +221,10 @@ def geo_scores(
         # §4 diagnostic: leave-one-out generalization of the register (None
         # when <3 matches). Zero composite weight, like `alignment`.
         "pose_probe": pose_probe_loo(pairs),
+        # §4 Step 1 diagnostic (zero weight): pos_raw AS IF stored coords were
+        # inverse-registered — but only where the fit is trustworthy (else raw).
+        "pos_recovered": recovery["pos_recovered"],
+        "recovery_gated_on": recovery["gated_on"],
         "alignment": (
             {
                 "scale": round(align.scale, 3),

--- a/apps/modal-backend/tests/recon_bench/runner.py
+++ b/apps/modal-backend/tests/recon_bench/runner.py
@@ -326,6 +326,12 @@ def recon_fns(sweep: dict[str, Any]) -> dict[str, Any]:
             scores["pose_err_raw"] = probe["err_raw"]
             scores["pose_err_recovered"] = probe["err_recovered"]
             scores["pose_gain"] = probe["recovery_gain"]
+        # §4 Step 1 (zero weight): pos_raw AS IF we STORED inverse-registered
+        # coords, gated to healthy fits. recovery_gated_on=1 marks the cells where
+        # the register is safe to bake in; pos_recovered ≥ pos_raw there.
+        if "pos_recovered" in geo:
+            scores["pos_recovered"] = round(float(geo["pos_recovered"]), 3)
+            scores["recovery_gated_on"] = 1.0 if geo.get("recovery_gated_on") else 0.0
         used = {k: w for k, w in weights.items() if k in scores and w > 0}
         if used:
             total = sum(used.values())

--- a/apps/modal-backend/tests/recon_bench/test_recon.py
+++ b/apps/modal-backend/tests/recon_bench/test_recon.py
@@ -4,13 +4,16 @@ the expected-layout builder produces correct bins + height ratios, and
 corpus scenario resolution honours the verified-only contract."""
 from __future__ import annotations
 
+from math import hypot
 from typing import Any
 
 import pytest
 
 from tests.recon_bench._align import (
     Alignment,
+    _pos_score,
     fit_alignment,
+    gated_recovery,
     geo_scores,
     pose_probe_loo,
 )
@@ -21,6 +24,10 @@ from tests.recon_bench.runner import _expected_layout, corpus_scenarios
 
 def _pairs(transform, pts: list[tuple[float, float]]):
     return [(p, transform(p)) for p in pts]
+
+
+def _pos(e: tuple[float, float], o: tuple[float, float]) -> float:
+    return _pos_score(hypot(e[0] - o[0], e[1] - o[1]))
 
 
 PTS = [(10.0, 10.0), (50.0, 30.0), (90.0, 50.0), (30.0, 45.0)]
@@ -115,6 +122,83 @@ def test_pose_probe_out_of_clamp_rescale_leaves_residual() -> None:
 
 def test_pose_probe_needs_three_pairs() -> None:
     assert pose_probe_loo(_pairs(lambda p: p, PTS[:2])) is None
+
+
+# --- §4 Step 1: fit-health-gated recovery ------------------------------------
+#
+# gated_recovery scores positions AS IF the stored coord were inverse-registered
+# into the metric frame — but ONLY when the fit is trustworthy (scale strictly
+# in-clamp, low residual, ≥3 matches). On an unhealthy fit it must fall back to
+# the raw coord, so recovery is never worse than storing raw (the phase-1 -35
+# clamped-fit disaster can never reach a stored coord).
+
+
+def test_gated_recovery_healthy_drift_beats_raw() -> None:
+    # A clean in-clamp similarity drift (scale 0.65 + shift, residual ~0): the
+    # gate opens and inverse-registering recovers the metric coords ~exactly, so
+    # pos_recovered clears pos_raw.
+    pairs = _pairs(lambda p: (0.65 * p[0] + 18, 0.65 * p[1] + 14), PTS)
+    raw = sum(_pos(e, o) for e, o in pairs) / len(pairs)
+    rec = gated_recovery(pairs)
+    assert rec["gated_on"] is True
+    assert rec["pos_recovered"] > raw
+    assert rec["pos_recovered"] == pytest.approx(1.0, abs=0.02)
+
+
+def test_gated_recovery_clamped_scale_gates_off() -> None:
+    # True scale 3.0 saturates the fitter at 2.0 — inverting through the wrong
+    # scale is the -35 hazard, so the gate stays SHUT and pos_recovered == raw.
+    pairs = _pairs(lambda p: (3.0 * p[0] + 5, 3.0 * p[1] + 5), PTS)
+    raw = sum(_pos(e, o) for e, o in pairs) / len(pairs)
+    rec = gated_recovery(pairs)
+    assert rec["gated_on"] is False
+    assert rec["pos_recovered"] == round(raw, 4)  # gates off ⇒ raw, unrounded-safe
+
+
+def test_gated_recovery_high_residual_gates_off() -> None:
+    # In-range scale (~1) but the layout doesn't fit ANY global similarity
+    # (per-point noise ~21 units > the residual gate): don't trust the invert.
+    noisy = [
+        ((10.0, 10.0), (25.0, -5.0)),
+        ((50.0, 30.0), (35.0, 45.0)),
+        ((90.0, 50.0), (105.0, 35.0)),
+        ((30.0, 45.0), (15.0, 60.0)),
+    ]
+    fit = fit_alignment(noisy)
+    assert fit is not None and 0.5 < fit.scale < 2.0 and fit.residual > 11.7
+    raw = sum(_pos(e, o) for e, o in noisy) / len(noisy)
+    rec = gated_recovery(noisy)
+    assert rec["gated_on"] is False
+    assert rec["pos_recovered"] == round(raw, 4)  # gates off ⇒ raw, unrounded-safe
+
+
+def test_gated_recovery_too_few_matches_gates_off() -> None:
+    # A perfect 2-point drift still can't be trusted (2 matches only exactly
+    # determine the 4-DOF fit — no residual left to expose overfit).
+    pairs = _pairs(lambda p: (0.65 * p[0] + 12, 0.65 * p[1] + 8), PTS[:2])
+    raw = sum(_pos(e, o) for e, o in pairs) / len(pairs)
+    rec = gated_recovery(pairs)
+    assert rec["gated_on"] is False
+    assert rec["pos_recovered"] == round(raw, 4)  # gates off ⇒ raw, unrounded-safe
+
+
+def test_gated_recovery_empty() -> None:
+    assert gated_recovery([]) == {"pos_recovered": 0.0, "gated_on": False}
+
+
+def test_gate_uses_expected_frame_residual() -> None:
+    # invert divides by scale, so a compression fit (scale<1) amplifies its
+    # observed residual by 1/scale in the storage frame. Gate on residual/scale:
+    # the SAME observed residual is healthy at scale 1 but not when compressed.
+    # (This is the recon-corpus scale-0.588 cell that wobbled pos_raw -0.009.)
+    from tests.recon_bench._align import _RECOVERY_RESIDUAL_MAX as MAX
+    from tests.recon_bench._align import _fit_is_healthy
+
+    resid = 0.9 * MAX  # comfortably under the cap in the OBSERVED frame
+    ok = Alignment(scale=1.0, tx=0, ty=0, flip_x=False, residual=resid, matched=4)
+    bad = Alignment(scale=0.6, tx=0, ty=0, flip_x=False, residual=resid, matched=4)
+    assert _fit_is_healthy(ok) is True  # 0.9*MAX / 1.0 <= MAX
+    assert _fit_is_healthy(bad) is False  # 0.9*MAX / 0.6 = 1.5*MAX > MAX
 
 
 # --- geometric scorecard -----------------------------------------------------


### PR DESCRIPTION
Phase 2 of §4 metric pose-recovery (the moat bet). Builds on the phase-1 probe (#195).

## The gap
Generated-image detections are stored in **relative** coords, not metric. `pos_aligned` (~0.7) proves the layout IS recoverable; `pos_raw` (~0.43) shows we store it un-registered. Phase 1 learned the hard constraint: the **naive inverse register is unsafe** — inverting a *clamped* fit doubles the error (−35 mean gain). Step 1 makes recovery safe and **measures** it.

## What this adds
- **`gated_recovery(pairs)`** (`_align.py`): scores positions AS IF the stored coord were inverse-registered into the metric frame — but only when the fit is **healthy**: scale strictly inside the `(0.5, 2.0)` clamp, ≥3 matches, and residual small **in the expected (storage) frame**. Otherwise keep raw (never worse). Reuses `fit_alignment` / `Alignment.invert` / `_pos_score` — no new geometry.
- `geo_scores` returns `pos_recovered` + `recovery_gated_on`; the runner surfaces them at **zero composite weight** (a diagnostic, like `pose_probe` / `alignment`).
- Golden tests: healthy drift beats raw; clamped / high-residual / <3-matches gate off (== raw); and the expected-frame residual gate (`÷scale`) is pinned.

## Measured — `make eval-recon`, 16 cached corpus cells ($0 new spend, re-scored offline through the gate)
| gated-ON cell | pos_raw | → pos_recovered | Δ |
|---|---|---|---|
| fantasy-treasure-island / graph | 0.704 | 0.787 | **+0.083** |
| fantasy-treasure-island / direct | 0.655 | 0.754 | **+0.099** |
| forest-yellowstone / direct (v1) | 0.561 | 0.664 | **+0.103** |
| forest-yellowstone / direct (v2) | 0.605 | 0.689 | **+0.084** |

4 cells gate ON (mean **+0.092**, min +0.083), 12 gate off (== raw). Every clamped-scale cell (the −35 hazard) correctly gates off.

## What the corpus caught that synthetic tests couldn't
A scale-**0.588** *compression* cell passed a naive residual gate, but its `invert` **amplified** noise (×1/scale), wobbling pos_raw **−0.009**. Fix: gate on residual **in the storage frame** (`residual / scale`), which flags exactly those noise-amplifying compressions. After it, every gated cell is monotone-safe.

## Safety / scope
- Default-off by construction (zero composite weight, diagnostic only).
- `pos_raw` baseline (0.434) and composite (0.713) both still PASS. (`height_order` regression on this run is the known stale-yellowstone-cell false alarm, pre-existing, unrelated.)
- Next: **Step 2** adds rotation to the fit; **Step 3** wires this to production behind `POSE_REGISTER_FIX`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)