### PR TITLE
feat(world): graduate WORLD_NEST_INSIDE — validated live, default ON

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -201,8 +201,11 @@ FAL_EDIT_TIER=balanced
 # instead of flat same-frame stacking. Absolute geometry is identical either
 # way (the nested form is a pure re-expression), so renders and taps do not
 # change; what changes is the stored world model: interior edits ripple in the
-# container's frame and an enter reuses it. Default off = flat v1.
-# WORLD_NEST_INSIDE=false
+# container's frame and an enter reuses it. GRADUATED to default ON
+# (2026-08-23: live-validated on real planner output including a two-level
+# chain — telescope inside study inside tower — worst absolute drift 2e-5).
+# WORLD_NEST_INSIDE=0 restores flat v1.
+# WORLD_NEST_INSIDE=true
 
 # --- Web (apps/web/.env.local) ---
 # Cloudflare R2 (S3-compatible)

--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -1767,11 +1767,13 @@ async def plan_world_endpoint(req: Request, body: PlanWorldBody) -> JSONResponse
         description_len=len(body.description or ""), answers=len(body.answers))
     try:
         graph = await llm_provider.plan_world_from_description(body.description, body.answers or None)
-        # WORLD_NEST_INSIDE (P4, default off): `inside` children come back as
-        # true sub-frame nests (parent_id + local pos + learned scale) instead
-        # of flat-v1 same-frame stacking. Absolute geometry is identical either
-        # way — the nested form is a pure re-expression.
-        result = solve_layout(graph, nest_inside=env_flag("WORLD_NEST_INSIDE"))
+        # WORLD_NEST_INSIDE (P4, default ON since 2026-08-23 — live-validated
+        # on real planner output incl. a two-level chain, worst drift 2e-5):
+        # `inside` children come back as true sub-frame nests (parent_id +
+        # local pos + learned scale) instead of flat-v1 same-frame stacking.
+        # Absolute geometry is identical either way — the nested form is a
+        # pure re-expression. =0 restores flat v1.
+        result = solve_layout(graph, nest_inside=env_flag("WORLD_NEST_INSIDE", "true"))
     except Exception as exc:
         record_error("plan_world", exc, session_id=body.session_id)
         return _err_json(exc, trace_id)

--- a/apps/modal-backend/tests/conftest.py
+++ b/apps/modal-backend/tests/conftest.py
@@ -50,6 +50,7 @@ _SCRUB = (
     # World Mode (tap enters a place; graduated default ON — scrub so a host
     # kill-switch can't flip the routing tests).
     "WORLD_MODE",
+    "WORLD_NEST_INSIDE",
     "FAL_CONTINUE_MODEL",
     # Enter-via-edit (default ON — scrub so a host kill-switch can't silently
     # flip the routing tests) + the edit-tier knobs it can interact with.


### PR DESCRIPTION
## What

Item 4 of the five. The P4 sub-frame nesting shipped default-off in #225 pending real-generation validation. That validation ran today against the **real planner** (one Gemini call, ~$0.01):

- A lighthouse-station description → 7 entities, 4 `inside` relations, **including a two-level chain** (telescope *inside* study *inside* tower).
- The nested solve reproduced the flat solve's absolute geometry to a **worst drift of 2e-5** across every axis — positions, footprints, and the chain units composing correctly (0.060 / 0.080).
- `check_geo_entities` clean on the nested output.

The pure-re-expression construction holds on live planner output, not just the synthetic goldens — so the endpoint default flips to ON. `WORLD_NEST_INSIDE=0` restores flat v1. The flag joins the conftest scrub list; the bench's `solve_layout(graph)` call keeps its explicit flat default, so recon cells are untouched.

## Gates

Backend suite green, ruff clean, mypy 50 files; the nested goldens + two-level chain + invariant tests from #225 continue to pin both arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)