### PR TITLE
feat(embed): embeddable world viewer + oEmbed — worlds in any page

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Sped up 4×: landing → `"how does a steam engine work"` deeplink → two click
   - Default: one-shot 5s MP4 from `fal-ai/ltx-video/image-to-video`. Cheap (~$0.02/clip), no GPU on your side.
   - Streaming: the same LTXF binary WebSocket protocol Flipbook uses, deployed to your own Modal account — true fragmented-MP4 streaming into a `<video>` tag via Media Source Extensions.
 - **Permalinks.** `/n/:id` hydrates from Mongo + R2 without regenerating.
+- **Embeddable worlds.** Publish a world (right-click → Publish) and it becomes frameable: `/embed/:sessionId` is a read-only interactive viewer — tap the dots to walk the already-generated pages, zero model calls, works in any iframe. Platforms that speak oEmbed unfurl `/n/` links into it automatically; everyone else gets the one-line `<script src=".../embed.js">` + `<div data-openflipbook="...">` wrapper.
 - **Pin a style.** Hit the 📌 on any page and every new page in the session inherits that look (palette, line work, perspective). Persists across reload.
 - **Citations.** When the planner runs with `:online`, the source URLs ride through to a tiny `📎` chip in the corner of the page — one click, you can see what it actually read.
 - **Shift-drag to circle a region.** Freehand stroke on the image, release, and the next page focuses on what you scribbled. Same VLM as the click path, just more pointed.

--- a/apps/web/app/api/oembed/route.ts
+++ b/apps/web/app/api/oembed/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+
+import { getNode, getPublishedSession } from "@/lib/db";
+import { buildEmbedHtml, parseEmbedTarget } from "@/lib/embed";
+import { readServerEnv } from "@/lib/env";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// oEmbed provider (JSON only) for openflipbook worlds: paste an /n/<id> or
+// /embed/<sessionId> link into a consumer (WordPress, Discourse, ...) and it
+// renders the interactive embed. Same publish gate as /embed itself — the
+// endpoint must not confirm the existence of unpublished sessions.
+
+export async function GET(req: Request) {
+  const env = readServerEnv();
+  if (!env.MONGODB_URI || !env.MONGODB_DB || !env.R2_PUBLIC_BASE_URL) {
+    return NextResponse.json({ error: "persistence not configured" }, { status: 503 });
+  }
+  const reqUrl = new URL(req.url);
+  const format = reqUrl.searchParams.get("format");
+  if (format && format !== "json") {
+    // Per the oEmbed spec: 501 for unimplemented formats (no XML here).
+    return NextResponse.json({ error: "only format=json" }, { status: 501 });
+  }
+  const raw = reqUrl.searchParams.get("url");
+  const target = raw ? parseEmbedTarget(raw) : null;
+  if (!target) {
+    return NextResponse.json({ error: "unrecognized url" }, { status: 404 });
+  }
+
+  let sessionId: string;
+  let nodeId: string | null;
+  if (target.kind === "node") {
+    const node = await getNode(target.nodeId).catch(() => null);
+    if (!node) return NextResponse.json({ error: "not found" }, { status: 404 });
+    sessionId = node.session_id;
+    nodeId = node.id;
+  } else {
+    sessionId = target.sessionId;
+    nodeId = target.nodeId;
+  }
+
+  const published = await getPublishedSession(sessionId).catch(() => null);
+  if (!published) {
+    return NextResponse.json({ error: "not found" }, { status: 404 });
+  }
+
+  const maxWidthRaw = reqUrl.searchParams.get("maxwidth");
+  const maxWidth = maxWidthRaw ? Number(maxWidthRaw) : null;
+  const embed = buildEmbedHtml(
+    reqUrl.origin,
+    sessionId,
+    nodeId,
+    Number.isFinite(maxWidth ?? NaN) ? maxWidth : null
+  );
+  const posterBase = env.R2_PUBLIC_BASE_URL!.replace(/\/$/, "");
+  return NextResponse.json({
+    version: "1.0",
+    type: "rich",
+    provider_name: "openflipbook",
+    provider_url: reqUrl.origin,
+    title: published.title || published.query,
+    html: embed.html,
+    width: embed.width,
+    height: embed.height,
+    thumbnail_url: `${posterBase}/${published.poster_key}`,
+  });
+}

--- a/apps/web/app/embed/[sessionId]/page.tsx
+++ b/apps/web/app/embed/[sessionId]/page.tsx
@@ -1,0 +1,71 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import EmbedViewer from "@/components/embed-viewer";
+import {
+  getNode,
+  getPublishedSession,
+  getSessionRootNode,
+  type NodeRow,
+} from "@/lib/db";
+import { readServerEnv } from "@/lib/env";
+
+// Read-only embeddable world viewer. PUBLISH-GATED: only sessions the owner
+// put in the gallery render here — a leaked session id must not make a
+// private world frameable (the embed exposes the whole session graph, wider
+// than one /n/ node). Zero model calls on this surface; navigation hops
+// through already-generated nodes only.
+
+interface EmbedPageProps {
+  params: Promise<{ sessionId: string }>;
+  searchParams: Promise<{ node?: string }>;
+}
+
+export const metadata: Metadata = {
+  // A widget surface, not a destination — the canonical pages are /n/<id>.
+  robots: { index: false, follow: false },
+  title: "openflipbook world",
+};
+
+export default async function EmbedPage({ params, searchParams }: EmbedPageProps) {
+  let { sessionId } = await params;
+  const { node: nodeParam } = await searchParams;
+  const env = readServerEnv();
+  if (!env.MONGODB_URI || !env.MONGODB_DB || !env.R2_PUBLIC_BASE_URL) {
+    notFound();
+  }
+
+  // public/embed.js mounts /n/<nodeId> permalinks as /embed/_from-node?node=…
+  // (the script can't resolve node → session client-side). Resolve it here;
+  // the publish gate below still applies to the resolved session.
+  if (sessionId === "_from-node") {
+    const viaNode = nodeParam ? await getNode(nodeParam).catch(() => null) : null;
+    if (!viaNode) notFound();
+    sessionId = viaNode.session_id;
+  }
+
+  const published = await getPublishedSession(sessionId).catch(() => null);
+  if (!published) notFound();
+
+  let start: NodeRow | null = null;
+  if (nodeParam) {
+    const candidate = await getNode(nodeParam).catch(() => null);
+    // A ?node= from another session must not smuggle a foreign page into
+    // this session's published frame.
+    if (candidate && candidate.session_id === sessionId) start = candidate;
+  }
+  if (!start) start = await getSessionRootNode(sessionId).catch(() => null);
+  if (!start) notFound();
+
+  const base = env.R2_PUBLIC_BASE_URL!.replace(/\/$/, "");
+  return (
+    <EmbedViewer
+      initial={{
+        id: start.id,
+        title: start.page_title || start.query || published.title,
+        imageUrl: `${base}/${start.image_key}`,
+      }}
+      continueUrl={`/play?continue=${encodeURIComponent(sessionId)}`}
+    />
+  );
+}

--- a/apps/web/app/n/[id]/page.tsx
+++ b/apps/web/app/n/[id]/page.tsx
@@ -67,7 +67,15 @@ export async function generateMetadata({
       description,
       ...(imageUrl ? { images: [imageUrl] } : {}),
     },
-    alternates: { canonical: `/n/${id}` },
+    alternates: {
+      canonical: `/n/${id}`,
+      // oEmbed discovery: consumers that fetch this page find the provider
+      // endpoint and swap the link for the interactive world embed
+      // (publish-gated — /api/oembed 404s for unpublished sessions).
+      types: {
+        "application/json+oembed": `/api/oembed?url=${encodeURIComponent(`/n/${id}`)}`,
+      },
+    },
   };
 }
 

--- a/apps/web/components/embed-viewer.tsx
+++ b/apps/web/components/embed-viewer.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+// Read-only navigable world viewer for the /embed surface. Zero model calls:
+// every navigation is a hop to an ALREADY-GENERATED node via the public
+// children endpoint (the share-continue zero-generate hydration contract).
+// Taps on unexplored ground get a hint instead of dead silence — the /n/
+// permalink "dead taps" lesson, made an explicit UX contract at the frontier.
+
+export interface EmbedNode {
+  id: string;
+  title: string;
+  imageUrl: string;
+}
+
+interface ChildRow {
+  id: string;
+  page_title: string;
+  image_url: string;
+  click_in_parent: { x_pct: number; y_pct: number } | null;
+}
+
+interface EmbedViewerProps {
+  initial: EmbedNode;
+  continueUrl: string;
+}
+
+export default function EmbedViewer({ initial, continueUrl }: EmbedViewerProps) {
+  const [current, setCurrent] = useState<EmbedNode>(initial);
+  const [stack, setStack] = useState<EmbedNode[]>([]);
+  const [children, setChildren] = useState<ChildRow[]>([]);
+  const [hint, setHint] = useState<{ x: number; y: number } | null>(null);
+  const hintTimer = useRef<number | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setChildren([]);
+    (async () => {
+      try {
+        const res = await fetch(
+          `/api/nodes/${encodeURIComponent(current.id)}/children`,
+          { cache: "no-store" }
+        );
+        if (!res.ok) return;
+        const json = (await res.json()) as { children: ChildRow[] };
+        if (!cancelled) setChildren(json.children ?? []);
+      } catch {
+        /* frontier stays dotless; the continue link is always visible */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [current.id]);
+
+  const enter = (c: ChildRow) => {
+    setStack((s) => [...s, current]);
+    setCurrent({ id: c.id, title: c.page_title, imageUrl: c.image_url });
+    setHint(null);
+  };
+
+  const back = () => {
+    setStack((s) => {
+      const prev = s[s.length - 1];
+      if (prev) setCurrent(prev);
+      return s.slice(0, -1);
+    });
+    setHint(null);
+  };
+
+  // A tap that misses every dot = unexplored ground: show a transient hint
+  // anchored at the tap instead of doing nothing.
+  const onGroundClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    setHint({
+      x: (e.clientX - rect.left) / rect.width,
+      y: (e.clientY - rect.top) / rect.height,
+    });
+    if (hintTimer.current) window.clearTimeout(hintTimer.current);
+    hintTimer.current = window.setTimeout(() => setHint(null), 2600);
+  };
+
+  const dots = children.filter(
+    (c): c is ChildRow & { click_in_parent: { x_pct: number; y_pct: number } } =>
+      c.click_in_parent != null
+  );
+
+  return (
+    <div className="flex h-dvh flex-col bg-[#faf7f1] text-[#1c1917]">
+      <header className="flex items-center justify-between gap-2 px-3 py-2 text-xs">
+        <div className="flex min-w-0 items-center gap-2">
+          {stack.length > 0 && (
+            <button
+              type="button"
+              onClick={back}
+              className="rounded-full border border-black/25 px-2.5 py-0.5 hover:bg-black/5"
+            >
+              ← back
+            </button>
+          )}
+          <span className="truncate font-medium">{current.title}</span>
+        </div>
+        <span className="shrink-0 opacity-50">
+          {dots.length > 0
+            ? `${dots.length} place${dots.length === 1 ? "" : "s"} to enter`
+            : "world frontier"}
+        </span>
+      </header>
+
+      <div
+        className="relative min-h-0 flex-1 cursor-pointer overflow-hidden"
+        onClick={onGroundClick}
+        data-testid="embed-stage"
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={current.imageUrl}
+          alt={current.title}
+          className="h-full w-full object-contain"
+          draggable={false}
+        />
+        {dots.map((c) => (
+          <button
+            key={c.id}
+            type="button"
+            title={`Enter ${c.page_title}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              enter(c);
+            }}
+            className="group absolute -translate-x-1/2 -translate-y-1/2"
+            style={{
+              left: `${c.click_in_parent.x_pct * 100}%`,
+              top: `${c.click_in_parent.y_pct * 100}%`,
+            }}
+          >
+            <span className="block h-3.5 w-3.5 rounded-full border-2 border-white bg-amber-500 shadow-md transition-transform group-hover:scale-125" />
+            <span className="pointer-events-none absolute left-1/2 top-4 z-10 hidden -translate-x-1/2 whitespace-nowrap rounded bg-black/75 px-1.5 py-0.5 text-[10px] text-white group-hover:block">
+              {c.page_title}
+            </span>
+          </button>
+        ))}
+        {hint && (
+          <a
+            href={continueUrl}
+            target="_blank"
+            rel="noopener"
+            onClick={(e) => e.stopPropagation()}
+            className="absolute z-20 -translate-x-1/2 whitespace-nowrap rounded-full bg-black/80 px-3 py-1 text-[11px] text-white shadow-lg"
+            style={{
+              left: `${hint.x * 100}%`,
+              top: `${Math.min(hint.y * 100 + 4, 92)}%`,
+            }}
+          >
+            unexplored — continue this world on openflipbook →
+          </a>
+        )}
+      </div>
+
+      <footer className="flex items-center justify-between gap-2 px-3 py-2 text-[11px]">
+        <span className="opacity-50">an openflipbook world</span>
+        <a
+          href={continueUrl}
+          target="_blank"
+          rel="noopener"
+          className="rounded-full border border-black/25 px-3 py-1 font-medium hover:bg-black/5"
+        >
+          Continue this world →
+        </a>
+      </footer>
+    </div>
+  );
+}

--- a/apps/web/e2e/embed.spec.ts
+++ b/apps/web/e2e/embed.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "@playwright/test";
+
+import { clickAtImageFraction, waitForStableImage } from "./helpers";
+
+// The embeddable world viewer: publish-gated, zero-generate, navigable
+// through already-generated nodes only. One session exercises the whole
+// contract — gate closed → publish → gate open → dot navigation → frontier
+// hint → oEmbed provider.
+test("embed viewer is publish-gated, navigates generated nodes, serves oEmbed", async ({
+  page,
+}) => {
+  let sessionId = "";
+  page.on("request", (req) => {
+    if (req.url().includes("/api/generate-page") && req.method() === "POST") {
+      const body = JSON.parse(req.postData() ?? "{}");
+      if (body.session_id) sessionId = body.session_id;
+    }
+  });
+  const rootPersist = page.waitForResponse(
+    (r) => r.url().includes("/api/nodes") && r.request().method() === "POST",
+    { timeout: 90_000 },
+  );
+  await page.goto("/play?q=" + encodeURIComponent("an old stone tower"));
+  await waitForStableImage(page);
+  const root = (await (await rootPersist).json()) as { id?: string };
+  expect(root.id).toBeTruthy();
+  expect(sessionId).toBeTruthy();
+
+  // One tap → one generated CHILD (the embed's navigation target).
+  const childPersist = page.waitForResponse(
+    (r) => r.url().includes("/api/nodes") && r.request().method() === "POST",
+    { timeout: 90_000 },
+  );
+  await clickAtImageFraction(page, 0.5, 0.5);
+  const child = (await (await childPersist).json()) as { id?: string };
+  expect(child.id).toBeTruthy();
+
+  // 1) Gate closed: an unpublished session must not be frameable — and the
+  // oEmbed provider must not confirm it exists.
+  const closed = await page.goto(`/embed/${encodeURIComponent(sessionId)}`);
+  expect(closed!.status()).toBe(404);
+  const oembedClosed = await page.request.get(
+    `/api/oembed?url=${encodeURIComponent(`/n/${root.id}`)}`,
+  );
+  expect(oembedClosed.status()).toBe(404);
+
+  // Publish (first-touch owner claim rides this browser context's cookie).
+  const pub = await page.request.post("/api/gallery/publish", {
+    data: { session_id: sessionId, node_id: root.id },
+  });
+  expect(pub.ok()).toBeTruthy();
+
+  // 2) Gate open: the viewer renders the root with the child's entry dot.
+  await page.goto(`/embed/${encodeURIComponent(sessionId)}`);
+  await expect(page.getByTestId("embed-stage").locator("img")).toBeVisible({
+    timeout: 30_000,
+  });
+  const dot = page.locator('button[title^="Enter "]');
+  await expect(dot).toBeVisible({ timeout: 15_000 });
+
+  // 3) Dot navigation: enter the child (ZERO generates on this surface),
+  // then back returns to the root.
+  let generates = 0;
+  page.on("request", (req) => {
+    if (req.url().includes("/api/generate-page") && req.method() === "POST") {
+      generates += 1;
+    }
+  });
+  await dot.click();
+  await expect(page.getByRole("button", { name: "← back" })).toBeVisible();
+  // The child is the frontier — no children of its own.
+  await expect(page.getByText("world frontier")).toBeVisible({ timeout: 15_000 });
+
+  // 4) Frontier tap → the continue hint, not silence (the /n/ dead-tap lesson).
+  await page.getByTestId("embed-stage").click({ position: { x: 40, y: 40 } });
+  await expect(page.getByText(/unexplored — continue this world/)).toBeVisible();
+  expect(generates).toBe(0);
+
+  // 5) oEmbed provider: a /n/ permalink resolves to the published session's
+  // interactive iframe.
+  const oembed = await page.request.get(
+    `/api/oembed?url=${encodeURIComponent(`/n/${root.id}`)}`,
+  );
+  expect(oembed.ok()).toBeTruthy();
+  const payload = (await oembed.json()) as {
+    type?: string;
+    html?: string;
+    thumbnail_url?: string;
+  };
+  expect(payload.type).toBe("rich");
+  expect(payload.html).toContain(`/embed/${sessionId}`);
+  expect(payload.html).toContain("iframe");
+});

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -498,6 +498,40 @@ export async function unpublishSession(sessionId: string): Promise<boolean> {
   return res.deletedCount > 0;
 }
 
+/** The gallery-publish record for one session, or null. The embed surface
+ * gates on this: only sessions the owner deliberately published render in an
+ * iframe — a leaked session id must not make a private world frameable. */
+export async function getPublishedSession(
+  sessionId: string
+): Promise<PublishedSessionRow | null> {
+  const doc = await (await publishedSessions()).findOne({ _id: sessionId });
+  if (!doc) return null;
+  return {
+    session_id: doc._id,
+    node_id: doc.node_id,
+    title: doc.title,
+    query: doc.query,
+    poster_key: doc.poster_key,
+    published_at: doc.published_at.toISOString(),
+  };
+}
+
+/** The session's current top-of-world node: the NEWEST parentless node —
+ * after an OUTWARD ascend the old root is re-pointed under the synthesized
+ * container (setNodeParent), so the latest parentless node is the widest
+ * view. Sessions normally carry exactly one. */
+export async function getSessionRootNode(
+  sessionId: string
+): Promise<NodeRow | null> {
+  const collection = await nodes();
+  const doc = await collection
+    .find({ session_id: sessionId, parent_id: null })
+    .sort({ created_at: -1, _id: -1 })
+    .limit(1)
+    .next();
+  return doc ? toRow(doc) : null;
+}
+
 export async function listPublishedSessions(
   limit = 60
 ): Promise<PublishedSessionRow[]> {

--- a/apps/web/lib/embed.test.ts
+++ b/apps/web/lib/embed.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { buildEmbedHtml, parseEmbedTarget } from "./embed";
+
+describe("parseEmbedTarget", () => {
+  it("resolves /n/<id> permalinks to a node target on any origin", () => {
+    expect(
+      parseEmbedTarget("https://openflipbook.example/n/abc-123")
+    ).toEqual({ kind: "node", nodeId: "abc-123" });
+    expect(parseEmbedTarget("http://localhost:3000/n/xyz")).toEqual({
+      kind: "node",
+      nodeId: "xyz",
+    });
+  });
+
+  it("resolves /embed/<sessionId> with an optional start node", () => {
+    expect(parseEmbedTarget("https://x.test/embed/sess-1")).toEqual({
+      kind: "session",
+      sessionId: "sess-1",
+      nodeId: null,
+    });
+    expect(parseEmbedTarget("https://x.test/embed/sess-1?node=n9")).toEqual({
+      kind: "session",
+      sessionId: "sess-1",
+      nodeId: "n9",
+    });
+  });
+
+  it("accepts relative paths (the /n/ discovery link's shape)", () => {
+    expect(parseEmbedTarget("/n/abc")).toEqual({ kind: "node", nodeId: "abc" });
+    expect(parseEmbedTarget("/embed/s1?node=n2")).toEqual({
+      kind: "session",
+      sessionId: "s1",
+      nodeId: "n2",
+    });
+  });
+
+  it("rejects everything else (other routes, missing ids)", () => {
+    for (const bad of [
+      "https://x.test/play?continue=s1",
+      "https://x.test/n/",
+      "https://x.test/embed/",
+      "https://x.test/n/a/b",
+      "::not a url::",
+    ]) {
+      expect(parseEmbedTarget(bad)).toBeNull();
+    }
+  });
+});
+
+describe("buildEmbedHtml", () => {
+  it("builds the iframe with clamped width and 16:10 height", () => {
+    const e = buildEmbedHtml("https://x.test/", "s1", "n2", 2000);
+    expect(e.width).toBe(1280);
+    expect(e.height).toBe(800);
+    expect(e.html).toContain('src="https://x.test/embed/s1?node=n2"');
+    expect(e.html).toContain("iframe");
+  });
+
+  it("defaults to 720 wide and omits the node param when absent", () => {
+    const e = buildEmbedHtml("https://x.test", "s1", null);
+    expect(e.width).toBe(720);
+    expect(e.html).toContain('src="https://x.test/embed/s1"');
+  });
+});

--- a/apps/web/lib/embed.ts
+++ b/apps/web/lib/embed.ts
@@ -1,0 +1,68 @@
+// The embeddable-world surface's pure half: resolve an oEmbed `url` param to
+// an embed target, and build the iframe snippet consumers paste. Kept free of
+// I/O so the URL grammar is unit-testable (the /api/oembed route does the
+// Mongo lookups + publish gating).
+
+export type EmbedTarget =
+  | { kind: "node"; nodeId: string }
+  | { kind: "session"; sessionId: string; nodeId: string | null };
+
+/** Parse an oEmbed `url` parameter. Accepted shapes (any origin — consumers
+ *  send whatever domain the deploy lives on):
+ *    …/n/<nodeId>                     → the node's session, starting AT it
+ *    …/embed/<sessionId>[?node=<id>] → that session (optional start node)
+ *  Anything else → null. */
+export function parseEmbedTarget(rawUrl: string): EmbedTarget | null {
+  let url: URL;
+  try {
+    // Lenient on origin: the /n/ discovery link passes a relative path (the
+    // server can't know its public origin at metadata time), and consumers
+    // pass their own absolute page URLs. Both parse.
+    url = new URL(rawUrl, "http://relative.local");
+  } catch {
+    return null;
+  }
+  const parts = url.pathname.split("/").filter(Boolean);
+  if (parts.length === 2 && parts[0] === "n" && parts[1]) {
+    return { kind: "node", nodeId: decodeURIComponent(parts[1]) };
+  }
+  if (parts.length === 2 && parts[0] === "embed" && parts[1]) {
+    return {
+      kind: "session",
+      sessionId: decodeURIComponent(parts[1]),
+      nodeId: url.searchParams.get("node"),
+    };
+  }
+  return null;
+}
+
+export interface EmbedHtml {
+  html: string;
+  width: number;
+  height: number;
+}
+
+/** The iframe snippet oEmbed consumers (and public/embed.js) inject. 16:10 to
+ *  fit the image plus the viewer's slim chrome; capped by the consumer's
+ *  maxwidth per the oEmbed spec. */
+export function buildEmbedHtml(
+  origin: string,
+  sessionId: string,
+  nodeId: string | null,
+  maxWidth?: number | null
+): EmbedHtml {
+  const width = Math.min(Math.max(maxWidth ?? 720, 320), 1280);
+  const height = Math.round(width * 0.625);
+  const src =
+    `${origin.replace(/\/$/, "")}/embed/${encodeURIComponent(sessionId)}` +
+    (nodeId ? `?node=${encodeURIComponent(nodeId)}` : "");
+  return {
+    html:
+      `<iframe src="${src}" width="${width}" height="${height}" ` +
+      `frameborder="0" loading="lazy" allowfullscreen ` +
+      `style="border:0;max-width:100%;border-radius:12px" ` +
+      `title="openflipbook world"></iframe>`,
+    width,
+    height,
+  };
+}

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -5,6 +5,19 @@ const nextConfig = {
   reactStrictMode: true,
   transpilePackages: ["@openflipbook/config"],
   typedRoutes: true,
+  async headers() {
+    return [
+      {
+        // The embed surface is MADE to be framed (publish-gated server-side);
+        // declare it explicitly so a future global anti-framing header can't
+        // silently kill every embed in the wild.
+        source: "/embed/:path*",
+        headers: [
+          { key: "Content-Security-Policy", value: "frame-ancestors *" },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/apps/web/public/embed.js
+++ b/apps/web/public/embed.js
@@ -1,0 +1,54 @@
+// openflipbook embed wrapper — for pages whose platform doesn't speak oEmbed.
+// Usage (one line each):
+//   <div data-openflipbook="https://<host>/n/<nodeId>"></div>
+//   <script async src="https://<host>/embed.js"></script>
+// Each tagged div is swapped for the interactive world iframe, built with DOM
+// methods only (no innerHTML — the attribute is page-author input). The world
+// must be published (right-click → Publish) or the framed page 404s.
+(function () {
+  function targetSrc(raw) {
+    var url;
+    try {
+      url = new URL(raw, window.location.href);
+    } catch (e) {
+      return null;
+    }
+    var parts = url.pathname.split("/").filter(Boolean);
+    if (parts.length !== 2) return null;
+    if (parts[0] === "embed") return url.origin + "/embed/" + parts[1] + url.search;
+    if (parts[0] === "n") {
+      // A /n/<nodeId> permalink: let the provider resolve node -> session.
+      return (
+        url.origin + "/embed/_from-node?node=" + encodeURIComponent(parts[1])
+      );
+    }
+    return null;
+  }
+  function mount(el) {
+    var raw = el.getAttribute("data-openflipbook");
+    if (!raw || el.getAttribute("data-ofb-mounted")) return;
+    var src = targetSrc(raw);
+    if (!src) return;
+    el.setAttribute("data-ofb-mounted", "1");
+    var width = Math.max(320, Math.min(1280, Math.round(el.clientWidth || 720)));
+    var frame = document.createElement("iframe");
+    frame.src = src;
+    frame.width = String(width);
+    frame.height = String(Math.round(width * 0.625));
+    frame.loading = "lazy";
+    frame.title = "openflipbook world";
+    frame.style.border = "0";
+    frame.style.maxWidth = "100%";
+    frame.style.borderRadius = "12px";
+    el.appendChild(frame);
+  }
+  function scan() {
+    var els = document.querySelectorAll("[data-openflipbook]");
+    for (var i = 0; i < els.length; i++) mount(els[i]);
+  }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", scan);
+  } else {
+    scan();
+  }
+})();


### PR DESCRIPTION
## What

The distinguisher-stint winner (moat 8 / feasibility 8): openflipbook worlds become embeddable. A read-only `/embed/[sessionId]` viewer navigates **already-generated** nodes — zero model calls, images straight from R2, ~$0 per view — so a world lives interactively inside any blog/forum/Notion page. No real-time competitor can do this (framing their worlds = a GPU stream per viewer). Every embed carries a **Continue this world →** funnel into `/play`.

## Surfaces

- **`/embed/[sessionId]`** (+ `?node=` deep link, + `_from-node` resolution for the script wrapper). **Publish-gated**: only gallery-published sessions render — a leaked session id must not make a private world frameable (the embed exposes the whole graph, wider than one `/n/` node). Entry dots at each child's `click_in_parent`, a back stack, and taps on unexplored ground get a transient "continue on openflipbook" hint — the `/n/` dead-tap lesson promoted to a UX contract at the frontier.
- **`/api/oembed`** (JSON only, 501 for other formats per spec): resolves `/n/<node>` and `/embed/<session>` URLs, same publish gate — 404 for unpublished so the endpoint never confirms a private session exists.
- **Discovery**: `application/json+oembed` alternate on `/n/[id]`; `frame-ancestors *` CSP for `/embed` only.
- **`public/embed.js`**: one-line wrapper for platforms without oEmbed — builds the iframe with DOM methods only (no `innerHTML`; the data attribute is page-author input).
- **db**: `getPublishedSession` + `getSessionRootNode` (newest parentless node = the post-ascend widest view).

## Gates

- `lib/embed` pure URL-grammar vitest (6) — accepts absolute + relative (discovery-link) shapes.
- Full web suite 847 green, tsc clean, build registers `/embed/[sessionId]` + `/api/oembed`.
- **New `e2e/embed.spec.ts`** on the required mock job: gate closed (404 + oEmbed 404) → publish (first-touch owner claim) → viewer renders with the child's dot → dot navigation with **zero** `/api/generate-page` calls → frontier hint → oEmbed rich payload with the iframe.

Merging only after CI is green — the new spec's first run is its proving ground.

🤖 Generated with [Claude Code](https://claude.com/claude-code)