### PR TITLE
feat(preview): graduate VIEW_LOOP_PREVIEW — paint attempt-0 before judging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,9 +103,11 @@ FAL_EDIT_TIER=balanced
 # Paint the first render the instant it lands, BEFORE judging (cuts perceived
 # latency on BOTH the immersive enter tap and the right-click zoom: an accepted /
 # kept-best first attempt otherwise shows nothing until the judge tail + any
-# retry). The judged verdict still follows and swaps it. Off by default — it
-# surfaces an un-judged frame. VIEW_LOOP_PREVIEW=true to enable.
-# VIEW_LOOP_PREVIEW=false
+# retry). The judged verdict still follows and swaps it. GRADUATED to default
+# ON (2026-08-23: three live taps painted early with seamless judged swaps,
+# and the verdict receipt now labels kept-best arrivals honestly).
+# VIEW_LOOP_PREVIEW=0 restores judge-first painting.
+# VIEW_LOOP_PREVIEW=true
 # Retry-model swap for VIEW_LOOP experiments: attempt 0 stays on the router's
 # production fal edit slug; only judged retry attempts use this alternate.
 # ENTER_RETRY_MODEL_SWAP=false

--- a/apps/modal-backend/providers/generate_modes/tap.py
+++ b/apps/modal-backend/providers/generate_modes/tap.py
@@ -729,7 +729,7 @@ async def stream_tap(
                 model_override=redraw_model if submap_redraw else body.image_model,
             )
 
-        if env_flag("VIEW_LOOP_PREVIEW"):
+        if env_flag("VIEW_LOOP_PREVIEW", "true"):
             zoom_preview_q = _asyncio.Queue()
 
         async def _judged_zoom() -> GeneratedImage:
@@ -965,7 +965,7 @@ async def stream_tap(
                 60.0,
                 ingress_timeout_s - 180.0 - (_time.perf_counter() - started),
             )
-            enter_preview = env_flag("VIEW_LOOP_PREVIEW")
+            enter_preview = env_flag("VIEW_LOOP_PREVIEW", "true")
             loop_attempts: list[Attempt] = []
             async for loop_att in render_loop.iter_attempts(
                 _render_enter,

--- a/apps/modal-backend/tests/conftest.py
+++ b/apps/modal-backend/tests/conftest.py
@@ -84,6 +84,7 @@ _SCRUB = (
     # The render loop (default ON for deliberate-camera enters — scrub for
     # hermeticity).
     "VIEW_LOOP",
+    "VIEW_LOOP_PREVIEW",
     "VIEW_LOOP_MAX_ATTEMPTS",
     "VIEW_LOOP_ACCEPT_CONFORMANCE",
     "VIEW_LOOP_ACCEPT_SAME_PLACE",

--- a/apps/modal-backend/tests/test_generate_enter.py
+++ b/apps/modal-backend/tests/test_generate_enter.py
@@ -143,7 +143,10 @@ async def test_enter_skips_progressive_draft(
 ) -> None:
     # A text-only nano draft can't preview a conditioned edit — it would be a
     # second unconditioned reinvention flashing before the faithful render.
+    # VIEW_LOOP_PREVIEW is killed here so the assertion isolates the DRAFT
+    # race (the judged preview is a different, legitimate frame source).
     monkeypatch.setenv("PROGRESSIVE_DRAFT", "true")
+    monkeypatch.setenv("VIEW_LOOP_PREVIEW", "0")
     _mock_plan(monkeypatch)
     edit = _mock_edit(monkeypatch)
     gen = _mock_fresh(monkeypatch)

--- a/apps/modal-backend/tests/test_generate_view.py
+++ b/apps/modal-backend/tests/test_generate_view.py
@@ -453,7 +453,10 @@ async def test_view_loop_accept_fast_no_retry(
     events = await _collect(_event_stream(_steep_body(), "t1"))
 
     edit.assert_awaited_once()
-    assert not [e for e in events if e["type"] == "progress"]
+    # Graduated VIEW_LOOP_PREVIEW: the accepted attempt-0 paints ONCE as the
+    # preview and the final swaps it — never a second (double) frame.
+    progress = [e for e in events if e["type"] == "progress"]
+    assert [p["frame_index"] for p in progress] == [0]
 
 
 async def test_view_loop_kill_switch(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -486,7 +489,8 @@ async def test_view_loop_judges_aerial_enters_too(
 
     edit.assert_awaited_once()
     assert conf.await_count == 1
-    assert not [e for e in events if e["type"] == "progress"]
+    # One preview frame (graduated default), judged and kept — no doubles.
+    assert [e["frame_index"] for e in events if e["type"] == "progress"] == [0]
 
 
 async def test_view_loop_medium_drift_retries(


### PR DESCRIPTION
## What

Item 2 of the five. The preview machinery (#208/#209) painted the first render before the judge tail — built, tested, and default-off for lack of play data. That data now exists: **three live taps during this week's demos** (fresh draft, judged interior enter, judged zoom enter) each painted seconds early with a seamless judged swap — no flicker, no double frames — and since #229 the **verdict receipt labels kept-best arrivals honestly**, which closes the original "surfaces an un-judged frame" objection.

- Both backend read sites default on; `VIEW_LOOP_PREVIEW=0` restores judge-first painting.
- Tests re-encode the default: the accepted attempt-0 paints **once** (the no-double-frame rule becomes an assertion instead of an absence); the draft-race test kills preview explicitly to keep isolating its own concern; the flag joins the conftest scrub list.
- The TEMPORARY `docker-compose.override.yml` is retired — both flags it carried are now defaults, and its own header said delete when done.

## Gates

Backend suite green (1,046 collected), ruff, mypy 50 files. e2e-mock rides CI as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)