### PR TITLE
fix(animate): inline local blob URLs — the one proxy that skipped it

### DIFF
--- a/apps/web/app/api/animate/route.ts
+++ b/apps/web/app/api/animate/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { modalAuthHeaders, modalUrl as joinModalUrl } from "@/lib/modal";
+import { inlineStoredImage } from "@/lib/r2";
 import { TRACE_HEADER, newTraceId } from "@/lib/trace";
 
 export const runtime = "nodejs";
@@ -14,7 +15,24 @@ export async function POST(req: Request) {
     );
   }
   const traceId = req.headers.get(TRACE_HEADER) || newTraceId();
-  const body = await req.text();
+  let body = await req.text();
+  // A ?continue=-hydrated page carries the R2 PUBLIC URL, not a data URI —
+  // on the docker stack that's a localhost minio URL fal refuses ("Input
+  // must be a valid HTTPS URL or a Data URI", live-caught 2026-08-22).
+  // Same inline-before-forward treatment the resolve-click and
+  // generate-page proxies already have; animate was the one that skipped it.
+  try {
+    const parsed = JSON.parse(body) as { image_data_url?: string };
+    if (parsed.image_data_url && !parsed.image_data_url.startsWith("data:")) {
+      const inlined = await inlineStoredImage(parsed.image_data_url);
+      if (inlined) {
+        parsed.image_data_url = inlined;
+        body = JSON.stringify(parsed);
+      }
+    }
+  } catch {
+    /* non-JSON body — forward as-is, the backend rejects it */
+  }
   let upstream: Response;
   try {
     upstream = await fetch(joinModalUrl(modalUrl, "/animate"), {


### PR DESCRIPTION
## Live-caught

Animate on a `?continue=`-hydrated page **502'd silently** on the docker stack (found while demoing). Hydrated pages carry the R2 **public URL**, not a data URI — and locally that's a localhost Minio URL two upstreams refuse:

- Gemini motion-rewrite: `Cannot fetch from private/localhost URLs` (best-effort, degraded only)
- fal ltx-video: `Input must be a valid HTTPS URL or a Data URI` → hard 502

Fresh pages worked (they hold real data URIs), which is why past demos never hit it.

## Fix

`lib/r2.inlineStoredImage` exists for exactly this class — its own docstring describes this failure — and the resolve-click + generate-page proxies already use it. `/api/animate` was the one proxy forwarding the body raw. Same treatment: inline our own stored-image URLs server-side before proxying; foreign URLs and data URIs pass through unchanged.

## Receipt

The identical localhost URL that 502'd now returns 200 through the fixed route with a real 5-second MP4 (`fal-ai/ltx-video`, live call, ~$0.10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)