### PR TITLE
refactor(recon): §4 Step 3a — extract the register into a prod-importable module

### DIFF
--- a/apps/modal-backend/providers/register.py
+++ b/apps/modal-backend/providers/register.py
@@ -1,0 +1,149 @@
+"""Coordinate-frame register: fit a similarity between two frames + the fit-health
+gate that says when the fit is safe to trust. Pure, golden-tested.
+
+A regenerated (or re-detected) map can have the right RELATIVE layout while the
+whole composition shifts or rescales — a render-register difference, not a
+reconstruction failure. `fit_alignment` recovers that similarity (uniform scale
++ translation, optionally x-flipped, NO rotation — maps are upright);
+`Alignment.invert` maps an observed coordinate back into the expected (storage)
+frame. Recovery is only SAFE when the fit is healthy (`_fit_is_healthy`) — a
+saturated scale or a high residual means the similarity does not explain the
+drift, and inverting through it amplifies error.
+
+Prod home (§4 pose recovery): the recon bench scores with this
+(tests/recon_bench/_align.py re-exports); the extract seam registers detections
+onto the persistent world with it. Single source — no duplicate geometry.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import hypot
+
+FRAME_W = 100.0
+FRAME_H = 60.0
+
+Point = tuple[float, float]
+
+
+@dataclass(frozen=True)
+class Alignment:
+    scale: float
+    tx: float
+    ty: float
+    flip_x: bool
+    residual: float  # RMS distance after transform, frame units
+    matched: int
+
+    def apply(self, p: Point) -> Point:
+        x = (FRAME_W - p[0]) if self.flip_x else p[0]
+        return (self.scale * x + self.tx, self.scale * p[1] + self.ty)
+
+    def invert(self, p: Point) -> Point:
+        """Observed frame -> expected (storage) frame — the read-side register:
+        what a recovered coordinate for a fresh detection would be."""
+        x = (p[0] - self.tx) / self.scale
+        y = (p[1] - self.ty) / self.scale
+        return ((FRAME_W - x) if self.flip_x else x, y)
+
+
+def fit_alignment(
+    pairs: list[tuple[Point, Point]], *, min_scale: float = 0.5
+) -> Alignment | None:
+    """Least-squares uniform scale + translation over (expected, observed)
+    centre pairs; tries the x-flipped register too and keeps the lower
+    residual. None when <2 pairs (nothing to anchor). `min_scale` is the lower
+    scale clamp (default 0.5, the pos_aligned register); recovery re-fits with a
+    lower floor to reach coherent deep compressions (see register_positions)."""
+    if len(pairs) < 2:
+        return None
+    best: Alignment | None = None
+    for flip in (False, True):
+        exp = [((FRAME_W - e[0]) if flip else e[0], e[1]) for e, _ in pairs]
+        obs = [o for _, o in pairs]
+        n = len(pairs)
+        ex = sum(p[0] for p in exp) / n
+        ey = sum(p[1] for p in exp) / n
+        ox = sum(p[0] for p in obs) / n
+        oy = sum(p[1] for p in obs) / n
+        num = sum(
+            (e[0] - ex) * (o[0] - ox) + (e[1] - ey) * (o[1] - oy)
+            for e, o in zip(exp, obs, strict=True)
+        )
+        den = sum((e[0] - ex) ** 2 + (e[1] - ey) ** 2 for e in exp)
+        s = num / den if den > 1e-9 else 1.0
+        s = max(min_scale, min(2.0, s))
+        tx = ox - s * ex
+        ty = oy - s * ey
+        residual = (
+            sum(
+                (s * e[0] + tx - o[0]) ** 2 + (s * e[1] + ty - o[1]) ** 2
+                for e, o in zip(exp, obs, strict=True)
+            )
+            / n
+        ) ** 0.5
+        cand = Alignment(s, tx, ty, flip, residual, n)
+        if best is None or cand.residual < best.residual:
+            best = cand
+    return best
+
+
+# §4 fit-health gate. Storing inverse-registered coords is only safe when the fit
+# actually explains the drift; a saturated scale (fitter pinned the clamp) or a
+# high residual means it does NOT, and inverting through such a fit can DOUBLE the
+# error (phase-1 probe measured -35 mean gain on clamped fits). Gate: scale
+# STRICTLY inside the recovery range, residual small in the EXPECTED (storage)
+# frame, and enough matches to over-determine the 4-DOF similarity.
+#
+# The residual is measured in the storage frame — residual / scale — because
+# `invert` divides by scale, so a compression fit (scale < 1) AMPLIFIES its
+# observed-frame residual by 1/scale on the way back (the recon corpus caught a
+# scale-0.588 cell whose invert wobbled pos_raw -0.009; expected-frame residual
+# flags exactly those noise-amplifying compressions). This gate SELF-TIGHTENS as
+# scale drops: at 0.40 it admits only observed residual ≤ 0.40·MAX ≈ 4.7 — a very
+# coherent fit — which is what lets the floor go below the pos_aligned clamp.
+#
+# _RECOVERY_MIN_SCALE (0.40) < the pos_aligned register floor (0.5): the recon
+# corpus draws some maps (Schiaparelli's Mars) at a coherent ~½ scale that pins
+# the 0.5 clamp; re-fitting recovery down to 0.40 reaches them (pos_raw 0.05→0.62)
+# while the residual gate keeps the scrambled cells (yellowstone/village) out.
+_RECOVERY_MIN_MATCHED = 3
+_RECOVERY_MIN_SCALE = 0.40
+_RECOVERY_RESIDUAL_MAX = 0.10 * hypot(FRAME_W, FRAME_H)  # ~11.7 frame units
+
+
+def _fit_is_healthy(align: Alignment) -> bool:
+    return (
+        align.matched >= _RECOVERY_MIN_MATCHED
+        and _RECOVERY_MIN_SCALE < align.scale < 2.0  # strictly inside, not saturated
+        and align.residual / align.scale <= _RECOVERY_RESIDUAL_MAX  # expected frame
+    )
+
+
+def register_positions(
+    expected: dict[str, Point],
+    detected: dict[str, Point],
+) -> dict[str, Point] | None:
+    """Snap a fresh render's detected positions onto the persistent-world frame.
+
+    The §4 read-side use of the register: `expected` is where entities already
+    live in the stored world, `detected` is this render's read of the same
+    scene. Fit the similarity on the labels present in BOTH; if the fit is
+    healthy, return ALL detected positions inverse-registered into the world
+    frame — recurring AND new, so one transform places the whole render
+    consistently (a re-render's global scale/shift drift is corrected; the
+    relative layout the detector found is kept). None when too few labels match
+    or the fit isn't trustworthy — the caller then keeps the raw detections
+    (recovery is never worse than storing raw; the phase-1 -35 clamped-fit
+    hazard can't reach a stored coord).
+
+    Positions are in frame units (x_pct * FRAME_W, y_pct * FRAME_H); the caller
+    converts to/from its 0-1 normalized coords.
+    """
+    matched = sorted(set(expected) & set(detected))
+    if len(matched) < _RECOVERY_MIN_MATCHED:
+        return None
+    pairs = [(expected[k], detected[k]) for k in matched]
+    align = fit_alignment(pairs, min_scale=_RECOVERY_MIN_SCALE)
+    if align is None or not _fit_is_healthy(align):
+        return None
+    return {label: align.invert(pos) for label, pos in detected.items()}

--- a/apps/modal-backend/tests/recon_bench/_align.py
+++ b/apps/modal-backend/tests/recon_bench/_align.py
@@ -1,125 +1,34 @@
-"""Coordinate-frame alignment + geometric scoring. Pure, golden-tested.
+"""Geometric SCORING for the recon bench. Pure, golden-tested.
 
-A regenerated map can have the right RELATIVE layout while the whole
-composition shifts or rescales — that is a render-register difference, not
-a reconstruction failure. So we score positions twice: `pos_raw` (absolute
-placement in the shared frame) and `pos_aligned` (after fitting a
-similarity transform: uniform scale 0.5..2 + translation, optionally
-x-flipped, NO rotation — maps are upright). Fewer than 2 label matches
-can't anchor a transform → aligned := raw, flagged unalignable.
+The coordinate-frame register — Alignment, fit_alignment, and the fit-health
+gate — moved to providers.register (the prod-importable source the extract seam
+shares; single source, no duplicate geometry). This module keeps the bench-only
+scoring on top: `pos_raw` (absolute placement in the shared frame) and
+`pos_aligned` (after the fitted similarity), the fit-health-gated recovery
+diagnostic, the leave-one-out pose probe, and the full geo scorecard.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
 from math import hypot, log2
 from typing import Any
 
-FRAME_W = 100.0
-FRAME_H = 60.0
+from providers.register import (
+    _RECOVERY_MIN_SCALE,
+    FRAME_H,
+    FRAME_W,
+    Point,
+    _fit_is_healthy,
+    fit_alignment,
+)
+
 # A matched entity scores 0 when it lands this fraction of the frame
 # diagonal away from ground truth (linear falloff in between).
 _POS_TOLERANCE_FRAC = 0.25
-
-Point = tuple[float, float]
-
-
-@dataclass(frozen=True)
-class Alignment:
-    scale: float
-    tx: float
-    ty: float
-    flip_x: bool
-    residual: float  # RMS distance after transform, frame units
-    matched: int
-
-    def apply(self, p: Point) -> Point:
-        x = (FRAME_W - p[0]) if self.flip_x else p[0]
-        return (self.scale * x + self.tx, self.scale * p[1] + self.ty)
-
-    def invert(self, p: Point) -> Point:
-        """Observed frame -> expected (metric) frame — the read-side register:
-        what a recovered coordinate for a fresh detection would be."""
-        x = (p[0] - self.tx) / self.scale
-        y = (p[1] - self.ty) / self.scale
-        return ((FRAME_W - x) if self.flip_x else x, y)
-
-
-def fit_alignment(
-    pairs: list[tuple[Point, Point]], *, min_scale: float = 0.5
-) -> Alignment | None:
-    """Least-squares uniform scale + translation over (expected, observed)
-    centre pairs; tries the x-flipped register too and keeps the lower
-    residual. None when <2 pairs (nothing to anchor). `min_scale` is the lower
-    scale clamp (default 0.5, the pos_aligned register); recovery re-fits with a
-    lower floor to reach coherent deep compressions (see gated_recovery)."""
-    if len(pairs) < 2:
-        return None
-    best: Alignment | None = None
-    for flip in (False, True):
-        exp = [((FRAME_W - e[0]) if flip else e[0], e[1]) for e, _ in pairs]
-        obs = [o for _, o in pairs]
-        n = len(pairs)
-        ex = sum(p[0] for p in exp) / n
-        ey = sum(p[1] for p in exp) / n
-        ox = sum(p[0] for p in obs) / n
-        oy = sum(p[1] for p in obs) / n
-        num = sum(
-            (e[0] - ex) * (o[0] - ox) + (e[1] - ey) * (o[1] - oy)
-            for e, o in zip(exp, obs, strict=True)
-        )
-        den = sum((e[0] - ex) ** 2 + (e[1] - ey) ** 2 for e in exp)
-        s = num / den if den > 1e-9 else 1.0
-        s = max(min_scale, min(2.0, s))
-        tx = ox - s * ex
-        ty = oy - s * ey
-        residual = (
-            sum(
-                (s * e[0] + tx - o[0]) ** 2 + (s * e[1] + ty - o[1]) ** 2
-                for e, o in zip(exp, obs, strict=True)
-            )
-            / n
-        ) ** 0.5
-        cand = Alignment(s, tx, ty, flip, residual, n)
-        if best is None or cand.residual < best.residual:
-            best = cand
-    return best
 
 
 def _pos_score(dist: float) -> float:
     tol = _POS_TOLERANCE_FRAC * hypot(FRAME_W, FRAME_H)
     return max(0.0, 1.0 - dist / tol)
-
-
-# §4 fit-health-gated recovery. Storing inverse-registered coords is only safe
-# when the fit actually explains the drift; a saturated scale (fitter pinned the
-# clamp) or a high residual means it does NOT, and inverting through such a fit
-# can DOUBLE the error (phase-1 probe measured -35 mean gain on clamped fits).
-# Gate: scale STRICTLY inside the recovery range, residual small in the EXPECTED
-# (storage) frame, and enough matches to over-determine the 4-DOF similarity.
-#
-# The residual is measured in the storage frame — residual / scale — because
-# `invert` divides by scale, so a compression fit (scale < 1) AMPLIFIES its
-# observed-frame residual by 1/scale on the way back (the recon corpus caught a
-# scale-0.588 cell whose invert wobbled pos_raw -0.009; expected-frame residual
-# flags exactly those noise-amplifying compressions). This gate SELF-TIGHTENS as
-# scale drops: at 0.40 it admits only observed residual ≤ 0.40·MAX ≈ 4.7 — a very
-# coherent fit — which is what lets the floor go below the pos_aligned clamp.
-#
-# _RECOVERY_MIN_SCALE (0.40) < the pos_aligned register floor (0.5): the recon
-# corpus draws some maps (Schiaparelli's Mars) at a coherent ~½ scale that pins
-# the 0.5 clamp; re-fitting recovery down to 0.40 reaches them (pos_raw 0.05→0.62)
-# while the residual gate keeps the scrambled cells (yellowstone/village) out.
-_RECOVERY_MIN_MATCHED = 3
-_RECOVERY_MIN_SCALE = 0.40
-_RECOVERY_RESIDUAL_MAX = 0.10 * hypot(FRAME_W, FRAME_H)  # ~11.7 frame units
-
-
-def _fit_is_healthy(align: Alignment) -> bool:
-    return (
-        align.matched >= _RECOVERY_MIN_MATCHED
-        and _RECOVERY_MIN_SCALE < align.scale < 2.0  # strictly inside, not saturated
-        and align.residual / align.scale <= _RECOVERY_RESIDUAL_MAX  # expected frame
-    )
 
 
 def gated_recovery(pairs: list[tuple[Point, Point]]) -> dict[str, Any]:

--- a/apps/modal-backend/tests/recon_bench/test_recon.py
+++ b/apps/modal-backend/tests/recon_bench/test_recon.py
@@ -9,10 +9,9 @@ from typing import Any
 
 import pytest
 
+from providers.register import Alignment, fit_alignment
 from tests.recon_bench._align import (
-    Alignment,
     _pos_score,
-    fit_alignment,
     gated_recovery,
     geo_scores,
     pose_probe_loo,
@@ -191,8 +190,8 @@ def test_gate_uses_expected_frame_residual() -> None:
     # observed residual by 1/scale in the storage frame. Gate on residual/scale:
     # the SAME observed residual is healthy at scale 1 but not when compressed.
     # (This is the recon-corpus scale-0.588 cell that wobbled pos_raw -0.009.)
-    from tests.recon_bench._align import _RECOVERY_RESIDUAL_MAX as MAX
-    from tests.recon_bench._align import _fit_is_healthy
+    from providers.register import _RECOVERY_RESIDUAL_MAX as MAX
+    from providers.register import _fit_is_healthy
 
     resid = 0.9 * MAX  # comfortably under the cap in the OBSERVED frame
     ok = Alignment(scale=1.0, tx=0, ty=0, flip_x=False, residual=resid, matched=4)

--- a/apps/modal-backend/tests/test_register.py
+++ b/apps/modal-backend/tests/test_register.py
@@ -1,0 +1,52 @@
+"""Unit tests for the prod register entry point (providers.register).
+
+The fit + fit-health gate are golden-tested through the recon bench
+(tests/recon_bench/test_recon.py, which now imports them from here). These pin
+`register_positions` — the read-side use that snaps a fresh render's detections
+onto the persistent-world frame.
+"""
+from __future__ import annotations
+
+import pytest
+
+from providers.register import register_positions
+
+
+def _drift(p: tuple[float, float], s: float = 0.65, dx: float = 18.0, dy: float = 14.0):
+    return (s * p[0] + dx, s * p[1] + dy)
+
+
+def test_register_positions_healthy_snaps_to_world_frame() -> None:
+    # A coherent global drift (scale 0.65 + shift) of the stored world. The fit
+    # is healthy, so recurring entities snap back to ~their world positions and a
+    # NEW entity (only this render sees it) is placed by the SAME transform.
+    world = {"a": (20.0, 10.0), "b": (70.0, 40.0), "c": (40.0, 50.0), "d": (30.0, 20.0)}
+    detected = {k: _drift(v) for k, v in world.items()}
+    detected["e"] = _drift((55.0, 25.0))  # a new entity, not yet in the world
+    out = register_positions(world, detected)
+    assert out is not None
+    for k in world:
+        assert out[k] == pytest.approx(world[k], abs=0.5)
+    assert out["e"] == pytest.approx((55.0, 25.0), abs=0.5)  # invert of its drift
+
+
+def test_register_positions_clamped_scale_returns_none() -> None:
+    # True scale 3.0 saturates the fitter — inverting is the -35 hazard, so skip.
+    world = {"a": (20.0, 10.0), "b": (70.0, 40.0), "c": (40.0, 50.0), "d": (30.0, 20.0)}
+    detected = {k: (3.0 * v[0] + 5, 3.0 * v[1] + 5) for k, v in world.items()}
+    assert register_positions(world, detected) is None
+
+
+def test_register_positions_scatter_returns_none() -> None:
+    # In-range scale but the layout doesn't fit any global similarity (high
+    # residual) — the scrambled case; keep raw.
+    world = {"a": (10.0, 10.0), "b": (50.0, 30.0), "c": (90.0, 50.0), "d": (30.0, 45.0)}
+    detected = {"a": (25.0, -5.0), "b": (35.0, 45.0), "c": (105.0, 35.0), "d": (15.0, 60.0)}
+    assert register_positions(world, detected) is None
+
+
+def test_register_positions_too_few_matches_returns_none() -> None:
+    # Only 2 labels shared — can't over-determine the 4-DOF fit; keep raw.
+    world = {"a": (20.0, 10.0), "b": (70.0, 40.0)}
+    detected = {"a": _drift((20.0, 10.0)), "b": _drift((70.0, 40.0)), "c": _drift((40.0, 50.0))}
+    assert register_positions(world, detected) is None


### PR DESCRIPTION
Foundation for wiring §4 recovery into production (Step 3). The fit + fit-health gate lived in the recon bench (`tests/recon_bench/_align.py`), so prod couldn't import it. This extracts it to **`providers/register.py`** — the single golden-tested source the extract seam will share — with **zero behavior change**.

## Changes
- **`providers/register.py`** (new): `Alignment`, `fit_alignment` (with `min_scale`), the fit-health gate + constants — moved verbatim from the bench. Plus the read-side entry point:
  - **`register_positions(expected, detected)`** — fit the persistent world ↔ this render's detections on shared labels; if the fit is healthy, return **all** detections inverse-registered into the world frame (recurring + new, one transform). `None` when too few labels match or the fit isn't trustworthy → caller keeps raw (the −35 clamped-fit hazard can't reach a stored coord).
- **`tests/recon_bench/_align.py`** now imports the register from `providers.register` and keeps only the bench **scoring** (`pos_raw`/`pos_aligned`, `gated_recovery`, `pose_probe`, `geo_scores`).
- **`tests/test_register.py`** (new): unit tests for `register_positions` (healthy snaps recurring + new to the world frame; clamped / scatter / too-few → `None`).

## Verification
- **28 tests green** — the **24 recon tests are unchanged and pass through the new import path, proving the refactor is behavior-preserving** — plus 4 new register tests.
- `register_positions` has **no caller yet**; Step 3b plumbs prior entity positions to `extract_entities_endpoint` and calls it behind `POSE_REGISTER_FIX` (default off).

## Why this split
Discovery during Step 3 scoping found the plan's assumed seam (`estimate_view`) was wrong — it returns a camera pose, not entity coords — and that the real seam (`extract_entities_endpoint`) has no "expected" side plumbed to it. So Step 3 became: (3a) make the register prod-importable [this PR], (3b) plumb the persistent world's positions to the seam + register behind the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)