### PR TITLE
feat(world): graduate World Mode — the world set is default ON

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -178,6 +178,13 @@ FAL_EDIT_TIER=balanced
 # re-renders fresh from the ORIGINAL style text. 0 = OFF (no cap); the trade is
 # medium fidelity over pixel-continuity past the cap.
 # SCALE_OUTWARD_MAX_HOPS=0
+# World Mode — GRADUATED to default ON (2026-08-21). Taps ENTER places, the
+# world persists on a metric map, and the scale ladder (deeper / ascend /
+# around) is live. One knob restores the classic explainer stack wholesale
+# (compose couples GEOMETRIC_WORLD + SCALE_* + the NEXT_PUBLIC seed to it):
+# WORLD_MODE=false
+# Sessions still carry their own UI toggle either way — a stored session
+# preference always beats the deploy default.
 # §4 plan→image register fit-health gate (web-side). A similarity fit whose
 # scale saturated the [0.5,2] clamp, whose residual is high, or that rode only
 # 2 anchors is untrustworthy — applying it re-expresses every plan geo through

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Sped up 4×: landing → `"how does a steam engine work"` deeplink → two click
 - **Faster clicks.** As soon as a page renders, the VLM precomputes the 3–4 most clickable regions in the background, so most taps skip the resolve round-trip.
 - **Progressive render.** On the balanced/pro tiers the cheap fast model paints a draft in parallel, so you get something on screen seconds before the final lands. Toggle off with `PROGRESSIVE_DRAFT=false` if you'd rather save the extra fal call.
 - **Edit a page in place.** Describe a change and the page revises itself instead of spawning a child. With `EDIT_REGION` on you drag the exact region, the mask rides the edit, and a judge scores the result — verdict chip + one-click revert included.
-- **World Mode (off by default).** Flip `WORLD_MODE` and pages become places: tap a glowing region to *enter* it as a scene, go deeper, ascend back out, or pan to a logical neighbour — all rungs on one metric scale ladder. Every page gets its entities and camera extracted into a live geo overlay and a persistent world map, so revisiting a place brings back *that* place.
+- **World Mode (on by default).** Pages are places: tap a glowing region to *enter* it as a scene, go deeper, ascend back out, or pan to a logical neighbour — all rungs on one metric scale ladder. Every page gets its entities and camera extracted into a live geo overlay and a persistent world map, so revisiting a place brings back *that* place. `WORLD_MODE=false` restores the classic explainer flow, and each session has its own toggle.
 - **Critic loop.** Long renders (entering a scene, masked edits) are judged by a panel of VLM critics — wrong camera, wrong place, or wrong art medium gets rejected and retried with the critic's rationale folded into the prompt. You watch it self-correct instead of staring at a spinner.
 - **BYO keys.** No hosted backend. Clone it, run it, pay your own bills.
 
@@ -83,7 +83,7 @@ make demo                     # → http://localhost:3000/play
 
 That's it. Mongo, Minio, backend, and web all come up wired together. Open [`/status`](http://localhost:3000/status) for a live env check. Full compose reference: [`docs/DOCKER.md`](docs/DOCKER.md).
 
-**Want the world stuff?** `make demo-world` is the same two-key stack with World Mode + scale-ladder navigation switched on: taps *enter* places, you can go deeper, ascend back out, and pan to neighbours. (It's the same code, just flags — kept off in `make demo` so the classic flow stays untouched.)
+**The world stuff is the default now** — `make demo` boots with World Mode + scale-ladder navigation on: taps *enter* places, you can go deeper, ascend back out, and pan to neighbours. `WORLD_MODE=false make demo` brings back the classic explainer stack, and `make demo-world` still works (it additionally pins the planner to Gemini).
 
 **Images-only cloud:** `make demo-local` runs the planner + click VLM on local Ollama — only `FAL_KEY` needed (first run pulls multi-GB models; CPU-slow).
 

--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -359,10 +359,11 @@ class GenerateBody(BaseModel):
     trace_id: str | None = None
 
 
-# World Mode is gated behind an env flag (default off) so it's a no-op in prod
-# until a deployer turns it on — like EXPAND_MAP_PAN / IMAGE_CONDITIONING.
+# World Mode graduated to default ON (2026-08-21) — WORLD_MODE=0 is the
+# deploy-level kill switch. The CLIENT half still decides per session
+# (`requested` = the user's toggle), so classic sessions stay classic.
 def _world_mode_on(requested: bool) -> bool:
-    return bool(requested) and env_flag("WORLD_MODE")
+    return bool(requested) and env_flag("WORLD_MODE", "true")
 
 
 def _segment_borders_on() -> bool:
@@ -382,7 +383,7 @@ def _grounding_sam3_on() -> bool:
 def _geometric_world_on() -> bool:
     """Master gate for the geometric world (GEOMETRIC_WORLD). Off → the geo
     endpoints (e.g. /edit-entities) are disabled and behave as if absent."""
-    return env_flag("GEOMETRIC_WORLD")
+    return env_flag("GEOMETRIC_WORLD", "true")
 
 
 def _world_geometry_gen_on(world_mode: bool = False) -> bool:
@@ -424,9 +425,9 @@ def _layout_clause_for(body: GenerateBody, *, view_grammar: bool = False) -> str
     )
     # LAYOUT_REGISTER_PIN (default off): append the strict-grid register
     # sentence — the committed recon_base.v2 A/B winner against the pos_raw
-    # drift (AUDIT_BOX §4). Flag-gated until the recon bench blesses a
-    # default flip; off = byte-identical prompts.
-    pin = env_flag("LAYOUT_REGISTER_PIN")
+    # drift (AUDIT_BOX §4). Bench-blessed (#132: pos_raw 0.308 -> 0.604, no
+    # cell hurt) and default ON since the world-mode graduation; =0 reverts.
+    pin = env_flag("LAYOUT_REGISTER_PIN", "true")
     if not view_grammar:
         return geometry_prompt.layout_constraints(expected, register_pin=pin)
     return geometry_prompt.layout_constraints(
@@ -598,7 +599,7 @@ def _view_spec_for(
     # rotates a scene enter to a new side. Off ⇒ 0 ⇒ byte-identical.
     enter_index = (
         int(sv.enter_index)
-        if sv and sv.enter_index and sv.enter_index > 0 and env_flag("ENTER_AZIMUTH_ROTATE")
+        if sv and sv.enter_index and sv.enter_index > 0 and env_flag("ENTER_AZIMUTH_ROTATE", "true")
         else 0
     )
     return view_policy.default_view(

--- a/apps/modal-backend/providers/generate_modes/ascend.py
+++ b/apps/modal-backend/providers/generate_modes/ascend.py
@@ -39,7 +39,7 @@ async def stream_ascend(
     _view_grammar_on: Callable[[], bool],
     _abort_if_disconnected: Callable[[str], Awaitable[None]],
 ) -> AsyncIterator[bytes]:
-    if not (env_flag("SCALE_LADDER_NAV") and env_flag("SCALE_OUTWARD")):
+    if not (env_flag("SCALE_LADDER_NAV", "true") and env_flag("SCALE_OUTWARD", "true")):
         yield _sse(
             {"type": "error", "message": "OUTWARD disabled (SCALE_LADDER_NAV+SCALE_OUTWARD)"},
             trace_id,

--- a/apps/modal-backend/providers/generate_modes/expand.py
+++ b/apps/modal-backend/providers/generate_modes/expand.py
@@ -114,7 +114,7 @@ async def stream_expand(
     expand_world_context = [e.model_dump() for e in body.world_context]
     yield _sse({"type": "status", "stage": "planning"}, trace_id)
     await _abort_if_disconnected("pre-expand-plan")
-    around_on = env_flag("SCALE_AROUND_LOGICAL")
+    around_on = env_flag("SCALE_AROUND_LOGICAL", "true")
     neighbors = await llm.propose_neighbors(
         image_data_url=body.image,
         parent_title=body.parent_title or body.query,

--- a/apps/modal-backend/tests/conftest.py
+++ b/apps/modal-backend/tests/conftest.py
@@ -47,7 +47,8 @@ _SCRUB = (
     "IMAGE_API_KEY",
     "IMAGE_MODEL",
     "IMAGE_SIZE",
-    # World Mode (tap enters a place; gated off by default).
+    # World Mode (tap enters a place; graduated default ON — scrub so a host
+    # kill-switch can't flip the routing tests).
     "WORLD_MODE",
     "FAL_CONTINUE_MODEL",
     # Enter-via-edit (default ON — scrub so a host kill-switch can't silently

--- a/apps/modal-backend/tests/test_generate_ascend.py
+++ b/apps/modal-backend/tests/test_generate_ascend.py
@@ -169,10 +169,11 @@ async def test_ascend_outpaint_under_flag_steers_the_medium(monkeypatch: pytest.
     assert "engraving" in (mock.await_args.kwargs.get("prompt") or "")
 
 
-async def test_ascend_gated_off_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Flags unset → the branch refuses; prod byte-identical.
+async def test_ascend_kill_switch_refuses(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Graduated default: flags unset → OUTWARD is ON; an explicit =0 on
+    # either flag is the deploy kill switch and refuses like the old default.
     monkeypatch.delenv("SCALE_LADDER_NAV", raising=False)
-    monkeypatch.delenv("SCALE_OUTWARD", raising=False)
+    monkeypatch.setenv("SCALE_OUTWARD", "0")
     events = await _collect(_event_stream(_ascend_body(), "t1"))
     assert events[0]["type"] == "error"
     assert "disabled" in events[0]["message"]

--- a/apps/modal-backend/tests/test_generate_geometry.py
+++ b/apps/modal-backend/tests/test_generate_geometry.py
@@ -79,13 +79,23 @@ def test_layout_clause_world_mode_explicit_false_kills(
     assert generate._layout_clause_for(_world_body([_proj("Tower")])) == ""
 
 
-def test_layout_clause_world_request_without_env_keeps_old_default(
+def test_layout_clause_world_request_graduated_default_is_on(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A world_mode request against a WORLD_MODE-off deploy is NOT world mode
-    — the old default (off) stands, byte-identical prompts."""
+    """Graduated default: a world_mode request against an env-unset deploy IS
+    world mode — the layout clause fires without any flag set."""
     monkeypatch.delenv("WORLD_GEOMETRY_GEN", raising=False)
     monkeypatch.delenv("WORLD_MODE", raising=False)
+    assert "SCENE LAYOUT" in generate._layout_clause_for(_world_body([_proj("Tower")]))
+
+
+def test_layout_clause_world_mode_kill_switch_keeps_classic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """WORLD_MODE=0 restores the classic deploy: a world_mode request is NOT
+    world mode, byte-identical prompts."""
+    monkeypatch.delenv("WORLD_GEOMETRY_GEN", raising=False)
+    monkeypatch.setenv("WORLD_MODE", "0")
     assert generate._layout_clause_for(_world_body([_proj("Tower")])) == ""
 
 
@@ -252,10 +262,11 @@ def _edit_body() -> generate.EditEntitiesBody:
     )
 
 
-async def test_edit_entities_endpoint_403_when_flag_off(
+async def test_edit_entities_endpoint_403_when_flag_killed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("GEOMETRIC_WORLD", raising=False)
+    # Graduated default: unset = ON; GEOMETRIC_WORLD=0 is the kill switch.
+    monkeypatch.setenv("GEOMETRIC_WORLD", "0")
     resp = await generate.edit_entities_endpoint(SimpleNamespace(headers={}), _edit_body())
     assert resp.status_code == 403
 
@@ -472,7 +483,7 @@ def test_layout_register_pin_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     # committed recon_base.v2 A/B winner vs the pos_raw drift); flag off is
     # byte-identical to today's clause.
     monkeypatch.setenv("WORLD_GEOMETRY_GEN", "true")
-    monkeypatch.delenv("LAYOUT_REGISTER_PIN", raising=False)
+    monkeypatch.setenv("LAYOUT_REGISTER_PIN", "0")  # kill switch; unset = ON
     off = generate._layout_clause_for(_body([_proj("Tower")]))
     assert "strict grid" not in off
     monkeypatch.setenv("LAYOUT_REGISTER_PIN", "1")

--- a/apps/modal-backend/tests/test_generate_view.py
+++ b/apps/modal-backend/tests/test_generate_view.py
@@ -620,15 +620,22 @@ def test_azimuth_flag_on_rotates_a_revisit() -> None:
     assert spec is not None and spec.get("azimuth_deg") == 90.0
 
 
-def test_azimuth_flag_off_leaves_enter_index_inert() -> None:
-    """Flag OFF (default): even with enter_index set, the scene camera carries
-    no azimuth — byte-identical to today."""
+def test_azimuth_kill_switch_leaves_enter_index_inert() -> None:
+    """ENTER_AZIMUTH_ROTATE=0 (the kill switch; unset = ON since the world
+    graduation): even with enter_index set, the scene camera carries no
+    azimuth — byte-identical to the pre-rotation behaviour."""
+    import os
+
     from generate import _view_spec_for
 
-    spec = _view_spec_for(
-        _enter_index_body(1), "place_scene", world_mode=True, has_region=False,
-        subject="a tavern", subject_context="interior", place_form="interior",
-    )
+    os.environ["ENTER_AZIMUTH_ROTATE"] = "0"
+    try:
+        spec = _view_spec_for(
+            _enter_index_body(1), "place_scene", world_mode=True, has_region=False,
+            subject="a tavern", subject_context="interior", place_form="interior",
+        )
+    finally:
+        del os.environ["ENTER_AZIMUTH_ROTATE"]
     assert spec is not None and "azimuth_deg" not in spec
 
 

--- a/apps/web/app/api/world/[sessionId]/ascend/route.ts
+++ b/apps/web/app/api/world/[sessionId]/ascend/route.ts
@@ -44,7 +44,7 @@ interface AscendBody {
 export async function POST(req: Request, { params }: Params) {
   const { sessionId } = await params;
 
-  if (!(envFlag("SCALE_LADDER_NAV") && envFlag("SCALE_OUTWARD"))) {
+  if (!(envFlag("SCALE_LADDER_NAV", "true") && envFlag("SCALE_OUTWARD", "true"))) {
     return NextResponse.json(
       { error: "OUTWARD disabled (set SCALE_LADDER_NAV=1 and SCALE_OUTWARD=1)" },
       { status: 403 },

--- a/apps/web/app/api/world/[sessionId]/extract/route.ts
+++ b/apps/web/app/api/world/[sessionId]/extract/route.ts
@@ -213,7 +213,7 @@ export async function POST(req: Request, { params }: Params) {
     // top-down crop.
     const parentFrameId =
       sceneView && sceneView.level !== "map" ? sceneView.focus_id ?? null : null;
-    const geoOn = envFlag("GEOMETRIC_WORLD");
+    const geoOn = envFlag("GEOMETRIC_WORLD", "true");
     if (geoNodeId && geoOn && (parentFrameId || viewLevel === "map")) {
       try {
         // Map an on-node entity → a seedable geo item (or null to skip). Drops

--- a/apps/web/app/api/world/[sessionId]/map/route.ts
+++ b/apps/web/app/api/world/[sessionId]/map/route.ts
@@ -16,7 +16,7 @@ interface Params {
 }
 
 function geometricWorldEnabled(): boolean {
-  return envFlag("GEOMETRIC_WORLD");
+  return envFlag("GEOMETRIC_WORLD", "true");
 }
 
 function emptyMap(sessionId: string) {

--- a/apps/web/hooks/useWorldMode.test.tsx
+++ b/apps/web/hooks/useWorldMode.test.tsx
@@ -18,9 +18,11 @@ afterEach(() => {
 });
 
 describe("useWorldMode", () => {
-  it("defaults off / auto / no DOM labels when nothing is stored or seeded", () => {
+  it("defaults ON (graduated) / auto / no DOM labels when nothing is stored", () => {
+    // World mode graduated 2026-08-21: a fresh session seeds world-ON unless
+    // the build carries the NEXT_PUBLIC_WORLD_MODE=0 kill switch.
     const { result } = renderHook(() => useWorldMode("s1"));
-    expect(result.current.enabled).toBe(false);
+    expect(result.current.enabled).toBe(true);
     expect(result.current.autonomy).toBe("auto");
     expect(result.current.domLabels).toBe(false);
   });
@@ -47,13 +49,13 @@ describe("useWorldMode", () => {
     const { result, rerender } = renderHook(({ sid }) => useWorldMode(sid), {
       initialProps: { sid: "s1" },
     });
-    act(() => result.current.setEnabled(true));
+    act(() => result.current.setEnabled(false)); // opt s1 OUT of the default
 
     rerender({ sid: "s2" });
-    expect(result.current.enabled).toBe(false); // fresh session, fresh default
+    expect(result.current.enabled).toBe(true); // fresh session, fresh (ON) default
 
     rerender({ sid: "s1" });
-    expect(result.current.enabled).toBe(true); // s1's own toggle survives
+    expect(result.current.enabled).toBe(false); // s1's own toggle survives
   });
 
   it("coerces stored garbage back to safe values", () => {
@@ -62,7 +64,7 @@ describe("useWorldMode", () => {
       JSON.stringify({ enabled: "yes", autonomy: "yolo", domLabels: 1 }),
     );
     const { result } = renderHook(() => useWorldMode("s1"));
-    expect(result.current.enabled).toBe(false);
+    expect(result.current.enabled).toBe(true); // non-boolean -> the (ON) default
     expect(result.current.autonomy).toBe("auto");
     expect(result.current.domLabels).toBe(false);
   });
@@ -70,7 +72,7 @@ describe("useWorldMode", () => {
   it("falls back to the default on unparseable storage", () => {
     window.localStorage.setItem(key("s1"), "{not json");
     const { result } = renderHook(() => useWorldMode("s1"));
-    expect(result.current.enabled).toBe(false);
+    expect(result.current.enabled).toBe(true);
     expect(result.current.autonomy).toBe("auto");
   });
 
@@ -96,8 +98,8 @@ describe("useWorldMode", () => {
     expect(result.current.enabled).toBe(false);
   });
 
-  it("an unrecognized env value seeds OFF", async () => {
-    vi.stubEnv("NEXT_PUBLIC_WORLD_MODE", "on"); // not in the 1/true/yes set
+  it("the build-time kill switch (=0) seeds OFF", async () => {
+    vi.stubEnv("NEXT_PUBLIC_WORLD_MODE", "0");
     vi.resetModules();
     const fresh = await import("./useWorldMode");
     const { result } = renderHook(() => fresh.useWorldMode("s1"));

--- a/apps/web/hooks/useWorldMode.ts
+++ b/apps/web/hooks/useWorldMode.ts
@@ -16,12 +16,11 @@ export interface WorldModeState {
 const DOM_LABELS_DEFAULT = ["1", "true", "yes"].includes(
   (process.env.NEXT_PUBLIC_DOM_LABELS ?? "").toLowerCase(),
 );
-// Seed default for NEW sessions (build-time): a deploy that lives in world
-// mode (the demo stack) starts every session with it ON instead of silently
-// reverting to classic explainers — the "why did consistency regress"
-// footgun is that world mode is per-session and used to always seed off.
-// A session's own toggle still wins once stored.
-const WORLD_DEFAULT = ["1", "true", "yes"].includes(
+// Seed default for NEW sessions (build-time). Graduated to ON (2026-08-21):
+// a fresh session starts in world mode; NEXT_PUBLIC_WORLD_MODE=0 at build
+// time restores the classic seed. A session's own toggle still wins once
+// stored, so nobody's existing session changes underneath them.
+const WORLD_DEFAULT = !["0", "false", "no"].includes(
   (process.env.NEXT_PUBLIC_WORLD_MODE ?? "").toLowerCase(),
 );
 

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,6 +1,7 @@
-# World-on demo override — `make demo` stays untouched; layer this file
-# (`make demo-world`) to turn on the live-proven world/scale-nav set and pin
-# the planner to Gemini (the rate-limited qwen VLM was the old demo trap).
+# World-on demo override. MOSTLY REDUNDANT since the 2026-08-21 graduation —
+# `make demo` is world-on by default now. This overlay still pins the planner
+# to Gemini (the rate-limited qwen VLM was the old demo trap) and forces the
+# world set on even when the root .env carries WORLD_MODE=false.
 #
 #   make demo-world
 #   # or: docker compose -f docker-compose.yml -f docker-compose.demo.yml up --build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,9 +109,14 @@ services:
       MOCK_PROVIDERS: ${MOCK_PROVIDERS:-}
       # World Mode: a tap ENTERS the tapped place (an immersive scene / a closer
       # sub-map) instead of explaining a topic, and places persist + reopen.
-      # Default off — turn on per-session from the UI once enabled here:
-      #   WORLD_MODE=true docker compose up -d backend
-      WORLD_MODE: ${WORLD_MODE:-false}
+      # GRADUATED to default ON (2026-08-21). One knob kills the whole set:
+      #   WORLD_MODE=false docker compose up -d
+      # The geometry + scale-ladder flags follow it unless individually set.
+      WORLD_MODE: ${WORLD_MODE:-true}
+      GEOMETRIC_WORLD: ${GEOMETRIC_WORLD:-${WORLD_MODE:-true}}
+      SCALE_LADDER_NAV: ${SCALE_LADDER_NAV:-${WORLD_MODE:-true}}
+      SCALE_OUTWARD: ${SCALE_OUTWARD:-${WORLD_MODE:-true}}
+      SCALE_AROUND_LOGICAL: ${SCALE_AROUND_LOGICAL:-${WORLD_MODE:-true}}
       # Map-pan: "expand" (Around) outpaints the world outward in 4 directions
       # instead of blooming neighbour subjects. Default off:
       #   EXPAND_MAP_PAN=true docker compose up -d backend
@@ -139,10 +144,11 @@ services:
       # carry them — they must arrive as build args or the image ships the
       # flag-off bundle (the "why did consistency regress" footgun: world
       # mode seeded OFF in every fresh docker session). Both follow the root
-      # .env's WORLD_MODE so the single-file demo stays single-file.
+      # .env's WORLD_MODE (graduated default ON) so the single-file demo
+      # stays single-file and WORLD_MODE=false restores the classic bundle.
       args:
-        NEXT_PUBLIC_WORLD_MODE: ${NEXT_PUBLIC_WORLD_MODE:-${WORLD_MODE:-false}}
-        NEXT_PUBLIC_DOM_LABELS: ${NEXT_PUBLIC_DOM_LABELS:-${WORLD_MODE:-false}}
+        NEXT_PUBLIC_WORLD_MODE: ${NEXT_PUBLIC_WORLD_MODE:-${WORLD_MODE:-true}}
+        NEXT_PUBLIC_DOM_LABELS: ${NEXT_PUBLIC_DOM_LABELS:-${WORLD_MODE:-true}}
         NEXT_PUBLIC_ON_RAMP_COACH: ${NEXT_PUBLIC_ON_RAMP_COACH:-false}
         NEXT_PUBLIC_ENTER_COACH: ${NEXT_PUBLIC_ENTER_COACH:-false}
     container_name: openflipbook-web
@@ -176,6 +182,13 @@ services:
       R2_ACCESS_KEY_ID: ${MINIO_ROOT_USER:-openflipbook}
       R2_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:-openflipbook-local}
       R2_PUBLIC_BASE_URL: ${R2_PUBLIC_BASE_URL:-http://localhost:9000/openflipbook}
+      # The web server routes gate geometry seeding + scale-nav on these —
+      # same graduated single-knob coupling as the backend block above.
+      WORLD_MODE: ${WORLD_MODE:-true}
+      GEOMETRIC_WORLD: ${GEOMETRIC_WORLD:-${WORLD_MODE:-true}}
+      SCALE_LADDER_NAV: ${SCALE_LADDER_NAV:-${WORLD_MODE:-true}}
+      SCALE_OUTWARD: ${SCALE_OUTWARD:-${WORLD_MODE:-true}}
+      SCALE_AROUND_LOGICAL: ${SCALE_AROUND_LOGICAL:-${WORLD_MODE:-true}}
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
## What

Export-program Phase 4, on Eren's explicit go: the flagship loop (tap enters a place, the world persists on a metric map, deeper / ascend / around on one scale ladder) leaves its flag.

Defaults flipped to **ON**, each keeping an `=false` kill switch:

- Backend: `WORLD_MODE`, `GEOMETRIC_WORLD`, `SCALE_LADDER_NAV`, `SCALE_OUTWARD`, `SCALE_AROUND_LOGICAL`, `ENTER_AZIMUTH_ROTATE`, `LAYOUT_REGISTER_PIN` (bench-blessed in #132: pos_raw 0.308 → 0.604, no cell hurt)
- Web routes: `GEOMETRIC_WORLD`, `SCALE_LADDER_NAV`+`SCALE_OUTWARD` (geometry seeding + ascend)
- Web session seed: `NEXT_PUBLIC_WORLD_MODE` (build-time; `=0` restores the classic seed)

A stored session toggle still beats the deploy default — nobody's existing session changes underneath them, and the per-session UI switch stays.

## One knob

Compose couples the whole set to `WORLD_MODE`: `WORLD_MODE=false docker compose up` restores the classic stack wholesale (geometry/scale flags + both `NEXT_PUBLIC` build args follow it unless individually set). Verified with `docker compose config` in both knob positions, clean-room env. The CI e2e-mock stack already ran world-on (`WORLD_MODE: "true"` explicit) and is byte-identical. `make demo-world` survives as the Gemini-pinned overlay.

## Tests

The five default-off tests now encode the graduation: each became a kill-switch test (`=0` restores classic, byte-identical) and the geometry side gained an explicit graduated-default test. Backend suite green, web 841 green, tsc/ruff/mypy clean; e2e-mock rides the required CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)