### PR TITLE
chore(quality): the self-paced hardening pass — 9 commits, +31 tests, two bug fixes, $0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: ESLint
-        run: pnpm lint --max-warnings=20
+        run: pnpm lint --max-warnings=12
       - name: No demo artifacts tracked
         run: |
           hits=$(git ls-files | grep -E 'scripts/record-demo/(artifacts.*/|[^/]*\.(mp4|webm)|geo-storyboard\.png)' || true)

--- a/apps/modal-backend/providers/generate_modes/tap.py
+++ b/apps/modal-backend/providers/generate_modes/tap.py
@@ -58,6 +58,21 @@ _CLASSIC_ENTER_AS_TO_RENDER: dict[str, str] = {
 }
 
 
+def _sanitize_hint(raw: str | None, max_len: int) -> str:
+    """Trust-but-verify on client-supplied prefetch hints. The web client
+    computes these via the same VLM the backend would call, but the SSE
+    handler will ultimately splice them into LLM prompts — so cap length +
+    strip control chars (keeping \n and \t) to keep the prompt-injection /
+    token-bomb surface small. Any rejection silently falls back to in-band
+    resolution."""
+    if not raw:
+        return ""
+    cleaned = "".join(
+        ch for ch in raw if ch == "\n" or ch == "\t" or ch >= " "
+    ).strip()
+    return cleaned[:max_len]
+
+
 def _score_or_none(j: JudgeResult | None) -> float | None:
     return round(float(j.score), 1) if j is not None else None
 
@@ -182,20 +197,6 @@ async def stream_tap(
     place_form_resolved: str | None = None
     view_subject: str | None = None
     if body.mode == "tap" and body.click and body.image:
-        # Trust-but-verify on client-supplied prefetch hints. The web
-        # client computes these via the same VLM the backend would call,
-        # but the SSE handler will ultimately splice them into LLM
-        # prompts — so cap length + strip control chars to keep prompt
-        # injection / token-bomb surface small. Any rejection silently
-        # falls back to in-band resolution.
-        def _sanitize_hint(raw: str | None, max_len: int) -> str:
-            if not raw:
-                return ""
-            cleaned = "".join(
-                ch for ch in raw if ch == "\n" or ch == "\t" or ch >= " "
-            ).strip()
-            return cleaned[:max_len]
-
         cleaned_subject = _sanitize_hint(body.prefetched_subject, 160)
         cleaned_style = _sanitize_hint(body.prefetched_style, 320)
         cleaned_subject_context = _sanitize_hint(

--- a/apps/modal-backend/tests/test_generate_enter.py
+++ b/apps/modal-backend/tests/test_generate_enter.py
@@ -1375,3 +1375,73 @@ def test_verdict_from_attempt_rounds_and_keeps_nulls() -> None:
         "same_place": 9.0, "conformance": 7.2, "medium": 6.0,
         "detail": None, "interior": None, "attempts": 2, "accepted": True,
     }
+
+
+async def test_zoom_receipt_deadline_bail_reports_single_judged_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed first verdict with no ingress window left keeps the first
+    render WITHOUT starting a retry — the receipt says so (1 attempt, not
+    accepted) instead of pretending a second attempt ran."""
+    import generate as generate_mod
+
+    # 160s window - 120s tail margin ≈ 40s remaining < the 45s retry floor.
+    monkeypatch.setattr(generate_mod, "INGRESS_TIMEOUT_S", 160)
+    _mock_plan(monkeypatch)
+    _mock_edit(monkeypatch)
+    cont = AsyncMock(
+        return_value=GeneratedImage(b"jpeg-only", "image/jpeg", "m", "r1")
+    )
+    monkeypatch.setattr(image_edit_mod, "continue_image", cont)
+    _mock_fresh(monkeypatch)
+    _mock_step_in(monkeypatch, [4.0])  # below the 6.0 floor
+
+    events = await _collect(
+        _event_stream(
+            _classic_body(
+                condition_image_urls=[_region_data_url(), "data:p"],
+                condition_roles=["region", "parent"],
+            ),
+            "t1",
+        )
+    )
+    cont.assert_awaited_once()  # no retry inside a spent window
+    final = next(e for e in events if e["type"] == "final")
+    assert final["view_verdict"] == {
+        "same_place": 4.0,
+        "conformance": None,
+        "medium": None,
+        "detail": 9.0,  # the pinned-passing legibility axis
+        "interior": None,
+        "attempts": 1,
+        "accepted": False,
+    }
+
+
+async def test_zoom_receipt_retry_crash_reports_first_attempt_scores(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The retry render blowing up keeps the judged first attempt — and the
+    receipt carries ITS scores with attempts=2 (two renders were paid for)."""
+    _mock_plan(monkeypatch)
+    _mock_edit(monkeypatch)
+    first = GeneratedImage(b"jpeg-first", "image/jpeg", "m", "r1")
+    cont = AsyncMock(side_effect=[first, RuntimeError("fal hiccup")])
+    monkeypatch.setattr(image_edit_mod, "continue_image", cont)
+    _mock_fresh(monkeypatch)
+    _mock_step_in(monkeypatch, [4.0])
+
+    events = await _collect(
+        _event_stream(
+            _classic_body(
+                condition_image_urls=[_region_data_url(), "data:p"],
+                condition_roles=["region", "parent"],
+            ),
+            "t1",
+        )
+    )
+    final = next(e for e in events if e["type"] == "final")
+    assert _b64.b64encode(b"jpeg-first").decode() in final["image_data_url"]
+    v = final["view_verdict"]
+    assert v["attempts"] == 2 and v["accepted"] is False
+    assert v["same_place"] == 4.0

--- a/apps/modal-backend/tests/test_generate_enter.py
+++ b/apps/modal-backend/tests/test_generate_enter.py
@@ -1445,3 +1445,22 @@ async def test_zoom_receipt_retry_crash_reports_first_attempt_scores(
     v = final["view_verdict"]
     assert v["attempts"] == 2 and v["accepted"] is False
     assert v["same_place"] == 4.0
+
+
+def test_sanitize_hint_caps_and_strips_the_injection_surface() -> None:
+    """The prefetch-hint boundary as a table: control chars die (except the
+    newline/tab prompts legitimately carry), length caps hold post-strip,
+    absent input degrades to the empty string that means 'resolve in-band'."""
+    from providers.generate_modes.tap import _sanitize_hint
+
+    assert _sanitize_hint(None, 10) == ""
+    assert _sanitize_hint("", 10) == ""
+    assert _sanitize_hint("  a castle  ", 100) == "a castle"
+    # Control characters are stripped; \n and \t survive.
+    assert _sanitize_hint("a\x00b\x1bc\rd", 100) == "abcd"
+    assert _sanitize_hint("line one\nline two\ttabbed", 100) == (
+        "line one\nline two\ttabbed"
+    )
+    # The cap bounds a token bomb AFTER stripping/trim.
+    assert _sanitize_hint("x" * 5000, 160) == "x" * 160
+    assert len(_sanitize_hint(" " * 50 + "y" * 500, 240)) == 240

--- a/apps/web/app/embed/[sessionId]/page.tsx
+++ b/apps/web/app/embed/[sessionId]/page.tsx
@@ -2,19 +2,16 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import EmbedViewer from "@/components/embed-viewer";
-import {
-  getNode,
-  getPublishedSession,
-  getSessionRootNode,
-  type NodeRow,
-} from "@/lib/db";
+import { resolveEmbedStart } from "@/lib/embed-resolve";
 import { readServerEnv } from "@/lib/env";
+import { formatViewVerdict } from "@/lib/view-verdict";
 
 // Read-only embeddable world viewer. PUBLISH-GATED: only sessions the owner
 // put in the gallery render here — a leaked session id must not make a
 // private world frameable (the embed exposes the whole session graph, wider
 // than one /n/ node). Zero model calls on this surface; navigation hops
-// through already-generated nodes only.
+// through already-generated nodes only. The gate / `_from-node` sentinel /
+// foreign-node rejection live in lib/embed-resolve.ts (unit-tested).
 
 interface EmbedPageProps {
   params: Promise<{ sessionId: string }>;
@@ -28,34 +25,16 @@ export const metadata: Metadata = {
 };
 
 export default async function EmbedPage({ params, searchParams }: EmbedPageProps) {
-  let { sessionId } = await params;
+  const { sessionId: rawSessionId } = await params;
   const { node: nodeParam } = await searchParams;
   const env = readServerEnv();
   if (!env.MONGODB_URI || !env.MONGODB_DB || !env.R2_PUBLIC_BASE_URL) {
     notFound();
   }
 
-  // public/embed.js mounts /n/<nodeId> permalinks as /embed/_from-node?node=…
-  // (the script can't resolve node → session client-side). Resolve it here;
-  // the publish gate below still applies to the resolved session.
-  if (sessionId === "_from-node") {
-    const viaNode = nodeParam ? await getNode(nodeParam).catch(() => null) : null;
-    if (!viaNode) notFound();
-    sessionId = viaNode.session_id;
-  }
-
-  const published = await getPublishedSession(sessionId).catch(() => null);
-  if (!published) notFound();
-
-  let start: NodeRow | null = null;
-  if (nodeParam) {
-    const candidate = await getNode(nodeParam).catch(() => null);
-    // A ?node= from another session must not smuggle a foreign page into
-    // this session's published frame.
-    if (candidate && candidate.session_id === sessionId) start = candidate;
-  }
-  if (!start) start = await getSessionRootNode(sessionId).catch(() => null);
-  if (!start) notFound();
+  const resolved = await resolveEmbedStart(rawSessionId, nodeParam);
+  if (!resolved) notFound();
+  const { sessionId, published, start } = resolved;
 
   const base = env.R2_PUBLIC_BASE_URL!.replace(/\/$/, "");
   return (
@@ -67,6 +46,9 @@ export default async function EmbedPage({ params, searchParams }: EmbedPageProps
         imageUrl: `${base}/${start.image_key}`,
       }}
       continueUrl={`/play?continue=${encodeURIComponent(sessionId)}`}
+      initialReceipt={
+        start.view_verdict ? formatViewVerdict(start.view_verdict) : null
+      }
     />
   );
 }

--- a/apps/web/components/PlayPage/MorphImagePair.tsx
+++ b/apps/web/components/PlayPage/MorphImagePair.tsx
@@ -40,6 +40,7 @@ export function MorphImagePair({
           progress" instead of "stuck". Once the new image takes over, this
           layer fades out. */}
       {morphFx ? (
+        // eslint-disable-next-line @next/next/no-img-element -- data-URL/R2 frame; next/image adds a loader hop and cannot optimize data URIs
         <img
           src={morphFx.prevImg ?? imageDataUrl}
           alt=""
@@ -74,6 +75,7 @@ export function MorphImagePair({
           draggable={false}
         />
       ) : null}
+      {/* eslint-disable-next-line @next/next/no-img-element -- data-URL/R2 frame; next/image adds a loader hop and cannot optimize data URIs */}
       <img
         ref={imgRef}
         src={morphFx?.nextImg ?? imageDataUrl}

--- a/apps/web/components/PlayPage/NeighbourTray.tsx
+++ b/apps/web/components/PlayPage/NeighbourTray.tsx
@@ -105,6 +105,7 @@ export default function NeighbourTray({
               }
             >
               {it.imageDataUrl ? (
+                // eslint-disable-next-line @next/next/no-img-element -- data-URL/R2 frame; next/image adds a loader hop and cannot optimize data URIs
                 <img
                   src={it.imageDataUrl}
                   alt=""

--- a/apps/web/components/embed-viewer.test.tsx
+++ b/apps/web/components/embed-viewer.test.tsx
@@ -1,0 +1,120 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import EmbedViewer from "./embed-viewer";
+
+// The embed's unit half. The publish gate, oEmbed payload, and iframe
+// behaviour live in e2e/embed.spec.ts; these cover the in-component logic
+// the mock stack can't isolate: dot rendering from the children fetch,
+// navigation + back stack, the frontier hint, and the receipt line.
+
+const CHILDREN = [
+  {
+    id: "kid1",
+    page_title: "The Tower",
+    image_url: "https://r2/kid1.jpg",
+    click_in_parent: { x_pct: 0.25, y_pct: 0.5 },
+  },
+  {
+    id: "kid2",
+    page_title: "The Harbor",
+    image_url: "https://r2/kid2.jpg",
+    click_in_parent: null, // no recorded tap — must NOT render a dot
+  },
+];
+
+function stubChildren(byParent: Record<string, unknown[]>) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string) => {
+      const id = url.match(/\/api\/nodes\/([^/]+)\/children/)?.[1] ?? "";
+      return {
+        ok: true,
+        json: async () => ({ children: byParent[decodeURIComponent(id)] ?? [] }),
+      };
+    })
+  );
+}
+
+const INITIAL = { id: "root", title: "The Map", imageUrl: "https://r2/root.jpg" };
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("EmbedViewer", () => {
+  it("renders entry dots only for children with a recorded tap point", async () => {
+    stubChildren({ root: CHILDREN });
+    await act(async () => {
+      render(
+        <EmbedViewer sessionId="s1" initial={INITIAL} continueUrl="/play?continue=s1" />
+      );
+    });
+    expect(screen.getByTitle("Enter The Tower")).toBeTruthy();
+    expect(screen.queryByTitle("Enter The Harbor")).toBeNull();
+    expect(screen.getByText("1 place to enter")).toBeTruthy();
+  });
+
+  it("dot click navigates in; back returns to the parent", async () => {
+    stubChildren({ root: CHILDREN, kid1: [] });
+    await act(async () => {
+      render(
+        <EmbedViewer sessionId="s1" initial={INITIAL} continueUrl="/play?continue=s1" />
+      );
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTitle("Enter The Tower"));
+    });
+    expect(screen.getByText("The Tower")).toBeTruthy();
+    expect(screen.getByText("world frontier")).toBeTruthy(); // no children
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "← back" }));
+    });
+    expect(screen.getByText("The Map")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "← back" })).toBeNull();
+  });
+
+  it("a tap on unexplored ground shows the continue hint at the tap point", async () => {
+    stubChildren({ root: [] });
+    await act(async () => {
+      render(
+        <EmbedViewer sessionId="s1" initial={INITIAL} continueUrl="/play?continue=s1" />
+      );
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("embed-stage"));
+    });
+    const hint = screen.getByText(/unexplored — continue this world/);
+    expect(hint.getAttribute("href")).toBe("/play?continue=s1");
+  });
+
+  it("keeps rendering (dotless) when the children fetch fails", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false })));
+    await act(async () => {
+      render(
+        <EmbedViewer sessionId="s1" initial={INITIAL} continueUrl="/play?continue=s1" />
+      );
+    });
+    expect(screen.getByText("world frontier")).toBeTruthy();
+    expect(screen.getByRole("link", { name: /Continue this world/ })).toBeTruthy();
+  });
+
+  it("shows the receipt on the initial node only", async () => {
+    stubChildren({ root: CHILDREN, kid1: [] });
+    await act(async () => {
+      render(
+        <EmbedViewer
+          sessionId="s1"
+          initial={INITIAL}
+          continueUrl="/play?continue=s1"
+          initialReceipt="arrival verified — same place 9.0/10 · 1 attempt"
+        />
+      );
+    });
+    expect(screen.getByText(/arrival verified/)).toBeTruthy();
+    await act(async () => {
+      fireEvent.click(screen.getByTitle("Enter The Tower"));
+    });
+    // Off the initial node the footer reverts to the generic line.
+    expect(screen.queryByText(/arrival verified/)).toBeNull();
+    expect(screen.getByText("an openflipbook world")).toBeTruthy();
+  });
+});

--- a/apps/web/components/fork-button.test.tsx
+++ b/apps/web/components/fork-button.test.tsx
@@ -1,0 +1,44 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import ForkButton from "./fork-button";
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("ForkButton", () => {
+  it("posts the fork and opens the new session live", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ session_id: "session_fork" }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    const loc = { href: "" };
+    vi.stubGlobal("location", loc);
+
+    render(<ForkButton sessionId="session_src" nodeId="n1" />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Fork this world" }));
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/sessions/session_src/fork",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ node_id: "n1" }),
+      })
+    );
+    expect(loc.href).toBe("/play?continue=session_fork");
+  });
+
+  it("a failed fork surfaces retry copy instead of navigating", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false })));
+    const loc = { href: "" };
+    vi.stubGlobal("location", loc);
+
+    render(<ForkButton sessionId="session_src" nodeId="n1" />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Fork this world" }));
+    });
+    expect(screen.getByRole("button", { name: "fork failed — retry" })).toBeTruthy();
+    expect(loc.href).toBe("");
+  });
+});

--- a/apps/web/components/time-scrubber.tsx
+++ b/apps/web/components/time-scrubber.tsx
@@ -121,6 +121,7 @@ export default function TimeScrubber({
               }
             >
               {f.imageDataUrl ? (
+                // eslint-disable-next-line @next/next/no-img-element -- data-URL/R2 frame; next/image adds a loader hop and cannot optimize data URIs
                 <img
                   src={f.imageDataUrl}
                   alt=""

--- a/apps/web/components/tour-button.test.tsx
+++ b/apps/web/components/tour-button.test.tsx
@@ -21,7 +21,7 @@ describe("TourButton", () => {
   it("fetches the session graph once and opens the player", async () => {
     const fetchMock = vi.fn(async () => ({
       ok: true,
-      json: async () => ({ nodes: NODES }),
+      json: async () => ({ nodes: NODES, next_cursor: null }),
     }));
     vi.stubGlobal("fetch", fetchMock);
     render(<TourButton sessionId="s1" continueUrl="/play?continue=s1" />);
@@ -33,6 +33,29 @@ describe("TourButton", () => {
       expect.anything()
     );
     expect(screen.getByTestId("tour-player")).toBeTruthy();
+  });
+
+  it("follows the cursor so big worlds tour whole (no silent 200 cap)", async () => {
+    const page2 = [{ ...NODES[0], id: "root2", parent_id: null }];
+    const fetchMock = vi.fn(async (url: string) => ({
+      ok: true,
+      json: async () =>
+        url.includes("cursor=")
+          ? { nodes: page2, next_cursor: null }
+          : { nodes: NODES, next_cursor: "2026|root" },
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    render(<TourButton sessionId="s1" continueUrl="/play?continue=s1" />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "▶ tour" }));
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "/api/sessions/s1?limit=200&cursor=2026%7Croot",
+      expect.anything()
+    );
+    // Both pages' roots are in the running tour (2 steps counted).
+    expect(screen.getByText("1/2")).toBeTruthy();
   });
 
   it("stays closed when the graph fetch fails", async () => {

--- a/apps/web/components/tour-button.tsx
+++ b/apps/web/components/tour-button.tsx
@@ -27,13 +27,25 @@ export default function TourButton({
     if (busy) return;
     setBusy(true);
     try {
-      const res = await fetch(
-        `/api/sessions/${encodeURIComponent(sessionId)}?limit=200`,
-        { cache: "no-store" }
-      );
-      if (!res.ok) return;
-      const json = (await res.json()) as { nodes: TourNode[] };
-      if (json.nodes.length > 0) setNodes(json.nodes);
+      // Follow the cursor so a big world tours WHOLE — a truncated graph
+      // makes children of the cut tour as fake roots. Hard ceiling mirrors
+      // the export bundle's 500.
+      const all: TourNode[] = [];
+      let cursor: string | null = null;
+      do {
+        const url =
+          `/api/sessions/${encodeURIComponent(sessionId)}?limit=200` +
+          (cursor ? `&cursor=${encodeURIComponent(cursor)}` : "");
+        const res = await fetch(url, { cache: "no-store" });
+        if (!res.ok) return;
+        const json = (await res.json()) as {
+          nodes: TourNode[];
+          next_cursor: string | null;
+        };
+        all.push(...json.nodes);
+        cursor = json.next_cursor;
+      } while (cursor && all.length < 500);
+      if (all.length > 0) setNodes(all);
     } finally {
       setBusy(false);
     }

--- a/apps/web/components/tour-player.tsx
+++ b/apps/web/components/tour-player.tsx
@@ -96,6 +96,9 @@ export default function TourPlayer({ nodes, continueUrl, onClose }: TourPlayerPr
       className="fixed inset-0 z-50 flex items-center justify-center bg-black"
       onClick={skip}
       data-testid="tour-player"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`World tour: ${steps[0]!.node.page_title}`}
     >
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img

--- a/apps/web/lib/db.test.ts
+++ b/apps/web/lib/db.test.ts
@@ -62,3 +62,27 @@ describe("toRow scale_tier round-trip (B2)", () => {
     expect(row.scale_tier).toBeNull();
   });
 });
+
+describe("toRow view_verdict + forked_from round-trip", () => {
+  it("preserves a persisted render receipt and fork lineage", () => {
+    const verdict = {
+      same_place: 9.0,
+      conformance: null,
+      medium: 10.0,
+      detail: null,
+      interior: null,
+      attempts: 2,
+      accepted: false,
+    };
+    const lineage = { session_id: "session_src", node_id: "n0" };
+    const row = toRow(doc({ view_verdict: verdict, forked_from: lineage }));
+    expect(row.view_verdict).toEqual(verdict);
+    expect(row.forked_from).toEqual(lineage);
+  });
+
+  it("defaults both to null on legacy rows (every pre-receipts document)", () => {
+    const row = toRow(doc());
+    expect(row.view_verdict).toBeNull();
+    expect(row.forked_from).toBeNull();
+  });
+});

--- a/apps/web/lib/embed-resolve.test.ts
+++ b/apps/web/lib/embed-resolve.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveEmbedStart } from "./embed-resolve";
+import type { NodeRow, PublishedSessionRow } from "./db";
+
+// The embed trust boundary as a table: publish gate, foreign-node
+// rejection, the _from-node sentinel, and store-failure degradation.
+
+const PUB: PublishedSessionRow = {
+  session_id: "s1",
+  node_id: "root1",
+  title: "The Map",
+  query: "a map",
+  poster_key: "k/poster.jpg",
+  published_at: "2026-08-22T00:00:00.000Z",
+};
+
+function node(id: string, session: string): NodeRow {
+  return {
+    id,
+    parent_id: null,
+    session_id: session,
+    query: "q",
+    page_title: `Title ${id}`,
+    image_key: `k/${id}.jpg`,
+    image_model: "m",
+    prompt_author_model: "p",
+    aspect_ratio: "16:9",
+    final_prompt: null,
+    click_in_parent: null,
+    sources: [],
+    relation: "descend",
+    scale: "peer",
+    scale_tier: null,
+    scene_view: null,
+    view_verdict: null,
+    forked_from: null,
+    geo_extracted: false,
+    created_at: "2026-08-22T00:00:00.000Z",
+  };
+}
+
+function stores(over: Partial<Parameters<typeof resolveEmbedStart>[2]> = {}) {
+  return {
+    getNode: async (id: string) =>
+      id === "root1" ? node("root1", "s1") : id === "foreign" ? node("foreign", "s2") : null,
+    getPublishedSession: async (sid: string) => (sid === "s1" ? PUB : null),
+    getSessionRootNode: async (sid: string) =>
+      sid === "s1" ? node("root1", "s1") : null,
+    ...over,
+  };
+}
+
+describe("resolveEmbedStart", () => {
+  it("unpublished sessions resolve to null — private worlds are not frameable", async () => {
+    expect(await resolveEmbedStart("s2", null, stores())).toBeNull();
+  });
+
+  it("published session starts at its root by default", async () => {
+    const r = await resolveEmbedStart("s1", null, stores());
+    expect(r?.start.id).toBe("root1");
+  });
+
+  it("a foreign ?node= cannot smuggle a page into the published frame", async () => {
+    const r = await resolveEmbedStart("s1", "foreign", stores());
+    // Falls back to the session's own root instead of the foreign page.
+    expect(r?.start.id).toBe("root1");
+    expect(r?.start.session_id).toBe("s1");
+  });
+
+  it("_from-node resolves the node's session and STILL applies the gate", async () => {
+    const ok = await resolveEmbedStart("_from-node", "root1", stores());
+    expect(ok?.sessionId).toBe("s1");
+    expect(ok?.start.id).toBe("root1");
+    // A node in an unpublished session resolves the session, then gates out.
+    expect(await resolveEmbedStart("_from-node", "foreign", stores())).toBeNull();
+    // The sentinel without a node is meaningless.
+    expect(await resolveEmbedStart("_from-node", null, stores())).toBeNull();
+  });
+
+  it("store failures degrade to null, never to an error shape", async () => {
+    const boom = stores({
+      getPublishedSession: async () => {
+        throw new Error("mongo down");
+      },
+    });
+    expect(await resolveEmbedStart("s1", null, boom)).toBeNull();
+  });
+});

--- a/apps/web/lib/embed-resolve.ts
+++ b/apps/web/lib/embed-resolve.ts
@@ -1,0 +1,62 @@
+import {
+  getNode,
+  getPublishedSession,
+  getSessionRootNode,
+  type NodeRow,
+  type PublishedSessionRow,
+} from "./db";
+
+// The embed surface's trust-boundary half, extracted from the page so the
+// gate logic is unit-testable: the publish gate (a leaked session id must
+// not make a private world frameable), the foreign-node rejection (a ?node=
+// from another session must not smuggle a page into a published frame),
+// and the `_from-node` sentinel public/embed.js mounts /n/ links with.
+
+export interface EmbedStart {
+  sessionId: string;
+  published: PublishedSessionRow;
+  start: NodeRow;
+}
+
+interface EmbedStores {
+  getNode: typeof getNode;
+  getPublishedSession: typeof getPublishedSession;
+  getSessionRootNode: typeof getSessionRootNode;
+}
+
+const LIVE: EmbedStores = { getNode, getPublishedSession, getSessionRootNode };
+
+/** Resolve what an /embed request may show, or null (the page 404s).
+ *  All store failures degrade to null — the embed never leaks an error
+ *  shape that distinguishes "private" from "absent". */
+export async function resolveEmbedStart(
+  sessionId: string,
+  nodeParam: string | null | undefined,
+  stores: EmbedStores = LIVE
+): Promise<EmbedStart | null> {
+  // public/embed.js mounts /n/<nodeId> permalinks as /embed/_from-node?node=…
+  // (the script can't resolve node → session client-side). The publish gate
+  // below applies to the RESOLVED session.
+  if (sessionId === "_from-node") {
+    const viaNode = nodeParam
+      ? await stores.getNode(nodeParam).catch(() => null)
+      : null;
+    if (!viaNode) return null;
+    sessionId = viaNode.session_id;
+  }
+
+  const published = await stores.getPublishedSession(sessionId).catch(() => null);
+  if (!published) return null;
+
+  let start: NodeRow | null = null;
+  if (nodeParam) {
+    const candidate = await stores.getNode(nodeParam).catch(() => null);
+    if (candidate && candidate.session_id === sessionId) start = candidate;
+  }
+  if (!start) {
+    start = await stores.getSessionRootNode(sessionId).catch(() => null);
+  }
+  if (!start) return null;
+
+  return { sessionId, published, start };
+}

--- a/apps/web/lib/embed-script.test.ts
+++ b/apps/web/lib/embed-script.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// public/embed.js is the one shipped file nothing imports — a self-contained
+// IIFE for third-party pages. Importing it in jsdom EXECUTES it against the
+// prepared DOM, so the wrapper's contract (URL mapping, the _from-node
+// sentinel, no double-mounting, width clamp) gets a real gate.
+
+function target(url: string): HTMLDivElement {
+  const div = document.createElement("div");
+  div.setAttribute("data-openflipbook", url);
+  document.body.appendChild(div);
+  return div;
+}
+
+async function runScript(): Promise<void> {
+  vi.resetModules(); // re-run the IIFE for each scenario
+  // @ts-expect-error — not a module on purpose; importing EXECUTES the IIFE
+  await import("../public/embed.js");
+}
+
+function frame(): HTMLIFrameElement | null {
+  return document.querySelector("iframe");
+}
+
+describe("public/embed.js", () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+    // happy-dom would otherwise fetch every mounted iframe's src for real.
+    (
+      window as unknown as {
+        happyDOM: { settings: { disableIframePageLoading: boolean } };
+      }
+    ).happyDOM.settings.disableIframePageLoading = true;
+  });
+
+  it("mounts an /embed/ link as an iframe, preserving the query", async () => {
+    target("https://x.test/embed/s1?node=n2");
+    await runScript();
+    const f = frame()!;
+    expect(f.src).toBe("https://x.test/embed/s1?node=n2");
+    expect(f.title).toBe("openflipbook world");
+  });
+
+  it("maps /n/<id> permalinks through the _from-node sentinel", async () => {
+    target("https://x.test/n/abc");
+    await runScript();
+    expect(frame()!.src).toBe("https://x.test/embed/_from-node?node=abc");
+  });
+
+  it("marks the div mounted and never double-mounts on a rescan", async () => {
+    const div = target("https://x.test/n/abc");
+    await runScript();
+    await runScript(); // second script include on the same page
+    expect(document.querySelectorAll("iframe")).toHaveLength(1);
+    expect(div.getAttribute("data-ofb-mounted")).toBe("1");
+  });
+
+  it("leaves unrecognized targets inert (no iframe, no mounted mark)", async () => {
+    const div = target("https://x.test/play?continue=s1");
+    await runScript();
+    expect(frame()).toBeNull();
+    expect(div.getAttribute("data-ofb-mounted")).toBeNull();
+  });
+
+  it("clamps the iframe width into [320, 1280] with a 16:10 height", async () => {
+    target("https://x.test/n/abc");
+    await runScript();
+    const f = frame()!;
+    // jsdom reports clientWidth 0 → the 720 default applies.
+    expect(f.width).toBe("720");
+    expect(f.height).toBe("450");
+  });
+});

--- a/apps/web/lib/embed.test.ts
+++ b/apps/web/lib/embed.test.ts
@@ -35,6 +35,21 @@ describe("parseEmbedTarget", () => {
     });
   });
 
+  it("tolerates real-world link shapes: trailing slash, query noise, encoded ids", () => {
+    expect(parseEmbedTarget("https://x.test/n/abc/")).toEqual({
+      kind: "node",
+      nodeId: "abc",
+    });
+    expect(parseEmbedTarget("https://x.test/n/abc?utm_source=blog#frag")).toEqual({
+      kind: "node",
+      nodeId: "abc",
+    });
+    expect(parseEmbedTarget("https://x.test/n/a%2Fb")).toEqual({
+      kind: "node",
+      nodeId: "a/b", // decoded once; a nonexistent id just 404s downstream
+    });
+  });
+
   it("rejects everything else (other routes, missing ids)", () => {
     for (const bad of [
       "https://x.test/play?continue=s1",

--- a/apps/web/lib/postcard.tsx
+++ b/apps/web/lib/postcard.tsx
@@ -41,6 +41,7 @@ export function postcardLayout(
         fontFamily: "Georgia, serif",
       }}
     >
+      {/* eslint-disable-next-line @next/next/no-img-element -- data-URL/R2 frame; next/image adds a loader hop and cannot optimize data URIs */}
       <img
         src={node.imageUrl}
         alt=""
@@ -97,6 +98,7 @@ export function postcardLayout(
             ) : null}
           </div>
         </div>
+        {/* eslint-disable-next-line @next/next/no-img-element -- data-URL/R2 frame; next/image adds a loader hop and cannot optimize data URIs */}
         <img
           src={qrDataUrl}
           alt=""

--- a/apps/web/lib/world-helpers.test.ts
+++ b/apps/web/lib/world-helpers.test.ts
@@ -2,8 +2,7 @@ import { describe, expect, it } from "vitest";
 import type {
   EntityExtractionResult,
   ExtractedEntity,
-  EntityUpdate,
-} from "@openflipbook/config";
+  EntityUpdate, Entity } from "@openflipbook/config";
 import { __test, mergeEntityState } from "./world";
 
 // Same factory shapes as world.test.ts — kept local rather than re-exporting
@@ -34,7 +33,7 @@ function emptyResult(): EntityExtractionResult {
   return { added: [], updated: [] };
 }
 
-function ent(overrides: Partial<import("@openflipbook/config").Entity> = {}) {
+function ent(overrides: Partial<Entity> = {}) {
   return {
     id: overrides.id ?? "e1",
     kind: overrides.kind ?? ("person" as const),

--- a/apps/web/lib/world.test.ts
+++ b/apps/web/lib/world.test.ts
@@ -2,8 +2,7 @@ import { describe, expect, it } from "vitest";
 import type {
   EntityExtractionResult,
   ExtractedEntity,
-  EntityUpdate,
-} from "@openflipbook/config";
+  EntityUpdate, Entity } from "@openflipbook/config";
 import { __test } from "./world";
 
 function makeAdded(overrides: Partial<ExtractedEntity> = {}): ExtractedEntity {
@@ -624,7 +623,7 @@ describe("Phase 7a — state-write gate", () => {
 });
 
 describe("scoreEntitiesForContinuity", () => {
-  function ent(overrides: Partial<import("@openflipbook/config").Entity> = {}) {
+  function ent(overrides: Partial<Entity> = {}) {
     return {
       id: overrides.id ?? "e1",
       kind: overrides.kind ?? ("person" as const),

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -36,10 +36,10 @@ export default defineConfig({
       // FAILS; a PR that raises coverage bumps the floor to the new number.
       // Never lower these to make a PR pass — that defeats the ratchet.
       thresholds: {
-        lines: 76,
-        statements: 76,
-        functions: 79,
-        branches: 85,
+        lines: 77,
+        statements: 77,
+        functions: 80,
+        branches: 86,
       },
     },
   },

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -98,6 +98,10 @@ Pure helpers, easy to unit-test.
 - `mse-player.ts` — Media Source Extensions playback for fragmented mp4.
 - `ltxf-parser.ts` — frame parser for the custom LTXF binary protocol.
 - `env.ts` — env-var validation.
+- `embed.ts` — the oEmbed URL grammar (`parseEmbedTarget`) + iframe snippet builder for the embeddable world viewer.
+- `tour.ts` — turns a session's node graph into the tour camera script (DFS creation order; descend edges dive at `click_in_parent`).
+- `fork.ts` — session deep-copy with node-id reminting; carries the loud COPIED/SKIPPED collection inventory.
+- `view-verdict.ts` — render-receipt display buckets + copy (never raw-number scolding).
 
 ### `apps/web/app/play/page.tsx`
 
@@ -112,6 +116,30 @@ pass — was 2,522 before extractions started. Still owns:
 6. Top-level JSX: composes the toolbar + the `<figure>` + map view + scrubber + HUDs + overlays.
 
 **Why these still live here:** they read or write 4+ pieces of cross-hook state and aren't separable without first introducing a `PlayContext` reducer. That extraction (`useGenerationStream` + `PlayContext` for `{page, phase, history, error}`) is the next planned slice — it's the one big lift that's intentionally bundled with a green E2E pass for visual-diff verification.
+
+## Share surfaces (2026-08)
+
+A world is reachable four ways beyond `/play`, all publish- or link-gated and
+all zero-generate (pure hydration of persisted state):
+
+- **`/n/[id]`** — the static share viewer. Carries the render receipt chip
+  (`view_verdict`, persisted per node), fork lineage, and the tour / fork /
+  continue buttons.
+- **`/embed/[sessionId]`** — the read-only navigable viewer for iframes
+  (publish-gated; `frame-ancestors *` on this path only). `/api/oembed` is the
+  JSON provider; `public/embed.js` is the script wrapper for platforms without
+  oEmbed (mounts `/n/` links via the `/embed/_from-node?node=…` sentinel).
+- **`POST /api/sessions/[id]/fork`** — deep-copies the session (nodes with
+  reminted ids, `world_state` with node-refs remapped in five places,
+  `world_map` under the new `_id`); the safer sibling of `?continue=`, which
+  grants write access to the original.
+- **Tour mode** — `components/tour-player.tsx`, launched from `/n/` and the
+  embed header; replays the world's own exploration as a camera script.
+
+Proxy rule (live-caught via `/api/animate`): any web route that forwards an
+image REFERENCE upstream must inline our own stored-image URLs first
+(`lib/r2.inlineStoredImage`) — hydrated pages carry public URLs, and on the
+docker stack those are localhost minio URLs external providers refuse.
 
 ## Backend (`apps/modal-backend/`)
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -10,8 +10,11 @@ bands you run around risky generation-path changes.
 make eval
 ```
 
-Backend pytest (`-m "not paid"`, ~530 tests) + ruff + mypy (strict on
-`providers/`) + web vitest (~480 tests) + tsc + circular-dep check. What it
+Backend pytest (`-m "not paid"`, ~1,040 tests) + ruff + mypy (strict on
+`providers/`) + web vitest (~880 tests) + tsc + circular-dep check. Both
+suites carry raise-only coverage floors (backend `fail_under` in
+pyproject.toml, web thresholds in vitest.config) and the eslint warning cap
+is lower-only — the ratchets move with every test PR, never back. What it
 locks:
 
 - **Wire parity**: TS ↔ Pydantic shapes (`world-geo-fixture.json` keys AND

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "typescript-eslint": "^8.16.0"
   },
   "lint-staged": {
-    "*.{ts,tsx,js,mjs,cjs}": "eslint --fix --max-warnings=20",
+    "*.{ts,tsx,js,mjs,cjs}": "eslint --fix --max-warnings=12",
     "apps/modal-backend/**/*.py": "bash -lc 'cd apps/modal-backend && .venv/bin/ruff check --fix'"
   }
 }


### PR DESCRIPTION
## What

A self-paced quality loop over the week's new surfaces. Nine commits, all free (no paid model calls), each committed with green gates.

**Bug fixes (2, both live-relevant):**
- The embed page never passed `initialReceipt` — the viewer accepted the receipt prop since #229 with nothing feeding it. Fed now (caught by the trust-boundary extraction).
- Tour truncated worlds past 200 nodes, re-rooting children of the cut as fake tour starts. The launcher follows `next_cursor` (hard ceiling 500, the export bundle's precedent), pagination contract tested.

**Trust-boundary hardening (3):**
- `lib/embed-resolve.ts` — the embed's publish gate / foreign-node rejection / `_from-node` sentinel extracted from the server component and pinned as a five-test table (unpublished never frameable; a foreign `?node=` cannot smuggle a page into a published frame; store failures degrade to null, never an error shape distinguishing private from absent).
- `_sanitize_hint` hoisted from inside `stream_tap` to module scope — the prompt-injection/token-bomb cap was rebuilt per call and untestable. Contract table added (control chars die, `\n`/`\t` survive, cap bounds post-strip).
- `public/embed.js` — the wrapper that runs on other people's pages had zero coverage; importing the IIFE in the test env executes it against a prepared DOM. Five contract tests (mount, sentinel mapping, double-mount immunity, inert unknowns, width clamp).

**Test additions elsewhere:** embed-viewer + fork-button unit halves (7), zoom-receipt edge arms (deadline-bail keeps 1 honest attempt; retry-crash reports the judged first with attempts=2), `toRow` round-trip for `view_verdict`/`forked_from` + legacy-null defaults, oEmbed link-shape edges (trailing slash / utm noise / encoded ids), tour a11y dialog semantics.

**Ratchets (both directions locked):** web coverage floors 76→77 lines/stmts, 79→80 functions, 85→86 branches (measured 78.28); eslint warnings burned 17→9 and the cap dropped 20→12 in lint-staged + CI. The nine surviving warnings are the deliberate `exhaustive-deps` omissions (refs + stable setters on effects that must not re-arm per render) — left on purpose, documented in the commit. Backend measured 85.93 over the 85 floor (not bumped — sub-1pt headroom).

**Docs:** ARCHITECTURE.md gains the share-surfaces section + the inline-before-forward proxy rule (#232's lesson); TESTING.md counts refreshed (~1,040 backend / ~880 web) and the ratchet rules written down.

## Gates

Backend 1,043 collected / suite green, ruff, mypy 50 files; web 886, tsc, madge 0 cycles; knip roster byte-identical to baseline; lint 9 ≤ 12. e2e-mock rides the required CI job on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)