### PR TITLE
docs(env): document the SCALE_OUTWARD_MAX_HOPS drift cap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -171,6 +171,13 @@ FAL_EDIT_TIER=balanced
 # the strict shape degrades to json_object and is remembered for the process.
 # `false` = the old json_object-first ladder, byte-identical.
 # LLM_JSON_SCHEMA=true
+# Multi-hop OUTWARD drift cap. A long zoom-out chain conditions each container
+# on the previous (drifting) one, so delicate media (watercolor, ukiyo-e) lose
+# the original medium by ~hop 2 (tests/continuity_bench/chain_runner.py). Past N
+# consecutive ascends the ascend drops the previous-image conditioning and
+# re-renders fresh from the ORIGINAL style text. 0 = OFF (no cap); the trade is
+# medium fidelity over pixel-continuity past the cap.
+# SCALE_OUTWARD_MAX_HOPS=0
 
 # --- Web (apps/web/.env.local) ---
 # Cloudflare R2 (S3-compatible)


### PR DESCRIPTION
Health-sweep follow-up. The multi-hop drift mitigation from #216 (`SCALE_OUTWARD_MAX_HOPS`) shipped **default-OFF and undocumented** in the root `.env.example` — so the safety lever for the whole #215–#217 drift risk was invisible to operators. This adds it beside the other backend experiment flags, with a self-contained comment (what it guards, what happens past the cap, the fidelity/continuity trade-off).

Doc-only; no code change. The rest of the sweep came back clean: `make eval` green (838 web tests, backend + mypy + 0 circular deps), lint at the 17-warning baseline, and the flag code itself (`ascend.py`) is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)