### PR TITLE
eval(outward): S4 A/B — fresh rerender holds the medium (n=2)

### DIFF
--- a/docs/BRANCH2_CONSISTENCY.md
+++ b/docs/BRANCH2_CONSISTENCY.md
@@ -40,10 +40,16 @@ eyes-on before it lands.
 
 ## Deferred paid runs (harness ready, sequence when budget allows)
 
-- **S4 OUTWARD A/B** — does P2's edit-route beat the text-to-image no-op on medium fidelity?
-  (`docs/research/01`, `07`; the now-existing edit-route is the code S4 needed.) *Still deferred.*
+*(none currently — S4 ran; see Done below.)*
 
 ### Done (kept for provenance)
+
+- **S4 OUTWARD A/B** — DONE (n=2, `outward_runner.py`, ~$0.70). Both zoom-out paths hold the
+  source MEDIUM well at a single hop: outpaint mean 9.75, fresh `scale_parent` rerender mean
+  9.25, drift only 0.5. The FRESH default is **trustworthy** (clears the 6.5 bar at both cases:
+  engraving 9.5, watercolour 9.0) — the edit-route does NOT lose the medium vs the no-op here.
+  Caveat n=2: the runner asks for N≥10 before flipping `SCALE_OUTWARD_RERENDER` on by default.
+  (Single-hop only — the COMPOUNDING loss across many hops is the separate chain_runner finding.)
 
 - **Multi-hop drift `chain_runner` (`half_life`)** — DONE. `chain_runner.py` built (#215) and run
   (#216/#217): style-anchored OUTWARD still loses delicate media by ~hop 2; shipped the


### PR DESCRIPTION
Ran the last genuinely-deferred paid bench (~$0.70, self-contained — no web/:3000).

**Question:** does the OUTWARD edit-route (fresh `scale_parent` rerender) lose the source art MEDIUM vs the opt-in BRIA outpaint, at a single zoom-out hop?

**Finding (n=2):**

| case | outpaint | fresh rerender |
|---|---|---|
| engraving city | 9.5 | 9.5 |
| watercolour town | 10.0 | 9.0 |
| **mean** | **9.75** | **9.25** |

- Drift (outpaint − fresh) = **0.5** — small. Both paths hold the medium well at one hop.
- The **fresh default is trustworthy**: it clears the 6.5 medium-fidelity bar at both cases, so the edit-route does *not* lose the medium vs the outpaint no-op.
- **Caveat n=2** — the runner asks for N≥10 before flipping `SCALE_OUTWARD_RERENDER` default-on; this doesn't mandate a default change.
- Single-hop only. The *compounding* medium loss across many hops is the separate `chain_runner` finding that shipped the `SCALE_OUTWARD_MAX_HOPS` cap (#216).

Doc-only (records the finding + retires S4 from the deferred list); the report artifact stays gitignored/regenerable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)