### PR TITLE
feat(world): §4 Step 3b — pose register at the extract seam (POSE_REGISTER_FIX)

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -371,6 +371,50 @@ def _geometric_world_on() -> bool:
     return env_flag("GEOMETRIC_WORLD")
 
 
+def _pose_register_on() -> bool:
+    """Register a fresh render's detected centres onto the persistent-world frame
+    before storing (POSE_REGISTER_FIX, §4). Off → store the raw detector centres
+    (current behaviour). Fits the prior stored positions (web-sent on
+    PriorEntity) ↔ this render's detections; a healthy fit corrects the render's
+    global scale/shift drift so a place stays coherent across re-renders."""
+    return env_flag("POSE_REGISTER_FIX")
+
+
+def _register_detection_centres(
+    by_label: dict[str, Any], prior_entities: list[PriorEntity]
+) -> int:
+    """POSE_REGISTER_FIX core: remap the detected centres in `by_label` onto the
+    persistent-world frame using the prior stored positions. Fits prior ↔ this
+    render on shared labels; a healthy fit rewrites EVERY detection's centre
+    (recurring + new) by one similarity. Mutates `by_label` in place and returns
+    the count remapped — 0 when there's no prior anchor or the fit isn't
+    trustworthy (register.py gates out clamped/scattered fits), so the raw
+    detector centres stand. Pure given its inputs → unit-tests without the
+    endpoint. Positions are converted 0-1 ↔ the register's frame units."""
+    from providers import register as _register
+
+    prior_xy = {
+        p.name.lower().strip(): (p.x_pct * _register.FRAME_W, p.y_pct * _register.FRAME_H)
+        for p in prior_entities
+        if p.x_pct is not None and p.y_pct is not None
+    }
+    det_xy = {
+        lbl: (float(d["x_pct"]) * _register.FRAME_W, float(d["y_pct"]) * _register.FRAME_H)
+        for lbl, d in by_label.items()
+    }
+    snapped = _register.register_positions(prior_xy, det_xy)
+    if not snapped:
+        return 0
+    for lbl, (fx, fy) in snapped.items():
+        if lbl in by_label:
+            by_label[lbl] = {
+                **by_label[lbl],
+                "x_pct": min(1.0, max(0.0, fx / _register.FRAME_W)),
+                "y_pct": min(1.0, max(0.0, fy / _register.FRAME_H)),
+            }
+    return len(snapped)
+
+
 def _world_geometry_gen_on(world_mode: bool = False) -> bool:
     """Geometry steers generation (WORLD_GEOMETRY_GEN). Defaults ON under an
     active world mode — the layout clause is the only thing pinning the map's
@@ -1380,6 +1424,12 @@ class PriorEntity(BaseModel):
     name: str
     aliases: list[str] = Field(default_factory=list)
     appearance: str = ""
+    # Stored world-frame CENTRE (0-1) of this entity, when the web knows it.
+    # Lets the extract seam register this render's detections onto the
+    # persistent world (POSE_REGISTER_FIX). Absent = not yet localized → the
+    # entity just doesn't anchor the fit.
+    x_pct: float | None = None
+    y_pct: float | None = None
 
 
 class ExtractEntitiesBody(BaseModel):
@@ -1538,6 +1588,15 @@ async def extract_entities_endpoint(req: Request, body: ExtractEntitiesBody):
             if labels:
                 dets = await _detector.detect(geo_img_bytes, labels)
                 by_label = {str(d.get("label", "")).lower().strip(): d for d in dets}
+
+                # §4 pose register (POSE_REGISTER_FIX, default off): snap this
+                # render's detected centres onto the persistent-world frame so a
+                # place stays coherent across re-renders. No-op when off / no
+                # prior positions / untrustworthy fit → raw detector centres stand.
+                if _pose_register_on():
+                    n_reg = _register_detection_centres(by_label, body.prior_entities)
+                    if n_reg:
+                        log("info", "extract.pose_registered", registered=n_reg)
 
                 def _match(name: str) -> dict[str, float] | None:
                     key = name.lower().strip()

--- a/apps/modal-backend/tests/test_extract_register.py
+++ b/apps/modal-backend/tests/test_extract_register.py
@@ -1,0 +1,46 @@
+"""§4 Step 3b — the extract-seam pose register wire (_register_detection_centres).
+
+The register geometry + gate are tested in tests/test_register.py; these pin the
+generate.py wire: prior positions ↔ this render's detections get remapped onto
+the world frame when the fit is healthy, and left raw otherwise. The endpoint
+gates the whole thing behind POSE_REGISTER_FIX (default off) — off is a no-op.
+"""
+from __future__ import annotations
+
+import pytest
+
+from generate import PriorEntity, _register_detection_centres
+
+
+def _pe(name: str, x: float, y: float) -> PriorEntity:
+    return PriorEntity(kind="place", name=name, x_pct=x, y_pct=y)
+
+
+def _det(x: float, y: float) -> dict:
+    return {"label": "", "x_pct": x, "y_pct": y, "w_pct": 0.1, "h_pct": 0.08, "score": 0.9}
+
+
+def test_register_detection_centres_healthy_snaps_to_world() -> None:
+    # This render drew the world under a coherent global drift (scale 0.65 +
+    # shift). A healthy fit snaps every recurring centre back to its stored
+    # world position; the detector's box size (w/h) is untouched.
+    world = {"a": (0.2, 0.2), "b": (0.7, 0.7), "c": (0.4, 0.5), "d": (0.3, 0.3)}
+    prior = [_pe(n, x, y) for n, (x, y) in world.items()]
+    s, dx, dy = 0.65, 0.18, 0.14
+    by_label = {n: _det(s * x + dx, s * y + dy) for n, (x, y) in world.items()}
+    n = _register_detection_centres(by_label, prior)
+    assert n == 4
+    for name, (x, y) in world.items():
+        assert by_label[name]["x_pct"] == pytest.approx(x, abs=0.02)
+        assert by_label[name]["y_pct"] == pytest.approx(y, abs=0.02)
+    assert by_label["a"]["w_pct"] == 0.1 and by_label["a"]["h_pct"] == 0.08  # size kept
+
+
+def test_register_detection_centres_no_prior_positions_is_noop() -> None:
+    # Prior entities without stored positions can't anchor a fit → raw centres
+    # stand (the first-visit / not-yet-localized case).
+    prior = [PriorEntity(kind="place", name=n) for n in ("a", "b", "c")]
+    by_label = {"a": _det(0.3, 0.3), "b": _det(0.6, 0.6), "c": _det(0.4, 0.45)}
+    before = {k: (v["x_pct"], v["y_pct"]) for k, v in by_label.items()}
+    assert _register_detection_centres(by_label, prior) == 0
+    assert {k: (v["x_pct"], v["y_pct"]) for k, v in by_label.items()} == before


### PR DESCRIPTION
Wires the register (`providers.register`, #202) into the **one prod seam where detections become stored world coords** — `extract_entities_endpoint`. After the detector localizes this render's entities, register their centres onto the persistent-world frame using the prior stored positions, so a place's layout stays coherent across re-renders. Behind **`POSE_REGISTER_FIX`, default OFF** — byte-identical when off (guarded; no import, no compute).

## Changes
- **`_register_detection_centres(by_label, prior_entities)`** — pure helper: fit prior ↔ this render on shared labels; on a **healthy** fit rewrite every detection's centre (recurring + new) by one similarity, else raw centres stand (`register.py` gates out clamped/scattered fits — never worse than raw). Mutates `by_label` in place, returns the count remapped.
- **`PriorEntity`** gains optional `x_pct`/`y_pct` (the stored world centre) so the web can send an anchor; absent → the entity just doesn't anchor the fit.
- `_pose_register_on()` flag helper; the endpoint calls the register only when on.

## Verification
- Tests: healthy drift snaps recurring centres back to the world frame (box size preserved); no prior positions → no-op. `_pose_register_on()` defaults **False** (off path is a no-op). 30 register/recon tests green.

## ⚠️ Not yet active — open design question before the web send
The register only fires once the web **sends** prior positions, and that plumb is **not mechanical**: an entity stores `appearance_bboxes: Record<node_id, bbox>` (a **per-node** map, no single world position), and the extract seam runs on a **freshly-created** node — so there's no prior bbox for the new node yet. "Which prior frame anchors a new render" (parent map? last render of the same place? a canonical per-place position?) is an **architecture decision** I didn't want to guess.

This PR lands the tested, off-by-default **mechanism**. Activation = pick the anchoring frame → web sends those positions → flip the flag → real-gen validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)