### PR TITLE
feat(gallery): shelf of worlds — stats + tour/fork actions per card

### DIFF
--- a/apps/web/app/gallery/page.tsx
+++ b/apps/web/app/gallery/page.tsx
@@ -1,13 +1,18 @@
 import Link from "next/link";
 
-import { listPublishedSessions } from "@/lib/db";
+import ForkButton from "@/components/fork-button";
+import TourButton from "@/components/tour-button";
+import { galleryStats, listPublishedSessions } from "@/lib/db";
 import { readServerEnv } from "@/lib/env";
+import { countMapEntities } from "@/lib/world-map";
 
 export const dynamic = "force-dynamic";
 
-/** The opt-in public gallery: sessions their owners chose to publish
- * (right-click → "Publish session to gallery"), newest first. Each card
- * fronts the published page and links into its permalink. */
+/** The opt-in public gallery, upgraded from a thumbnail grid to a shelf of
+ * WORLDS: each card carries the world's stats (pages / places / forks) and
+ * its own tour + fork actions beside the permalink link-through. Sessions
+ * appear here only when their owners published them (right-click →
+ * "Publish session to gallery"), newest first. */
 export default async function GalleryPage() {
   const env = readServerEnv();
   if (!env.MONGODB_URI || !env.MONGODB_DB) {
@@ -19,6 +24,11 @@ export default async function GalleryPage() {
     );
   }
   const rows = await listPublishedSessions(60);
+  const ids = rows.map((r) => r.session_id);
+  const [stats, places] = await Promise.all([
+    galleryStats(ids),
+    countMapEntities(ids).catch(() => new Map<string, number>()),
+  ]);
   const base = (env.R2_PUBLIC_BASE_URL ?? "").replace(/\/$/, "");
   return (
     <main className="mx-auto max-w-6xl px-6 py-10">
@@ -35,28 +45,46 @@ export default async function GalleryPage() {
         </p>
       ) : (
         <ul className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {rows.map((row) => (
-            <li key={row.session_id}>
-              <Link
-                href={`/n/${row.node_id}`}
-                className="block overflow-hidden rounded-xl border border-[var(--color-edge)] bg-[var(--color-canvas)] shadow-sm transition-shadow hover:shadow-md"
+          {rows.map((row) => {
+            const s = stats.get(row.session_id) ?? { pages: 0, forks: 0 };
+            const placeCount = places.get(row.session_id) ?? 0;
+            return (
+              <li
+                key={row.session_id}
+                className="overflow-hidden rounded-xl border border-[var(--color-edge)] bg-[var(--color-canvas)] shadow-sm transition-shadow hover:shadow-md"
               >
-                {base && (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img
-                    src={`${base}/${row.poster_key}`}
-                    alt={row.title}
-                    className="aspect-video w-full object-cover"
-                    loading="lazy"
+                <Link href={`/n/${row.node_id}`} className="block">
+                  {base && (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={`${base}/${row.poster_key}`}
+                      alt={row.title}
+                      className="aspect-video w-full object-cover"
+                      loading="lazy"
+                    />
+                  )}
+                  <div className="px-4 pt-3">
+                    <h2 className="truncate text-sm font-medium">{row.title}</h2>
+                    <p className="mt-1 truncate text-xs opacity-60">{row.query}</p>
+                    <p className="mt-1 text-xs opacity-50">
+                      {s.pages} page{s.pages === 1 ? "" : "s"}
+                      {placeCount > 0 &&
+                        ` · ${placeCount} place${placeCount === 1 ? "" : "s"}`}
+                      {s.forks > 0 &&
+                        ` · ${s.forks} fork${s.forks === 1 ? "" : "s"}`}
+                    </p>
+                  </div>
+                </Link>
+                <div className="flex items-center gap-2 px-4 pb-3 pt-2">
+                  <TourButton
+                    sessionId={row.session_id}
+                    continueUrl={`/play?continue=${encodeURIComponent(row.session_id)}`}
                   />
-                )}
-                <div className="px-4 py-3">
-                  <h2 className="truncate text-sm font-medium">{row.title}</h2>
-                  <p className="mt-1 truncate text-xs opacity-60">{row.query}</p>
+                  <ForkButton sessionId={row.session_id} nodeId={row.node_id} />
                 </div>
-              </Link>
-            </li>
-          ))}
+              </li>
+            );
+          })}
         </ul>
       )}
     </main>

--- a/apps/web/e2e/embed.spec.ts
+++ b/apps/web/e2e/embed.spec.ts
@@ -100,4 +100,14 @@ test("embed viewer is publish-gated, navigates generated nodes, serves oEmbed", 
   await page.keyboard.press("Escape");
   await expect(tour).not.toBeVisible();
   expect(generates).toBe(0);
+
+  // 7) The gallery shelf: the published world's card carries its stats and
+  // its own tour + fork actions.
+  await page.goto("/gallery");
+  const card = page.locator("li", { hasText: "2 pages" }).first();
+  await expect(card).toBeVisible({ timeout: 15_000 });
+  await expect(card.getByRole("button", { name: "▶ tour" })).toBeVisible();
+  await expect(
+    card.getByRole("button", { name: "Fork this world" }),
+  ).toBeVisible();
 });

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -516,6 +516,51 @@ export async function unpublishSession(sessionId: string): Promise<boolean> {
   return res.deletedCount > 0;
 }
 
+export interface GalleryWorldStats {
+  pages: number;
+  forks: number;
+}
+
+/** Bulk per-session stats for the gallery shelf: page counts plus how many
+ * forks each world has spawned (fork roots stamp forked_from.session_id).
+ * One aggregation per axis, not per card. */
+export async function galleryStats(
+  sessionIds: string[]
+): Promise<Map<string, GalleryWorldStats>> {
+  const out = new Map<string, GalleryWorldStats>(
+    sessionIds.map((id) => [id, { pages: 0, forks: 0 }])
+  );
+  if (sessionIds.length === 0) return out;
+  const collection = await nodes();
+  const pages = await collection
+    .aggregate<{ _id: string; n: number }>([
+      { $match: { session_id: { $in: sessionIds } } },
+      { $group: { _id: "$session_id", n: { $sum: 1 } } },
+    ])
+    .toArray();
+  for (const row of pages) {
+    const entry = out.get(row._id);
+    if (entry) entry.pages = row.n;
+  }
+  const forks = await collection
+    .aggregate<{ _id: string; n: number }>([
+      {
+        $match: {
+          parent_id: null,
+          "forked_from.session_id": { $in: sessionIds },
+        },
+      },
+      { $group: { _id: "$forked_from.session_id", n: { $sum: 1 } } },
+    ])
+    .toArray();
+  for (const row of forks) {
+    const entry = out.get(row._id);
+    if (entry) entry.forks = row.n;
+  }
+  return out;
+}
+
+
 /** The gallery-publish record for one session, or null. The embed surface
  * gates on this: only sessions the owner deliberately published render in an
  * iframe — a leaked session id must not make a private world frameable. */

--- a/apps/web/lib/world-map.ts
+++ b/apps/web/lib/world-map.ts
@@ -615,6 +615,22 @@ export function registerPlanToImage(
   return { updated, fit };
 }
 
+/** Bulk entity counts for the gallery shelf — one projected read over the
+ *  requested sessions (world_map is keyed by _id = session id). */
+export async function countMapEntities(
+  sessionIds: string[]
+): Promise<Map<string, number>> {
+  const out = new Map<string, number>();
+  if (sessionIds.length === 0) return out;
+  const col = await collection();
+  const docs = await col
+    .find({ _id: { $in: sessionIds } })
+    .project<{ _id: string; entities?: unknown[] }>({ entities: 1 })
+    .toArray();
+  for (const d of docs) out.set(d._id, d.entities?.length ?? 0);
+  return out;
+}
+
 export const __test = {
   applyGeoUpsert,
   recomputeBounds,


### PR DESCRIPTION
## What

Item 1 of the five: the gallery becomes the distribution surface the new share features want. Each published world's card now shows **pages · places · forks** (one aggregation per axis — pages from nodes, places from a projected `world_map` read, forks from the `forked_from` lineage stamps) and carries its own **▶ tour** and **Fork this world** actions beside the permalink link-through.

Card restructured so interactive actions live outside the `<Link>` (nested interactives are invalid HTML). Zero model calls; two thin bulk helpers in their home modules (`db.galleryStats`, `world-map.countMapEntities`).

## Gates

tsc clean, web 886 green, madge clean; the required e2e-mock job gains a gallery step — the spec that already publishes a session now asserts the card's stats line and both actions render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)