### PR TITLE
feat(tap): paint attempt-0 before judging on the enter path (VIEW_LOOP_PREVIEW)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,6 +100,11 @@ FAL_EDIT_TIER=balanced
 # VIEW_LOOP_ACCEPT_CONFORMANCE=7
 # VIEW_LOOP_ACCEPT_SAME_PLACE=6
 # VIEW_LOOP_RETRY_BUDGET_S=240
+# Paint attempt-0 the instant it renders, BEFORE judging (cuts perceived latency
+# on the immersive tap: an accepted attempt-0 otherwise shows nothing until the
+# judge tail + encode). The judged verdict still follows and swaps it. Off by
+# default — it surfaces an un-judged frame. VIEW_LOOP_PREVIEW=true to enable.
+# VIEW_LOOP_PREVIEW=false
 # Retry-model swap for VIEW_LOOP experiments: attempt 0 stays on the router's
 # production fal edit slug; only judged retry attempts use this alternate.
 # ENTER_RETRY_MODEL_SWAP=false

--- a/apps/modal-backend/providers/generate_modes/tap.py
+++ b/apps/modal-backend/providers/generate_modes/tap.py
@@ -860,6 +860,7 @@ async def stream_tap(
                 60.0,
                 ingress_timeout_s - 180.0 - (_time.perf_counter() - started),
             )
+            enter_preview = env_flag("VIEW_LOOP_PREVIEW")
             loop_attempts: list[Attempt] = []
             async for loop_att in render_loop.iter_attempts(
                 _render_enter,
@@ -884,14 +885,36 @@ async def stream_tap(
                 render_for_attempt=_render_enter_attempt,
                 abort=_abort_if_disconnected,
                 deadline_s=loop_deadline,
+                emit_preview=enter_preview,
             ):
+                if loop_att.preview:
+                    # Pre-judge preview of attempt-0 (VIEW_LOOP_PREVIEW): paint it
+                    # NOW instead of holding it behind the judge tail. The judged
+                    # verdict still follows (accept → final swaps it in, reject →
+                    # the retry frame does). Not part of loop_attempts/conclude.
+                    preview_b64 = (
+                        await _asyncio.to_thread(
+                            base64.b64encode, loop_att.image.jpeg_bytes
+                        )
+                    ).decode("ascii")
+                    yield _sse(
+                        {
+                            "type": "progress",
+                            "frame_index": loop_att.index,
+                            "jpeg_b64": preview_b64,
+                        },
+                        trace_id,
+                    )
+                    continue
                 loop_attempts.append(loop_att)
                 # Stream only verdict-REJECTED attempts (a correction is
-                # coming); a degraded attempt (no critic) is the final.
+                # coming); a degraded attempt (no critic) is the final. Skip
+                # attempt-0 when its preview already painted it (no double frame).
                 if (
                     not loop_att.accepted
                     and loop_att.conformance is not None
                     and loop_att.index + 1 < loop_cfg.max_attempts
+                    and not (enter_preview and loop_att.index == 0)
                 ):
                     # Stream the rejected attempt — the user watches the
                     # agent self-correct instead of staring at a spinner.

--- a/apps/modal-backend/providers/render_loop.py
+++ b/apps/modal-backend/providers/render_loop.py
@@ -105,6 +105,10 @@ class Attempt:
     # None = no interior judge wired (every non-INTERIOR_ENTERS path). Last +
     # defaulted so existing positional constructions stay valid.
     interior: JudgeResult | None = None
+    # A PRE-JUDGE preview (VIEW_LOOP_PREVIEW): the rendered bytes, yielded before
+    # judging so the caller can paint attempt-0 immediately instead of holding it
+    # behind the judge tail. All judge fields are None; not part of conclude().
+    preview: bool = False
 
 
 @dataclass(frozen=True)
@@ -189,6 +193,7 @@ async def iter_attempts[ImageT: Rendered](
     abort: Callable[[str], Awaitable[None]] | None = None,
     clock: Callable[[], float] = time.monotonic,
     deadline_s: float | None = None,
+    emit_preview: bool = False,
 ) -> AsyncIterator[Attempt]:
     """Yield attempts until acceptance / budget / max attempts. The caller
     (the SSE generator) can emit a progress frame between yields. Attempt-0
@@ -224,6 +229,17 @@ async def iter_attempts[ImageT: Rendered](
                 )
                 return
         latency = clock() - started
+
+        # Pre-judge preview (VIEW_LOOP_PREVIEW): the attempt-0 bytes exist now,
+        # but judging is another ~2-5s (and a retry hides a whole second render).
+        # Yield the render for the caller to paint immediately; the judged
+        # verdict + any retry still follow and swap it. Attempt-0 only — later
+        # attempts already stream via the caller's rejected-attempt frames.
+        if emit_preview and index == 0:
+            yield Attempt(
+                index, image, suffix, None, None, None, None, False, latency, None,
+                preview=True,
+            )
 
         # The five axes are independent verdicts on the same image — judged
         # concurrently (the Ankh-Morpork re-shoot: sequential judging alone

--- a/apps/modal-backend/tests/test_render_loop.py
+++ b/apps/modal-backend/tests/test_render_loop.py
@@ -468,3 +468,32 @@ async def test_interior_keep_best_prefers_higher_interior_score() -> None:
     result = conclude(attempts)
     assert result.accepted is False
     assert result.image.jpeg_bytes == b"b"
+
+
+async def test_preview_emits_pre_judge_frame_for_attempt_zero() -> None:
+    # VIEW_LOOP_PREVIEW: attempt-0's render is yielded BEFORE judging (so the
+    # caller paints it immediately), then the judged verdict follows. One render.
+    render = AsyncMock(return_value=_Img(b"a"))
+    attempts = await _drain(
+        render=render, projection="top_down", region_bytes=b"r",
+        judge_conformance=AsyncMock(return_value=_j(9.0)),
+        judge_same_place=AsyncMock(return_value=_j(9.0)),
+        config=_cfg(), emit_preview=True,
+    )
+    assert len(attempts) == 2
+    assert attempts[0].preview is True
+    assert attempts[0].image.jpeg_bytes == b"a"
+    assert attempts[0].conformance is None and attempts[0].same_place is None
+    assert attempts[1].preview is False and attempts[1].accepted is True
+    render.assert_awaited_once()  # the preview reuses the render — no extra call
+    # the preview is NOT a real attempt: conclude sees only the judged ones
+    assert conclude([a for a in attempts if not a.preview]).accepted is True
+
+
+async def test_preview_off_by_default_yields_no_preview() -> None:
+    attempts = await _drain(
+        render=AsyncMock(return_value=_Img(b"a")), projection="top_down",
+        region_bytes=b"r", judge_conformance=AsyncMock(return_value=_j(9.0)),
+        judge_same_place=AsyncMock(return_value=_j(9.0)), config=_cfg(),
+    )
+    assert len(attempts) == 1 and attempts[0].preview is False


### PR DESCRIPTION
Latency win on the flagship immersive tap. Today the enter/VIEW_LOOP path renders attempt-0, judges it concurrently (~2–5s), **then** streams — a *rejected* attempt streams as a progress frame, but an **accepted attempt-0 shows nothing until `final`**, so first-pixel = render + judges + encode even though the bytes existed seconds earlier (and a 2-attempt loop hides a whole second render behind a spinner). *(From a latency-path audit of the tap→first-pixel flow.)*

## Change
- **`iter_attempts(emit_preview=…)`** yields attempt-0's render as a `preview` Attempt (judge fields all None) **right after render, before judging**. The judged verdict still follows and the caller swaps it (accept → `final`, reject → retry frame).
- **`Attempt.preview: bool`** marks it; never appended to `loop_attempts`, so `conclude()` / billing are unchanged.
- **tap.py** paints the preview as a `progress` SSE frame (the frontend already renders those) and skips attempt-0's rejected-stream frame when the preview already showed it (no double frame).
- Behind **`VIEW_LOOP_PREVIEW` (default OFF, byte-identical)** — it surfaces an un-judged frame, so opt-in and eyeball before defaulting on. Cuts perceived first-pixel on the accepted-first tap from render+judges(+retry) down to just render.

## Verification
- Tests: preview yields the pre-judge frame for attempt-0 with **one** render and isn't counted by `conclude`; off-by-default yields no preview. 29 render_loop + view tests green, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)