### PR TITLE
feat(atlas): the artifact half — travelogue + the map you earned

### DIFF
--- a/apps/web/app/atlas/[sessionId]/page.tsx
+++ b/apps/web/app/atlas/[sessionId]/page.tsx
@@ -10,6 +10,9 @@ import AtlasView, {
   type AtlasEntity,
   type AtlasNode,
 } from "@/components/atlas-view";
+import FogMap from "@/components/fog-map";
+import { buildTravelogue } from "@/lib/travelogue";
+import type { MapCrop } from "@openflipbook/config";
 
 interface AtlasPageProps {
   params: Promise<{ sessionId: string }>;
@@ -183,9 +186,11 @@ export default async function AtlasPage({ params }: AtlasPageProps) {
   // an unseeded session (or a Mongo hiccup) just renders the atlas without
   // anchors, exactly as before.
   let geoMap: { entities: WorldEntityGeo[] } = { entities: [] };
+  let mapBounds: MapCrop | null = null;
   try {
     const map = await getWorldMap(sessionId);
     geoMap = { entities: map.entities };
+    mapBounds = map.bounds;
   } catch {
     geoMap = { entities: [] };
   }
@@ -193,15 +198,58 @@ export default async function AtlasPage({ params }: AtlasPageProps) {
   const latest = nodes[nodes.length - 1];
   const root = nodes.find((n) => n.parentId == null) ?? nodes[0];
 
+  // The artifact half: the journey retold + the map you earned. Rendered as
+  // a native <details> overlay so the atlas canvas stays untouched.
+  const travelogue = buildTravelogue(
+    rows.map((row) => ({
+      id: row.id,
+      parentId: row.parent_id,
+      title: row.page_title || row.query,
+      createdAt: row.created_at,
+      relation: row.relation,
+    }))
+  );
+
   return (
-    <AtlasView
-      sessionId={sessionId}
-      nodes={nodes}
-      latestNodeId={latest?.id ?? null}
-      rootTitle={root?.title ?? "session"}
-      entities={atlasEntities}
-      sceneViews={sceneViews}
-      geoMap={geoMap}
-    />
+    <>
+      <AtlasView
+        sessionId={sessionId}
+        nodes={nodes}
+        latestNodeId={latest?.id ?? null}
+        rootTitle={root?.title ?? "session"}
+        entities={atlasEntities}
+        sceneViews={sceneViews}
+        geoMap={geoMap}
+      />
+      <details className="fixed bottom-4 left-4 z-40 w-80 max-w-[85vw] rounded-xl border border-black/20 bg-[var(--color-canvas,#faf7f1)] shadow-lg">
+        <summary className="cursor-pointer select-none px-4 py-2 text-sm font-medium">
+          📜 Travelogue
+        </summary>
+        <div className="max-h-[55vh] overflow-y-auto px-4 pb-4">
+          {mapBounds && geoMap.entities.length > 0 && (
+            <FogMap
+              entities={geoMap.entities}
+              bounds={mapBounds}
+              className="mb-3 h-auto w-full rounded-lg border border-black/10"
+            />
+          )}
+          <ol className="space-y-1.5 text-xs leading-snug">
+            {travelogue.map((entry) => (
+              <li key={entry.nodeId}>
+                <a
+                  href={`/n/${encodeURIComponent(entry.nodeId)}`}
+                  className="hover:underline"
+                >
+                  <span className="opacity-45">
+                    {entry.ts.slice(0, 10)}{" "}
+                  </span>
+                  {entry.line}
+                </a>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </details>
+    </>
   );
 }

--- a/apps/web/components/fog-map.test.tsx
+++ b/apps/web/components/fog-map.test.tsx
@@ -1,0 +1,46 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { WorldEntityGeo } from "@openflipbook/config";
+
+import FogMap from "./fog-map";
+
+function geo(id: string, x: number, y: number): WorldEntityGeo {
+  return {
+    id,
+    entity_id: id,
+    kind: "place",
+    label: id,
+    pos: { x, y },
+    height: 4,
+    footprint: { w: 8, d: 6 },
+    visual: "",
+    state: {},
+    confidence: 1,
+    source: "derived",
+    updated_at: "t",
+  };
+}
+
+describe("FogMap", () => {
+  it("burns one fog hole per known place and pads the frontier", () => {
+    const { container } = render(
+      <FogMap
+        entities={[geo("a", 10, 10), geo("b", 60, 40)]}
+        bounds={{ x: 0, y: 0, w: 100, h: 60 }}
+      />
+    );
+    const svg = container.querySelector("svg")!;
+    // 18% padding on the larger bound (100): viewBox starts at -18.
+    expect(svg.getAttribute("viewBox")).toBe("-18 -18 136 96");
+    expect(container.querySelectorAll("mask circle")).toHaveLength(2);
+    expect(svg.getAttribute("aria-label")).toContain("2 known places");
+  });
+
+  it("renders nothing for a session with no world map", () => {
+    const { container } = render(
+      <FogMap entities={[]} bounds={{ x: 0, y: 0, w: 0, h: 0 }} />
+    );
+    expect(container.querySelector("svg")).toBeNull();
+  });
+});

--- a/apps/web/components/fog-map.tsx
+++ b/apps/web/components/fog-map.tsx
@@ -1,0 +1,82 @@
+import type { MapCrop, WorldEntityGeo } from "@openflipbook/config";
+
+// The map you EARNED: the session's world map with fog over everything the
+// explorer hasn't reached. Pure server-renderable SVG — each known entity
+// burns a soft hole in the fog around its footprint; the frontier (the
+// bounds margin and the gaps between places) stays clouded. No interaction,
+// no client JS: this is the artifact half of the atlas, not a control.
+
+interface FogMapProps {
+  entities: WorldEntityGeo[];
+  bounds: MapCrop;
+  className?: string;
+}
+
+export default function FogMap({ entities, bounds, className }: FogMapProps) {
+  if (entities.length === 0) return null;
+  // Pad the viewBox so unexplored margin is VISIBLE around the known world —
+  // fog with nothing beyond it reads as a border, not a frontier.
+  const pad = Math.max(bounds.w, bounds.h, 1) * 0.18;
+  const vb = {
+    x: bounds.x - pad,
+    y: bounds.y - pad,
+    w: bounds.w + pad * 2,
+    h: bounds.h + pad * 2,
+  };
+  return (
+    <svg
+      viewBox={`${vb.x} ${vb.y} ${vb.w} ${vb.h}`}
+      className={className ?? "h-auto w-full"}
+      role="img"
+      aria-label={`Explored world map: ${entities.length} known places, fog beyond`}
+    >
+      <defs>
+        <radialGradient id="fog-hole">
+          <stop offset="0%" stopColor="black" />
+          <stop offset="70%" stopColor="black" stopOpacity="0.85" />
+          <stop offset="100%" stopColor="black" stopOpacity="0" />
+        </radialGradient>
+        <mask id="fog-mask">
+          {/* White = fog stays; each known place burns a soft hole. */}
+          <rect x={vb.x} y={vb.y} width={vb.w} height={vb.h} fill="white" />
+          {entities.map((e) => (
+            <circle
+              key={e.id}
+              cx={e.pos.x}
+              cy={e.pos.y}
+              r={Math.max(e.footprint.w, e.footprint.d) * 1.6}
+              fill="url(#fog-hole)"
+            />
+          ))}
+        </mask>
+      </defs>
+      {/* Parchment ground */}
+      <rect x={vb.x} y={vb.y} width={vb.w} height={vb.h} fill="#efe7d6" />
+      {/* Known places: footprint plates + a dot */}
+      {entities.map((e) => (
+        <g key={e.id}>
+          <rect
+            x={e.pos.x - e.footprint.w / 2}
+            y={e.pos.y - e.footprint.d / 2}
+            width={e.footprint.w}
+            height={e.footprint.d}
+            rx={Math.min(e.footprint.w, e.footprint.d) * 0.2}
+            fill="#b9a77f"
+            opacity={0.55}
+          />
+          <circle cx={e.pos.x} cy={e.pos.y} r={vb.w * 0.006} fill="#4a3f2a" />
+        </g>
+      ))}
+      {/* The fog itself, masked open over the explored places. */}
+      <rect
+        x={vb.x}
+        y={vb.y}
+        width={vb.w}
+        height={vb.h}
+        fill="#2b2416"
+        mask="url(#fog-mask)"
+        opacity={0.62}
+      />
+    </svg>
+  );
+}

--- a/apps/web/lib/travelogue.test.ts
+++ b/apps/web/lib/travelogue.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { buildTravelogue, type TravelogueNode } from "./travelogue";
+
+function n(
+  id: string,
+  parent: string | null,
+  created: string,
+  relation: TravelogueNode["relation"] = parent ? "descend" : null
+): TravelogueNode {
+  return { id, parentId: parent, title: `T-${id}`, createdAt: created, relation };
+}
+
+describe("buildTravelogue", () => {
+  it("retells the graph in creation order with the moves actually made", () => {
+    const entries = buildTravelogue([
+      n("kid", "root", "2026-01-02"),
+      n("root", null, "2026-01-01"),
+      n("peer", "root", "2026-01-03", "expand"),
+      n("up", "kid", "2026-01-04", "ascend"),
+      n("fix", "kid", "2026-01-05", "edit"),
+    ]);
+    expect(entries.map((e) => e.line)).toEqual([
+      "arrived in T-root",
+      "entered T-kid from T-root",
+      "drifted over to T-peer from T-root",
+      "rose out to T-up from T-kid",
+      "reshaped T-fix from T-kid",
+    ]);
+  });
+
+  it("an orphan (parent outside the window) reads as an arrival, not a crash", () => {
+    const [entry] = buildTravelogue([n("lost", "gone", "2026-01-01")]);
+    expect(entry!.line).toBe("arrived in T-lost");
+  });
+});

--- a/apps/web/lib/travelogue.ts
+++ b/apps/web/lib/travelogue.ts
@@ -1,0 +1,46 @@
+// The travelogue: a session's node graph retold as a journey log — the
+// atlas's readable half. Pure and creation-ordered; each entry names the
+// move the explorer actually made (the relation) and where it happened from.
+
+export interface TravelogueNode {
+  id: string;
+  parentId: string | null;
+  title: string;
+  createdAt: string;
+  relation?: "descend" | "expand" | "ascend" | "edit" | null;
+}
+
+export interface TravelogueEntry {
+  nodeId: string;
+  ts: string;
+  /** The sentence fragment after the timestamp, e.g.
+   *  "entered The Tower from The Map". */
+  line: string;
+}
+
+const VERBS: Record<string, string> = {
+  descend: "entered",
+  expand: "drifted over to",
+  ascend: "rose out to",
+  edit: "reshaped",
+};
+
+export function buildTravelogue(nodes: TravelogueNode[]): TravelogueEntry[] {
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+  return [...nodes]
+    .sort((a, b) =>
+      a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : 0
+    )
+    .map((n) => {
+      const parent = n.parentId ? byId.get(n.parentId) : null;
+      if (!parent) {
+        return { nodeId: n.id, ts: n.createdAt, line: `arrived in ${n.title}` };
+      }
+      const verb = VERBS[n.relation ?? "descend"] ?? "entered";
+      return {
+        nodeId: n.id,
+        ts: n.createdAt,
+        line: `${verb} ${n.title} from ${parent.title}`,
+      };
+    });
+}


### PR DESCRIPTION
## What

Item 3 of the five: the atlas becomes an artifact of play, not just a debug tree. A native `<details>` overlay (platform disclosure element, zero JS) sits beside the untouched 888-line tile canvas with two pieces:

- **Travelogue** — the session retold as a journey log in creation order: *"arrived in The Celestial Neon Night Market"*, *"entered The Kiosk from The Market"*, *"drifted over to…"*, *"rose out to…"* — each entry linking to its permalink. Pure builder (`lib/travelogue.ts`), table-tested, orphans read as arrivals.
- **The map you earned** — `FogMap`, pure server-rendered SVG: every known place burns a soft radial hole in the fog; the frontier (18% padded margin + the gaps between places) stays clouded. No interaction by design — it's the artifact, not a control.

$0, no model calls, AtlasView untouched.

## Gates

4 new tests (travelogue table + orphan arrival; fog hole-per-place + padded viewBox + empty-null), web 890 green, tsc, madge clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)