### PR TITLE
fix(eval): scrub stale cached height keys — the 08-05 height_order trip was phantom

### DIFF
--- a/apps/modal-backend/tests/recon_bench/runner.py
+++ b/apps/modal-backend/tests/recon_bench/runner.py
@@ -353,6 +353,43 @@ def recon_fns(sweep: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def scrub_stale_heights(
+    report: dict[str, Any],
+    scenarios: list[Scenario],
+    weights: dict[str, float],
+) -> bool:
+    """Drop height keys from replayed cells of maps with no built heights.
+
+    score_fn omits height_order/height_abs when the description carries no
+    height_m (the #133 honesty rule), but the matrix cache replays scores
+    verbatim — cells scored before that rule still carry height_order 0.0
+    (mars x4 dragged the 2026-08-05 gate to 0.650, a phantom regression).
+    Applies the same rule to replayed cells and re-derives their composite.
+    Returns True when anything changed (caller persists the report)."""
+    heightless = {
+        s.id
+        for s in scenarios
+        if not any(e.get("height_m") for e in s.payload["entities"])
+    }
+    dirty = False
+    for c in report.get("cells", []):
+        scores = c.get("scores")
+        if not scores or c.get("scenario_id") not in heightless:
+            continue
+        if "height_order" not in scores and "height_abs" not in scores:
+            continue
+        scores.pop("height_order", None)
+        scores.pop("height_abs", None)
+        used = {k: w for k, w in weights.items() if k in scores and w > 0}
+        if used:
+            total = sum(used.values())
+            scores["composite"] = round(
+                sum(scores[k] * w for k, w in used.items()) / total, 3
+            )
+        dirty = True
+    return dirty
+
+
 def _load_env() -> None:
     env_path = Path(__file__).resolve().parents[2] / ".env"
     if env_path.exists():
@@ -385,6 +422,10 @@ def main() -> int:
         report_path=report_path,
         **recon_fns(sweep),
     )
+    if scrub_stale_heights(
+        report, scenarios, dict(sweep.get("composite_weights", {}))
+    ):
+        report_path.write_text(json.dumps(report, indent=1))
     if live:
         cells = [c for c in report["cells"] if "scores" in c]
         composites = [

--- a/apps/modal-backend/tests/recon_bench/test_recon.py
+++ b/apps/modal-backend/tests/recon_bench/test_recon.py
@@ -337,3 +337,41 @@ def test_corpus_scenarios_rejects_unverified() -> None:
         pytest.skip("no drafts in the corpus right now")
     with pytest.raises(SystemExit, match="not a VERIFIED"):
         corpus_scenarios([f"corpus:{drafts[0]}"])
+
+
+def test_scrub_stale_heights_drops_cached_keys_and_recomputes_composite() -> None:
+    """Cache replay keeps scores verbatim — cells scored before the #133
+    height-omission rule still carry height_order 0.0 for height-less maps
+    (the 2026-08-05 phantom gate trip). The scrub applies the rule to
+    replayed cells."""
+    from tests.matrix_bench.runner import Scenario
+    from tests.recon_bench.runner import scrub_stale_heights
+
+    weights = {"pos_raw": 0.5, "height_order": 0.5}
+    scenarios = [
+        Scenario(id="mars", desc_sha="x", payload={"entities": [{"label": "a"}]}),
+        Scenario(
+            id="manor",
+            desc_sha="y",
+            payload={"entities": [{"label": "b", "height_m": 12.0}]},
+        ),
+    ]
+    report = {
+        "cells": [
+            {  # stale: height keys on a height-less map
+                "scenario_id": "mars",
+                "scores": {"pos_raw": 0.8, "height_order": 0.0, "composite": 0.4},
+            },
+            {  # legit height-bearing cell — untouched
+                "scenario_id": "manor",
+                "scores": {"pos_raw": 0.6, "height_order": 1.0, "composite": 0.8},
+            },
+        ]
+    }
+    assert scrub_stale_heights(report, scenarios, weights) is True
+    mars, manor = report["cells"]
+    assert "height_order" not in mars["scores"]
+    assert mars["scores"]["composite"] == 0.8  # pos_raw alone
+    assert manor["scores"] == {"pos_raw": 0.6, "height_order": 1.0, "composite": 0.8}
+    # second pass: nothing left to scrub
+    assert scrub_stale_heights(report, scenarios, weights) is False


### PR DESCRIPTION
## What

The 2026-08-05 `eval-recon` run flagged `height_order` 0.650, below the 0.67 band floor. That was not a regression. The matrix cache replays cell scores verbatim, and the four mars cells were scored before the #133 height-omission rule. They still carried `height_order: 0.0` for a map that has no built heights.

## Fix

`scrub_stale_heights` applies the #133 rule to replayed cells, the same rule `score_fn` applies to fresh ones. It drops the stale height keys and re-derives the composite from the remaining weighted scores. The runner calls it after `run_matrix` and persists the scrubbed report.

## Receipts

Cached replay, $0.00 billed, all three gates pass:

- `height_order`: **0.867** over the 12 height-bearing cells (was 0.650 over 16)
- `recon_fidelity`: 0.733
- `recon_pos_raw`: 0.434

No re-baseline. The 0.82 baseline stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)