### PR TITLE
feat(export): Phase 2 — whole-world export bundle

### DIFF
--- a/apps/web/app/api/export/session/[sessionId]/route.ts
+++ b/apps/web/app/api/export/session/[sessionId]/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from "next/server";
+
+import { listNodesBySession } from "@/lib/db";
+import { readServerEnv } from "@/lib/env";
+import { buildWorldZip, type WorldExportNode } from "@/lib/export-build";
+import { getStoredBytes } from "@/lib/r2";
+import { getWorldState } from "@/lib/world";
+import { getWorldMap } from "@/lib/world-map";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface Params {
+  params: Promise<{ sessionId: string }>;
+}
+
+// Bound memory on a runaway session: export the first NODE_CAP nodes and set a
+// header so the truncation isn't silent. A session that large is already an
+// outlier; the whole-DAG walk stays O(nodes) regardless.
+const NODE_CAP = 500;
+
+/** GET /api/export/session/[sessionId] — the whole-world bundle (ZIP): every
+ * branch's image + graph.json (topology + provenance + poses) + world-map.json
+ * (geometry) + entities.json (registry). Session-scoped, unlike the node-path
+ * /api/export/[nodeId]. */
+export async function GET(_req: Request, { params }: Params) {
+  const { sessionId } = await params;
+  const env = readServerEnv();
+  if (!env.MONGODB_URI || !env.MONGODB_DB) {
+    return NextResponse.json({ error: "persistence not configured" }, { status: 503 });
+  }
+
+  // The whole DAG — listNodesBySession is cursor-paged, so accumulate up to the
+  // cap. Sorted by created_at, so graph.json reads chronologically.
+  const rows: Awaited<ReturnType<typeof listNodesBySession>>["rows"] = [];
+  let cursor: string | null = null;
+  do {
+    const page = await listNodesBySession(sessionId, { cursor, limit: 200 });
+    rows.push(...page.rows);
+    cursor = page.next_cursor;
+  } while (cursor && rows.length < NODE_CAP);
+  if (rows.length === 0) {
+    return NextResponse.json({ error: "session not found or empty" }, { status: 404 });
+  }
+  const capped = rows.slice(0, NODE_CAP);
+  const truncated = rows.length > NODE_CAP || (cursor != null && rows.length >= NODE_CAP);
+  if (truncated) {
+    console.warn(
+      `[export.world] session ${sessionId} exceeds ${NODE_CAP} nodes — bundle truncated`,
+    );
+  }
+
+  const [worldMap, entities] = await Promise.all([
+    getWorldMap(sessionId),
+    getWorldState(sessionId),
+  ]);
+
+  const nodes: WorldExportNode[] = [];
+  for (const r of capped) {
+    const stored = await getStoredBytes(r.image_key);
+    nodes.push({
+      id: r.id,
+      parent_id: r.parent_id,
+      title: r.page_title || r.query,
+      query: r.query,
+      created_at: r.created_at,
+      relation: r.relation,
+      scale_tier: r.scale_tier,
+      click_in_parent: r.click_in_parent,
+      scene_view: r.scene_view,
+      sources: r.sources,
+      bytes: stored ? stored.bytes : null,
+    });
+  }
+
+  const bytes = await buildWorldZip(nodes, worldMap, entities);
+  const stamp = sessionId.slice(0, 8);
+  return new Response(Buffer.from(bytes), {
+    headers: {
+      "Content-Type": "application/zip",
+      "Content-Disposition": `attachment; filename="openflipbook-world-${stamp}.zip"`,
+      ...(truncated ? { "X-Export-Truncated": String(NODE_CAP) } : {}),
+    },
+  });
+}

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -1853,6 +1853,15 @@ export default function PlayPage() {
           },
         });
       }
+      // The whole world (not just the root→here path): every branch's image +
+      // graph/geometry/entities JSON. Session-scoped route.
+      items.push({
+        label: "Export world (ZIP)",
+        onClick: () => {
+          close();
+          window.open(`/api/export/session/${page.sessionId}`, "_blank");
+        },
+      });
       // Opt-in gallery (Wave 7): this page fronts the published session.
       const publishSessionId = page.sessionId;
       items.push({

--- a/apps/web/e2e/export.spec.ts
+++ b/apps/web/e2e/export.spec.ts
@@ -45,3 +45,33 @@ test("right-click exposes image export; /api/image serves attachment + inline", 
   expect(inline.headers()["content-disposition"] ?? "").toBeFalsy();
   expect(inline.headers()["content-type"] ?? "").toContain("image/");
 });
+
+// Phase 2: the whole-world bundle — every branch's image + graph/geometry/
+// entities JSON, session-scoped.
+test("world export returns the session DAG as a ZIP", async ({ page }) => {
+  let sessionId = "";
+  page.on("request", (req) => {
+    if (req.url().includes("/api/generate-page") && req.method() === "POST") {
+      const body = JSON.parse(req.postData() ?? "{}");
+      if (body.session_id) sessionId = body.session_id;
+    }
+  });
+  const persistPromise = page.waitForResponse(
+    (r) => r.url().includes("/api/nodes") && r.request().method() === "POST",
+    { timeout: 90_000 },
+  );
+  await page.goto("/play?q=" + encodeURIComponent("a walled coastal city"));
+  await waitForStableImage(page);
+  await persistPromise;
+  expect(sessionId).toBeTruthy();
+
+  const resp = await page.request.get(`/api/export/session/${sessionId}`);
+  expect(resp.status()).toBe(200);
+  expect(resp.headers()["content-type"] ?? "").toContain("zip");
+  expect(resp.headers()["content-disposition"] ?? "").toContain("attachment");
+  const zip = await resp.body();
+  // ZIP local-file-header magic "PK\x03\x04".
+  expect(zip.length).toBeGreaterThan(0);
+  expect(zip[0]).toBe(0x50);
+  expect(zip[1]).toBe(0x4b);
+});

--- a/apps/web/lib/export-build.test.ts
+++ b/apps/web/lib/export-build.test.ts
@@ -5,9 +5,11 @@ import { describe, expect, it } from "vitest";
 import {
   buildFlipbookPdf,
   buildGif,
+  buildWorldZip,
   buildZip,
   sampleEvenly,
   type ExportPage,
+  type WorldExportNode,
 } from "./export-build";
 
 // A minimal valid JPEG (1x1, generated once with jpeg-js) — enough for the
@@ -52,6 +54,66 @@ describe("buildZip", () => {
     const graph = JSON.parse(await zip.file("graph.json")!.async("string"));
     expect(graph.exported_path).toHaveLength(2);
     expect(graph.exported_path[1].parent_id).toBe("a");
+  });
+});
+
+function worldNode(
+  id: string,
+  bytes: Uint8Array | null,
+  parent: string | null,
+  extra: Partial<WorldExportNode> = {},
+): WorldExportNode {
+  return {
+    id,
+    parent_id: parent,
+    title: `Page ${id}`,
+    query: `q ${id}`,
+    created_at: "2026-06-11T00:00:00Z",
+    relation: "descend",
+    scale_tier: null,
+    click_in_parent: null,
+    scene_view: null,
+    sources: [],
+    bytes,
+    ...extra,
+  };
+}
+
+describe("buildWorldZip", () => {
+  it("bundles every node's image + a rich graph, world-map, and entities json", async () => {
+    const jpg = await tinyJpeg();
+    const bytes = await buildWorldZip(
+      [
+        worldNode("a", jpg, null, { scale_tier: "city" }),
+        worldNode("b", jpg, "a", {
+          relation: "expand",
+          click_in_parent: { x_pct: 0.5, y_pct: 0.5 },
+        }),
+        worldNode("c", null, "b"), // missing blob → stays in the graph, no image file
+      ],
+      { entities: [{ id: "geo_a" }], bounds: { x: 0, y: 0, w: 10, h: 10 } },
+      { entities: [{ id: "e1", name: "Mira" }] },
+    );
+    const zip = await JSZip.loadAsync(bytes);
+    const names = Object.keys(zip.files);
+    // Two images (c has no bytes) + the three JSON files.
+    expect(names.filter((n) => n.endsWith(".jpg"))).toHaveLength(2);
+
+    const graph = JSON.parse(await zip.file("graph.json")!.async("string"));
+    expect(graph.nodes).toHaveLength(3);
+    expect(graph.nodes[1]).toMatchObject({
+      id: "b",
+      parent_id: "a",
+      relation: "expand",
+      click_in_parent: { x_pct: 0.5, y_pct: 0.5 },
+    });
+    expect(graph.nodes[1].image).toMatch(/^pages\/002-/);
+    expect(graph.nodes[2].image).toBeNull();
+
+    const worldMap = JSON.parse(await zip.file("world-map.json")!.async("string"));
+    expect(worldMap.entities[0].id).toBe("geo_a");
+    const entities = JSON.parse(await zip.file("entities.json")!.async("string"));
+    expect(entities.entities[0].name).toBe("Mira");
   });
 });
 

--- a/apps/web/lib/export-build.ts
+++ b/apps/web/lib/export-build.ts
@@ -56,6 +56,61 @@ export async function buildZip(pages: ExportPage[]): Promise<Uint8Array> {
   return zip.generateAsync({ type: "uint8array" });
 }
 
+/** A node in the whole-session ("world") export: the full page metadata plus
+ * its bytes (null when the blob is missing — the node still appears in the
+ * graph, just without an image file). Decoupled from the db NodeRow so the
+ * builder stays pure. */
+export interface WorldExportNode {
+  id: string;
+  parent_id: string | null;
+  title: string;
+  query: string;
+  created_at: string;
+  relation: string;
+  scale_tier: string | null;
+  click_in_parent: unknown;
+  scene_view: unknown;
+  sources: unknown[];
+  bytes: Uint8Array | null;
+}
+
+/** The whole-world bundle: every branch's image + a rich graph.json (topology,
+ * click provenance, per-node observer pose) + the geometric world-map.json and
+ * the entities.json registry. The read side of "download your whole world" —
+ * enough to reconstruct or re-open the session anywhere. */
+export async function buildWorldZip(
+  nodes: WorldExportNode[],
+  worldMap: unknown,
+  entities: unknown,
+): Promise<Uint8Array> {
+  const zip = new JSZip();
+  const graph = nodes.map((n, i) => {
+    let image: string | null = null;
+    if (n.bytes) {
+      const slug = n.title.replace(/[^\w\- ]+/g, "").trim().slice(0, 60) || n.id;
+      image = `pages/${String(i + 1).padStart(3, "0")}-${slug}.jpg`;
+      zip.file(image, n.bytes);
+    }
+    return {
+      id: n.id,
+      parent_id: n.parent_id,
+      title: n.title,
+      query: n.query,
+      created_at: n.created_at,
+      relation: n.relation,
+      scale_tier: n.scale_tier,
+      click_in_parent: n.click_in_parent,
+      scene_view: n.scene_view,
+      sources: n.sources,
+      image,
+    };
+  });
+  zip.file("graph.json", JSON.stringify({ nodes: graph }, null, 2));
+  zip.file("world-map.json", JSON.stringify(worldMap ?? null, null, 2));
+  zip.file("entities.json", JSON.stringify(entities ?? null, null, 2));
+  return zip.generateAsync({ type: "uint8array" });
+}
+
 /** Flipbook PDF: one full-bleed page per image with a slim title strip under
  * it — the artifact the project is named after. */
 export async function buildFlipbookPdf(pages: ExportPage[]): Promise<Uint8Array> {


### PR DESCRIPTION
Second phase of the export/maps/data program: **download your whole world**, not just the root→here path.

New session-scoped `GET /api/export/session/[sessionId]` walks the full session DAG (`listNodesBySession`, cursor-paged, capped at 500 with an `X-Export-Truncated` header + server warn) and returns a ZIP:
- `pages/NNN-title.jpg` — every branch's image (not just the ancestor chain the node-path export walks)
- `graph.json` — per node: topology + **provenance** (`relation`, `scale_tier`, `click_in_parent`, `scene_view`/observer pose, `sources`), well beyond the path export's titles+parents
- `world-map.json` — the geometric numeric map (`getWorldMap`: coords/footprint/height/heading/borders/bounds)
- `entities.json` — the entity registry (`getWorldState`)

Reuses `export-build.ts`'s jszip machinery via a new **pure** `buildWorldZip` (a node with a missing blob stays in `graph.json` with `image: null` — the structure isn't lost). Wired as an **"Export world (ZIP)"** right-click item beside the existing "Export path", using the current page's `sessionId`.

Because Phase 1a turned out already-fixed (the `updated`-entity bbox persistence is intact + regression-tested), `world-map.json` carries non-lossy geometry.

**Verification:** `buildWorldZip` unit-tested (unzip → assert the rich graph, geometry, entities, and missing-blob handling); `e2e/export.spec.ts` smoke-tests the route returns a real ZIP (magic bytes + attachment) on the required e2e-mock job. Local gates green: typecheck, lint (17 = baseline), coverage (838 tests, `export-build.ts` 100%), build (route registered).

Branched off main after Phase 1 (#212) merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)