### PR TITLE
eval(matrix): labelled-map model A/B — finding + reproducible sweep

### DIFF
--- a/apps/modal-backend/tests/matrix_bench/sweeps/map-model-ab.json
+++ b/apps/modal-backend/tests/matrix_bench/sweeps/map-model-ab.json
@@ -1,0 +1,38 @@
+{
+  "name": "map-model-ab",
+  "_comment": "Labelled-map model A/B: two verified geographic maps × the three nano-banana tiers × one variant. Re-picks the default map-generation model on price/effect. Trimmed from default.json (map-clean scenarios only, single variant) to stay ~$0.7 under the cap.",
+  "scenarios": [
+    "corpus:fantasy-treasure-island",
+    "corpus:forest-yellowstone-1904"
+  ],
+  "arms": [
+    "graph"
+  ],
+  "models": [
+    "fal-ai/nano-banana",
+    "fal-ai/nano-banana-2",
+    "fal-ai/nano-banana-pro"
+  ],
+  "variants": [
+    "recon_base.v1"
+  ],
+  "params": {
+    "aspect_ratio": "16:9"
+  },
+  "judges": [
+    "style_pair",
+    "map_plausibility",
+    "prompt_alignment"
+  ],
+  "composite_weights": {
+    "presence": 0.2,
+    "pos_aligned": 0.2,
+    "pos_raw": 0.05,
+    "size": 0.1,
+    "height_order": 0.1,
+    "style_pair": 0.15,
+    "map_plausibility": 0.1,
+    "prompt_alignment": 0.1
+  },
+  "budget_usd": 1.0
+}


### PR DESCRIPTION
Phase 3 of the export/maps/data program: the one paid eval you green-lit (~$0.70 ceiling; **actual incremental spend ~$0.28** — 4 of 6 cells were cached, only 2 fresh images generated; the matrix's $0.69 figure is the full-matrix nominal cost).

Adds a trimmed, map-clean sweep (`map-model-ab.json`: 2 verified geographic maps × the three nano-banana tiers × 1 variant) so this is reproducible: `MATRIX_SWEEP=tests/matrix_bench/sweeps/map-model-ab.json make eval-matrix-dry` ($0 preview) then `… make eval-matrix`.

## Finding (n=2 — directional, not a production mandate)

| Model | $/img | Quality (composite) | $/cell |
|---|---|---|---|
| nano-banana | $0.039 | 0.655 | $0.064 |
| nano-banana-2 | $0.08 | 0.666 | $0.105 |
| **nano-banana-pro** (current default) | $0.15 | **0.762** | $0.175 |

- **nano-banana-pro earns its price**: ~+0.10 composite over both cheaper tiers, driven by the forest map (presence 1.0 vs 0.875, size 0.69 vs 0.12, recovered pose error 8.7 vs 15.6). The current default is justified — this A/B does **not** support a cheaper swap.
- **nano-banana-2 is dominated**: +0.011 quality over plain nano-banana for +64% cost. If a budget floor is ever wanted, it's plain nano-banana ($0.039), not nano-banana-2.
- This nuances the earlier bakeoff ("pro ~7× worse price/effect") — on real corpus maps at full composite, pro's quality lead is real.

**Caveat: n=2.** Two maps is a directional signal; re-run over the full map-tier corpus before changing any production default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)