### PR TITLE
feat(recon): §4 Step 2 — relax recovery scale floor to reach coherent ½-scale maps

### DIFF
--- a/apps/modal-backend/tests/recon_bench/_align.py
+++ b/apps/modal-backend/tests/recon_bench/_align.py
@@ -44,10 +44,14 @@ class Alignment:
         return ((FRAME_W - x) if self.flip_x else x, y)
 
 
-def fit_alignment(pairs: list[tuple[Point, Point]]) -> Alignment | None:
+def fit_alignment(
+    pairs: list[tuple[Point, Point]], *, min_scale: float = 0.5
+) -> Alignment | None:
     """Least-squares uniform scale + translation over (expected, observed)
     centre pairs; tries the x-flipped register too and keeps the lower
-    residual. None when <2 pairs (nothing to anchor)."""
+    residual. None when <2 pairs (nothing to anchor). `min_scale` is the lower
+    scale clamp (default 0.5, the pos_aligned register); recovery re-fits with a
+    lower floor to reach coherent deep compressions (see gated_recovery)."""
     if len(pairs) < 2:
         return None
     best: Alignment | None = None
@@ -65,7 +69,7 @@ def fit_alignment(pairs: list[tuple[Point, Point]]) -> Alignment | None:
         )
         den = sum((e[0] - ex) ** 2 + (e[1] - ey) ** 2 for e in exp)
         s = num / den if den > 1e-9 else 1.0
-        s = max(0.5, min(2.0, s))
+        s = max(min_scale, min(2.0, s))
         tx = ox - s * ex
         ty = oy - s * ey
         residual = (
@@ -86,25 +90,34 @@ def _pos_score(dist: float) -> float:
     return max(0.0, 1.0 - dist / tol)
 
 
-# §4 Step 1 — fit-health-gated recovery. Storing inverse-registered coords is only
-# safe when the fit actually explains the drift; a clamped scale (the fitter
-# saturated at 0.5/2.0) or a high residual means it does NOT, and inverting through
-# such a fit can DOUBLE the error (phase-1 probe measured -35 mean gain on clamped
-# fits). Gate: scale STRICTLY inside the clamp, residual small in the EXPECTED
+# §4 fit-health-gated recovery. Storing inverse-registered coords is only safe
+# when the fit actually explains the drift; a saturated scale (fitter pinned the
+# clamp) or a high residual means it does NOT, and inverting through such a fit
+# can DOUBLE the error (phase-1 probe measured -35 mean gain on clamped fits).
+# Gate: scale STRICTLY inside the recovery range, residual small in the EXPECTED
 # (storage) frame, and enough matches to over-determine the 4-DOF similarity.
+#
 # The residual is measured in the storage frame — residual / scale — because
 # `invert` divides by scale, so a compression fit (scale < 1) AMPLIFIES its
 # observed-frame residual by 1/scale on the way back (the recon corpus caught a
 # scale-0.588 cell whose invert wobbled pos_raw -0.009; expected-frame residual
-# flags exactly those noise-amplifying compressions). Fail ⇒ keep raw.
+# flags exactly those noise-amplifying compressions). This gate SELF-TIGHTENS as
+# scale drops: at 0.40 it admits only observed residual ≤ 0.40·MAX ≈ 4.7 — a very
+# coherent fit — which is what lets the floor go below the pos_aligned clamp.
+#
+# _RECOVERY_MIN_SCALE (0.40) < the pos_aligned register floor (0.5): the recon
+# corpus draws some maps (Schiaparelli's Mars) at a coherent ~½ scale that pins
+# the 0.5 clamp; re-fitting recovery down to 0.40 reaches them (pos_raw 0.05→0.62)
+# while the residual gate keeps the scrambled cells (yellowstone/village) out.
 _RECOVERY_MIN_MATCHED = 3
+_RECOVERY_MIN_SCALE = 0.40
 _RECOVERY_RESIDUAL_MAX = 0.10 * hypot(FRAME_W, FRAME_H)  # ~11.7 frame units
 
 
 def _fit_is_healthy(align: Alignment) -> bool:
     return (
         align.matched >= _RECOVERY_MIN_MATCHED
-        and 0.5 < align.scale < 2.0  # strictly inside the clamp, not saturated
+        and _RECOVERY_MIN_SCALE < align.scale < 2.0  # strictly inside, not saturated
         and align.residual / align.scale <= _RECOVERY_RESIDUAL_MAX  # expected frame
     )
 
@@ -123,7 +136,7 @@ def gated_recovery(pairs: list[tuple[Point, Point]]) -> dict[str, Any]:
     if not pairs:
         return {"pos_recovered": 0.0, "gated_on": False}
     raw = sum(_pos_score(hypot(e[0] - o[0], e[1] - o[1])) for e, o in pairs) / len(pairs)
-    align = fit_alignment(pairs)
+    align = fit_alignment(pairs, min_scale=_RECOVERY_MIN_SCALE)
     if align is None or not _fit_is_healthy(align):
         return {"pos_recovered": round(raw, 4), "gated_on": False}
     recovered = sum(

--- a/apps/modal-backend/tests/recon_bench/test_recon.py
+++ b/apps/modal-backend/tests/recon_bench/test_recon.py
@@ -201,6 +201,21 @@ def test_gate_uses_expected_frame_residual() -> None:
     assert _fit_is_healthy(bad) is False  # 0.9*MAX / 0.6 = 1.5*MAX > MAX
 
 
+def test_gated_recovery_reaches_coherent_deep_compression() -> None:
+    # A COHERENT ~0.45-scale compression (Schiaparelli's Mars is drawn at ~half
+    # size): the pos_aligned register (floor 0.5) clamps it away, but recovery
+    # re-fits down to _RECOVERY_MIN_SCALE=0.40, reaches the true scale, and the
+    # near-zero residual clears the (self-tightening) expected-frame gate — the
+    # recon corpus went pos_raw 0.05 -> 0.62 on exactly this shape.
+    pairs = _pairs(lambda p: (0.45 * p[0] + 30, 0.45 * p[1] + 18), PTS)
+    assert fit_alignment(pairs).scale == 0.5  # default floor 0.5 clamps it away
+    raw = sum(_pos(e, o) for e, o in pairs) / len(pairs)
+    rec = gated_recovery(pairs)
+    assert rec["gated_on"] is True  # recovery's 0.40 floor reaches scale 0.45
+    assert rec["pos_recovered"] > raw + 0.3  # a big lift, not a wobble
+    assert rec["pos_recovered"] == pytest.approx(1.0, abs=0.02)
+
+
 # --- geometric scorecard -----------------------------------------------------
 
 


### PR DESCRIPTION
Phase 2 of §4 metric pose-recovery. **Pivoted from the planned "add rotation"** after the recon diagnosis showed rotation was aimed at a problem that isn't there.

## Why not rotation
Pulling the *unclamped* best-fit scale for every clamped cell showed the hard cells split cleanly, and **none are rotated**:

| cell | true scale | extent ratio | read |
|---|---|---|---|
| mars / graph+direct | 0.42–0.49 | 0.46–0.64 | scale **and** extent agree ~½ → **coherent half-scale** |
| yellowstone / graph | 0.11–0.29 | 1.13 | scale ≪ extent → **scrambled positions** |
| village / graph+direct | 0.25–0.59 | 0.70–0.95 | scale ≪ extent → **partial scatter** |

The compressed cells (Mars is literally drawn at ~half size) **are** recoverable — Step 1's gate only rejected them because they pin the 0.5 register clamp. The scrambled cells aren't a register problem at all (no similarity — rotation, homography, nothing — reorders scrambled points); they're a generation/extraction-quality issue, out of scope here.

## Change
- `fit_alignment` gains a keyword-only `min_scale` (**default 0.5 — byte-identical for `pos_aligned` and every existing caller**). `gated_recovery` re-fits at `_RECOVERY_MIN_SCALE = 0.40`; the health gate's scale check follows.
- Safety rides entirely on the **expected-frame residual gate** (`residual / scale`), which self-tightens as scale drops: at 0.40 it admits only observed residual ≤ 0.40·MAX ≈ 4.7 — a very coherent fit. So a deep compression must be *clean* (Mars) to pass; scrambled cells stay out. Floors of 0.33/0.25 recover nothing more, so 0.40 is the least relaxation that claims the signal.

## Measured — `make eval-recon` corpus, re-scored through committed `geo_scores`
| gated-ON cell | pos_raw | → recovered | Δ |
|---|---|---|---|
| fantasy / graph | 0.704 | 0.787 | +0.083 |
| fantasy / direct | 0.655 | 0.754 | +0.099 |
| yellowstone / direct v1 | 0.561 | 0.664 | +0.103 |
| yellowstone / direct v2 | 0.605 | 0.689 | +0.084 |
| **mars / graph** | **0.059** | **0.623** | **+0.564** |
| **mars / direct** | **0.051** | **0.669** | **+0.619** |

gated-ON **4 → 6 / 16**, mean pos_raw lift **+0.092 → +0.259**, min **+0.083** (still **monotone-safe** — zero negative gated lifts).

## Safety / scope
- Still default-off (zero composite weight, diagnostic only).
- `pos_aligned` / composite (0.713) / pos_raw (0.434) baselines **unchanged** — the default register floor stays 0.5; only recovery re-fits lower.
- 24 golden tests green (added: coherent deep-compression recovers where the 0.5 floor clamps it away). `height_order` regression on the run is the known stale-yellowstone false alarm, unrelated.
- Next: **Step 3** extracts the fit + gated-recovery into a prod module behind `POSE_REGISTER_FIX`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)