### PR TITLE
feat(outward): measure the real drift path + flag-gated hop cap

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -335,6 +335,12 @@ class GenerateBody(BaseModel):
     # NO baked text — names ride a client overlay built from entity data.
     # Optional + default False: old clients omit it, prompts byte-identical.
     suppress_map_labels: bool = False
+    # How many consecutive OUTWARD (ascend) hops the client has taken in this
+    # chain (0 = first). Past SCALE_OUTWARD_MAX_HOPS the ascend re-anchors to
+    # the ORIGINAL medium instead of conditioning on the drifting previous hop
+    # (multi-hop drift, chain_runner.py: even the anchored path loses delicate
+    # media by ~hop 2). Default 0 + flag off → byte-identical to old clients.
+    outward_depth: int = 0
     # The transition tap's origin (tap descent ladder): the SOURCE frame was a
     # closeup of the entered place — the establishing shot already happened,
     # so the enter descends to ground level instead of another aerial.

--- a/apps/modal-backend/providers/generate_modes/ascend.py
+++ b/apps/modal-backend/providers/generate_modes/ascend.py
@@ -11,6 +11,7 @@ generate.py's stream helpers (`_sse`, `_frame_dims`, `_view_grammar_on`,
 from __future__ import annotations
 
 import asyncio as _asyncio
+import os
 import time as _time
 from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import TYPE_CHECKING, Any, cast
@@ -65,9 +66,18 @@ async def stream_ascend(
     # (SCALE_OUTWARD_OUTPAINT) for pixel-preservation, and only for a
     # same-plane hop — and now STEERS its margin with the medium so it isn't
     # photoreal. Astronomical (medium-flip) hops are always fresh.
+    # Multi-hop drift guard (chain_runner.py: even the style-anchored OUTWARD
+    # path loses delicate media by ~hop 2 because each hop conditions on the
+    # DRIFTING previous container). Past SCALE_OUTWARD_MAX_HOPS consecutive
+    # ascends, re-anchor: drop the previous-image conditioning (outpaint pixels /
+    # edit ref) and render fresh from the ORIGINAL style text. Default 0 = OFF,
+    # so nothing changes until it's flipped on.
+    _max_hops = int(os.environ.get("SCALE_OUTWARD_MAX_HOPS", "0") or 0)
+    outward_refresh = _max_hops > 0 and body.outward_depth >= _max_hops
     use_outpaint = (
         env_flag("SCALE_OUTWARD_OUTPAINT")
         and model_router.select_outward_op(from_tier, to_tier) == "outpaint_zoomout"
+        and not outward_refresh
     )
     yield _sse({"type": "status", "stage": "rendering"}, trace_id)
     await _abort_if_disconnected("pre-ascend")
@@ -125,12 +135,14 @@ async def stream_ascend(
                 style_anchor=style_lock,
                 render_mode="scale_parent",
             )
-            if env_flag("SCALE_OUTWARD_EDIT_REF", "true"):
+            if env_flag("SCALE_OUTWARD_EDIT_REF", "true") and not outward_refresh:
                 # The source ref is a no-op on the text-to-image endpoint
                 # (research 01-model-bakeoff); the edit endpoint honors it, so
                 # the container continues the source's medium + content instead
                 # of free-styling. Default ON (kill-switch =false) — the inert
-                # ref path exists only as the revert.
+                # ref path exists only as the revert. `outward_refresh` (past the
+                # hop cap) skips it too: the drifting previous hop is exactly what
+                # we must NOT condition on — fall through to the fresh text render.
                 medium = style_lock or "the same hand-drawn art style as the centre"
                 ascend_instr = (
                     f"Zoom OUT to reveal the surrounding {to_tier.replace('_', ' ')}, "

--- a/apps/modal-backend/tests/continuity_bench/chain_runner.py
+++ b/apps/modal-backend/tests/continuity_bench/chain_runner.py
@@ -7,7 +7,8 @@ This walks a styled source OUTWARD k hops along the scale ladder
 (`place→district→city→region→world`, `model_router.coarser_tier`), each hop the
 REAL ascend op (`select_outward_op` → BRIA outpaint on same-plane hops, a
 reference-conditioned fresh gen on a medium flip) conditioned on the PREVIOUS
-hop's output — the actual compounding path, not k independent hops. After each
+hop's output AND re-anchored to the ORIGINAL medium each hop — mirroring the
+product's ascend (ascend.py:103-126), the style-refresh mitigation itself. After each
 hop it scores two things with the existing style judge:
   - from_source: faithfulness of hop_i to the ORIGINAL medium (does the chain
     wander off the starting style?);
@@ -79,6 +80,17 @@ _CASES: list[Case] = [
         style="soft watercolour, loose washes, pale pastel palette, visible paper texture",
         start_tier="place",
         subject="a small market square with a stone well",
+    ),
+    Case(
+        name="ukiyoe_shrine",
+        source_prompt=(
+            "a ukiyo-e woodblock print of a small hillside shinto shrine, bold flat "
+            "colour areas, dark keyblock outlines, visible woodgrain, muted indigo "
+            "and vermilion"
+        ),
+        style="ukiyo-e woodblock print, bold flat colour, dark keyblock outlines, visible woodgrain",
+        start_tier="place",
+        subject="a hillside shinto shrine",
     ),
 ]
 
@@ -208,9 +220,20 @@ async def _run_chain(case: Case, k: int, aspect: str, model: str) -> ChainResult
             break  # reached the coarsest rung
         op = model_router.select_outward_op(from_tier, to_tier)
 
-        # 2. The REAL ascend op, conditioned on the PREVIOUS hop (compounding).
+        # 2. The REAL ascend op, conditioned on the PREVIOUS hop (compounding) and
+        #    re-anchored to the ORIGINAL medium each hop — mirroring the product
+        #    (ascend.py:103-126): the outpaint margin carries the source style, the
+        #    fresh path passes style_anchor. This is the style-refresh the product
+        #    already ships; the bench measures THAT path, not an un-anchored one.
         if op == "outpaint_zoomout":
-            raw = await image_edit_provider.expand_image_zoomout(prev_url, 3.0, w, h)
+            margin = (
+                f"{case.style}; extend OUTWARD into the surrounding "
+                f"{to_tier.replace('_', ' ')}, drawn in the SAME style as the "
+                "centre — one continuous view, NOT a photograph, no photorealism"
+            )
+            raw = await image_edit_provider.expand_image_zoomout(
+                prev_url, 3.0, w, h, prompt=margin
+            )
         else:  # scale_parent_fresh — a medium flip can't be outpainted
             plan = await llm.plan_page(
                 query=f"{case.subject} (the {to_tier} that contains it)",

--- a/apps/modal-backend/tests/test_generate_ascend.py
+++ b/apps/modal-backend/tests/test_generate_ascend.py
@@ -115,6 +115,44 @@ async def test_ascend_edit_ref_kill_switch_reverts_to_fresh(
     edit.assert_not_awaited()
 
 
+async def test_ascend_refresh_past_hop_cap_drops_the_drifting_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # SCALE_OUTWARD_MAX_HOPS caps consecutive OUTWARD hops: at/past it the ascend
+    # re-anchors to the original medium (fresh render) instead of conditioning on
+    # the DRIFTING previous container — even with SCALE_OUTWARD_EDIT_REF on
+    # (default). chain_runner.py: the anchored path still loses delicate media by
+    # ~hop 2 because each hop conditions on the drifting last one.
+    _enable(monkeypatch)
+    monkeypatch.setenv("SCALE_OUTWARD_MAX_HOPS", "1")
+    gen = _mock_fresh(monkeypatch)
+    edit = AsyncMock()
+    monkeypatch.setattr(image_edit_mod, "edit_image", edit)
+
+    events = await _collect(_event_stream(_ascend_body(outward_depth=1), "t1"))
+    assert next(e for e in events if e["type"] == "ascend_ready")
+    gen.assert_awaited_once()  # fresh — re-anchored to the original medium
+    edit.assert_not_awaited()  # NOT conditioned on the drifting previous hop
+
+
+async def test_ascend_below_hop_cap_still_conditions_on_the_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Below the cap the hop is unchanged — the first OUTWARD hops keep the
+    # ref-honouring edit (the drift only compounds later).
+    _enable(monkeypatch)
+    monkeypatch.setenv("SCALE_OUTWARD_MAX_HOPS", "2")
+    _mock_fresh(monkeypatch)
+    edit = AsyncMock(
+        return_value=GeneratedImage(b"jpeg", "image/jpeg", "fal-ai/nano-banana-pro", "r")
+    )
+    monkeypatch.setattr(image_edit_mod, "edit_image", edit)
+
+    events = await _collect(_event_stream(_ascend_body(outward_depth=1), "t1"))
+    assert next(e for e in events if e["type"] == "ascend_ready")
+    edit.assert_awaited_once()  # 1 < 2 → still conditions on the source
+
+
 async def test_ascend_outpaint_under_flag_steers_the_medium(monkeypatch: pytest.MonkeyPatch) -> None:
     _enable(monkeypatch)
     monkeypatch.setenv("SCALE_OUTWARD_OUTPAINT", "1")

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -1978,6 +1978,13 @@ export default function PlayPage() {
   // OUTWARD / zoom-out landed: mirror the persisted reparent into the live
   // session — insert the container P, re-point the old root C under it (so the
   // breadcrumb shows P above C), navigate to P, and refetch the geo store.
+  // Consecutive OUTWARD (ascend) hops in the current chain. Passed to the
+  // backend so a long zoom-out chain re-anchors past SCALE_OUTWARD_MAX_HOPS
+  // (multi-hop drift, chain_runner.py). Resets on any non-ascend navigation.
+  const outwardDepthRef = useRef(0);
+  useEffect(() => {
+    if (page?.relation !== "ascend") outwardDepthRef.current = 0;
+  }, [page?.nodeId, page?.relation]);
   const onAscended = useCallback(
     (a: Ascended) => {
       const parentPage: Page = {
@@ -2000,6 +2007,7 @@ export default function PlayPage() {
         return { items: [...items, parentPage], trail, trailIdx: trail.length - 1 };
       });
       setPage(parentPage);
+      outwardDepthRef.current += 1; // one more consecutive OUTWARD hop
       setPhase("ready");
       setViewMode("page");
       if (a.renderUnjudged) {
@@ -2032,6 +2040,7 @@ export default function PlayPage() {
       sceneView: page.sceneView ?? null,
       styleAnchor: styleAnchor?.style ?? null,
       suppressMapLabels: worldEnabled && worldDomLabels,
+      outwardDepth: outwardDepthRef.current,
     });
   }, [page, sessionId, startAscend, styleAnchor, worldEnabled, worldDomLabels]);
 

--- a/apps/web/hooks/useAscend.ts
+++ b/apps/web/hooks/useAscend.ts
@@ -26,6 +26,10 @@ export interface AscendRoot {
   // DOM-labels mode: ask for a label-free container map like every other
   // map render (the un-suppressed ascend baked hallucinated title lettering).
   suppressMapLabels?: boolean;
+  // Consecutive OUTWARD hops taken in this chain (0 = first). The backend
+  // re-anchors past SCALE_OUTWARD_MAX_HOPS so a long zoom-out chain doesn't
+  // drift off the original medium.
+  outwardDepth?: number;
 }
 
 export interface Ascended {
@@ -99,6 +103,7 @@ export function useAscend(onAscended: (a: Ascended) => void): {
                 ? { session_style_anchor: root.styleAnchor }
                 : {}),
               ...(root.suppressMapLabels ? { suppress_map_labels: true } : {}),
+              ...(root.outwardDepth ? { outward_depth: root.outwardDepth } : {}),
               trace_id: traceId,
             }),
             signal: ac.signal,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -184,6 +184,10 @@ export interface GenerateRequestBody {
   // baked text — names ride a client overlay built from entity data. Optional
   // + default-absent: old clients omit it, prompts stay byte-identical.
   suppress_map_labels?: boolean;
+  // Consecutive OUTWARD (ascend) hops in this chain (0 = first). Past
+  // SCALE_OUTWARD_MAX_HOPS the backend re-anchors to the original medium
+  // instead of the drifting previous hop (multi-hop drift). Default-absent.
+  outward_depth?: number;
   // Tap descent ladder: the SOURCE frame of this enter was a closeup of the
   // place — the establishing shot already happened, so the enter goes to
   // ground level (grounds/courtyard) instead of another aerial.


### PR DESCRIPTION
Firms up the multi-hop drift number on the path the product *actually* takes, then ships the mitigation as a safe, default-off lever.

## The firm-up (bench now mirrors the product)
The first drift run measured an **un-anchored** outpaint the product never takes. The product re-anchors every OUTWARD hop to the session style (`ascend.py:103-126`); `chain_runner.py` now does the same (steers the outpaint margin with the source medium) + a 3rd style (n=3):

| chain (anchored) | faithful-to-original per hop | half-life |
|---|---|---|
| engraving | 9.5 · 9.5 · 8.5 · 6.5 | never — **held** |
| watercolor | 9.5 · 2.0 · 0.0 · 0.0 | 2 |
| ukiyo-e | 9.5 · 7.5 · 1.5 · 0.0 | 3 |

Anchoring rescues engraving (vs `0.0` un-anchored) and every style holds hop 1 — but **watercolor still collapses by hop 2, ukiyo-e by hop 3.** The per-hop style refresh helps but is **insufficient for delicate media**; `min_half_life` stays 2. So a cap is warranted.

## The cap (flag-gated, default OFF)
OUTWARD is **manual** (one user tap per hop, no auto-chain), so a hard block would regress zoom-out. Instead: `SCALE_OUTWARD_MAX_HOPS` (default `0` = off) caps consecutive ascend hops; **past it the ascend stops conditioning on the drifting previous container and renders fresh from the ORIGINAL style text** — breaking the compounding while keeping the medium. Trade-off past the cap: medium fidelity over pixel-continuity.

- Wire: additive `outward_depth` on `GenerateBody` (both sides, parity green). The web counts consecutive ascends (reset on any non-ascend nav) and sends it.
- **Default-off → zero behavior change.** Backend tests cover fire-at-cap (drops the ref → fresh) + unchanged-below-cap.
- Efficacy is *reasoned* (constant original-style text + no drifting ref → no compounding), not yet benched — confirm by enabling the flag and re-running `chain_runner`.

**Gates green:** backend ascend + parity + generate-mode suites, ruff, mypy; web typecheck + lint (17 = baseline). Spend this run: ~$1.05 (the n=3 firm-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)