### PR TITLE
feat(tour): tour mode — the world plays itself

### DIFF
--- a/apps/web/app/embed/[sessionId]/page.tsx
+++ b/apps/web/app/embed/[sessionId]/page.tsx
@@ -60,6 +60,7 @@ export default async function EmbedPage({ params, searchParams }: EmbedPageProps
   const base = env.R2_PUBLIC_BASE_URL!.replace(/\/$/, "");
   return (
     <EmbedViewer
+      sessionId={sessionId}
       initial={{
         id: start.id,
         title: start.page_title || start.query || published.title,

--- a/apps/web/app/n/[id]/page.tsx
+++ b/apps/web/app/n/[id]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { getNode, type NodeRow } from "@/lib/db";
 import { readServerEnv } from "@/lib/env";
 import ForkButton from "@/components/fork-button";
+import TourButton from "@/components/tour-button";
 import PermalinkImage from "@/components/permalink-image";
 import { formatViewVerdict } from "@/lib/view-verdict";
 
@@ -109,6 +110,10 @@ export default async function PermalinkPage({ params }: PermalinkPageProps) {
       <header className="flex items-baseline justify-between">
         <h1 className="text-xl font-bold">{node.page_title}</h1>
         <span className="flex items-center gap-2">
+          <TourButton
+            sessionId={node.session_id}
+            continueUrl={`/play?continue=${encodeURIComponent(node.session_id)}`}
+          />
           <ForkButton sessionId={node.session_id} nodeId={node.id} />
           <a
             href={`/play?continue=${encodeURIComponent(node.session_id)}`}

--- a/apps/web/components/embed-viewer.tsx
+++ b/apps/web/components/embed-viewer.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useRef, useState } from "react";
 
+import TourButton from "@/components/tour-button";
+
 // Read-only navigable world viewer for the /embed surface. Zero model calls:
 // every navigation is a hop to an ALREADY-GENERATED node via the public
 // children endpoint (the share-continue zero-generate hydration contract).
@@ -22,6 +24,7 @@ interface ChildRow {
 }
 
 interface EmbedViewerProps {
+  sessionId: string;
   initial: EmbedNode;
   continueUrl: string;
   // The start node's render receipt, preformatted server-side (the embed
@@ -30,6 +33,7 @@ interface EmbedViewerProps {
 }
 
 export default function EmbedViewer({
+  sessionId,
   initial,
   continueUrl,
   initialReceipt,
@@ -108,10 +112,17 @@ export default function EmbedViewer({
           )}
           <span className="truncate font-medium">{current.title}</span>
         </div>
-        <span className="shrink-0 opacity-50">
-          {dots.length > 0
-            ? `${dots.length} place${dots.length === 1 ? "" : "s"} to enter`
-            : "world frontier"}
+        <span className="flex shrink-0 items-center gap-2">
+          <span className="opacity-50">
+            {dots.length > 0
+              ? `${dots.length} place${dots.length === 1 ? "" : "s"} to enter`
+              : "world frontier"}
+          </span>
+          <TourButton
+            sessionId={sessionId}
+            continueUrl={continueUrl}
+            className="rounded-full border border-black/25 px-2.5 py-0.5 hover:bg-black/5 disabled:opacity-50"
+          />
         </span>
       </header>
 

--- a/apps/web/components/tour-button.test.tsx
+++ b/apps/web/components/tour-button.test.tsx
@@ -1,0 +1,46 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import TourButton from "./tour-button";
+
+const NODES = [
+  {
+    id: "root",
+    parent_id: null,
+    page_title: "The Map",
+    image_url: "https://r2/root.jpg",
+    click_in_parent: null,
+    relation: null,
+    created_at: "2026-01-01",
+  },
+];
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("TourButton", () => {
+  it("fetches the session graph once and opens the player", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ nodes: NODES }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    render(<TourButton sessionId="s1" continueUrl="/play?continue=s1" />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "▶ tour" }));
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/sessions/s1?limit=200",
+      expect.anything()
+    );
+    expect(screen.getByTestId("tour-player")).toBeTruthy();
+  });
+
+  it("stays closed when the graph fetch fails", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false })));
+    render(<TourButton sessionId="s1" continueUrl="/play?continue=s1" />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "▶ tour" }));
+    });
+    expect(screen.queryByTestId("tour-player")).toBeNull();
+  });
+});

--- a/apps/web/components/tour-button.tsx
+++ b/apps/web/components/tour-button.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState } from "react";
+
+import TourPlayer from "@/components/tour-player";
+import type { TourNode } from "@/lib/tour";
+
+// "▶ tour" — fetch the session graph once on demand and hand it to the
+// player. Sits on the share surfaces (/n/, the embed); a world with a
+// single page still plays (one hold + the end card).
+
+interface TourButtonProps {
+  sessionId: string;
+  continueUrl: string;
+  className?: string;
+}
+
+export default function TourButton({
+  sessionId,
+  continueUrl,
+  className,
+}: TourButtonProps) {
+  const [nodes, setNodes] = useState<TourNode[] | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const open = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const res = await fetch(
+        `/api/sessions/${encodeURIComponent(sessionId)}?limit=200`,
+        { cache: "no-store" }
+      );
+      if (!res.ok) return;
+      const json = (await res.json()) as { nodes: TourNode[] };
+      if (json.nodes.length > 0) setNodes(json.nodes);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={open}
+        disabled={busy}
+        className={
+          className ??
+          "rounded-full border border-[var(--color-ink)]/40 px-3 py-1 text-xs hover:bg-[var(--color-ink)]/5 disabled:opacity-50"
+        }
+        title="Watch this world play itself — every page, diving into each tap"
+      >
+        {busy ? "loading…" : "▶ tour"}
+      </button>
+      {nodes && (
+        <TourPlayer
+          nodes={nodes}
+          continueUrl={continueUrl}
+          onClose={() => setNodes(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/components/tour-player.test.tsx
+++ b/apps/web/components/tour-player.test.tsx
@@ -1,0 +1,97 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import TourPlayer from "./tour-player";
+import type { TourNode } from "@/lib/tour";
+
+function node(
+  id: string,
+  parent: string | null,
+  created: string,
+  click: { x_pct: number; y_pct: number } | null = parent
+    ? { x_pct: 0.25, y_pct: 0.75 }
+    : null
+): TourNode {
+  return {
+    id,
+    parent_id: parent,
+    page_title: `Title ${id}`,
+    image_url: `https://r2/${id}.jpg`,
+    click_in_parent: click,
+    relation: parent ? "descend" : null,
+    created_at: created,
+  };
+}
+
+const WORLD = [node("root", null, "2026-01-01"), node("kid", "root", "2026-01-02")];
+
+describe("TourPlayer", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("holds on the first page, dives at the tap point, then advances", async () => {
+    render(
+      <TourPlayer nodes={WORLD} continueUrl="/play?continue=s" onClose={() => {}} />
+    );
+    const img = screen.getByAltText("Title root");
+    // Hold phase: gentle drift, transform-origin aimed at the NEXT tap point.
+    expect(img.style.transform).toBe("scale(1.06)");
+    expect(img.style.transformOrigin).toBe("25% 75%");
+
+    await act(async () => {
+      vi.advanceTimersByTime(2700); // hold elapses -> dive
+    });
+    expect(screen.getByAltText("Title root").style.transform).toBe("scale(2.4)");
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000); // dive elapses -> next step
+    });
+    expect(screen.getByAltText("Title kid")).toBeTruthy();
+    expect(screen.getByText("2/2")).toBeTruthy();
+  });
+
+  it("ends on the card with replay + the continue funnel", async () => {
+    render(
+      <TourPlayer nodes={WORLD} continueUrl="/play?continue=s" onClose={() => {}} />
+    );
+    // The machine chains one setTimeout per phase — advance them in turn.
+    for (const ms of [2700, 1000, 2700]) {
+      await act(async () => {
+        vi.advanceTimersByTime(ms); // root hold -> dive -> kid hold -> done
+      });
+    }
+    const explore = screen.getByText("explore it yourself →");
+    expect(explore.getAttribute("href")).toBe("/play?continue=s");
+    // Replay rewinds to the first page.
+    await act(async () => {
+      fireEvent.click(screen.getByText("↻ replay"));
+    });
+    expect(screen.getByAltText("Title root")).toBeTruthy();
+  });
+
+  it("click skips ahead; Escape closes", async () => {
+    const onClose = vi.fn();
+    render(
+      <TourPlayer nodes={WORLD} continueUrl="/play?continue=s" onClose={onClose} />
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("tour-player"));
+    });
+    expect(screen.getByAltText("Title kid")).toBeTruthy();
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "Escape" });
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("prefers-reduced-motion drops every transform", () => {
+    vi.stubGlobal("matchMedia", (q: string) => ({
+      matches: q.includes("reduce"),
+    }));
+    render(
+      <TourPlayer nodes={WORLD} continueUrl="/play?continue=s" onClose={() => {}} />
+    );
+    expect(screen.getByAltText("Title root").style.transform).toBe("none");
+    vi.unstubAllGlobals();
+  });
+});

--- a/apps/web/components/tour-player.tsx
+++ b/apps/web/components/tour-player.tsx
@@ -28,7 +28,7 @@ export default function TourPlayer({ nodes, continueUrl, onClose }: TourPlayerPr
   const reduced = useMemo(
     () =>
       typeof window !== "undefined" &&
-      window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+      (window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false),
     []
   );
 

--- a/apps/web/components/tour-player.tsx
+++ b/apps/web/components/tour-player.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { buildTour, type TourNode, type TourStep } from "@/lib/tour";
+
+// Tour mode: the world plays itself. Each step HOLDS on a page with a slow
+// Ken Burns drift, then leaves the way the explorer did — a camera DIVE into
+// the exact tap point before crossfading to the child, or a plain cut on
+// branch jumps. Pure CSS transforms over already-generated images: zero
+// model calls, works inside the embed iframe. Click = skip ahead, Esc = out.
+
+const HOLD_MS = 2600;
+const DIVE_MS = 950;
+const CUT_MS = 500;
+
+interface TourPlayerProps {
+  nodes: TourNode[];
+  continueUrl: string;
+  onClose: () => void;
+}
+
+export default function TourPlayer({ nodes, continueUrl, onClose }: TourPlayerProps) {
+  const steps = useMemo(() => buildTour(nodes), [nodes]);
+  const [i, setI] = useState(0);
+  const [phase, setPhase] = useState<"hold" | "exit" | "done">("hold");
+  const timer = useRef<number | null>(null);
+  const reduced = useMemo(
+    () =>
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+    []
+  );
+
+  const step: TourStep | undefined = steps[i];
+
+  useEffect(() => {
+    if (!step) return;
+    if (timer.current) window.clearTimeout(timer.current);
+    if (phase === "hold") {
+      timer.current = window.setTimeout(
+        () => setPhase(step.exit === "end" ? "done" : "exit"),
+        HOLD_MS
+      );
+    } else if (phase === "exit") {
+      const ms = reduced ? CUT_MS : step.exit === "dive" ? DIVE_MS : CUT_MS;
+      timer.current = window.setTimeout(() => {
+        setI((cur) => cur + 1);
+        setPhase("hold");
+      }, ms);
+    }
+    return () => {
+      if (timer.current) window.clearTimeout(timer.current);
+    };
+  }, [phase, i, step, reduced]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  if (!step) return null;
+  const next = steps[i + 1];
+
+  const skip = () => {
+    if (phase === "done") return;
+    if (next) {
+      setI(i + 1);
+      setPhase("hold");
+    } else {
+      setPhase("done");
+    }
+  };
+
+  // The current frame's transform. Hold = gentle drift toward the exit
+  // target; dive = hard zoom anchored on the tap point. Reduced motion
+  // keeps every frame static and rides opacity alone.
+  const origin = step.target
+    ? `${step.target.x_pct * 100}% ${step.target.y_pct * 100}%`
+    : "50% 50%";
+  const transform = reduced
+    ? "none"
+    : phase === "exit" && step.exit === "dive"
+      ? "scale(2.4)"
+      : phase === "hold"
+        ? "scale(1.06)"
+        : "scale(1)";
+  const transitionMs =
+    phase === "hold" ? HOLD_MS + 200 : step.exit === "dive" ? DIVE_MS : CUT_MS;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black"
+      onClick={skip}
+      data-testid="tour-player"
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        key={step.node.id}
+        src={step.node.image_url}
+        alt={step.node.page_title}
+        className="h-full w-full object-contain"
+        style={{
+          transform,
+          transformOrigin: origin,
+          transition: `transform ${transitionMs}ms ease-in, opacity ${CUT_MS}ms`,
+          opacity: phase === "exit" && step.exit !== "dive" ? 0 : 1,
+        }}
+        draggable={false}
+      />
+      {next && (
+        // Preload the next frame under the current one.
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={next.node.image_url}
+          alt=""
+          className="pointer-events-none absolute h-0 w-0 opacity-0"
+          draggable={false}
+        />
+      )}
+      <div className="pointer-events-none absolute bottom-4 left-0 right-0 text-center text-sm text-white/90">
+        {step.node.page_title}
+      </div>
+      <div className="absolute right-3 top-3 flex items-center gap-2">
+        <span className="rounded-full bg-white/10 px-2 py-0.5 text-[11px] text-white/70">
+          {i + 1}/{steps.length}
+        </span>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onClose();
+          }}
+          className="rounded-full bg-white/15 px-2.5 py-0.5 text-sm text-white hover:bg-white/25"
+          aria-label="Close tour"
+        >
+          ×
+        </button>
+      </div>
+      {phase === "done" && (
+        <div
+          className="absolute inset-0 flex flex-col items-center justify-center gap-4 bg-black/70"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <p className="px-6 text-center text-lg text-white">
+            {steps[0]!.node.page_title}
+          </p>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={() => {
+                setI(0);
+                setPhase("hold");
+              }}
+              className="rounded-full border border-white/40 px-4 py-1.5 text-sm text-white hover:bg-white/10"
+            >
+              ↻ replay
+            </button>
+            <a
+              href={continueUrl}
+              target="_blank"
+              rel="noopener"
+              className="rounded-full bg-white px-4 py-1.5 text-sm font-medium text-black"
+            >
+              explore it yourself →
+            </a>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/e2e/embed.spec.ts
+++ b/apps/web/e2e/embed.spec.ts
@@ -90,4 +90,14 @@ test("embed viewer is publish-gated, navigates generated nodes, serves oEmbed", 
   expect(payload.type).toBe("rich");
   expect(payload.html).toContain(`/embed/${sessionId}`);
   expect(payload.html).toContain("iframe");
+
+  // 6) Tour mode: the world plays itself inside the embed — the overlay
+  // opens on the root page and Escape closes it (zero generates, again).
+  await page.getByRole("button", { name: "▶ tour" }).click();
+  const tour = page.getByTestId("tour-player");
+  await expect(tour).toBeVisible({ timeout: 15_000 });
+  await expect(tour.locator("img").first()).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(tour).not.toBeVisible();
+  expect(generates).toBe(0);
 });

--- a/apps/web/lib/tour.test.ts
+++ b/apps/web/lib/tour.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { buildTour, type TourNode } from "./tour";
+
+function n(
+  id: string,
+  parent: string | null,
+  created: string,
+  over: Partial<TourNode> = {}
+): TourNode {
+  return {
+    id,
+    parent_id: parent,
+    page_title: id,
+    image_url: `https://r2/${id}.jpg`,
+    click_in_parent: parent ? { x_pct: 0.5, y_pct: 0.4 } : null,
+    relation: parent ? "descend" : null,
+    created_at: created,
+    ...over,
+  };
+}
+
+describe("buildTour", () => {
+  it("walks depth-first in creation order; descend edges dive at the tap point", () => {
+    const steps = buildTour([
+      n("root", null, "2026-01-01"),
+      n("b", "root", "2026-01-03"),
+      n("a", "root", "2026-01-02"),
+      n("a1", "a", "2026-01-04"),
+    ]);
+    expect(steps.map((s) => s.node.id)).toEqual(["root", "a", "a1", "b"]);
+    // root -> a is a child edge with a tap point: the camera dives there.
+    expect(steps[0]).toMatchObject({
+      exit: "dive",
+      target: { x_pct: 0.5, y_pct: 0.4 },
+    });
+    // a1 -> b is a backtrack across the tree: plain cut.
+    expect(steps[2]!.exit).toBe("cut");
+    expect(steps[3]!.exit).toBe("end");
+  });
+
+  it("cuts (never dives) when a child has no recorded tap point", () => {
+    const steps = buildTour([
+      n("root", null, "2026-01-01"),
+      n("kid", "root", "2026-01-02", { click_in_parent: null }),
+    ]);
+    expect(steps[0]!.exit).toBe("cut");
+  });
+
+  it("skips edit revisions and tours orphans as roots", () => {
+    const steps = buildTour([
+      n("root", null, "2026-01-01"),
+      n("fix", "root", "2026-01-02", { relation: "edit" }),
+      n("lost", "gone-parent", "2026-01-03"),
+    ]);
+    expect(steps.map((s) => s.node.id)).toEqual(["root", "lost"]);
+  });
+
+  it("a single page is just an end card", () => {
+    expect(buildTour([n("solo", null, "2026-01-01")])).toEqual([
+      { node: expect.objectContaining({ id: "solo" }), exit: "end", target: null },
+    ]);
+  });
+});

--- a/apps/web/lib/tour.ts
+++ b/apps/web/lib/tour.ts
@@ -1,0 +1,62 @@
+// Tour mode's pure half: turn a session's node graph into a playable
+// sequence. The story a world already tells — every page plus the exact
+// spot that was tapped to descend — becomes a camera script: HOLD on a
+// page, then DIVE into the tap point and crossfade to the child. No model
+// calls, no new data; the graph is the screenplay.
+
+export interface TourNode {
+  id: string;
+  parent_id: string | null;
+  page_title: string;
+  image_url: string;
+  click_in_parent: { x_pct: number; y_pct: number } | null;
+  relation?: "descend" | "expand" | "ascend" | "edit" | null;
+  created_at: string;
+}
+
+export interface TourStep {
+  node: TourNode;
+  /** How the camera leaves this step toward the next:
+   *  "dive" — zoom into `target` (the NEXT node's tap point on THIS image),
+   *  "cut"  — plain crossfade (branch jump / no tap point recorded),
+   *  "end"  — last step. */
+  exit: "dive" | "cut" | "end";
+  target: { x_pct: number; y_pct: number } | null;
+}
+
+/** Depth-first, creation-ordered walk from the earliest root — the order the
+ *  world was actually explored. Edits are skipped (they revise a page, not
+ *  visit a place). Orphans (parent outside the fetched window) tour as
+ *  roots rather than vanish. */
+export function buildTour(nodes: TourNode[]): TourStep[] {
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+  const children = new Map<string, TourNode[]>();
+  const roots: TourNode[] = [];
+  const byCreated = (a: TourNode, b: TourNode) =>
+    a.created_at < b.created_at ? -1 : a.created_at > b.created_at ? 1 : 0;
+  for (const n of [...nodes].sort(byCreated)) {
+    if (n.relation === "edit") continue;
+    if (n.parent_id && byId.has(n.parent_id)) {
+      const list = children.get(n.parent_id) ?? [];
+      list.push(n);
+      children.set(n.parent_id, list);
+    } else {
+      roots.push(n);
+    }
+  }
+  const order: TourNode[] = [];
+  const visit = (n: TourNode) => {
+    order.push(n);
+    for (const c of children.get(n.id) ?? []) visit(c);
+  };
+  for (const r of roots) visit(r);
+
+  return order.map((node, i) => {
+    const next = order[i + 1];
+    if (!next) return { node, exit: "end" as const, target: null };
+    if (next.parent_id === node.id && next.click_in_parent) {
+      return { node, exit: "dive" as const, target: next.click_in_parent };
+    }
+    return { node, exit: "cut" as const, target: null };
+  });
+}


### PR DESCRIPTION
## What

Every world already contains its own screenplay: the pages, the order they were explored, and the exact pixel tapped to descend. **Tour mode replays it** — hold on a page with a slow Ken Burns drift, then dive the camera into the recorded tap point and crossfade into the child; branch jumps cut; it ends on a replay / explore-it-yourself card. Pure CSS transforms over already-generated images: **zero model calls**, zero new data, and it works inside the embed iframe — so an embedded world on someone's blog can now play itself like a title sequence.

This is the roadmap's I2 ("one-click shareable moment") landing on top of the stint podium: embeds got a play button.

## Pieces

- `lib/tour.ts` (pure, tested): depth-first creation-ordered walk from the earliest root — the order the world was actually explored. Edits skipped (they revise, not visit); orphans tour as roots; a child with no recorded tap point cuts instead of diving.
- `components/tour-player.tsx`: the step machine — HOLD (2.6s drift toward the exit target) → DIVE (950ms zoom anchored at the tap point, `transform-origin` = `click_in_parent`) or CUT (500ms crossfade). Click skips, Escape closes, next frame preloads. `prefers-reduced-motion` drops all transforms and rides opacity.
- `components/tour-button.tsx`: fetches the public session graph once on demand; on `/n/` beside Fork/Continue and in the embed header.

## Gates

4 tour-builder unit tests (DFS order + dive/cut/end grammar, edit-skip, orphan roots, single-page world); the embed e2e extended — tour opens inside the iframe surface, closes on Escape, and the generate counter stays at zero. Web 859 green, tsc clean. Holding merge for CI as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)