### PR TITLE
feat(bench): multi-hop drift runner (chain_runner.py) — Risk #1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,15 @@ eval-style:
 #   make eval-outward-drift
 eval-outward-drift:
 	cd apps/modal-backend && OUTWARD_BENCH_RUN=1 .venv/bin/python -m tests.continuity_bench.outward_runner
+# MULTI-HOP DRIFT (Risk #1): walk a styled source OUTWARD k hops (each container
+# conditioned on the PREVIOUS hop — the compounding path) and score style
+# faithfulness to the ORIGINAL after every hop → a half-life (the hop drift crosses
+# the floor). Product rule falls out: cap auto-OUTWARD at half_life - 1.
+# Dry preview ($0): make eval-chain-drift-dry ; PAID: make eval-chain-drift
+eval-chain-drift-dry:
+	cd apps/modal-backend && .venv/bin/python -m tests.continuity_bench.chain_runner
+eval-chain-drift:
+	cd apps/modal-backend && CHAIN_BENCH_RUN=1 .venv/bin/python -m tests.continuity_bench.chain_runner
 # ENTER-consistency A/B: tap a landmark on a styled map and render the entered
 # scene the OLD way (fresh text-to-image, refs ignored) vs the NEW way (edit
 # endpoint on the region crop) → "same place?" judge vs the tapped region → the

--- a/apps/modal-backend/tests/continuity_bench/chain_runner.py
+++ b/apps/modal-backend/tests/continuity_bench/chain_runner.py
@@ -83,6 +83,30 @@ _CASES: list[Case] = [
 ]
 
 
+def _active_cases() -> list[Case]:
+    """CHAIN_BENCH_CASES=N runs the first N chains (0/unset = all) — the spend knob."""
+    n = int(os.environ.get("CHAIN_BENCH_CASES", "0"))
+    return _CASES[:n] if n > 0 else _CASES
+
+
+def _fit_frame(jpeg_bytes: bytes, w: int, h: int) -> bytes:
+    """Downscale a hop's output back into the base frame. Each OUTWARD zoom-out
+    canvas = its INPUT's real pixel size x factor (image_edit.expand_image_zoomout
+    reads the input dims), so feeding the growing output straight back compounds
+    the canvas past fal's 25MP cap by ~hop 2. Bounding each rung to a fixed page
+    keeps the zoom-out compounding in CONTENT, not pixels — and matches what the
+    product stores (every node is a fixed-size frame)."""
+    from io import BytesIO
+
+    from PIL import Image
+
+    im = Image.open(BytesIO(jpeg_bytes)).convert("RGB")
+    im.thumbnail((w, h), Image.LANCZOS)
+    out = BytesIO()
+    im.save(out, format="JPEG", quality=90)
+    return out.getvalue()
+
+
 def plan_chain(start_tier: str, k: int) -> list[tuple[str, str, str]]:
     """Pure: the (from_tier, to_tier, op) sequence a k-hop OUTWARD walk takes,
     stopping early at the coarsest rung. Drives both the dry preview and the run."""
@@ -169,11 +193,12 @@ async def _run_chain(case: Case, k: int, aspect: str, model: str) -> ChainResult
     src = await image_provider.generate_image(
         prompt=case.source_prompt, aspect_ratio=aspect, tier="balanced", model_override=model
     )
+    src_bytes = _fit_frame(src.jpeg_bytes, w, h)  # the fixed-frame source of truth
     _REPORTS.mkdir(parents=True, exist_ok=True)
-    (_REPORTS / f"chain_{case.name}_00_source.jpg").write_bytes(src.jpeg_bytes)
+    (_REPORTS / f"chain_{case.name}_00_source.jpg").write_bytes(src_bytes)
 
-    prev_bytes = src.jpeg_bytes
-    prev_url = image_provider.encode_data_url(src.jpeg_bytes)
+    prev_bytes = src_bytes
+    prev_url = image_provider.encode_data_url(src_bytes)
     from_tier = case.start_tier
     hops: list[HopResult] = []
 
@@ -185,7 +210,7 @@ async def _run_chain(case: Case, k: int, aspect: str, model: str) -> ChainResult
 
         # 2. The REAL ascend op, conditioned on the PREVIOUS hop (compounding).
         if op == "outpaint_zoomout":
-            img = await image_edit_provider.expand_image_zoomout(prev_url, 3.0, w, h)
+            raw = await image_edit_provider.expand_image_zoomout(prev_url, 3.0, w, h)
         else:  # scale_parent_fresh — a medium flip can't be outpainted
             plan = await llm.plan_page(
                 query=f"{case.subject} (the {to_tier} that contains it)",
@@ -193,14 +218,15 @@ async def _run_chain(case: Case, k: int, aspect: str, model: str) -> ChainResult
                 style_anchor=case.style,
                 render_mode="scale_parent",
             )
-            img = await image_provider.generate_image(
+            raw = await image_provider.generate_image(
                 plan.prompt, aspect, tier="balanced", reference_urls=[prev_url], model_override=model
             )
+        hop_bytes = _fit_frame(raw.jpeg_bytes, w, h)  # bound before it feeds the next hop
 
         # 3. Two judgements: faithfulness to the ORIGINAL, and to the last hop.
-        fs = await score_style_pair(src.jpeg_bytes, img.jpeg_bytes)
-        st = await score_style_pair(prev_bytes, img.jpeg_bytes)
-        (_REPORTS / f"chain_{case.name}_{idx + 1:02d}_{to_tier}.jpg").write_bytes(img.jpeg_bytes)
+        fs = await score_style_pair(src_bytes, hop_bytes)
+        st = await score_style_pair(prev_bytes, hop_bytes)
+        (_REPORTS / f"chain_{case.name}_{idx + 1:02d}_{to_tier}.jpg").write_bytes(hop_bytes)
         hops.append(
             HopResult(
                 to_tier=to_tier,
@@ -211,15 +237,15 @@ async def _run_chain(case: Case, k: int, aspect: str, model: str) -> ChainResult
                 step_rationale=st.rationale,
             )
         )
-        prev_bytes = img.jpeg_bytes
-        prev_url = image_provider.encode_data_url(img.jpeg_bytes)
+        prev_bytes = hop_bytes
+        prev_url = image_provider.encode_data_url(hop_bytes)
         from_tier = to_tier
 
     return ChainResult(name=case.name, hops=hops)
 
 
 async def run_bench(k: int, model: str) -> dict[str, Any]:
-    results = [await _run_chain(c, k, "16:9", model) for c in _CASES]
+    results = [await _run_chain(c, k, "16:9", model) for c in _active_cases()]
     per_case = []
     for r in results:
         summary = summarize(
@@ -266,12 +292,13 @@ def _load_env() -> None:
 
 def _print_dry_preview(model: str) -> None:
     print(f"MULTI-HOP DRIFT — dry preview (k={_HOPS} hops, floor={_FLOOR}, model={model})")
-    for c in _CASES:
+    cases = _active_cases()
+    for c in cases:
         chain = plan_chain(c.start_tier, _HOPS)
         path = c.start_tier + "".join(f" → {to}" for _f, to, _op in chain)
         ops = ", ".join(op for _f, _t, op in chain)
         print(f"  {c.name}: {path}   [{ops}]")
-    print(f"total to-bill (est): ${estimate_cost(_CASES, _HOPS)} over {len(_CASES)} chains")
+    print(f"total to-bill (est): ${estimate_cost(cases, _HOPS)} over {len(cases)} chains")
     print("set CHAIN_BENCH_RUN=1 to spend.")
 
 

--- a/apps/modal-backend/tests/continuity_bench/chain_runner.py
+++ b/apps/modal-backend/tests/continuity_bench/chain_runner.py
@@ -1,0 +1,299 @@
+"""MULTI-HOP DRIFT — the design's Risk #1 (`PLAN_OUTWARD.md:118,123`), previously
+unmeasured. `outward_runner.py` scores ONE hop; the real failure mode is
+compounding drift as each OUTWARD container becomes the source for the next
+(exposure bias / autoregressive error accumulation).
+
+This walks a styled source OUTWARD k hops along the scale ladder
+(`place→district→city→region→world`, `model_router.coarser_tier`), each hop the
+REAL ascend op (`select_outward_op` → BRIA outpaint on same-plane hops, a
+reference-conditioned fresh gen on a medium flip) conditioned on the PREVIOUS
+hop's output — the actual compounding path, not k independent hops. After each
+hop it scores two things with the existing style judge:
+  - from_source: faithfulness of hop_i to the ORIGINAL medium (does the chain
+    wander off the starting style?);
+  - step:        faithfulness of hop_i to hop_{i-1} (WHERE the wandering happens).
+`summarize` turns the sequence into a `half_life` (the hop drift first crosses a
+floor) — the product rule falls out: cap auto-OUTWARD at `half_life - 1`.
+
+Paid (fal gens + Gemini judge). Self-contained — no session / web needed:
+    cd apps/modal-backend && CHAIN_BENCH_RUN=1 \
+      .venv/bin/python -m tests.continuity_bench.chain_runner
+or:  make eval-chain-drift   (dry preview, $0: make eval-chain-drift-dry)
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import statistics
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from ._score import score_style_pair
+
+_REPORTS = Path(__file__).resolve().parent / "reports"
+# Below this style-faithfulness the chain has wandered off the source medium;
+# the hop where from_source first drops under it is the half-life.
+_FLOOR = float(os.environ.get("CHAIN_BENCH_FLOOR", "6.0"))
+_HOPS = int(os.environ.get("CHAIN_BENCH_HOPS", "4"))
+
+# Rough per-op fal prices (docs/COSTS.md) for the $0 dry preview.
+_OP_COST = {"outpaint_zoomout": 0.04, "scale_parent_fresh": 0.15}
+_SOURCE_COST = 0.15  # nano-banana-pro source gen
+_JUDGE_COST = 0.005  # x2 per hop (from_source + step)
+
+
+@dataclass(frozen=True)
+class Case:
+    name: str
+    # The finest-rung source, generated in this exact medium; every OUTWARD
+    # container must keep it.
+    source_prompt: str
+    style: str
+    # The source's rung; the chain walks one step coarser each hop.
+    start_tier: str
+    # The subject phrase a fresh (medium-flip) hop expands into the wider view.
+    subject: str
+
+
+_CASES: list[Case] = [
+    Case(
+        name="engraving_cottage",
+        source_prompt=(
+            "a hand-drawn antique engraving of a lone lighthouse keeper's cottage "
+            "on a rocky headland, sepia ink, dense cross-hatching, woodcut linework, "
+            "aged paper"
+        ),
+        style="hand-drawn antique engraving, sepia ink, dense cross-hatching, woodcut linework",
+        start_tier="place",
+        subject="a lighthouse keeper's cottage on a rocky headland",
+    ),
+    Case(
+        name="watercolor_square",
+        source_prompt=(
+            "a soft watercolour of a small market square with a stone well, loose "
+            "washes, pale pastel palette, visible paper texture"
+        ),
+        style="soft watercolour, loose washes, pale pastel palette, visible paper texture",
+        start_tier="place",
+        subject="a small market square with a stone well",
+    ),
+]
+
+
+def plan_chain(start_tier: str, k: int) -> list[tuple[str, str, str]]:
+    """Pure: the (from_tier, to_tier, op) sequence a k-hop OUTWARD walk takes,
+    stopping early at the coarsest rung. Drives both the dry preview and the run."""
+    from providers import model_router
+
+    hops: list[tuple[str, str, str]] = []
+    tier = start_tier
+    for _ in range(k):
+        to_tier = model_router.coarser_tier(tier)
+        if to_tier is None:
+            break
+        hops.append((tier, to_tier, model_router.select_outward_op(tier, to_tier)))
+        tier = to_tier
+    return hops
+
+
+def estimate_cost(cases: list[Case], k: int) -> float:
+    """$0 dry-preview estimate: source gen + per-hop op + 2 judges, per case."""
+    total = 0.0
+    for c in cases:
+        total += _SOURCE_COST
+        for _from, _to, op in plan_chain(c.start_tier, k):
+            total += _OP_COST.get(op, _SOURCE_COST) + 2 * _JUDGE_COST
+    return round(total, 4)
+
+
+@dataclass(frozen=True)
+class HopResult:
+    to_tier: str
+    op: str
+    from_source: float  # faithfulness of this hop to the ORIGINAL source medium
+    step: float  # faithfulness of this hop to the previous hop
+    from_source_rationale: str
+    step_rationale: str
+
+
+@dataclass(frozen=True)
+class ChainResult:
+    name: str
+    hops: list[HopResult]
+
+
+def summarize(
+    from_source: list[float],
+    step: list[float],
+    *,
+    source_baseline: float = 10.0,
+    floor: float = _FLOOR,
+) -> dict[str, Any]:
+    """Pure gate brain over one chain's per-hop faithfulness sequences.
+
+    `from_source[i]` = style faithfulness of hop i+1 to the ORIGINAL source (decays
+    as the chain wanders); `step[i]` = faithfulness to the previous hop. The
+    half-life is the FIRST hop (1-based) whose from_source drops strictly BELOW
+    `floor` — the point drift crosses the band; None if it never does. Pure, so the
+    stopping rule is unit-tested without spending (test_chain.py)."""
+    k = len(from_source)
+    half_life = next((i + 1 for i, s in enumerate(from_source) if s < floor), None)
+    final = from_source[-1] if from_source else source_baseline
+    total_drift = round(source_baseline - final, 4)
+    return {
+        "k_hops": k,
+        "from_source": [round(s, 4) for s in from_source],
+        "step": [round(s, 4) for s in step],
+        "half_life": half_life,
+        "half_life_reached": half_life is not None,
+        "total_drift": total_drift,
+        "mean_drift_per_hop": round(total_drift / k, 4) if k else 0.0,
+        "mean_step_retention": round(statistics.mean(step), 4) if step else source_baseline,
+        "floor": floor,
+        # Product rule: cap auto-OUTWARD one hop before drift crosses the floor.
+        "safe_hops": (half_life - 1) if half_life is not None else k,
+    }
+
+
+async def _run_chain(case: Case, k: int, aspect: str, model: str) -> ChainResult:
+    from providers import image as image_provider
+    from providers import image_edit as image_edit_provider
+    from providers import llm, model_router
+
+    w, h = (900, 1600) if aspect == "9:16" else (1600, 900)
+
+    # 1. The finest-rung styled source — the thing every hop must stay faithful to.
+    src = await image_provider.generate_image(
+        prompt=case.source_prompt, aspect_ratio=aspect, tier="balanced", model_override=model
+    )
+    _REPORTS.mkdir(parents=True, exist_ok=True)
+    (_REPORTS / f"chain_{case.name}_00_source.jpg").write_bytes(src.jpeg_bytes)
+
+    prev_bytes = src.jpeg_bytes
+    prev_url = image_provider.encode_data_url(src.jpeg_bytes)
+    from_tier = case.start_tier
+    hops: list[HopResult] = []
+
+    for idx in range(k):
+        to_tier = model_router.coarser_tier(from_tier)
+        if to_tier is None:
+            break  # reached the coarsest rung
+        op = model_router.select_outward_op(from_tier, to_tier)
+
+        # 2. The REAL ascend op, conditioned on the PREVIOUS hop (compounding).
+        if op == "outpaint_zoomout":
+            img = await image_edit_provider.expand_image_zoomout(prev_url, 3.0, w, h)
+        else:  # scale_parent_fresh — a medium flip can't be outpainted
+            plan = await llm.plan_page(
+                query=f"{case.subject} (the {to_tier} that contains it)",
+                web_search=False,
+                style_anchor=case.style,
+                render_mode="scale_parent",
+            )
+            img = await image_provider.generate_image(
+                plan.prompt, aspect, tier="balanced", reference_urls=[prev_url], model_override=model
+            )
+
+        # 3. Two judgements: faithfulness to the ORIGINAL, and to the last hop.
+        fs = await score_style_pair(src.jpeg_bytes, img.jpeg_bytes)
+        st = await score_style_pair(prev_bytes, img.jpeg_bytes)
+        (_REPORTS / f"chain_{case.name}_{idx + 1:02d}_{to_tier}.jpg").write_bytes(img.jpeg_bytes)
+        hops.append(
+            HopResult(
+                to_tier=to_tier,
+                op=op,
+                from_source=fs.score,
+                step=st.score,
+                from_source_rationale=fs.rationale,
+                step_rationale=st.rationale,
+            )
+        )
+        prev_bytes = img.jpeg_bytes
+        prev_url = image_provider.encode_data_url(img.jpeg_bytes)
+        from_tier = to_tier
+
+    return ChainResult(name=case.name, hops=hops)
+
+
+async def run_bench(k: int, model: str) -> dict[str, Any]:
+    results = [await _run_chain(c, k, "16:9", model) for c in _CASES]
+    per_case = []
+    for r in results:
+        summary = summarize(
+            [h.from_source for h in r.hops], [h.step for h in r.hops]
+        )
+        per_case.append({"name": r.name, "hops": [asdict(h) for h in r.hops], "summary": summary})
+
+    half_lives = [c["summary"]["half_life"] for c in per_case if c["summary"]["half_life"]]
+    return {
+        "judge_model": os.environ.get("CONTINUITY_BENCH_JUDGE_MODEL"),
+        "image_model": model,
+        "started_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "k_hops": k,
+        "floor": _FLOOR,
+        "cases": per_case,
+        "bench": {
+            # The conservative product cap = the WORST chain's half-life.
+            "min_half_life": min(half_lives) if half_lives else None,
+            "mean_total_drift": round(
+                statistics.mean(c["summary"]["total_drift"] for c in per_case), 4
+            )
+            if per_case
+            else 0.0,
+            "safe_auto_hops": (min(half_lives) - 1) if half_lives else k,
+        },
+    }
+
+
+def _load_env() -> None:
+    """Load apps/modal-backend/.env, force nano-banana-pro for balanced (the .env
+    pins plain nano-banana — memory project_fal_model_pin) and pin the judge + text
+    model to Gemini (the .env's qwen rate-limits)."""
+    env_path = Path(__file__).resolve().parents[2] / ".env"
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, val = line.partition("=")
+            os.environ.setdefault(key.strip(), val.strip().strip('"').strip("'"))
+    os.environ.setdefault("CONTINUITY_BENCH_JUDGE_MODEL", "google/gemini-3-flash-preview")
+    os.environ.setdefault("FAL_IMAGE_MODEL_BALANCED", "fal-ai/nano-banana-pro")
+
+
+def _print_dry_preview(model: str) -> None:
+    print(f"MULTI-HOP DRIFT — dry preview (k={_HOPS} hops, floor={_FLOOR}, model={model})")
+    for c in _CASES:
+        chain = plan_chain(c.start_tier, _HOPS)
+        path = c.start_tier + "".join(f" → {to}" for _f, to, _op in chain)
+        ops = ", ".join(op for _f, _t, op in chain)
+        print(f"  {c.name}: {path}   [{ops}]")
+    print(f"total to-bill (est): ${estimate_cost(_CASES, _HOPS)} over {len(_CASES)} chains")
+    print("set CHAIN_BENCH_RUN=1 to spend.")
+
+
+def _cli() -> None:
+    model = os.environ.get("CHAIN_BENCH_MODEL", "fal-ai/nano-banana-pro")
+    if not os.environ.get("CHAIN_BENCH_RUN"):
+        _print_dry_preview(model)  # $0 preview is the default
+        return
+    _load_env()
+    if not os.environ.get("FAL_KEY") or not os.environ.get("OPENROUTER_API_KEY"):
+        raise SystemExit("FAL_KEY + OPENROUTER_API_KEY required (apps/modal-backend/.env)")
+    report = asyncio.run(run_bench(_HOPS, model))
+    _REPORTS.mkdir(parents=True, exist_ok=True)
+    (_REPORTS / "chain_latest.json").write_text(json.dumps(report, indent=2))
+    print(json.dumps(report, indent=2))
+    b = report["bench"]
+    print(
+        f"\nMIN half-life = {b['min_half_life']} hops (worst chain); "
+        f"mean total drift = {b['mean_total_drift']}. Product rule: cap auto-OUTWARD "
+        f"at {b['safe_auto_hops']} hops (force a style-anchor refresh / checkpoint there)."
+    )
+
+
+if __name__ == "__main__":
+    _cli()

--- a/apps/modal-backend/tests/continuity_bench/test_chain.py
+++ b/apps/modal-backend/tests/continuity_bench/test_chain.py
@@ -1,0 +1,47 @@
+"""Unit tests for the multi-hop drift bench's pure gate brain (`summarize`).
+
+The paid k-hop chain is exercised only under CHAIN_BENCH_RUN; the DECISION —
+half-life, total drift, the safe-hop cap — is pure over synthetic score
+sequences and tested here for free (research/05 §4.1: "unit-test summarize on
+synthetic score sequences")."""
+from __future__ import annotations
+
+from tests.continuity_bench.chain_runner import summarize
+
+
+def test_half_life_is_first_hop_below_the_floor() -> None:
+    # faithfulness-to-source decays; first value strictly under floor 6 is hop 3.
+    s = summarize([9.0, 8.0, 5.0, 3.0], [9.0, 8.0, 6.0, 7.0], floor=6.0)
+    assert s["half_life"] == 3
+    assert s["half_life_reached"] is True
+    # product rule: cap auto-OUTWARD one hop before the drift crosses.
+    assert s["safe_hops"] == 2
+
+
+def test_floor_is_strict_below_not_equal() -> None:
+    # exactly at the floor is still trusted — only BELOW crosses.
+    s = summarize([6.0, 6.0], [8.0, 8.0], floor=6.0)
+    assert s["half_life"] is None
+    assert s["half_life_reached"] is False
+    assert s["safe_hops"] == 2  # never crossed → all hops safe
+
+
+def test_total_and_mean_drift_from_the_source_baseline() -> None:
+    s = summarize([9.0, 8.0, 5.0, 3.0], [9.0, 8.0, 6.0, 7.0], source_baseline=10.0)
+    assert s["total_drift"] == 7.0  # 10 - final(3)
+    assert s["mean_drift_per_hop"] == 1.75  # 7 / 4 hops
+    assert s["mean_step_retention"] == 7.5  # mean of the step scores
+
+
+def test_a_chain_that_never_drifts_reports_no_half_life() -> None:
+    s = summarize([9.0, 9.0, 8.5, 8.0], [9.0, 9.0, 9.0, 9.0], floor=6.0)
+    assert s["half_life"] is None
+    assert s["safe_hops"] == 4
+    assert s["total_drift"] == 2.0
+
+
+def test_empty_chain_is_total() -> None:
+    s = summarize([], [], floor=6.0)
+    assert s["k_hops"] == 0
+    assert s["half_life"] is None
+    assert s["mean_drift_per_hop"] == 0.0


### PR DESCRIPTION
Builds the k-hop OUTWARD drift bench that `docs/research/05-baseline-methodology.md` §4.1 specced but that was **never written** (the missing file the earlier cost pass flagged). This is the coherence proof Phase 4's flag-graduation was supposed to lean on.

## What it measures
Walks a styled source OUTWARD **k hops** along the scale ladder (`place→district→city→region→world`, via `coarser_tier`), each container conditioned on the **previous hop's output** — the actual compounding path, not k independent hops — using the real ascend op (`select_outward_op`: BRIA outpaint on same-plane hops, reference-conditioned fresh gen on a medium flip). After each hop it scores style faithfulness two ways with the existing judge:
- **from_source** — faithfulness to the *original* medium (does the chain wander off-style?)
- **step** — faithfulness to the *previous* hop (where the wandering happens)

`summarize()` turns the sequence into a **half_life** (the hop faithfulness first drops below the floor), so the product rule falls out: **cap auto-OUTWARD at `half_life - 1`**.

## Verification (no spend)
- `summarize` is pure — the gate brain — and TDD'd on synthetic score sequences (`test_chain.py`, 5 cases incl. strict-floor + never-drift + empty). All pass; ruff clean.
- **Dry preview is the default (/bin/zsh)** — plans each chain + estimates cost:
  ```
  engraving_cottage: place → district → city → region → world  [outpaint ×4]
  watercolor_square: place → district → city → region → world  [outpaint ×4]
  total to-bill (est): $0.70 over 2 chains
  ```
- `CHAIN_BENCH_RUN=1` spends; modeled on `outward_runner` (reuses `_load_env`, `score_style_pair`, `reports/`). Targets: `make eval-chain-drift-dry` / `make eval-chain-drift`.

**Built + dry-run + unit-tested only — the paid run (~$0.70) awaits your OK.** (Tests-only change; doesn't touch the `providers`/`generate` coverage surface.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)