### PR TITLE
feat(world): §4 — recovery floor 0.40 for the gated register (rescue coherent compressions)

### DIFF
--- a/apps/web/lib/world-geometry.test.ts
+++ b/apps/web/lib/world-geometry.test.ts
@@ -218,6 +218,14 @@ describe("fitSimilarity (parity with recon_bench fit_alignment)", () => {
     expect(fitSimilarity([[PTS[0]!, PTS[0]!]])).toBeNull();
   });
 
+  it("reaches a deep compression with a lowered minScale (else clamps to 0.5)", () => {
+    // painter drew the layout at 0.45× the plan (tighter): the default 0.5 floor
+    // clamps it out; minScale 0.40 reaches the true scale (recon Step 2).
+    const compress = pairs((p) => ({ x: 0.45 * p.x + 5, y: 0.45 * p.y + 5 }));
+    expect(fitSimilarity(compress)!.scale).toBe(0.5);
+    expect(fitSimilarity(compress, { minScale: 0.4 })!.scale).toBeCloseTo(0.45);
+  });
+
   it("applySimilarity round-trips a known fit", () => {
     const out = applySimilarity(
       { scale: 1.5, tx: -10, ty: 5, flipX: false, residual: 0, matched: 4 },
@@ -247,9 +255,11 @@ describe("isFitHealthy (§4 safe-to-apply gate — port of register._fit_is_heal
     expect(isFitHealthy(fit({ matched: 2 }))).toBe(false);
   });
 
-  it("rejects a scale saturated at the clamp (0.5 or 2.0)", () => {
+  it("rejects a scale saturated at the recovery clamp (0.40 or 2.0)", () => {
     expect(isFitHealthy(fit({ scale: 2.0 }))).toBe(false);
-    expect(isFitHealthy(fit({ scale: 0.5 }))).toBe(false);
+    expect(isFitHealthy(fit({ scale: 0.4 }))).toBe(false);
+    expect(isFitHealthy(fit({ scale: 0.45 }))).toBe(true); // deep compression recovers
+    expect(isFitHealthy(fit({ scale: 0.5 }))).toBe(true); // the old floor is now in-range
   });
 
   it("rejects a high-residual (scattered) fit", () => {

--- a/apps/web/lib/world-geometry.ts
+++ b/apps/web/lib/world-geometry.ts
@@ -434,13 +434,17 @@ export interface SimilarityFit {
 const _FIT_FRAME_W = 100;
 
 /** Least-squares uniform scale + translation over (from, to) point pairs;
- *  tries the x-flipped register too and keeps the lower residual. Scale
- *  clamped [0.5, 2]; null when < 2 pairs (nothing to anchor). TS port of
- *  tests/recon_bench/_align.fit_alignment — keep the two in lockstep. */
+ *  tries the x-flipped register too and keeps the lower residual. Scale clamped
+ *  [minScale, 2] (default minScale 0.5); null when < 2 pairs (nothing to anchor).
+ *  TS port of tests/recon_bench/_align.fit_alignment — keep the two in lockstep.
+ *  The gated register lowers minScale to REGISTER_MIN_SCALE to reach coherent
+ *  deep compressions (a place drawn tighter than planned) the 0.5 clamp rejects. */
 export function fitSimilarity(
   pairs: [WorldVec2, WorldVec2][],
+  opts?: { minScale?: number },
 ): SimilarityFit | null {
   if (pairs.length < 2) return null;
+  const minScale = opts?.minScale ?? 0.5;
   let best: SimilarityFit | null = null;
   for (const flip of [false, true]) {
     const src = pairs.map(([f]) => ({
@@ -460,7 +464,7 @@ export function fitSimilarity(
       den += (src[i]!.x - sx) ** 2 + (src[i]!.y - sy) ** 2;
     }
     let s = den > 1e-9 ? num / den : 1.0;
-    s = Math.max(0.5, Math.min(2.0, s));
+    s = Math.max(minScale, Math.min(2.0, s));
     const tx = dx - s * sx;
     const ty = dy - s * sy;
     let sq = 0;
@@ -487,21 +491,27 @@ export function applySimilarity(f: SimilarityFit, p: WorldVec2): WorldVec2 {
 
 // §4 fit-health gate (port of providers/register.py::_fit_is_healthy, validated
 // in the recon bench). A fit is only safe to APPLY when it actually explains the
-// drift: a scale saturated at the [0.5,2] clamp or a high residual means it does
-// not, and applying it then DOUBLES error (phase-1 probe: -35 mean gain on
-// clamped fits). A 2-point fit is exactly-determined (residual 0 — always "looks
-// perfect"), so require ≥3 anchors to over-determine the 4-DOF similarity.
-// residual is RMS in the fit's TARGET frame — for registerPlanToImage that IS
-// the stored (image) frame, so no per-scale correction is needed here (unlike
-// the bench's invert direction, which stores in the ÷scale expected frame).
+// drift: a scale saturated at the [REGISTER_MIN_SCALE, 2] clamp or a high residual
+// means it does not, and applying it then DOUBLES error (phase-1 probe: -35 mean
+// gain on clamped fits). A 2-point fit is exactly-determined (residual 0 — always
+// "looks perfect"), so require ≥3 anchors to over-determine the 4-DOF similarity.
+// residual is RMS in the fit's TARGET frame — for registerPlanToImage that IS the
+// stored (image) frame, so no per-scale correction is needed here (unlike the
+// bench's invert direction, which stores in the ÷scale expected frame).
+//
+// REGISTER_MIN_SCALE (0.40) < the legacy 0.5 clamp: recon Step 2 (#201) showed
+// coherent deep compressions (a place drawn ~½ size, low residual) are
+// recoverable — the 0.5 floor just clamped them out. The gated register fits
+// down to 0.40; the residual gate keeps scattered compressions out.
+export const REGISTER_MIN_SCALE = 0.4;
 const _REGISTER_MIN_MATCHED = 3;
 const _REGISTER_RESIDUAL_MAX = 0.1 * Math.hypot(_FIT_FRAME_W, 60); // ~11.66, MAP_IMAGE_FRAME diag
 
 export function isFitHealthy(f: SimilarityFit): boolean {
   return (
     f.matched >= _REGISTER_MIN_MATCHED &&
-    f.scale > 0.5 &&
-    f.scale < 2.0 && // strictly inside the clamp — not saturated
+    f.scale > REGISTER_MIN_SCALE &&
+    f.scale < 2.0 && // strictly inside the recovery clamp — not saturated
     f.residual <= _REGISTER_RESIDUAL_MAX
   );
 }

--- a/apps/web/lib/world-map.test.ts
+++ b/apps/web/lib/world-map.test.ts
@@ -453,6 +453,23 @@ describe("registerPlanToImage (plan plane → image register)", () => {
     expect(registerPlanToImage(geos, "t9", { gate: true })).toBeNull();
     expect(registerPlanToImage(geos, "t9")).not.toBeNull();
   });
+
+  it("gate on: rescues a coherent deep compression (scale 0.45) via the recovery floor", () => {
+    // The painter drew the 3 features at 0.45× the planned spread — a clean
+    // compression. Legacy's 0.5 floor clamps to a wrong scale; the gated register
+    // fits down to 0.40, recovers the true 0.45, and (low residual) applies it.
+    const geos = [
+      plan("tower", "The Tower", 10, 10),
+      plan("harbor", "Harbor", 30, 20),
+      plan("wood", "Dark Wood", 50, 40),
+      img("geo_tower", "Tower", 9.5, 9.5), // 0.45·pos + 5
+      img("geo_harbor", "Harbor", 18.5, 14),
+      img("geo_wood", "Dark Wood", 27.5, 23),
+    ];
+    const reg = registerPlanToImage(geos, "t9", { gate: true })!;
+    expect(reg).not.toBeNull();
+    expect(reg.fit.scale).toBeCloseTo(0.45); // recovered below the 0.5 clamp
+  });
 });
 
 // ── Mongo wrappers + the extraction seeding bridge (fake collection) ────────

--- a/apps/web/lib/world-map.ts
+++ b/apps/web/lib/world-map.ts
@@ -23,6 +23,7 @@ import {
   estimateGeoFromBBox,
   fitSimilarity,
   isFitHealthy,
+  REGISTER_MIN_SCALE,
   localBounds,
   localExtent,
   mapPolygonToCrop,
@@ -581,7 +582,9 @@ export function registerPlanToImage(
     usedG.add(c.g.id);
     pairs.push([c.p.pos, c.g.pos]);
   }
-  const fit = fitSimilarity(pairs);
+  // Gated runs fit down to REGISTER_MIN_SCALE (0.40) to rescue coherent deep
+  // compressions the 0.5 clamp would reject; legacy keeps the 0.5 default.
+  const fit = fitSimilarity(pairs, opts?.gate ? { minScale: REGISTER_MIN_SCALE } : undefined);
   if (fit === null) return null;
   // Already registered (or trivially in register): skip the churn.
   if (


### PR DESCRIPTION
Follow-up to #204 (the register gate). #204 stopped bad snaps; this lets the register **recover more** — coherent deep compressions (a place drawn *tighter* than planned) that the 0.5 scale clamp wrongly rejected. Ports recon **Step 2** (#201, where mars went 0.05→0.62) to the live web register.

## Changes
- **`fitSimilarity(pairs, { minScale })`** — default `0.5`, **byte-identical for every existing caller**. The gated `registerPlanToImage` fits down to **`REGISTER_MIN_SCALE = 0.40`**; legacy keeps 0.5.
- **`isFitHealthy`** floors the scale check at `REGISTER_MIN_SCALE` (0.40), so a clean scale-0.45 compression passes while a fit saturated at the 0.40 floor is still rejected. Residual gate unchanged — and it stays the storage-frame residual (no `÷scale`) because the register applies forward.

## Verification
- `fitSimilarity` reaches 0.45 with `minScale: 0.40` (clamps to 0.5 by default); `isFitHealthy` now passes 0.45/0.5 and rejects 0.40/2.0; `registerPlanToImage` gate-on **rescues** a coherent 0.45 compression. **68 web tests green**, `tsc` clean.

## Scope / caveat
- Still behind `WORLD_REGISTER_GATE` (default off). Only the **low** end of the clamp moved — the fishing-village 2× *expansion* case (the #204 receipt) still correctly **skips**.
- No coherent-compression case exists in the current prod `world_map` data, so the live lift here is **bench-proven, not yet measured on web traffic**. It's a safe, gated extension of validated work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)