### PR TITLE
feat(tap): pre-judge preview on the zoom path too (VIEW_LOOP_PREVIEW)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,10 +100,11 @@ FAL_EDIT_TIER=balanced
 # VIEW_LOOP_ACCEPT_CONFORMANCE=7
 # VIEW_LOOP_ACCEPT_SAME_PLACE=6
 # VIEW_LOOP_RETRY_BUDGET_S=240
-# Paint attempt-0 the instant it renders, BEFORE judging (cuts perceived latency
-# on the immersive tap: an accepted attempt-0 otherwise shows nothing until the
-# judge tail + encode). The judged verdict still follows and swaps it. Off by
-# default — it surfaces an un-judged frame. VIEW_LOOP_PREVIEW=true to enable.
+# Paint the first render the instant it lands, BEFORE judging (cuts perceived
+# latency on BOTH the immersive enter tap and the right-click zoom: an accepted /
+# kept-best first attempt otherwise shows nothing until the judge tail + any
+# retry). The judged verdict still follows and swaps it. Off by default — it
+# surfaces an un-judged frame. VIEW_LOOP_PREVIEW=true to enable.
 # VIEW_LOOP_PREVIEW=false
 # Retry-model swap for VIEW_LOOP experiments: attempt 0 stays on the router's
 # production fal edit slug; only judged retry attempts use this alternate.

--- a/apps/modal-backend/providers/generate_modes/tap.py
+++ b/apps/modal-backend/providers/generate_modes/tap.py
@@ -62,6 +62,24 @@ def _classic_zoom_mode(enter_as: str | None) -> str | None:
     return _CLASSIC_ENTER_AS_TO_RENDER.get((enter_as or "").strip().lower())
 
 
+async def _race_preview(
+    q: _asyncio.Queue[bytes], task: _asyncio.Future
+) -> bytes | None:
+    """Return the queued pre-judge preview bytes if they land before `task`
+    finishes, else None. Racing against `task` (the judged render) means a
+    first-render failure — which resolves `task` without ever enqueueing —
+    can't deadlock the get. Pure/injectable, so the zoom-preview wiring in
+    stream_tap is unit-testable without the whole generate flow."""
+    get = _asyncio.ensure_future(q.get())
+    done, _pending = await _asyncio.wait(
+        {get, task}, return_when=_asyncio.FIRST_COMPLETED
+    )
+    if get in done:
+        return get.result()
+    get.cancel()
+    return None
+
+
 async def stream_tap(
     body: GenerateBody,
     trace_id: str,
@@ -639,6 +657,11 @@ async def stream_tap(
         )
     result: Any = None
     main_task: _asyncio.Task | None = None
+    # Zoom's pre-judge preview channel (VIEW_LOOP_PREVIEW): _judged_zoom is a
+    # task, not a generator, so it can't yield an SSE frame — it hands its first
+    # render to the streaming body through this queue, which the body drains and
+    # paints before the judge tail + keep-best retry. None = feature off.
+    zoom_preview_q: _asyncio.Queue[bytes] | None = None
     if use_continuation and region_ref is not None:
         # SUBMAP_REDRAW rides the pixel-honoring EDIT seam with a LOOSE-refs
         # model. The fresh path is NOT an option: fal's text-to-image endpoints
@@ -658,6 +681,9 @@ async def stream_tap(
                 model_override=redraw_model if submap_redraw else body.image_model,
             )
 
+        if env_flag("VIEW_LOOP_PREVIEW"):
+            zoom_preview_q = _asyncio.Queue()
+
         async def _judged_zoom() -> Any:
             """Judged zoom (redraw or Kontext) + one keep-best retry.
 
@@ -674,6 +700,11 @@ async def stream_tap(
             (place_closeup) skip the legibility axis.
             """
             first = await _render_zoom(zoom_instruction)
+            if zoom_preview_q is not None:
+                # Hand the first render to the SSE body to paint NOW, before the
+                # judge tail + keep-best retry (the zoom path shows nothing until
+                # `final` otherwise). Judged verdict still swaps it.
+                zoom_preview_q.put_nowait(first.jpeg_bytes)
             if not env_flag("TAP_ZOOM_JUDGE", "true") or body.verify is False:
                 return first
             from providers import judge, render_loop
@@ -1012,6 +1043,18 @@ async def stream_tap(
                 )
             result = await main_task
     elif main_task is not None:
+        if zoom_preview_q is not None:
+            # Zoom pre-judge preview (VIEW_LOOP_PREVIEW): paint the first render
+            # the instant it lands, before its judge + keep-best retry.
+            preview_bytes = await _race_preview(zoom_preview_q, main_task)
+            if preview_bytes is not None:
+                preview_b64 = (
+                    await _asyncio.to_thread(base64.b64encode, preview_bytes)
+                ).decode("ascii")
+                yield _sse(
+                    {"type": "progress", "frame_index": 0, "jpeg_b64": preview_b64},
+                    trace_id,
+                )
         result = await main_task
 
     # 3b. Geometric grounding (VLM_GROUNDING): verify the render against the

--- a/apps/modal-backend/tests/test_zoom_preview.py
+++ b/apps/modal-backend/tests/test_zoom_preview.py
@@ -1,0 +1,49 @@
+"""The zoom pre-judge preview bridge (_race_preview) — VIEW_LOOP_PREVIEW.
+
+_judged_zoom is a task, not a generator, so it hands its first render to the SSE
+body through a queue. `_race_preview` drains that queue but must never deadlock
+if the render fails (the queue then stays empty while the task raises).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from providers.generate_modes.tap import _race_preview
+
+
+async def test_race_preview_returns_bytes_when_render_lands_first() -> None:
+    q: asyncio.Queue[bytes] = asyncio.Queue()
+
+    async def judged() -> str:
+        await asyncio.sleep(0.05)  # the judge tail runs after the render enqueues
+        return "final"
+
+    task = asyncio.ensure_future(judged())
+    q.put_nowait(b"first-render")
+    assert await _race_preview(q, task) == b"first-render"
+    await task
+
+
+async def test_race_preview_none_when_task_finishes_without_a_render() -> None:
+    # First render never enqueued (e.g. a no-judge early return) — the get must
+    # not block forever; the task completing resolves the race to None.
+    q: asyncio.Queue[bytes] = asyncio.Queue()
+
+    async def judged() -> str:
+        return "final"
+
+    assert await _race_preview(q, asyncio.ensure_future(judged())) is None
+
+
+async def test_race_preview_none_when_render_raises_no_deadlock() -> None:
+    q: asyncio.Queue[bytes] = asyncio.Queue()
+
+    async def judged() -> str:
+        raise RuntimeError("first render failed")
+
+    task = asyncio.ensure_future(judged())
+    assert await _race_preview(q, task) is None  # no deadlock
+    with pytest.raises(RuntimeError):
+        await task  # the error still propagates to the real await


### PR DESCRIPTION
Extends the enter-path preview (#208) to right-click **"zoom in here."** The zoom path (`_judged_zoom`: render → step-in / legibility judge → one keep-best retry) shows **nothing until `final`** today — the same spinner-until-done bug the enter preview just fixed.

## The wrinkle
`_judged_zoom` is a *task*, not a generator, so it can't `yield` an SSE frame the way the enter loop does. It hands its first render to the streaming body through a small queue; the body paints it before the judge tail + retry.

- **`_race_preview(q, task)`** drains the preview queue but **races it against the judged task**, so a first-render failure (queue never enqueued) can't deadlock the `get` — module-level + pure, so it's unit-tested without the whole generate flow.
- Wired behind the existing **`VIEW_LOOP_PREVIEW`** flag (default OFF, byte-identical) — the same "surface the un-judged render early" toggle now covers **enter AND zoom**.

## Verification
- Tests: preview returns when the render lands first; `None` (no deadlock) when the task finishes, or **raises**, with nothing enqueued. 32 tap/loop tests green, ruff clean.
- Full backend + web suites were green before this (828 web + all backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)