### PR TITLE
chore(cleanup): rerun-4 report-only items — the five handed-back calls

### DIFF
--- a/apps/modal-backend/providers/generate_modes/_events.py
+++ b/apps/modal-backend/providers/generate_modes/_events.py
@@ -1,0 +1,58 @@
+"""Python twins of the SSE final-event wire shapes the generate modes emit.
+
+Hand-mirrored from packages/config/src/index.ts (the TS side is the source
+of truth). tests/test_geo_schema.py pins the field names in lockstep — the
+drift class that let `scene_description` ride the wire untyped. The twins
+gate the FIELD SET; nested payloads stay loose dicts on purpose.
+"""
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+
+class EditVerdict(TypedDict):
+    """Mirror of TS ``EditVerdict`` — the judged inpaint verdict on `final`."""
+
+    alignment: float | None
+    medium: float | None
+    outside_change: float | None
+    attempts: int
+    accepted: bool
+
+
+class GenerateFinalEvent(TypedDict, total=False):
+    """Mirror of TS ``GenerateFinalEvent``. total=False: the additive tail
+    is per-path; every build site sets the core fields in its literal."""
+
+    type: str
+    image_data_url: str
+    page_title: str
+    image_model: str
+    prompt_author_model: str
+    session_id: str
+    final_prompt: str
+    sources: list[dict[str, Any]]
+    image_op: str
+    grounding: dict[str, Any]
+    edit_verdict: EditVerdict
+    render_unjudged: bool
+    layout_suppressed: bool
+    scene_view: dict[str, Any]
+    session_spend_estimate: float
+    trace_id: str
+
+
+class GenerateAscendReadyEvent(TypedDict, total=False):
+    """Mirror of TS ``GenerateAscendReadyEvent`` (OUTWARD container ready)."""
+
+    type: str
+    page_title: str
+    image_data_url: str
+    image_model: str
+    prompt_author_model: str
+    final_prompt: str
+    scale_tier: str
+    from_tier: str
+    session_id: str
+    render_unjudged: bool
+    trace_id: str

--- a/apps/modal-backend/providers/generate_modes/_frames.py
+++ b/apps/modal-backend/providers/generate_modes/_frames.py
@@ -1,0 +1,30 @@
+"""Shared SSE progress-frame paint for the render/edit streams.
+
+Its own module, not ``__init__.py`` — the package init imports the mode
+modules, so a helper there would cycle.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+from collections.abc import Callable
+
+
+async def progress_frame(
+    sse: Callable[..., bytes],
+    jpeg_bytes: bytes,
+    index: int,
+    trace_id: str,
+) -> bytes:
+    """b64-encode a JPEG off-thread and wrap it as the ``progress`` SSE event.
+
+    The encode runs in a thread so the event loop stays free — a sync
+    b64encode of a 1-3MB JPEG stalls it ~5-15ms, in the hot path right
+    when the user watches. Byte-identical to the six hand-rolled paint
+    blocks this replaced.
+    """
+    b64 = (await asyncio.to_thread(base64.b64encode, jpeg_bytes)).decode("ascii")
+    return sse(
+        {"type": "progress", "frame_index": index, "jpeg_b64": b64},
+        trace_id,
+    )

--- a/apps/modal-backend/providers/generate_modes/ascend.py
+++ b/apps/modal-backend/providers/generate_modes/ascend.py
@@ -21,6 +21,7 @@ from obs import log, record_error
 from providers import image as image_provider
 from providers import image_edit as image_edit_provider
 from providers import llm, model_router, spend
+from providers.generate_modes._events import GenerateAscendReadyEvent
 
 if TYPE_CHECKING:
     from generate import GenerateBody
@@ -254,7 +255,7 @@ async def stream_ascend(
     # Spend accounting: this OUTWARD hop made real paid image calls (one per
     # judged attempt) — record them so the cap actually counts them.
     spend.record_generation(body.session_id, img.model, images=billed_images)
-    ascend_payload: dict[str, Any] = {
+    ascend_payload: GenerateAscendReadyEvent = {
         "type": "ascend_ready",
         "page_title": page_title,
         "image_data_url": data_url,

--- a/apps/modal-backend/providers/generate_modes/edit.py
+++ b/apps/modal-backend/providers/generate_modes/edit.py
@@ -10,8 +10,6 @@ lookup are threaded in as parameters.
 
 from __future__ import annotations
 
-import asyncio as _asyncio
-import base64
 import time as _time
 from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import TYPE_CHECKING, Any
@@ -21,6 +19,8 @@ from obs import log
 from providers import image as image_provider
 from providers import image_edit as image_edit_provider
 from providers import llm, spend
+from providers.generate_modes._events import EditVerdict, GenerateFinalEvent
+from providers.generate_modes._frames import progress_frame
 
 if TYPE_CHECKING:
     from generate import GenerateBody
@@ -99,7 +99,7 @@ async def stream_edit(
             if body.edit_region
             else None
         )
-        verdict: dict[str, Any] | None = None
+        verdict: EditVerdict | None = None
         if (
             body.verify is False
             or source_bytes is None
@@ -150,18 +150,8 @@ async def stream_edit(
                     and edit_att.alignment is not None
                     and edit_att.index + 1 < edit_cfg.max_attempts
                 ):
-                    frame_b64 = (
-                        await _asyncio.to_thread(
-                            base64.b64encode, edit_att.image.jpeg_bytes
-                        )
-                    ).decode("ascii")
-                    yield _sse(
-                        {
-                            "type": "progress",
-                            "frame_index": edit_att.index,
-                            "jpeg_b64": frame_b64,
-                        },
-                        trace_id,
+                    yield await progress_frame(
+                        _sse, edit_att.image.jpeg_bytes, edit_att.index, trace_id
                     )
             edit_loop_result = edit_loop.conclude_edit(edit_attempts)
             inp_result = edit_loop_result.image
@@ -173,7 +163,7 @@ async def stream_edit(
                 "attempts": len(edit_attempts),
                 "accepted": edit_loop_result.accepted,
             }
-        final_frame: dict[str, Any] = {
+        final_frame: GenerateFinalEvent = {
             "type": "final",
             "image_data_url": image_provider.encode_data_url(
                 inp_result.jpeg_bytes, inp_result.mime_type
@@ -252,18 +242,8 @@ async def stream_edit(
                     and judged_att.alignment is not None
                     and judged_att.index + 1 < judge_cfg.max_attempts
                 ):
-                    frame_b64 = (
-                        await _asyncio.to_thread(
-                            base64.b64encode, judged_att.image.jpeg_bytes
-                        )
-                    ).decode("ascii")
-                    yield _sse(
-                        {
-                            "type": "progress",
-                            "frame_index": judged_att.index,
-                            "jpeg_b64": frame_b64,
-                        },
-                        trace_id,
+                    yield await progress_frame(
+                        _sse, judged_att.image.jpeg_bytes, judged_att.index, trace_id
                     )
             judged_result = edit_loop.conclude_edit(judged_attempts)
             judged_best = judged_result.best

--- a/apps/modal-backend/providers/generate_modes/tap.py
+++ b/apps/modal-backend/providers/generate_modes/tap.py
@@ -14,7 +14,6 @@ deadline derives from the caller's `started` + `ingress_timeout_s`.
 from __future__ import annotations
 
 import asyncio as _asyncio
-import base64
 import contextlib
 import os
 import time as _time
@@ -26,6 +25,8 @@ from obs import log
 from providers import image as image_provider
 from providers import image_edit as image_edit_provider
 from providers import llm, model_router, spend
+from providers.generate_modes._events import GenerateFinalEvent
+from providers.generate_modes._frames import progress_frame
 
 if TYPE_CHECKING:
     from generate import GenerateBody, WorldContextEntity
@@ -942,18 +943,8 @@ async def stream_tap(
                     # NOW instead of holding it behind the judge tail. The judged
                     # verdict still follows (accept → final swaps it in, reject →
                     # the retry frame does). Not part of loop_attempts/conclude.
-                    preview_b64 = (
-                        await _asyncio.to_thread(
-                            base64.b64encode, loop_att.image.jpeg_bytes
-                        )
-                    ).decode("ascii")
-                    yield _sse(
-                        {
-                            "type": "progress",
-                            "frame_index": loop_att.index,
-                            "jpeg_b64": preview_b64,
-                        },
-                        trace_id,
+                    yield await progress_frame(
+                        _sse, loop_att.image.jpeg_bytes, loop_att.index, trace_id
                     )
                     continue
                 loop_attempts.append(loop_att)
@@ -968,18 +959,8 @@ async def stream_tap(
                 ):
                     # Stream the rejected attempt — the user watches the
                     # agent self-correct instead of staring at a spinner.
-                    frame_b64 = (
-                        await _asyncio.to_thread(
-                            base64.b64encode, loop_att.image.jpeg_bytes
-                        )
-                    ).decode("ascii")
-                    yield _sse(
-                        {
-                            "type": "progress",
-                            "frame_index": loop_att.index,
-                            "jpeg_b64": frame_b64,
-                        },
-                        trace_id,
+                    yield await progress_frame(
+                        _sse, loop_att.image.jpeg_bytes, loop_att.index, trace_id
                     )
             result = render_loop.conclude(loop_attempts).image
             billed_images = max(1, len(loop_attempts))
@@ -1024,7 +1005,8 @@ async def stream_tap(
             # skip the progress and continue — main is still running.
             try:
                 draft_result = draft_task.result()
-            except Exception:
+            except Exception as exc:
+                log("warn", "tap.draft_failed", error=f"{type(exc).__name__}: {exc}")
                 draft_result = None
             if draft_result is not None:
                 # The draft is a real fal call — bill it as it lands.
@@ -1042,23 +1024,8 @@ async def stream_tap(
                     },
                     trace_id,
                 )
-                # Encode in a thread so the event loop stays free for
-                # main_task progress. Sync b64encode of a 1-3MB JPEG
-                # otherwise stalls the loop for ~5-15ms — small per call,
-                # but it's stalls in the hot path right when the user
-                # cares most about latency.
-                draft_b64 = (
-                    await _asyncio.to_thread(
-                        base64.b64encode, draft_result.jpeg_bytes
-                    )
-                ).decode("ascii")
-                yield _sse(
-                    {
-                        "type": "progress",
-                        "frame_index": 0,
-                        "jpeg_b64": draft_b64,
-                    },
-                    trace_id,
+                yield await progress_frame(
+                    _sse, draft_result.jpeg_bytes, 0, trace_id
                 )
             result = await main_task
     elif main_task is not None:
@@ -1067,13 +1034,7 @@ async def stream_tap(
             # the instant it lands, before its judge + keep-best retry.
             preview_bytes = await _race_preview(zoom_preview_q, main_task)
             if preview_bytes is not None:
-                preview_b64 = (
-                    await _asyncio.to_thread(base64.b64encode, preview_bytes)
-                ).decode("ascii")
-                yield _sse(
-                    {"type": "progress", "frame_index": 0, "jpeg_b64": preview_b64},
-                    trace_id,
-                )
+                yield await progress_frame(_sse, preview_bytes, 0, trace_id)
         result = await main_task
 
     # 3b. Geometric grounding (VLM_GROUNDING): verify the render against the
@@ -1117,7 +1078,7 @@ async def stream_tap(
         {"url": c.url, "title": c.title}
         for c in (plan.sources or [])
     ]
-    final_payload: dict[str, Any] = {
+    final_payload: GenerateFinalEvent = {
         "type": "final",
         "image_data_url": data_url,
         "page_title": plan.page_title,

--- a/apps/modal-backend/providers/llm/client.py
+++ b/apps/modal-backend/providers/llm/client.py
@@ -492,6 +492,7 @@ def _with_json_hint(messages: list[Any], hint: str) -> list[Any]:
 def _choice_content(response: Any) -> str:
     try:
         if not response.choices:
+            _safe_log("warn", "llm.empty_choices")
             return ""
         return response.choices[0].message.content or ""
     except Exception as exc:

--- a/apps/modal-backend/providers/render_loop.py
+++ b/apps/modal-backend/providers/render_loop.py
@@ -126,6 +126,11 @@ def data_url_bytes(url: str | None) -> bytes | None:
     try:
         return base64.b64decode(url.split(",", 1)[1])
     except Exception:
+        from obs import log
+
+        # A corrupt data: URL is a client bug, unlike the by-design None for
+        # remote refs above — say so, or the judge axes disarm silently.
+        log("warn", "view.loop.region_decode_failed")
         return None
 
 

--- a/apps/modal-backend/providers/segmenter.py
+++ b/apps/modal-backend/providers/segmenter.py
@@ -300,7 +300,15 @@ async def _segment_sam3(
             arguments["box_prompts"] = [detector_box_to_sam_box(det, img_w, img_h)]
         try:
             result = await _fal_subscribe(model, arguments)
-        except Exception:
+        except Exception as exc:
+            from obs import log
+
+            log(
+                "warn",
+                "segmenter.sam3.label_failed",
+                label=label,
+                error=f"{type(exc).__name__}: {exc}",
+            )
             return None
         masks = result.get("masks") or []
         if not masks:
@@ -311,7 +319,15 @@ async def _segment_sam3(
         try:
             mask_bytes, _ = await _fetch_url_bytes(url)
             polygon = polygon_from_mask(Image.open(io.BytesIO(mask_bytes)))
-        except Exception:
+        except Exception as exc:
+            from obs import log
+
+            log(
+                "warn",
+                "segmenter.sam3.label_failed",
+                label=label,
+                error=f"{type(exc).__name__}: {exc}",
+            )
             return None
         if len(polygon) < MIN_VERTICES:
             return None

--- a/apps/modal-backend/tests/test_geo_schema.py
+++ b/apps/modal-backend/tests/test_geo_schema.py
@@ -177,3 +177,22 @@ def test_secondary_body_mirrors_match_ts(model: str, interface: str) -> None:
     endpoints with no TS interface by design — excluded.)"""
     py_fields = set(getattr(generate, model).model_fields.keys())
     assert py_fields == _ts_interface_fields(interface)
+
+
+@pytest.mark.parametrize(
+    ("typed_dict", "interface"),
+    [
+        ("EditVerdict", "EditVerdict"),
+        ("GenerateFinalEvent", "GenerateFinalEvent"),
+        ("GenerateAscendReadyEvent", "GenerateAscendReadyEvent"),
+    ],
+)
+def test_sse_event_twins_match_ts(typed_dict: str, interface: str) -> None:
+    """The SSE final-event dicts were the last untyped wire face — the same
+    field-drift class the body gates cover. The generate modes build these
+    payloads as TypedDicts now; this pins each twin's field set to its TS
+    interface."""
+    from providers.generate_modes import _events
+
+    py_fields = set(getattr(_events, typed_dict).__annotations__.keys())
+    assert py_fields == _ts_interface_fields(interface)

--- a/apps/web/lib/world-geometry.ts
+++ b/apps/web/lib/world-geometry.ts
@@ -436,7 +436,7 @@ const _FIT_FRAME_W = 100;
 /** Least-squares uniform scale + translation over (from, to) point pairs;
  *  tries the x-flipped register too and keeps the lower residual. Scale clamped
  *  [minScale, 2] (default minScale 0.5); null when < 2 pairs (nothing to anchor).
- *  TS port of tests/recon_bench/_align.fit_alignment — keep the two in lockstep.
+ *  TS port of providers/register.py fit_alignment — keep the two in lockstep.
  *  The gated register lowers minScale to REGISTER_MIN_SCALE to reach coherent
  *  deep compressions (a place drawn tighter than planned) the 0.5 clamp rejects. */
 export function fitSimilarity(

--- a/knip.json
+++ b/knip.json
@@ -23,6 +23,10 @@
     "scripts/perfbudget": {
       "entry": ["run.ts"],
       "project": ["*.ts"]
+    },
+    "scripts/ux-bench": {
+      "entry": ["run.ts"],
+      "project": ["*.ts"]
     }
   }
 }

--- a/scripts/record-demo/record-geo.ts
+++ b/scripts/record-demo/record-geo.ts
@@ -81,8 +81,8 @@ async function main(): Promise<void> {
   // ── 1. A world from scratch ────────────────────────────────────────────────
   console.log("[geo] opening play");
   // domcontentloaded, NOT networkidle: /play holds a persistent Mongo
-  // change-stream SSE open, so networkidle never fires (the record-ankh
-  // lesson) — wait for the query box instead.
+  // change-stream SSE open, so networkidle never fires — wait for the
+  // query box instead.
   await page.goto(`${BASE}/play`, { waitUntil: "domcontentloaded" });
   await page.getByRole("textbox").first().waitFor({ timeout: 30_000 });
   await page.waitForTimeout(1200);

--- a/scripts/ux-bench/package.json
+++ b/scripts/ux-bench/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@openflipbook/ux-bench",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Playwright + VLM agent loop that scores /play task understandability (make ux-bench).",
+  "type": "module",
+  "scripts": {
+    "start": "tsx run.ts"
+  },
+  "dependencies": {
+    "playwright": "^1.48.0",
+    "tsx": "^4.19.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "typescript": "^5.6.3"
+  }
+}


### PR DESCRIPTION
## What

PR #210 handed back five report-only items. This lands the four with real value and records the KEEP calls on the rest.

1. **knip workspace for `scripts/ux-bench`** — the bench had a Makefile entry and zero tool coverage. knip needs a `package.json` to see a workspace, so it gets a minimal one on the perfbudget pattern. Roster is byte-identical to the baseline, minus the `run.ts` unused-file false positive.
2. **`progress_frame` helper** — the six byte-equivalent b64-encode + progress-SSE paint blocks (tap.py ×4, edit.py ×2) collapse into `generate_modes/_frames.py`. `_sse` stays DI-passed. Frames are byte-identical.
3. **Four silent swallows made loud** — log-only, control flow unchanged: `tap.draft_failed`, `segmenter.sam3.label_failed` (both per-label blocks), `view.loop.region_decode_failed` (corrupt-data-URL arm only), `llm.empty_choices`.
4. **SSE final-event TypedDict twins** — `GenerateFinalEvent`, `EditVerdict`, `GenerateAscendReadyEvent` in `generate_modes/_events.py`, typed at the build sites. `test_geo_schema` pins each twin to its TS interface (26 → 29 assertions). This closes the last untyped wire face of the drift class that let `scene_description` slip.
5. **Two stale comment pointers** — world-geometry.ts now cites `providers/register.py` (post-#203 home of `fit_alignment`); record-geo.ts drops its citation of a recorder deleted in #99.

**Adjudicated KEEP, not done** (per the assessment's own verdicts): page.tsx resolve casts (taste call), "byte-identical to today" trims (lean KEEP), feedback.py critic-block (KEEP-leaning), provider-side SceneView twin (tolerant reads are boundary-correct today).

## Gates

Backend pytest not-paid green, ruff clean, mypy 50 files clean, test_geo_schema 29 passed, web vitest 838, tsc clean, madge 0 cycles. e2e-mock rides the required CI job (a live real-provider stack occupies :3000 locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)