### PR TITLE
feat(bench): recon_pos_recovered gate — watch what prod now relies on

### DIFF
--- a/apps/modal-backend/tests/eval_baselines.json
+++ b/apps/modal-backend/tests/eval_baselines.json
@@ -1,117 +1,124 @@
 {
-  "_comment": "Committed known-good eval baselines + regression bands. test_eval_baselines.py validates this file FREE every commit; a paid runner calls tests._baseline.compare(name, fresh_metric, n) so a silent eval regression fails loud (REGRESSION below the band, IMPROVED above, LOW_N when undersampled). Re-baseline only via a reviewed diff to this file. Bands are wide because the VLM judge is a ranker (~0.6 Spearman), not a calibrated meter \u2014 gate on drop-vs-baseline, not absolute scores.",
-  "baselines": {
-    "layout_fidelity": {
-      "metric": "mean_lift",
-      "baseline": 0.33,
-      "regression_band": 0.15,
-      "n_min": 2,
-      "source": "docs/research/07 + make eval-layout (with-clause vs without)"
-    },
-    "style_medium_lock": {
-      "metric": "mean_lift",
-      "baseline": 8.5,
-      "regression_band": 2.0,
-      "n_min": 1,
-      "source": "SESSION_AUDIT.md \u00a75 + make eval-style"
-    },
-    "enter_same_place": {
-      "metric": "mean_lift",
-      "baseline": 2.33,
-      "regression_band": 2.0,
-      "n_min": 2,
-      "source": "make eval-enter-drift first run 2026-06-10: fresh 6.67 -> edit 9.0 same-place (medium 9.33); arms: nano-banana-2/edit 9.33, gpt-image-2/edit 8.67, kontext 3.33 (rejected for enter). 3-run history: +2.33, -1.0 (one noisy castle sample; goldens byte-identical), +2.33 \u2014 the band catches single bad samples by design"
-    },
-    "view_conformance": {
-      "metric": "intended_conformance_mean",
-      "baseline": 6.0,
-      "regression_band": 2.5,
-      "n_min": 2,
-      "source": "make eval-view 2026-06-10 (calibrated judge, single-shot bench mode): oblique 10.0, isometric 9.0 (the policy's auto registers); top_down/eye_level 2.5-6 single-shot (nano's aerial attractor). PRODUCTION (steep router + VIEW_LOOP, make eval-view-loop, same date): 9.75 mean \u2014 top_down 10.0, oblique 10.0, isometric 9.0, eye_level 10.0; view_trustworthy TRUE; same_place 9.0-10 every arm; 3/4 steep arms accepted at attempt 1, the 4th self-corrected at attempt 2. This baseline tracks the DEFAULT (single-shot) bench so the loop's lift stays measurable."
-    },
-    "edit_region": {
-      "metric": "alignment_mean",
-      "baseline": 10.0,
-      "regression_band": 2.0,
-      "n_min": 2,
-      "source": "make eval-edit-region first run 2026-06-10 (flux fill, single-shot, production fill register): alignment 10.0 + medium 10.0 on both cases, outside-change 0.0000 per case (the compositor's promise, gated per-case not by mean). Tracks the production arm only; extra A/B arms via EDIT_REGION_BENCH_MODELS report but never gate. Band 2.0 absorbs single judge-noise samples."
-    },
-    "recon_fidelity": {
-      "metric": "composite_mean",
-      "baseline": 0.69,
-      "regression_band": 0.12,
-      "n_min": 4,
-      "source": "make eval-recon 2026-06-12 (3 verified corpus maps x graph/direct, nano-banana, recon_base.v1; judge ~0.6 Spearman so the band is wide)"
-    },
-    "recon_pos_raw": {
-      "metric": "pos_raw_mean",
-      "baseline": 0.45,
-      "regression_band": 0.15,
-      "n_min": 4,
-      "source": "make eval-recon 2026-07-04 (12 cells, v1+v2 arms; the LAYOUT_REGISTER_PIN A/B: v1 mean 0.308 vs v2 0.604 — the strict-grid sentence doubles raw register fidelity, every drifting cell fixed). Pre-pin history: 0.242 over the 2026-06-24 v1 cells, fitted scale clamped at 0.5 on 4/5"
-    },
-    "recon_closeup_fidelity": {
-      "metric": "composite_mean",
-      "baseline": 0.86,
-      "regression_band": 0.12,
-      "n_min": 4,
-      "source": "make eval-recon-closeup 2026-06-24 (3 verified Met closeups x graph/direct, nano-banana, recon_closeup_base.v1; object-parts feature_articulation judge — objects reconstruct higher than maps)"
-    },
-    "recon_interior_fidelity": {
-      "metric": "composite_mean",
-      "baseline": 0.80,
-      "regression_band": 0.15,
-      "n_min": 4,
-      "source": "make eval-recon-interior 2026-06-24 (3 verified interiors x graph/direct, nano-banana, recon_interior_base.v1; prose-decoupled so geo weighted low, image judges carry it — wider band as interior positions are approximate)"
-    },
-    "grounding": {
-      "metric": "grounding_mean",
-      "baseline": 0.55,
-      "regression_band": 0.15,
-      "n_min": 2,
-      "source": "make eval-grounding first baseline 2026-06-13 (2 layout scenes, detector+diff)"
-    },
-    "height_order": {
-      "metric": "height_order_mean",
-      "baseline": 0.82,
-      "regression_band": 0.15,
-      "n_min": 3,
-      "source": "re-baselined 2026-07-04 over the HEIGHT-BEARING cells of the 12-cell v1+v2 run (mean 0.821, n=8) after the honesty fix: maps with no built heights (mars, astronomical) no longer score 0.0 on a metric they can't have — the key is absent, like an absent judge. One genuine 0 (treasure/direct/v1) stays in"
-    },
-    "continuity": {
-      "metric": "hop2_step_in_mean",
-      "baseline": 7.0,
-      "regression_band": 2.0,
-      "n_min": 3,
-      "source": "chain_bench over ladder-proof hops — step-in on closeup→enter"
-    },
-    "ux_task_success": {
-      "metric": "success_rate",
-      "baseline": 0.6,
-      "regression_band": 0.2,
-      "n_min": 3,
-      "source": "ux-bench blind agent tasks — fraction completing scripted success criteria"
-    },
-    "lab_layout": {
-      "metric": "composite_mean",
-      "baseline": 0.87,
-      "regression_band": 0.15,
-      "n_min": 4,
-      "source": "scenario_lab layout sweep first live run 2026-06-13 (4 scenes x fresh/fresh_layout, nano-banana-pro; composite = layout_fidelity). Per-cell: market fresh 0.42 -> fresh_layout 0.98, lighthouse 0.67 -> 0.97 (the layout clause's lift); mean across all 8 = 0.866. Band wide — VLM ranker, and fresh arms score low by design."
-    },
-    "lab_pov": {
-      "metric": "composite_mean",
-      "baseline": 0.81,
-      "regression_band": 0.2,
-      "n_min": 2,
-      "source": "scenario_lab pov sweep first live run 2026-06-13 (loft eye_level + harbor top_down, nano-banana-pro; composite = 0.5*layout_fidelity + 0.5*view_conformance). loft eye_level 1.0, harbor top_down 0.62 (fresh render reads oblique not plan -> view_conformance 0.3). view_conformance backfilled onto the layout-cached images."
-    },
-    "lab_style": {
-      "metric": "composite_mean",
-      "baseline": 9.0,
-      "regression_band": 2.0,
-      "n_min": 2,
-      "source": "scenario_lab style sweep first live run 2026-06-13 (engraving + blueprint x edit_without_lock/edit_with_lock, nano-banana-pro/edit; composite = style_pair 0-10). All 4 cells 10.0 — nano-banana-pro/edit preserves the engraving/blueprint medium with AND without the lock clause (no lift here, unlike the watercolor case in continuity_bench). blueprint is now review.status=draft so a verified-only sweep runs engraving alone (also 10.0; baseline holds). NOTE: style_pair judges MEDIUM only, not whether the requested edit landed."
-    }
+ "_comment": "Committed known-good eval baselines + regression bands. test_eval_baselines.py validates this file FREE every commit; a paid runner calls tests._baseline.compare(name, fresh_metric, n) so a silent eval regression fails loud (REGRESSION below the band, IMPROVED above, LOW_N when undersampled). Re-baseline only via a reviewed diff to this file. Bands are wide because the VLM judge is a ranker (~0.6 Spearman), not a calibrated meter \u2014 gate on drop-vs-baseline, not absolute scores.",
+ "baselines": {
+  "layout_fidelity": {
+   "metric": "mean_lift",
+   "baseline": 0.33,
+   "regression_band": 0.15,
+   "n_min": 2,
+   "source": "docs/research/07 + make eval-layout (with-clause vs without)"
+  },
+  "style_medium_lock": {
+   "metric": "mean_lift",
+   "baseline": 8.5,
+   "regression_band": 2.0,
+   "n_min": 1,
+   "source": "SESSION_AUDIT.md \u00a75 + make eval-style"
+  },
+  "enter_same_place": {
+   "metric": "mean_lift",
+   "baseline": 2.33,
+   "regression_band": 2.0,
+   "n_min": 2,
+   "source": "make eval-enter-drift first run 2026-06-10: fresh 6.67 -> edit 9.0 same-place (medium 9.33); arms: nano-banana-2/edit 9.33, gpt-image-2/edit 8.67, kontext 3.33 (rejected for enter). 3-run history: +2.33, -1.0 (one noisy castle sample; goldens byte-identical), +2.33 \u2014 the band catches single bad samples by design"
+  },
+  "view_conformance": {
+   "metric": "intended_conformance_mean",
+   "baseline": 6.0,
+   "regression_band": 2.5,
+   "n_min": 2,
+   "source": "make eval-view 2026-06-10 (calibrated judge, single-shot bench mode): oblique 10.0, isometric 9.0 (the policy's auto registers); top_down/eye_level 2.5-6 single-shot (nano's aerial attractor). PRODUCTION (steep router + VIEW_LOOP, make eval-view-loop, same date): 9.75 mean \u2014 top_down 10.0, oblique 10.0, isometric 9.0, eye_level 10.0; view_trustworthy TRUE; same_place 9.0-10 every arm; 3/4 steep arms accepted at attempt 1, the 4th self-corrected at attempt 2. This baseline tracks the DEFAULT (single-shot) bench so the loop's lift stays measurable."
+  },
+  "edit_region": {
+   "metric": "alignment_mean",
+   "baseline": 10.0,
+   "regression_band": 2.0,
+   "n_min": 2,
+   "source": "make eval-edit-region first run 2026-06-10 (flux fill, single-shot, production fill register): alignment 10.0 + medium 10.0 on both cases, outside-change 0.0000 per case (the compositor's promise, gated per-case not by mean). Tracks the production arm only; extra A/B arms via EDIT_REGION_BENCH_MODELS report but never gate. Band 2.0 absorbs single judge-noise samples."
+  },
+  "recon_fidelity": {
+   "metric": "composite_mean",
+   "baseline": 0.69,
+   "regression_band": 0.12,
+   "n_min": 4,
+   "source": "make eval-recon 2026-06-12 (3 verified corpus maps x graph/direct, nano-banana, recon_base.v1; judge ~0.6 Spearman so the band is wide)"
+  },
+  "recon_pos_raw": {
+   "metric": "pos_raw_mean",
+   "baseline": 0.45,
+   "regression_band": 0.15,
+   "n_min": 4,
+   "source": "make eval-recon 2026-07-04 (12 cells, v1+v2 arms; the LAYOUT_REGISTER_PIN A/B: v1 mean 0.308 vs v2 0.604 \u2014 the strict-grid sentence doubles raw register fidelity, every drifting cell fixed). Pre-pin history: 0.242 over the 2026-06-24 v1 cells, fitted scale clamped at 0.5 on 4/5"
+  },
+  "recon_closeup_fidelity": {
+   "metric": "composite_mean",
+   "baseline": 0.86,
+   "regression_band": 0.12,
+   "n_min": 4,
+   "source": "make eval-recon-closeup 2026-06-24 (3 verified Met closeups x graph/direct, nano-banana, recon_closeup_base.v1; object-parts feature_articulation judge \u2014 objects reconstruct higher than maps)"
+  },
+  "recon_interior_fidelity": {
+   "metric": "composite_mean",
+   "baseline": 0.8,
+   "regression_band": 0.15,
+   "n_min": 4,
+   "source": "make eval-recon-interior 2026-06-24 (3 verified interiors x graph/direct, nano-banana, recon_interior_base.v1; prose-decoupled so geo weighted low, image judges carry it \u2014 wider band as interior positions are approximate)"
+  },
+  "grounding": {
+   "metric": "grounding_mean",
+   "baseline": 0.55,
+   "regression_band": 0.15,
+   "n_min": 2,
+   "source": "make eval-grounding first baseline 2026-06-13 (2 layout scenes, detector+diff)"
+  },
+  "height_order": {
+   "metric": "height_order_mean",
+   "baseline": 0.82,
+   "regression_band": 0.15,
+   "n_min": 3,
+   "source": "re-baselined 2026-07-04 over the HEIGHT-BEARING cells of the 12-cell v1+v2 run (mean 0.821, n=8) after the honesty fix: maps with no built heights (mars, astronomical) no longer score 0.0 on a metric they can't have \u2014 the key is absent, like an absent judge. One genuine 0 (treasure/direct/v1) stays in"
+  },
+  "continuity": {
+   "metric": "hop2_step_in_mean",
+   "baseline": 7.0,
+   "regression_band": 2.0,
+   "n_min": 3,
+   "source": "chain_bench over ladder-proof hops \u2014 step-in on closeup\u2192enter"
+  },
+  "ux_task_success": {
+   "metric": "success_rate",
+   "baseline": 0.6,
+   "regression_band": 0.2,
+   "n_min": 3,
+   "source": "ux-bench blind agent tasks \u2014 fraction completing scripted success criteria"
+  },
+  "lab_layout": {
+   "metric": "composite_mean",
+   "baseline": 0.87,
+   "regression_band": 0.15,
+   "n_min": 4,
+   "source": "scenario_lab layout sweep first live run 2026-06-13 (4 scenes x fresh/fresh_layout, nano-banana-pro; composite = layout_fidelity). Per-cell: market fresh 0.42 -> fresh_layout 0.98, lighthouse 0.67 -> 0.97 (the layout clause's lift); mean across all 8 = 0.866. Band wide \u2014 VLM ranker, and fresh arms score low by design."
+  },
+  "lab_pov": {
+   "metric": "composite_mean",
+   "baseline": 0.81,
+   "regression_band": 0.2,
+   "n_min": 2,
+   "source": "scenario_lab pov sweep first live run 2026-06-13 (loft eye_level + harbor top_down, nano-banana-pro; composite = 0.5*layout_fidelity + 0.5*view_conformance). loft eye_level 1.0, harbor top_down 0.62 (fresh render reads oblique not plan -> view_conformance 0.3). view_conformance backfilled onto the layout-cached images."
+  },
+  "lab_style": {
+   "metric": "composite_mean",
+   "baseline": 9.0,
+   "regression_band": 2.0,
+   "n_min": 2,
+   "source": "scenario_lab style sweep first live run 2026-06-13 (engraving + blueprint x edit_without_lock/edit_with_lock, nano-banana-pro/edit; composite = style_pair 0-10). All 4 cells 10.0 \u2014 nano-banana-pro/edit preserves the engraving/blueprint medium with AND without the lock clause (no lift here, unlike the watercolor case in continuity_bench). blueprint is now review.status=draft so a verified-only sweep runs engraving alone (also 10.0; baseline holds). NOTE: style_pair judges MEDIUM only, not whether the requested edit landed."
+  },
+  "recon_pos_recovered": {
+   "metric": "pos_recovered_mean",
+   "baseline": 0.53,
+   "regression_band": 0.15,
+   "n_min": 4,
+   "source": "make eval-recon 2026-08-23, backfilled from cached detections (16 cells, $0): gated recovery ON for 6/16 (mars graph 0.059->0.623, mars direct 0.051->0.669, treasure/yellowstone partial lifts), gate-off cells identical to pos_raw. Watches what prod relies on since the register gate went default-ON (#223): the recoverable-drift class staying recoverable. Additive gate; composite weights untouched."
   }
+ }
 }

--- a/apps/modal-backend/tests/recon_bench/runner.py
+++ b/apps/modal-backend/tests/recon_bench/runner.py
@@ -353,6 +353,59 @@ def recon_fns(sweep: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def backfill_pose_recovery(
+    report: dict[str, Any],
+    scenarios: list[Scenario],
+    load_record: Any,
+) -> bool:
+    """Compute pos_recovered / recovery_gated_on for replayed cells that
+    predate the #200/#201 instrumentation.
+
+    The cache replays scores verbatim, so every cell scored before the pose
+    diagnostics existed lacks them — and a baseline gate reading the key
+    would silently skip (the height_order lesson, inverted: missing NEW keys
+    instead of stale OLD ones). The raw material (detections) IS cached, so
+    the diagnostic recomputes free. Only the two recovery keys are written;
+    every other score stays verbatim. Returns True when anything changed."""
+    by_id = {s.id: s for s in scenarios}
+    dirty = False
+    for c in report.get("cells", []):
+        scores = c.get("scores")
+        if not scores or "pos_recovered" in scores:
+            continue
+        scenario = by_id.get(c.get("scenario_id"))
+        record = load_record(c.get("cell_key")) if c.get("cell_key") else None
+        if scenario is None or record is None:
+            continue
+        detections = (record.get("outputs") or {}).get("detections") or []
+        # Mirror score_fn's frames exactly: expected = the ground-truth
+        # description entities, observed = the cached detections.
+        expected = {
+            _norm(e["label"]): {
+                "pos": (e["pos"]["x"], e["pos"]["y"]),
+                "diag": (e["footprint"]["w"] ** 2 + e["footprint"]["d"] ** 2)
+                ** 0.5,
+            }
+            for e in scenario.payload["entities"]
+        }
+        observed = {
+            _norm(d["label"]): {
+                "pos": (d["x_pct"] * FRAME_W, d["y_pct"] * FRAME_H),
+                "diag": (
+                    (d["w_pct"] * FRAME_W) ** 2 + (d["h_pct"] * FRAME_H) ** 2
+                ) ** 0.5,
+            }
+            for d in detections
+        }
+        geo = geo_scores(expected, observed)
+        if "pos_recovered" not in geo:
+            continue
+        scores["pos_recovered"] = round(float(geo["pos_recovered"]), 3)
+        scores["recovery_gated_on"] = 1.0 if geo.get("recovery_gated_on") else 0.0
+        dirty = True
+    return dirty
+
+
 def scrub_stale_heights(
     report: dict[str, Any],
     scenarios: list[Scenario],
@@ -422,9 +475,13 @@ def main() -> int:
         report_path=report_path,
         **recon_fns(sweep),
     )
-    if scrub_stale_heights(
+    from tests.matrix_bench._cache import CellCache
+
+    dirty = scrub_stale_heights(
         report, scenarios, dict(sweep.get("composite_weights", {}))
-    ):
+    )
+    dirty = backfill_pose_recovery(report, scenarios, CellCache().load) or dirty
+    if dirty:
         report_path.write_text(json.dumps(report, indent=1))
     if live:
         cells = [c for c in report["cells"] if "scores" in c]
@@ -447,6 +504,10 @@ def main() -> int:
                     # gate — pos_raw's 0.05 composite weight made a 10x drift
                     # nearly invisible in the fidelity number.
                     baselines.append(("recon_pos_raw", "pos_raw"))
+                    # What prod now relies on (the gated register, default ON
+                    # since #223): is the recoverable-drift class still
+                    # recoverable? Additive gate — composite untouched.
+                    baselines.append(("recon_pos_recovered", "pos_recovered"))
                 for name, key in baselines:
                     vals = [c["scores"][key] for c in cells if key in c.get("scores", {})]
                     if vals:

--- a/apps/modal-backend/tests/recon_bench/test_recon.py
+++ b/apps/modal-backend/tests/recon_bench/test_recon.py
@@ -375,3 +375,44 @@ def test_scrub_stale_heights_drops_cached_keys_and_recomputes_composite() -> Non
     assert manor["scores"] == {"pos_raw": 0.6, "height_order": 1.0, "composite": 0.8}
     # second pass: nothing left to scrub
     assert scrub_stale_heights(report, scenarios, weights) is False
+
+
+def test_backfill_pose_recovery_fills_only_missing_keys() -> None:
+    """Replayed cells that predate the #200 instrumentation get the recovery
+    diagnostic recomputed from their cached detections; instrumented cells
+    and cache misses stay untouched."""
+    from tests.matrix_bench.runner import Scenario
+    from tests.recon_bench.runner import backfill_pose_recovery
+
+    payload = {
+        "entities": [
+            {"label": "Tower", "pos": {"x": 10.0, "y": 10.0}, "footprint": {"w": 4, "d": 4}},
+            {"label": "Harbor", "pos": {"x": 40.0, "y": 20.0}, "footprint": {"w": 4, "d": 4}},
+            {"label": "Wood", "pos": {"x": 70.0, "y": 45.0}, "footprint": {"w": 4, "d": 4}},
+        ]
+    }
+    scenarios = [Scenario(id="isle", desc_sha="x", payload=payload)]
+    # Detections at exactly half scale — a coherent deep compression the
+    # gated recovery should rescue (and the gate should arm).
+    dets = [
+        {"label": e["label"], "x_pct": e["pos"]["x"] * 0.5 / 100,
+         "y_pct": e["pos"]["y"] * 0.5 / 60, "w_pct": 0.02, "h_pct": 0.02}
+        for e in payload["entities"]
+    ]
+    records = {"k1": {"outputs": {"detections": dets}}}
+    report = {
+        "cells": [
+            {"cell_key": "k1", "scenario_id": "isle", "scores": {"pos_raw": 0.1}},
+            {"cell_key": "k2", "scenario_id": "isle", "scores": {"pos_raw": 0.9, "pos_recovered": 0.9}},
+            {"cell_key": "k3", "scenario_id": "isle", "scores": {"pos_raw": 0.5}},  # cache miss
+        ]
+    }
+    assert backfill_pose_recovery(report, scenarios, records.get) is True
+    filled = report["cells"][0]["scores"]
+    assert "pos_recovered" in filled and "recovery_gated_on" in filled
+    assert filled["pos_raw"] == 0.1  # existing scores stay verbatim
+    # Already-instrumented cell untouched; cache miss left alone.
+    assert report["cells"][1]["scores"] == {"pos_raw": 0.9, "pos_recovered": 0.9}
+    assert "pos_recovered" not in report["cells"][2]["scores"]
+    # Second pass: nothing left to fill.
+    assert backfill_pose_recovery(report, scenarios, records.get) is False


### PR DESCRIPTION
## The §4 acceptance decision, taken the least-invasive way

Delegated call ("whatever makes the most sense"): **no composite weights move, no existing baseline shifts.** Instead a NEW dedicated gate on `pos_recovered` joins `recon_pos_raw`, watching the thing prod actually relies on since the register gate went default-ON (#223): *is the recoverable-drift class still recoverable?*

## The $0 trick

The cached cells predate the #200/#201 instrumentation and replay scores verbatim — a gate reading the missing key would silently skip (the height_order lesson **inverted**: missing NEW keys instead of stale OLD ones). Same fix shape: `backfill_pose_recovery` recomputes the diagnostic from the **cached detections** at report time. The backfill reproduces #201's receipts exactly — 6/16 gate-on, mars 0.051→0.669 / 0.059→0.623, gate-off cells verbatim — for $0.00.

## Receipts

- Baseline minted from the backfilled run: **0.53 ± 0.15** (n_min 4); live gate reads `PASS: recon_pos_recovered: 0.531`.
- All four recon gates green on a cached ($0) run.
- Unit test pins the backfill contract: only missing keys fill, existing scores stay verbatim, cache misses untouched, second pass no-op.
- Backend suite green, ruff, mypy 50 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)