### PR TITLE
feat(world): §4 register telemetry — shadow-log unhealthy fits

### DIFF
--- a/apps/web/app/api/world/[sessionId]/extract/route.ts
+++ b/apps/web/app/api/world/[sessionId]/extract/route.ts
@@ -8,6 +8,7 @@ import {
   upsertEntityGeos,
 } from "@/lib/world-map";
 import { MAP_IMAGE_FRAME } from "@/lib/geo-tap";
+import { isFitHealthy } from "@/lib/world-geometry";
 import { readServerEnv } from "@/lib/env";
 import { envFlag } from "@/lib/env-flag";
 import { isSafeId } from "@/lib/ids";
@@ -301,6 +302,7 @@ export async function POST(req: Request, { params }: Params) {
               );
               if (reg) {
                 await upsertEntityGeos(sessionId, reg.updated);
+                const healthy = isFitHealthy(reg.fit);
                 planRegistration = {
                   scale: Number(reg.fit.scale.toFixed(3)),
                   tx: Number(reg.fit.tx.toFixed(1)),
@@ -308,7 +310,24 @@ export async function POST(req: Request, { params }: Params) {
                   flip_x: reg.fit.flipX,
                   residual: Number(reg.fit.residual.toFixed(2)),
                   matched: reg.fit.matched,
+                  gate_healthy: healthy,
                 };
+                // §4 telemetry: with the gate OFF an UNHEALTHY fit is applied
+                // anyway (the -35 hazard) — the shadow signal for whether flipping
+                // WORLD_REGISTER_GATE on is warranted. Greppable in deploy logs;
+                // stops appearing once the gate is on (those fits get skipped).
+                if (!healthy) {
+                  console.warn(
+                    "[world.register] unhealthy fit applied (WORLD_REGISTER_GATE off)",
+                    JSON.stringify({
+                      session: sessionId,
+                      node: body.node_id,
+                      scale: Number(reg.fit.scale.toFixed(3)),
+                      residual: Number(reg.fit.residual.toFixed(2)),
+                      matched: reg.fit.matched,
+                    }),
+                  );
+                }
               }
             } catch {
               // registration is strictly additive polish


### PR DESCRIPTION
To justify flipping `WORLD_REGISTER_GATE` on (Step 4) we need real-traffic data on how often the register fit is untrustworthy. Today there's zero — only 3 sessions in the whole DB even carry plan geos. This adds the shadow signal.

With the gate **off** (default), an unhealthy fit is applied anyway — so log exactly those:
- **`plan_registration.gate_healthy`** (bool) rides the extract response / debug HUD.
- A **`console.warn("[world.register] unhealthy fit applied …")`** fires *only* when a fit fails `isFitHealthy` while the gate is off — greppable in deploy logs, low-noise (only the bad cases), and it **stops** once the gate is on (those get skipped). That count is the shadow metric for the flip.

No behaviour change — telemetry only; `isFitHealthy` is already unit-tested (tsc + eslint clean). Follow-up: aggregate the warns before/after flipping the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)