### PR TITLE
feat(world): §4 — gate the LIVE plan→image register (WORLD_REGISTER_GATE)

### DIFF
--- a/apps/web/app/api/world/[sessionId]/extract/route.ts
+++ b/apps/web/app/api/world/[sessionId]/extract/route.ts
@@ -297,6 +297,7 @@ export async function POST(req: Request, { params }: Params) {
               const reg = registerPlanToImage(
                 snap.entities,
                 new Date().toISOString(),
+                { gate: envFlag("WORLD_REGISTER_GATE") },
               );
               if (reg) {
                 await upsertEntityGeos(sessionId, reg.updated);

--- a/apps/web/lib/world-geometry.test.ts
+++ b/apps/web/lib/world-geometry.test.ts
@@ -9,11 +9,13 @@ import {
   applySimilarity,
   cropEntities,
   fitSimilarity,
+  isFitHealthy,
   neighborsOf,
   project,
   projectScene,
   projectTopDown,
   type ProjectInput,
+  type SimilarityFit,
 } from "./world-geometry";
 
 // P1 geometry gate (TS side, FREE). Reproduces the SAME shared golden the Python
@@ -223,5 +225,36 @@ describe("fitSimilarity (parity with recon_bench fit_alignment)", () => {
     );
     expect(out.x).toBeCloseTo(5);
     expect(out.y).toBeCloseTo(20);
+  });
+});
+
+describe("isFitHealthy (§4 safe-to-apply gate — port of register._fit_is_healthy)", () => {
+  const fit = (over: Partial<SimilarityFit>): SimilarityFit => ({
+    scale: 1.2,
+    tx: 0,
+    ty: 0,
+    flipX: false,
+    residual: 3,
+    matched: 4,
+    ...over,
+  });
+
+  it("passes a healthy fit (≥3 anchors, in-clamp scale, low residual)", () => {
+    expect(isFitHealthy(fit({}))).toBe(true);
+  });
+
+  it("rejects an under-determined fit (<3 anchors)", () => {
+    expect(isFitHealthy(fit({ matched: 2 }))).toBe(false);
+  });
+
+  it("rejects a scale saturated at the clamp (0.5 or 2.0)", () => {
+    expect(isFitHealthy(fit({ scale: 2.0 }))).toBe(false);
+    expect(isFitHealthy(fit({ scale: 0.5 }))).toBe(false);
+  });
+
+  it("rejects a high-residual (scattered) fit", () => {
+    // MAP_IMAGE_FRAME diagonal is ~116.6; the gate is 0.1× that ≈ 11.66.
+    expect(isFitHealthy(fit({ residual: 15 }))).toBe(false);
+    expect(isFitHealthy(fit({ residual: 11 }))).toBe(true); // just under
   });
 });

--- a/apps/web/lib/world-geometry.ts
+++ b/apps/web/lib/world-geometry.ts
@@ -485,6 +485,27 @@ export function applySimilarity(f: SimilarityFit, p: WorldVec2): WorldVec2 {
   return { x: f.scale * x + f.tx, y: f.scale * p.y + f.ty };
 }
 
+// §4 fit-health gate (port of providers/register.py::_fit_is_healthy, validated
+// in the recon bench). A fit is only safe to APPLY when it actually explains the
+// drift: a scale saturated at the [0.5,2] clamp or a high residual means it does
+// not, and applying it then DOUBLES error (phase-1 probe: -35 mean gain on
+// clamped fits). A 2-point fit is exactly-determined (residual 0 — always "looks
+// perfect"), so require ≥3 anchors to over-determine the 4-DOF similarity.
+// residual is RMS in the fit's TARGET frame — for registerPlanToImage that IS
+// the stored (image) frame, so no per-scale correction is needed here (unlike
+// the bench's invert direction, which stores in the ÷scale expected frame).
+const _REGISTER_MIN_MATCHED = 3;
+const _REGISTER_RESIDUAL_MAX = 0.1 * Math.hypot(_FIT_FRAME_W, 60); // ~11.66, MAP_IMAGE_FRAME diag
+
+export function isFitHealthy(f: SimilarityFit): boolean {
+  return (
+    f.matched >= _REGISTER_MIN_MATCHED &&
+    f.scale > 0.5 &&
+    f.scale < 2.0 && // strictly inside the clamp — not saturated
+    f.residual <= _REGISTER_RESIDUAL_MAX
+  );
+}
+
 /** Axis-aligned bounds over entities' OWN pos+footprint (no parent resolve) —
  *  the LOCAL frame of a place's interior, where each child's pos is local. */
 export function localBounds<

--- a/apps/web/lib/world-map.test.ts
+++ b/apps/web/lib/world-map.test.ts
@@ -408,6 +408,51 @@ describe("registerPlanToImage (plan plane → image register)", () => {
       ),
     ).toBeNull();
   });
+
+  // §4 fit-health gate (WORLD_REGISTER_GATE): opt-in skip of untrustworthy fits.
+  it("gate on: a clamped-scale fit skips instead of corrupting the world", () => {
+    // True scale 3.0 saturates fitSimilarity at 2.0 — applying it re-expresses
+    // every plan through a bad transform (phase-1: doubles error).
+    const geos = [
+      plan("tower", "The Tower", 10, 10),
+      plan("harbor", "Harbor", 30, 20),
+      plan("wood", "Dark Wood", 50, 40),
+      img("geo_tower", "Tower", 35, 35),
+      img("geo_harbor", "Harbor", 95, 65),
+      img("geo_wood", "Dark Wood", 155, 125),
+    ];
+    expect(registerPlanToImage(geos, "t9", { gate: true })).toBeNull();
+    // Legacy (gate off) STILL applies the bad fit — the behaviour we're fixing.
+    expect(registerPlanToImage(geos, "t9")).not.toBeNull();
+  });
+
+  it("gate on: a healthy fit (≥3 anchors, in-clamp, low residual) still fires", () => {
+    const geos = [
+      plan("tower", "The Tower", 10, 10),
+      plan("harbor", "Harbor", 30, 20),
+      plan("wood", "Dark Wood", 50, 40),
+      plan("mill", "Old Mill", 20, 30), // unmatched rider still moves
+      img("geo_tower", "Tower", 22, 22), // clean 1.4× + 8 register
+      img("geo_harbor", "Harbor", 50, 36),
+      img("geo_wood", "Dark Wood", 78, 64),
+    ];
+    const reg = registerPlanToImage(geos, "t9", { gate: true })!;
+    expect(reg).not.toBeNull();
+    expect(reg.fit.matched).toBe(3);
+    expect(reg.fit.scale).toBeCloseTo(1.4);
+    expect(reg.updated).toHaveLength(4);
+  });
+
+  it("gate on: a 2-anchor fit skips (under-determined — legacy applied it)", () => {
+    const geos = [
+      plan("tower", "The Tower", 10, 10),
+      plan("harbor", "Harbor", 30, 20),
+      img("geo_tower", "the tower", 25, 25),
+      img("geo_harbor", "Harbor", 55, 40),
+    ];
+    expect(registerPlanToImage(geos, "t9", { gate: true })).toBeNull();
+    expect(registerPlanToImage(geos, "t9")).not.toBeNull();
+  });
 });
 
 // ── Mongo wrappers + the extraction seeding bridge (fake collection) ────────

--- a/apps/web/lib/world-map.ts
+++ b/apps/web/lib/world-map.ts
@@ -22,6 +22,7 @@ import {
   applySimilarity,
   estimateGeoFromBBox,
   fitSimilarity,
+  isFitHealthy,
   localBounds,
   localExtent,
   mapPolygonToCrop,
@@ -520,6 +521,7 @@ export async function deriveGeoFromExtraction(
 export function registerPlanToImage(
   geos: WorldEntityGeo[],
   nowIso: string,
+  opts?: { gate?: boolean },
 ): { updated: WorldEntityGeo[]; fit: SimilarityFit } | null {
   const plans = geos.filter(
     (g) => g.id.startsWith("geo_plan_") && (g.parent_id ?? null) === null,
@@ -590,6 +592,13 @@ export function registerPlanToImage(
   ) {
     return null;
   }
+  // §4 fit-health gate (opt-in, WORLD_REGISTER_GATE): a fit whose scale saturated
+  // the [0.5,2] clamp, whose residual is high, or that rode only 2 anchors is
+  // untrustworthy — applying it re-expresses EVERY plan geo through a bad
+  // transform and corrupts the world (phase-1 probe: doubles error). Skip it and
+  // keep the plan positions. Off (default) = legacy behaviour: apply any
+  // non-identity fit with ≥2 matches.
+  if (opts?.gate && !isFitHealthy(fit)) return null;
   const updated = plans.map((p) => ({
     ...p,
     pos: applySimilarity(fit, p.pos),


### PR DESCRIPTION
**The §4 register was never missing from prod — it's been running as the *unsafe* version.** `registerPlanToImage` (the extract-seam step that re-expresses the planner's plan geos into the image frame — the frame every consumer reads) applied its similarity fit whenever ≥2 anchors matched and it wasn't ≈identity, with **no fit-health check**. So a fit whose scale saturated the `[0.5,2]` clamp, whose residual was high, or that rode only 2 anchors got applied anyway — corrupting every plan geo. That's the exact hazard the phase-1 probe measured: applying a bad fit **doubles** error.

This ports the validated bench gate (`providers/register.py::_fit_is_healthy`, Steps 1–2 in #200/#201) to the live web register.

## Changes
- **`isFitHealthy(fit)`** (world-geometry.ts): `matched ≥ 3` (a 2-point fit is exactly-determined → always "looks perfect"), scale **strictly inside** the clamp (not saturated at 0.5/2.0), residual ≤ `0.1·frame-diag` (~11.66). Residual here is already in the stored **image** frame — the register *applies forward* — so no `÷scale` (that correction is for the bench's *invert* direction, which stores in the expected frame).
- **`registerPlanToImage(geos, nowIso, { gate })`**: when gated, an unhealthy fit is **skipped** (keep the plan positions) instead of applied. **Default OFF = byte-identical legacy behaviour**; the extract route passes `gate: envFlag("WORLD_REGISTER_GATE")`.

## Verification
- New tests: `isFitHealthy` per branch (healthy / <3 anchors / saturated scale / high residual); `registerPlanToImage` **gate-on skips** a clamped fit and a 2-anchor fit *while legacy still applies them*, and a healthy ≥3-anchor fit still fires.
- **66 web tests green**, `tsc --noEmit` clean, eslint clean.

## Context
This came out of scoping the "build a canonical per-place frame" milestone — which turned out to already exist (the `world_map` collection) with the register already wired. So the real work collapsed to hardening it. This **supersedes #203** (the backend detection-register — a detour; the live register is web-side; #203 stays dormant/flag-off).

Next: measure gate-on vs off on real revisits (does it stop bad snaps without dropping good ones?), then port the Step-2 0.40 floor for coherent ½-scale places.

🤖 Generated with [Claude Code](https://claude.com/claude-code)