### PR TITLE
feat(fork): fork this world — remix with lineage, $0 a copy

### DIFF
--- a/apps/web/app/api/sessions/[id]/fork/route.ts
+++ b/apps/web/app/api/sessions/[id]/fork/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+
+import { forkSession } from "@/lib/fork";
+import { readServerEnv } from "@/lib/env";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface Params {
+  params: Promise<{ id: string }>;
+}
+
+/** Fork a session into a fresh one the caller can extend as their own.
+ * Openness matches the existing share surfaces: anyone who can reach a
+ * session (a /n/ link, ?continue=) can fork it — forking is the SAFER
+ * alternative to ?continue=, which grants write access to the original.
+ * The fork starts unowned (the forker's first write claims it) and
+ * unpublished. $0: Mongo doc copies, images by R2 reference. */
+export async function POST(req: Request, { params }: Params) {
+  const { id } = await params;
+  const env = readServerEnv();
+  if (!env.MONGODB_URI || !env.MONGODB_DB) {
+    return NextResponse.json(
+      { error: "persistence not configured" },
+      { status: 503 }
+    );
+  }
+  let nodeId: string | null = null;
+  try {
+    const body = (await req.json()) as { node_id?: string };
+    nodeId = body.node_id ?? null;
+  } catch {
+    /* body optional — lineage just loses the page pointer */
+  }
+  const forked = await forkSession(id, nodeId);
+  if (!forked) {
+    return NextResponse.json({ error: "session not found" }, { status: 404 });
+  }
+  return NextResponse.json(forked);
+}

--- a/apps/web/app/n/[id]/page.tsx
+++ b/apps/web/app/n/[id]/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getNode, type NodeRow } from "@/lib/db";
 import { readServerEnv } from "@/lib/env";
+import ForkButton from "@/components/fork-button";
 import PermalinkImage from "@/components/permalink-image";
 import { formatViewVerdict } from "@/lib/view-verdict";
 
@@ -107,13 +108,31 @@ export default async function PermalinkPage({ params }: PermalinkPageProps) {
     <main className="mx-auto flex min-h-dvh max-w-5xl flex-col gap-4 px-4 py-6">
       <header className="flex items-baseline justify-between">
         <h1 className="text-xl font-bold">{node.page_title}</h1>
-        <a
-          href={`/play?continue=${encodeURIComponent(node.session_id)}`}
-          className="rounded-full border border-[var(--color-ink)]/40 px-3 py-1 text-xs"
-        >
-          Continue this session
-        </a>
+        <span className="flex items-center gap-2">
+          <ForkButton sessionId={node.session_id} nodeId={node.id} />
+          <a
+            href={`/play?continue=${encodeURIComponent(node.session_id)}`}
+            className="rounded-full border border-[var(--color-ink)]/40 px-3 py-1 text-xs"
+          >
+            Continue this session
+          </a>
+        </span>
       </header>
+      {node.forked_from && (
+        <p className="self-start text-xs opacity-60">
+          forked from{" "}
+          {node.forked_from.node_id ? (
+            <a
+              className="underline"
+              href={`/n/${encodeURIComponent(node.forked_from.node_id)}`}
+            >
+              this world
+            </a>
+          ) : (
+            "another world"
+          )}
+        </p>
+      )}
       {node.view_verdict && (
         // The receipt: what the render critics saw on the kept attempt —
         // the coherence machinery made visible exactly where the page gets

--- a/apps/web/components/fork-button.tsx
+++ b/apps/web/components/fork-button.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState } from "react";
+
+// "Fork this world" on the share surfaces: copy the whole session (nodes +
+// world model, images by reference, $0) into a fresh one the viewer OWNS,
+// then open it live. The safer sibling of "Continue this session", which
+// writes into the original.
+
+interface ForkButtonProps {
+  sessionId: string;
+  nodeId: string;
+}
+
+export default function ForkButton({ sessionId, nodeId }: ForkButtonProps) {
+  const [busy, setBusy] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  const fork = async () => {
+    if (busy) return;
+    setBusy(true);
+    setFailed(false);
+    try {
+      const res = await fetch(
+        `/api/sessions/${encodeURIComponent(sessionId)}/fork`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ node_id: nodeId }),
+        }
+      );
+      if (!res.ok) throw new Error(`fork ${res.status}`);
+      const { session_id } = (await res.json()) as { session_id: string };
+      window.location.href = `/play?continue=${encodeURIComponent(session_id)}`;
+    } catch {
+      setFailed(true);
+      setBusy(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={fork}
+      disabled={busy}
+      className="rounded-full border border-[var(--color-ink)]/40 px-3 py-1 text-xs hover:bg-[var(--color-ink)]/5 disabled:opacity-50"
+      title="Copy this whole world into a fresh session of your own — the original stays untouched"
+    >
+      {busy ? "forking…" : failed ? "fork failed — retry" : "Fork this world"}
+    </button>
+  );
+}

--- a/apps/web/e2e/share-fork.spec.ts
+++ b/apps/web/e2e/share-fork.spec.ts
@@ -13,7 +13,10 @@ test("fork copies the world; taps grow the fork, never the source", async ({
   page.on("request", (req) => {
     if (req.url().includes("/api/generate-page") && req.method() === "POST") {
       const body = JSON.parse(req.postData() ?? "{}");
-      if (body.session_id) sessionId = body.session_id;
+      // Capture the SOURCE session once — the later tap inside the FORK also
+      // fires a generate, and letting it overwrite this made sourceCount()
+      // count the fork (the first CI run's red).
+      if (body.session_id && !sessionId) sessionId = body.session_id;
     }
   });
   const persist = page.waitForResponse(

--- a/apps/web/e2e/share-fork.spec.ts
+++ b/apps/web/e2e/share-fork.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "@playwright/test";
+
+import { clickAtImageFraction, waitForStableImage } from "./helpers";
+
+// Fork this world: a viewer with a share link gets their OWN copy to extend
+// (nodes + world model, ids reminted) — the safer sibling of ?continue=,
+// which writes into the original. Hydrating a fork generates NOTHING, a tap
+// grows only the fork, and the source session stays byte-count-identical.
+test("fork copies the world; taps grow the fork, never the source", async ({
+  page,
+}) => {
+  let sessionId = "";
+  page.on("request", (req) => {
+    if (req.url().includes("/api/generate-page") && req.method() === "POST") {
+      const body = JSON.parse(req.postData() ?? "{}");
+      if (body.session_id) sessionId = body.session_id;
+    }
+  });
+  const persist = page.waitForResponse(
+    (r) => r.url().includes("/api/nodes") && r.request().method() === "POST",
+    { timeout: 90_000 },
+  );
+  await page.goto("/play?q=" + encodeURIComponent("a walled harbor town"));
+  await waitForStableImage(page);
+  const root = (await (await persist).json()) as { id?: string };
+  expect(root.id).toBeTruthy();
+
+  const sourceCount = async () => {
+    const res = await page.request.get(
+      `/api/sessions/${encodeURIComponent(sessionId)}?limit=200`,
+    );
+    const json = (await res.json()) as { nodes: unknown[] };
+    return json.nodes.length;
+  };
+  const before = await sourceCount();
+  expect(before).toBeGreaterThan(0);
+
+  // Fork via the API (the /n/ page's button posts exactly this).
+  const forkRes = await page.request.post(
+    `/api/sessions/${encodeURIComponent(sessionId)}/fork`,
+    { data: { node_id: root.id } },
+  );
+  expect(forkRes.ok()).toBeTruthy();
+  const fork = (await forkRes.json()) as { session_id: string; nodes: number };
+  expect(fork.session_id).not.toBe(sessionId);
+  expect(fork.nodes).toBe(before);
+
+  // Hydrating the fork generates NOTHING…
+  let generates = 0;
+  page.on("request", (req) => {
+    if (req.url().includes("/api/generate-page") && req.method() === "POST") {
+      generates += 1;
+    }
+  });
+  await page.goto(`/play?continue=${encodeURIComponent(fork.session_id)}`);
+  await expect(
+    page.locator('img[alt^="Generated illustration"]').first(),
+  ).toBeVisible({ timeout: 30_000 });
+  await page.waitForTimeout(2000);
+  expect(generates).toBe(0);
+
+  // …and a tap grows the FORK, not the source.
+  const forkPersist = page.waitForResponse(
+    (r) => r.url().includes("/api/nodes") && r.request().method() === "POST",
+    { timeout: 90_000 },
+  );
+  await clickAtImageFraction(page, 0.5, 0.5);
+  await forkPersist;
+  expect(await sourceCount()).toBe(before); // source untouched
+
+  const forkNodes = await page.request.get(
+    `/api/sessions/${encodeURIComponent(fork.session_id)}?limit=200`,
+  );
+  const forkJson = (await forkNodes.json()) as { nodes: unknown[] };
+  expect(forkJson.nodes.length).toBe(before + 1);
+});

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -134,6 +134,10 @@ export interface NodeDoc extends Document {
   // The render receipt: the judges' scores on the kept attempt (judged
   // enter/zoom paths only). Optional + null for unjudged / legacy nodes.
   view_verdict?: ViewVerdict | null;
+  // Fork lineage, stamped on a forked session's ROOT node(s): which session
+  // (and which shared page) this world was forked from. Absent everywhere
+  // else — additive, and it rides the export ZIP's graph.json provenance.
+  forked_from?: { session_id: string; node_id: string | null } | null;
   // When entity extraction last RAN for this node (set even if it found zero
   // entities). Durable "already extracted" marker so a later revisit / reload
   // never silently re-runs the non-deterministic VLM pass. Absent on legacy
@@ -187,6 +191,8 @@ export interface NodeRow {
   // The render receipt shown on the share surfaces. Null on unjudged paths
   // and every pre-receipts node.
   view_verdict: ViewVerdict | null;
+  // Fork lineage (root nodes of forked sessions only).
+  forked_from: { session_id: string; node_id: string | null } | null;
   // Whether entity extraction has already run for this node. Read back on
   // revisit so the client never auto-re-extracts a node it has already done.
   geo_extracted: boolean;
@@ -204,6 +210,7 @@ export function toRow(doc: NodeDoc): NodeRow {
     scale_tier,
     scene_view,
     view_verdict,
+    forked_from,
     geo_extracted_at,
     ...rest
   } = doc;
@@ -217,6 +224,7 @@ export function toRow(doc: NodeDoc): NodeRow {
     scale_tier: scale_tier ?? null,
     scene_view: scene_view ?? null,
     view_verdict: view_verdict ?? null,
+    forked_from: forked_from ?? null,
     geo_extracted: geo_extracted_at != null,
     created_at: created_at.toISOString(),
   };

--- a/apps/web/lib/fork.test.ts
+++ b/apps/web/lib/fork.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from "vitest";
+
+// In-memory Mongo stand-in with PER-COLLECTION stores — forkSession touches
+// nodes + world_map + world_state, and the test must prove all three copy
+// (the silent-corruption class: one missed collection = a fork that loses
+// its geo state).
+const mongo = vi.hoisted(() => {
+  const stores = new Map<string, Map<string, Record<string, unknown>>>();
+  const store = (name: string) => {
+    if (!stores.has(name)) stores.set(name, new Map());
+    return stores.get(name)!;
+  };
+  const collection = (name: string) => ({
+    find(filter: { session_id?: string }) {
+      const rows = [...store(name).values()].filter(
+        (d) => !filter.session_id || d.session_id === filter.session_id
+      );
+      return {
+        sort() {
+          return this;
+        },
+        async toArray() {
+          return rows;
+        },
+      };
+    },
+    async findOne(filter: { _id: string }) {
+      return store(name).get(filter._id) ?? null;
+    },
+    async insertOne(doc: { _id: string }) {
+      if (store(name).has(doc._id)) throw new Error("dup");
+      store(name).set(doc._id, doc);
+    },
+    async insertMany(docs: { _id: string }[]) {
+      for (const d of docs) {
+        if (store(name).has(d._id)) throw new Error("dup");
+        store(name).set(d._id, d);
+      }
+    },
+  });
+  return { stores, store, collection };
+});
+
+vi.mock("./db", () => ({
+  getDb: async () => ({ collection: mongo.collection }),
+}));
+
+import { forkSession } from "./fork";
+
+const SRC = "session_src";
+
+function seed() {
+  mongo.stores.clear();
+  const nodes = mongo.store("nodes");
+  nodes.set("root1", {
+    _id: "root1",
+    session_id: SRC,
+    parent_id: null,
+    page_title: "The Map",
+    image_key: "k/root.jpg",
+    scene_view: null,
+    created_at: new Date("2026-01-01"),
+  });
+  nodes.set("child1", {
+    _id: "child1",
+    session_id: SRC,
+    parent_id: "root1",
+    page_title: "The Tower",
+    image_key: "k/tower.jpg",
+    scene_view: { node_id: "child1", level: "building", observer: null },
+    created_at: new Date("2026-01-02"),
+  });
+  nodes.set("other", {
+    _id: "other",
+    session_id: "session_unrelated",
+    parent_id: null,
+    page_title: "Elsewhere",
+    image_key: "k/x.jpg",
+    scene_view: null,
+    created_at: new Date("2026-01-01"),
+  });
+  mongo.store("world_map").set(SRC, {
+    _id: SRC,
+    entities: [{ id: "geo_tower", pos: { x: 1, y: 2 } }],
+    bounds: { x: 0, y: 0, w: 100, h: 60 },
+  });
+  mongo.store("world_state").set(SRC, {
+    _id: SRC,
+    entities: [
+      {
+        id: "tower",
+        name: "The Tower",
+        first_seen_node_id: "root1",
+        last_seen_node_id: "child1",
+        appears_on_node_ids: ["root1", "child1", "long-gone"],
+        appearance_bboxes: { child1: { x: 0.1, y: 0.1, w: 0.2, h: 0.3 } },
+        appearance_borders: { child1: [[0.1, 0.1]] },
+      },
+    ],
+  });
+}
+
+describe("forkSession", () => {
+  it("copies nodes + world_map + world_state under a fresh session, ids reminted", async () => {
+    seed();
+    const forked = await forkSession(SRC, "child1");
+    expect(forked).not.toBeNull();
+    const { session_id } = forked!;
+    expect(session_id).not.toBe(SRC);
+
+    const newNodes = [...mongo.store("nodes").values()].filter(
+      (n) => n.session_id === session_id
+    );
+    expect(newNodes).toHaveLength(2); // the unrelated session's node stays out
+    const newRoot = newNodes.find((n) => n.parent_id === null)!;
+    const newChild = newNodes.find((n) => n.parent_id !== null)!;
+    // ids reminted, parent chain + scene_view self-reference remapped
+    expect(newRoot._id).not.toBe("root1");
+    expect(newChild.parent_id).toBe(newRoot._id);
+    expect((newChild.scene_view as { node_id: string }).node_id).toBe(
+      newChild._id
+    );
+    // lineage on the root only
+    expect(newRoot.forked_from).toEqual({
+      session_id: SRC,
+      node_id: "child1",
+    });
+    expect(newChild.forked_from).toBeUndefined();
+
+    // world_map copied under the new _id (the Ankh gotcha), content verbatim
+    const map = mongo.store("world_map").get(session_id)!;
+    expect((map.entities as { id: string }[])[0]!.id).toBe("geo_tower");
+
+    // world_state entity node-refs remapped in all five places; a dangling
+    // pre-fork id stays as-is (never invented, never dropped)
+    const st = mongo.store("world_state").get(session_id)!;
+    const e = (st.entities as Record<string, unknown>[])[0]!;
+    expect(e.first_seen_node_id).toBe(newRoot._id);
+    expect(e.last_seen_node_id).toBe(newChild._id);
+    expect(e.appears_on_node_ids).toEqual([
+      newRoot._id,
+      newChild._id,
+      "long-gone",
+    ]);
+    expect(Object.keys(e.appearance_bboxes as object)).toEqual([newChild._id]);
+    expect(Object.keys(e.appearance_borders as object)).toEqual([newChild._id]);
+  });
+
+  it("leaves the source session byte-identical", async () => {
+    seed();
+    const before = JSON.stringify([
+      mongo.store("nodes").get("root1"),
+      mongo.store("nodes").get("child1"),
+      mongo.store("world_map").get(SRC),
+      mongo.store("world_state").get(SRC),
+    ]);
+    await forkSession(SRC, "child1");
+    const after = JSON.stringify([
+      mongo.store("nodes").get("root1"),
+      mongo.store("nodes").get("child1"),
+      mongo.store("world_map").get(SRC),
+      mongo.store("world_state").get(SRC),
+    ]);
+    expect(after).toBe(before);
+  });
+
+  it("returns null for an unknown session (the route 404s)", async () => {
+    seed();
+    expect(await forkSession("session_nope", null)).toBeNull();
+  });
+
+  it("forks sessions that never built a world model (nodes only)", async () => {
+    seed();
+    mongo.store("world_map").delete(SRC);
+    mongo.store("world_state").delete(SRC);
+    const forked = await forkSession(SRC, null);
+    expect(forked!.nodes).toBe(2);
+    expect(mongo.store("world_map").get(forked!.session_id)).toBeUndefined();
+  });
+});

--- a/apps/web/lib/fork.ts
+++ b/apps/web/lib/fork.ts
@@ -1,0 +1,135 @@
+import type { Document } from "mongodb";
+
+import { getDb, type NodeDoc } from "./db";
+
+// Fork a session: deep-copy its world into a fresh session_id so anyone with
+// a share link gets their OWN world to extend instead of write access to the
+// original (the ?continue= hazard). Images are referenced by the existing R2
+// image_key — a fork costs $0 in model calls and no object copies.
+//
+// The session-scoped collection inventory — the loud list, so a future
+// collection can't silently miss the copy (the corruption class the fork
+// review flagged):
+//   COPIED    nodes        (node ids REMINTED — they are globally unique;
+//                           parent_id + scene_view.node_id remapped)
+//             world_state  (_id = session; entity node-refs remapped in all
+//                           five places: first/last_seen, appears_on,
+//                           appearance_bboxes keys, appearance_borders keys)
+//             world_map    (_id = session — the Ankh gotcha; geo ids are
+//                           session-local, no remap needed)
+//   SKIPPED   session_owners     (the forker claims the fork on first write)
+//             published_sessions (forks start unpublished)
+//             session_presence   (ephemeral)
+//             idempotency_keys / spend_ledger / errors (per-session ledgers)
+
+export interface ForkResult {
+  session_id: string;
+  nodes: number;
+}
+
+function remapKeys<T>(
+  map: Record<string, T> | undefined,
+  idMap: Map<string, string>
+): Record<string, T> | undefined {
+  if (!map) return map;
+  const out: Record<string, T> = {};
+  for (const [k, v] of Object.entries(map)) out[idMap.get(k) ?? k] = v;
+  return out;
+}
+
+export async function forkSession(
+  sourceSessionId: string,
+  // The node the fork was taken FROM (the /n/ page's node) — stamped as
+  // lineage on the fork's root(s).
+  sourceNodeId: string | null
+): Promise<ForkResult | null> {
+  const db = await getDb();
+  const nodesCol = db.collection<NodeDoc>("nodes");
+  const sourceNodes = await nodesCol
+    .find({ session_id: sourceSessionId })
+    .sort({ created_at: 1, _id: 1 })
+    .toArray();
+  if (sourceNodes.length === 0) return null;
+
+  const newSessionId = `session_${crypto.randomUUID()}`;
+  const idMap = new Map<string, string>(
+    sourceNodes.map((n) => [n._id, crypto.randomUUID()])
+  );
+
+  const forkedNodes: NodeDoc[] = sourceNodes.map((n) => {
+    const sceneView = n.scene_view
+      ? {
+          ...n.scene_view,
+          ...(n.scene_view.node_id
+            ? { node_id: idMap.get(n.scene_view.node_id) ?? n.scene_view.node_id }
+            : {}),
+        }
+      : (n.scene_view ?? null);
+    return {
+      ...n,
+      _id: idMap.get(n._id)!,
+      session_id: newSessionId,
+      parent_id: n.parent_id ? (idMap.get(n.parent_id) ?? null) : null,
+      scene_view: sceneView,
+      // Lineage rides the fork's root(s); created_at is preserved so the
+      // world's history (hydration order, atlas) stays the world's history.
+      ...(n.parent_id == null
+        ? {
+            forked_from: {
+              session_id: sourceSessionId,
+              node_id: sourceNodeId,
+            },
+          }
+        : {}),
+    };
+  });
+  await nodesCol.insertMany(forkedNodes);
+
+  // world_map: keyed by _id = session id. Geo ids (geo_*/geo_plan_*) are
+  // session-local strings — copy verbatim.
+  const worldMap = await db
+    .collection<Document & { _id: string }>("world_map")
+    .findOne({ _id: sourceSessionId });
+  if (worldMap) {
+    await db
+      .collection<Document & { _id: string }>("world_map")
+      .insertOne({ ...worldMap, _id: newSessionId });
+  }
+
+  // world_state: keyed by _id = session id; entities reference node ids in
+  // five places — remap them all (an unmapped id is kept as-is: it was
+  // already dangling in the source, the fork must not invent or drop data).
+  interface WorldStateEntity extends Document {
+    first_seen_node_id: string;
+    last_seen_node_id: string;
+    appears_on_node_ids: string[];
+    appearance_bboxes?: Record<string, unknown>;
+    appearance_borders?: Record<string, unknown>;
+  }
+  const worldState = await db
+    .collection<Document & { _id: string; entities?: WorldStateEntity[] }>(
+      "world_state"
+    )
+    .findOne({ _id: sourceSessionId });
+  if (worldState) {
+    const entities = (worldState.entities ?? []).map((e) => ({
+      ...e,
+      first_seen_node_id: idMap.get(e.first_seen_node_id) ?? e.first_seen_node_id,
+      last_seen_node_id: idMap.get(e.last_seen_node_id) ?? e.last_seen_node_id,
+      appears_on_node_ids: (e.appears_on_node_ids ?? []).map(
+        (id) => idMap.get(id) ?? id
+      ),
+      ...(e.appearance_bboxes
+        ? { appearance_bboxes: remapKeys(e.appearance_bboxes, idMap) }
+        : {}),
+      ...(e.appearance_borders
+        ? { appearance_borders: remapKeys(e.appearance_borders, idMap) }
+        : {}),
+    }));
+    await db
+      .collection<Document & { _id: string }>("world_state")
+      .insertOne({ ...worldState, _id: newSessionId, entities });
+  }
+
+  return { session_id: newSessionId, nodes: forkedNodes.length };
+}


### PR DESCRIPTION
## What

The distinguisher-stint third pick: **fork this world**. A viewer with a share link gets their OWN world to extend instead of write access to yours — the safer sibling of `?continue=` (which the embed's continue-funnel just amplified). No realtime competitor has a serializable world artifact to fork; here it is a Mongo doc copy with images by R2 reference — **$0 per fork**, no new infra.

## The one real risk, handled loudly

The stint review flagged it: miss one session-scoped collection and forks silently lose geo state. `lib/fork.ts` carries the full inventory as a contract:

- **COPIED** — `nodes` (ids **reminted** — they're globally unique — with `parent_id` + `scene_view.node_id` remapped), `world_state` (`_id` = session; entity node-refs remapped in all **five** places: first/last-seen, appears-on, and the `appearance_bboxes`/`appearance_borders` key maps), `world_map` (`_id` = session — the Ankh gotcha; geo ids are session-local).
- **SKIPPED on purpose** — `session_owners` (the forker claims on first write), `published_sessions` (forks start private), presence + the per-session ledgers.
- A dangling pre-fork node ref is kept as-is: the fork never invents or drops data.

## Surfaces

`POST /api/sessions/[id]/fork` (openness matches the share surfaces); a **Fork this world** button beside Continue on `/n/`; "forked from → this world" lineage on a fork's root permalink; `forked_from` rides `NodeRow` into the export ZIP's provenance.

## Gates

4 unit tests on a per-collection mongo stand-in (full three-collection copy + remap incl. bbox/border keys, **source byte-identity**, unknown-session 404, nodes-only sessions) and a new **`e2e/share-fork.spec.ts`** on the required mock job: fork → zero-generate hydration → a tap grows the fork while the source node count stays put. Web 855 green, tsc clean.

Holding the merge until the new e2e spec proves itself in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)