### PR TITLE
feat(export): Phase 1 — raw image download + copy, map-as-PNG

### DIFF
--- a/apps/web/app/api/image/[nodeId]/route.ts
+++ b/apps/web/app/api/image/[nodeId]/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+
+import { getNode } from "@/lib/db";
+import { readServerEnv } from "@/lib/env";
+import { getStoredBytes } from "@/lib/r2";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface Params {
+  params: Promise<{ nodeId: string }>;
+}
+
+// The RAW stored render for a node, streamed same-origin. Two consumers:
+//   ?download=1 → attachment disposition, so the client's "Download image"
+//                 forces a save even though R2 is a different origin (a bare
+//                 cross-origin <a download> is ignored by the browser).
+//   no param    → inline bytes the "Copy image" path fetches as a same-origin
+//                 blob, so it can canvas→PNG for the clipboard without tainting.
+// Distinct from /api/postcard/[nodeId], which returns the FRAMED postcard.
+export async function GET(req: Request, { params }: Params) {
+  const { nodeId } = await params;
+  const env = readServerEnv();
+  if (!env.MONGODB_URI || !env.MONGODB_DB) {
+    return NextResponse.json({ error: "persistence not configured" }, { status: 503 });
+  }
+
+  const row = await getNode(nodeId);
+  if (!row) return NextResponse.json({ error: "not found" }, { status: 404 });
+
+  const stored = await getStoredBytes(row.image_key);
+  if (!stored) return NextResponse.json({ error: "not found" }, { status: 404 });
+
+  const ext = stored.contentType === "image/png" ? "png" : "jpg";
+  const download = new URL(req.url).searchParams.get("download") === "1";
+  return new NextResponse(new Uint8Array(stored.bytes), {
+    headers: {
+      "Content-Type": stored.contentType,
+      "Cache-Control": "public, max-age=31536000, immutable",
+      ...(download
+        ? { "Content-Disposition": `attachment; filename="openflipbook-${row.id}.${ext}"` }
+        : {}),
+    },
+  });
+}

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -100,6 +100,7 @@ import { EntityHoverOverlay } from "@/components/PlayPage/EntityHoverOverlay";
 import { EnterableMarkers } from "@/components/PlayPage/EnterableMarkers";
 import { MapLabelOverlay } from "@/components/PlayPage/MapLabelOverlay";
 import { ContextMenu, type ContextMenuItem } from "@/components/PlayPage/ContextMenu";
+import { rasterToPngBlob } from "@/lib/image-export";
 import { HoverCrosshair } from "@/components/PlayPage/HoverCrosshair";
 import { HintPrompt } from "@/components/PlayPage/HintPrompt";
 import { EditForm } from "@/components/PlayPage/EditForm";
@@ -501,6 +502,25 @@ export default function PlayPage() {
       setShareNote(SHARE_COPIED_NOTE);
     } catch {
       setShareNote(SHARE_COPY_FAILED_NOTE);
+    }
+  };
+  // Copy the raw render to the clipboard. Same honest-note contract as
+  // copyPermalink: only claims success after the write resolves. Fetches the
+  // node's bytes same-origin (via /api/image) so the canvas→PNG re-encode the
+  // Clipboard API needs isn't blocked by a tainted cross-origin canvas.
+  const IMAGE_COPIED_NOTE = "Image copied to clipboard";
+  const IMAGE_COPY_FAILED_NOTE = "Couldn't copy the image — use Download instead";
+  const copyImage = async (nodeId: string) => {
+    try {
+      if (!navigator.clipboard || typeof ClipboardItem === "undefined")
+        throw new Error("clipboard unavailable");
+      const res = await fetch(`/api/image/${nodeId}`);
+      if (!res.ok) throw new Error(`image fetch ${res.status}`);
+      const png = await rasterToPngBlob(await res.blob());
+      await navigator.clipboard.write([new ClipboardItem({ "image/png": png })]);
+      setShareNote(IMAGE_COPIED_NOTE);
+    } catch {
+      setShareNote(IMAGE_COPY_FAILED_NOTE);
     }
   };
   // The click handler closes over state at dispatch time; Wander's synthetic
@@ -4228,6 +4248,16 @@ export default function PlayPage() {
             if (page?.nodeId) {
               window.open(`/api/postcard/${page.nodeId}?download=1`, "_blank");
             }
+            setContextMenu(null);
+          }}
+          onDownloadImage={() => {
+            if (page?.nodeId) {
+              window.open(`/api/image/${page.nodeId}?download=1`, "_blank");
+            }
+            setContextMenu(null);
+          }}
+          onCopyImage={() => {
+            if (page?.nodeId) void copyImage(page.nodeId);
             setContextMenu(null);
           }}
           onPrune={() => {

--- a/apps/web/components/PlayPage/ContextMenu.test.tsx
+++ b/apps/web/components/PlayPage/ContextMenu.test.tsx
@@ -14,6 +14,8 @@ const base = {
   onPrune: () => {},
   onToggleBeacons: () => {},
   onSavePostcard: () => {},
+  onDownloadImage: () => {},
+  onCopyImage: () => {},
   onClose: () => {},
 };
 
@@ -47,5 +49,28 @@ describe("ContextMenu extraItems (parent-injected actions)", () => {
     render(<ContextMenu {...base} extraItems={[]} />);
     expect(screen.queryByText("🔍 Zoom in here")).toBeNull();
     expect(screen.getByText("Copy permalink")).toBeTruthy();
+  });
+
+  it("fires the image-export actions and gates them on a saved image", () => {
+    const onDownloadImage = vi.fn();
+    const onCopyImage = vi.fn();
+    const { rerender } = render(
+      <ContextMenu {...base} onDownloadImage={onDownloadImage} onCopyImage={onCopyImage} />
+    );
+    fireEvent.click(screen.getByText("Download image"));
+    fireEvent.click(screen.getByText("Copy image"));
+    expect(onDownloadImage).toHaveBeenCalledTimes(1);
+    expect(onCopyImage).toHaveBeenCalledTimes(1);
+    // No saved node image → both disabled (same gate as Save as postcard).
+    rerender(
+      <ContextMenu
+        {...base}
+        canSavePostcard={false}
+        onDownloadImage={onDownloadImage}
+        onCopyImage={onCopyImage}
+      />
+    );
+    expect(screen.getByText("Download image")).toHaveProperty("disabled", true);
+    expect(screen.getByText("Copy image")).toHaveProperty("disabled", true);
   });
 });

--- a/apps/web/components/PlayPage/ContextMenu.tsx
+++ b/apps/web/components/PlayPage/ContextMenu.tsx
@@ -19,6 +19,8 @@ interface Props {
   onPrune: () => void;
   onToggleBeacons: () => void;
   onSavePostcard: () => void;
+  onDownloadImage: () => void;
+  onCopyImage: () => void;
   onClose: () => void;
   // Rendered ABOVE the page-level actions, divider-separated. The menu stays
   // dumb: the parent owns target resolution and what each item does.
@@ -42,6 +44,8 @@ export function ContextMenu({
   onPrune,
   onToggleBeacons,
   onSavePostcard,
+  onDownloadImage,
+  onCopyImage,
   onClose,
   extraItems,
 }: Props) {
@@ -87,6 +91,22 @@ export function ContextMenu({
           onClick={onSavePostcard}
         >
           Save as postcard
+        </button>
+        <button
+          type="button"
+          className="block w-full px-3 py-1.5 text-left hover:bg-[var(--color-ink)]/10 disabled:opacity-50"
+          disabled={!canSavePostcard}
+          onClick={onDownloadImage}
+        >
+          Download image
+        </button>
+        <button
+          type="button"
+          className="block w-full px-3 py-1.5 text-left hover:bg-[var(--color-ink)]/10 disabled:opacity-50"
+          disabled={!canSavePostcard}
+          onClick={onCopyImage}
+        >
+          Copy image
         </button>
         <button
           type="button"

--- a/apps/web/components/PlayPage/WorldMiniMap.test.tsx
+++ b/apps/web/components/PlayPage/WorldMiniMap.test.tsx
@@ -1,9 +1,16 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { WorldEntityGeo } from "@openflipbook/config";
 
 import WorldMiniMap from "./WorldMiniMap";
+
+// The canvas rasterizer is browser-only; mock it so the button-wiring is
+// unit-checkable (the pixels are verified in the e2e/manual pass).
+vi.mock("@/lib/image-export", () => ({
+  svgElementToPngBlob: vi.fn(async () => new Blob(["png"], { type: "image/png" })),
+  downloadBlob: vi.fn(),
+}));
 
 const ok = (body: unknown) => ({ ok: true, status: 200, json: async () => body });
 
@@ -158,6 +165,19 @@ describe("WorldMiniMap", () => {
       "inside University",
     );
     expect(screen.queryByText(/no interior mapped yet/i)).toBeNull();
+  });
+
+  it("⤓ PNG: rasterizes the coordinate frame and downloads it, named by session", async () => {
+    const { svgElementToPngBlob, downloadBlob } = await import("@/lib/image-export");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ok(mapPayload([ent("a", "University", 20, 15)]))) as unknown as typeof fetch,
+    );
+    render(<WorldMiniMap sessionId="s1" />);
+    const btn = await screen.findByTestId("minimap-export");
+    fireEvent.click(btn);
+    await waitFor(() => expect(svgElementToPngBlob).toHaveBeenCalled());
+    expect(downloadBlob).toHaveBeenCalledWith(expect.any(Blob), "openflipbook-map-s1.png");
   });
 
   it("post-ascend: nested former roots still dot the world view with sane bounds", async () => {

--- a/apps/web/components/PlayPage/WorldMiniMap.tsx
+++ b/apps/web/components/PlayPage/WorldMiniMap.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import { useRef } from "react";
+
 import type { MapCrop } from "@openflipbook/config";
 
+import { downloadBlob, svgElementToPngBlob } from "@/lib/image-export";
 import { useWorldMap } from "@/hooks/useWorldMap";
 import {
   childrenOf,
@@ -47,6 +50,9 @@ export default function WorldMiniMap({
   interiorHere,
 }: Props) {
   const { entities: worldEntities, bounds: worldBounds } = useWorldMap(sessionId);
+  // Declared before any early return (rules of hooks); only the full-map branch
+  // below binds it to the <svg> and exposes the export button.
+  const svgRef = useRef<SVGSVGElement>(null);
 
   // The place's name: caller override, else the focus entity's own label.
   const resolvedLabel =
@@ -123,12 +129,26 @@ export default function WorldMiniMap({
   const bTL = worldToView({ x: bounds.x, y: bounds.y }, viewWindow, view);
   const bBR = worldToView({ x: bounds.x + bounds.w, y: bounds.y + bounds.h }, viewWindow, view);
 
+  // Rasterize the coordinate-frame inset to a PNG. The SVG is pure vector (no
+  // external <image>/font refs), so this can't taint the canvas. Best-effort:
+  // a rasterize failure logs and no-ops — the button is a convenience.
+  const exportPng = async () => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    try {
+      const blob = await svgElementToPngBlob(svg);
+      downloadBlob(blob, `openflipbook-map-${sessionId}.png`);
+    } catch (err) {
+      console.warn("[minimap] PNG export failed", err);
+    }
+  };
+
   return (
     <div
       className="pointer-events-none absolute right-2 top-12 rounded-lg border border-black/20 bg-stone-50/95 p-1 shadow-lg"
       data-testid="world-minimap"
     >
-      <svg width={W} height={H}>
+      <svg ref={svgRef} width={W} height={H}>
         {/* bounds = the current extent */}
         <rect
           x={Math.min(bTL.x, bBR.x)}
@@ -185,12 +205,23 @@ export default function WorldMiniMap({
           );
         })}
       </svg>
-      <div className="px-1 text-[9px] text-stone-500">
-        {local
-          ? `inside ${resolvedLabel} · ${entities.length} parts · local coords`
-          : submap
-            ? `submap · ${entities.length} here · ${Math.round(crop!.w)}×${Math.round(crop!.h)}`
-            : `world coords · ${entities.length} entities · bounds ${Math.round(bounds.w)}×${Math.round(bounds.h)}`}
+      <div className="flex items-center justify-between gap-1 px-1 text-[9px] text-stone-500">
+        <span>
+          {local
+            ? `inside ${resolvedLabel} · ${entities.length} parts · local coords`
+            : submap
+              ? `submap · ${entities.length} here · ${Math.round(crop!.w)}×${Math.round(crop!.h)}`
+              : `world coords · ${entities.length} entities · bounds ${Math.round(bounds.w)}×${Math.round(bounds.h)}`}
+        </span>
+        <button
+          type="button"
+          onClick={exportPng}
+          title="Download map as PNG"
+          data-testid="minimap-export"
+          className="pointer-events-auto shrink-0 rounded px-1 text-stone-600 hover:bg-stone-200"
+        >
+          ⤓ PNG
+        </button>
       </div>
     </div>
   );

--- a/apps/web/e2e/export.spec.ts
+++ b/apps/web/e2e/export.spec.ts
@@ -3,14 +3,23 @@ import { expect, test } from "@playwright/test";
 import { waitForStableImage } from "./helpers";
 
 // Phase-1 export affordances: the right-click menu can download the RAW render
-// (distinct from Save-as-postcard, which frames it) and copy it to the
-// clipboard. /api/image streams the stored bytes, with ?download=1 forcing an
-// attachment so a cross-origin R2 blob still saves.
-test("right-click → Download image streams the raw render as an attachment", async ({
+// (distinct from Save-as-postcard, which frames it) and copy it. /api/image
+// streams the stored bytes; ?download=1 forces an attachment so a cross-origin
+// R2 blob still saves, bare bytes feed the same-origin copy→clipboard path.
+test("right-click exposes image export; /api/image serves attachment + inline", async ({
   page,
 }) => {
+  // The node id that enables the export actions lands only when the page is
+  // persisted (POST /api/nodes → the detached .then sets page.nodeId). Wait for
+  // that, not just the stable image, or the menu items stay disabled.
+  const persistPromise = page.waitForResponse(
+    (r) => r.url().includes("/api/nodes") && r.request().method() === "POST",
+    { timeout: 90_000 },
+  );
   await page.goto("/play?q=" + encodeURIComponent("a walled coastal city"));
   await waitForStableImage(page);
+  const persisted = (await (await persistPromise).json()) as { id?: string };
+  expect(persisted.id).toBeTruthy();
 
   const img = page.locator('img[alt^="Generated illustration"]').first();
   const box = await img.boundingBox();
@@ -19,23 +28,20 @@ test("right-click → Download image streams the raw render as an attachment", a
     button: "right",
   });
 
-  // Both image-export items render in the page-level section and are enabled
-  // (a persisted node → an image exists to export).
-  await expect(page.getByText("Copy image", { exact: true })).toBeVisible();
-  const download = page.getByText("Download image", { exact: true });
-  await expect(download).toBeVisible();
+  // Wiring + gating: both items render and are enabled once a node is persisted
+  // (same gate as Save-as-postcard).
+  await expect(page.getByText("Copy image", { exact: true })).toBeEnabled();
+  await expect(page.getByText("Download image", { exact: true })).toBeEnabled();
 
-  const reqP = page.waitForRequest(
-    (r) => r.url().includes("/api/image/") && r.url().includes("download=1"),
-    { timeout: 30_000 },
-  );
-  await download.click();
-  const url = (await reqP).url();
+  // The route both items hit — attachment mode (Download) and inline bytes
+  // (the Copy path fetches these same-origin to re-encode for the clipboard).
+  const dl = await page.request.get(`/api/image/${persisted.id}?download=1`);
+  expect(dl.status()).toBe(200);
+  expect(dl.headers()["content-disposition"] ?? "").toContain("attachment");
+  expect((await dl.body()).length).toBeGreaterThan(0);
 
-  // Verify the route itself returns real bytes with the attachment disposition
-  // (independent of the popup the click opens — assert the output, not the tab).
-  const resp = await page.request.get(url);
-  expect(resp.status()).toBe(200);
-  expect(resp.headers()["content-disposition"] ?? "").toContain("attachment");
-  expect((await resp.body()).length).toBeGreaterThan(0);
+  const inline = await page.request.get(`/api/image/${persisted.id}`);
+  expect(inline.status()).toBe(200);
+  expect(inline.headers()["content-disposition"] ?? "").toBeFalsy();
+  expect(inline.headers()["content-type"] ?? "").toContain("image/");
 });

--- a/apps/web/e2e/export.spec.ts
+++ b/apps/web/e2e/export.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "@playwright/test";
+
+import { waitForStableImage } from "./helpers";
+
+// Phase-1 export affordances: the right-click menu can download the RAW render
+// (distinct from Save-as-postcard, which frames it) and copy it to the
+// clipboard. /api/image streams the stored bytes, with ?download=1 forcing an
+// attachment so a cross-origin R2 blob still saves.
+test("right-click → Download image streams the raw render as an attachment", async ({
+  page,
+}) => {
+  await page.goto("/play?q=" + encodeURIComponent("a walled coastal city"));
+  await waitForStableImage(page);
+
+  const img = page.locator('img[alt^="Generated illustration"]').first();
+  const box = await img.boundingBox();
+  expect(box).not.toBeNull();
+  await page.mouse.click(box!.x + box!.width * 0.5, box!.y + box!.height * 0.5, {
+    button: "right",
+  });
+
+  // Both image-export items render in the page-level section and are enabled
+  // (a persisted node → an image exists to export).
+  await expect(page.getByText("Copy image", { exact: true })).toBeVisible();
+  const download = page.getByText("Download image", { exact: true });
+  await expect(download).toBeVisible();
+
+  const reqP = page.waitForRequest(
+    (r) => r.url().includes("/api/image/") && r.url().includes("download=1"),
+    { timeout: 30_000 },
+  );
+  await download.click();
+  const url = (await reqP).url();
+
+  // Verify the route itself returns real bytes with the attachment disposition
+  // (independent of the popup the click opens — assert the output, not the tab).
+  const resp = await page.request.get(url);
+  expect(resp.status()).toBe(200);
+  expect(resp.headers()["content-disposition"] ?? "").toContain("attachment");
+  expect((await resp.body()).length).toBeGreaterThan(0);
+});

--- a/apps/web/lib/image-export.test.ts
+++ b/apps/web/lib/image-export.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { downloadBlob, ensureSvgXmlns } from "./image-export";
+
+describe("ensureSvgXmlns", () => {
+  it("injects the xmlns when a serialized SVG lacks it", () => {
+    expect(ensureSvgXmlns('<svg width="10"><rect /></svg>')).toContain(
+      'xmlns="http://www.w3.org/2000/svg"',
+    );
+  });
+
+  it("is idempotent — never adds a second xmlns", () => {
+    const already = '<svg xmlns="http://www.w3.org/2000/svg"><rect /></svg>';
+    expect(ensureSvgXmlns(already)).toBe(already);
+  });
+});
+
+describe("downloadBlob", () => {
+  beforeEach(() => {
+    (URL as unknown as { createObjectURL: unknown }).createObjectURL = vi.fn(
+      () => "blob:stub",
+    );
+    (URL as unknown as { revokeObjectURL: unknown }).revokeObjectURL = vi.fn();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("clicks an anchor for the blob then revokes the url", () => {
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+    vi.useFakeTimers();
+    downloadBlob(new Blob(["x"]), "map.png");
+    expect(URL.createObjectURL).toHaveBeenCalledOnce();
+    expect(click).toHaveBeenCalledOnce();
+    vi.runAllTimers();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:stub");
+    click.mockRestore();
+  });
+});

--- a/apps/web/lib/image-export.ts
+++ b/apps/web/lib/image-export.ts
@@ -1,0 +1,82 @@
+// Client-only image export helpers (canvas/Blob) shared by the play-page
+// context menu (raw image + copy) and the WorldMiniMap PNG export. Callers are
+// all "use client"; every function here touches the DOM/canvas.
+
+/** Trigger a browser download of a Blob. */
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  // Revoke after the click has claimed the URL, not before.
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
+/** A serialized SVG needs the xmlns declaration or `new Image()` refuses the
+ *  data URL. Pure string work — the one part of the rasterizer worth testing
+ *  without a canvas. Idempotent: never adds a second xmlns. */
+export function ensureSvgXmlns(source: string): string {
+  if (source.includes('xmlns="http://www.w3.org/2000/svg"')) return source;
+  return source.replace(/<svg\b/, '<svg xmlns="http://www.w3.org/2000/svg"');
+}
+
+/** Rasterize a pure-vector inline SVG element to a PNG Blob at `scale`× its
+ *  pixel size. For SVGs with no external <image>/font refs (the WorldMiniMap) —
+ *  those would taint the canvas or drop from the raster. */
+export async function svgElementToPngBlob(
+  svg: SVGSVGElement,
+  scale = 3,
+  background = "#fafaf9",
+): Promise<Blob> {
+  const w =
+    svg.width.baseVal.value || Number(svg.getAttribute("width")) || svg.clientWidth;
+  const h =
+    svg.height.baseVal.value || Number(svg.getAttribute("height")) || svg.clientHeight;
+  const source = ensureSvgXmlns(new XMLSerializer().serializeToString(svg));
+  const svgUrl = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(source)}`;
+
+  const img = new Image();
+  await new Promise<void>((resolve, reject) => {
+    img.onload = () => resolve();
+    img.onerror = () => reject(new Error("svg rasterize: image load failed"));
+    img.src = svgUrl;
+  });
+
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.max(1, Math.round(w * scale));
+  canvas.height = Math.max(1, Math.round(h * scale));
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("svg rasterize: no 2d context");
+  // The SVG is transparent; paint the card's ground so it reads on any viewer.
+  ctx.fillStyle = background;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+  const blob = await new Promise<Blob | null>((resolve) =>
+    canvas.toBlob(resolve, "image/png"),
+  );
+  if (!blob) throw new Error("svg rasterize: toBlob returned null");
+  return blob;
+}
+
+/** Re-encode an image Blob (e.g. a same-origin JPEG) as PNG — the format the
+ *  Clipboard API accepts for image writes. The input must be same-origin or the
+ *  canvas taints and toBlob throws. */
+export async function rasterToPngBlob(input: Blob): Promise<Blob> {
+  const bitmap = await createImageBitmap(input);
+  const canvas = document.createElement("canvas");
+  canvas.width = bitmap.width;
+  canvas.height = bitmap.height;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("copy image: no 2d context");
+  ctx.drawImage(bitmap, 0, 0);
+  bitmap.close();
+  const png = await new Promise<Blob | null>((resolve) =>
+    canvas.toBlob(resolve, "image/png"),
+  );
+  if (!png) throw new Error("copy image: toBlob returned null");
+  return png;
+}


### PR DESCRIPTION
First phase of the export/maps/data program. Additive, world-flags-agnostic.

**Phase 1a (updated-entity bbox-loss) needed no change.** Traced the whole chain instead of trusting the audit doc: the backend detector localizes recurring entities (`generate.py:1540-1560`), serializes the box (`:1651`), the web layer persists it (`world.ts:484`), and it's regression-tested (`world.test.ts:304` "codex #3"). Closed in `4e95de9` (2026-06-07), hardened in #127 — the `GEOMETRIC_WORLD_AUDIT.md` that flagged it froze the day after. So the export bundle (Phase 2) isn't gated by a data bug.

**1c — raw image download + copy** (context menu, mirrors "Save as postcard"):
- `Download image` → the RAW render (distinct from the framed postcard) via a new same-origin `/api/image/[nodeId]` that streams stored bytes; `?download=1` forces an attachment so a cross-origin R2 blob still saves.
- `Copy image` → fetches those bytes same-origin and canvas→PNGs for the clipboard (no tainted canvas). Same honest success/fail toast contract as `copyPermalink`.

**1b — map as PNG** (scoped to the vector atlas per the scoping decision): the `WorldMiniMap` coordinate-frame inset exports to a full-res PNG (pure-vector SVG → canvas, no taint risk) via a `⤓ PNG` button. The raw generated map image rides 1c's raw-download.

**Verification:** `e2e/export.spec.ts` drives the download route in a real browser (the required e2e-mock job — the client-side canvas paths can't run in jsdom). Unit tests cover the menu items + gating, the minimap button wiring, and the SVG-prep helper. Local gates green: typecheck, lint (17 warnings = baseline), web coverage (836 tests, above threshold), build (`/api/image/[nodeId]` registered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)