### PR TITLE
feat(models): promote seedream v5 for enters and balanced maps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,7 +60,10 @@ OPENROUTER_ENABLE_WEB_SEARCH=true
 # Per-request override available in body.image_tier from the frontend.
 FAL_IMAGE_TIER=balanced
 # Per-tier slug overrides (optional — leave UNSET to track the code defaults:
-# fast=fal-ai/nano-banana, balanced=fal-ai/nano-banana-pro,
+# fast=fal-ai/nano-banana, balanced=bytedance/seedream/v5/pro/text-to-image
+# (2026-08-23 A/B: composite tie with nano-banana-pro, 43% faster, $0.0675,
+# native map lettering; FAL_IMAGE_MODEL_BALANCED=fal-ai/nano-banana-pro
+# restores the old pin),
 # pro=openrouter:sourceful/riverflow-v2.5-pro — the bakeoff quality winner,
 # docs/research/07; it rides OPENROUTER_API_KEY and takes 1-3 MINUTES/image,
 # so the fast draft race doubles as the keep-alive while it renders).
@@ -84,7 +87,9 @@ FAL_EDIT_TIER=balanced
 # Ref-honouring alternates for the enter model: fal-ai/flux-pro/kontext (strict),
 # openai/gpt-image-2/edit, fal-ai/nano-banana-2/edit.
 # ENTER_EDIT_REF=true
-# FAL_ENTER_MODEL=fal-ai/nano-banana-pro/edit
+# FAL_ENTER_MODEL=fal-ai/bytedance/seedream/v5/lite/edit
+# (the 2026-08-23 default — tied nano-banana-pro/edit on the judged enter
+# bench at $0.035 vs $0.15; set fal-ai/nano-banana-pro/edit to restore)
 # Another angle on re-enter: when the client sends scene_view.enter_index > 0
 # (a revisit), rotate the scene camera one 90° step so the place is seen from a
 # new side instead of redrawn the same. Default OFF; the first enter is always

--- a/apps/modal-backend/.env.example
+++ b/apps/modal-backend/.env.example
@@ -53,7 +53,7 @@ OPENROUTER_ENABLE_WEB_SEARCH=true
 # Per-request override available in body.image_tier from the frontend.
 FAL_IMAGE_TIER=balanced
 # Per-tier slug overrides (optional — leave UNSET to track the code defaults:
-# fast=fal-ai/nano-banana, balanced=fal-ai/nano-banana-pro,
+# fast=fal-ai/nano-banana, balanced=bytedance/seedream/v5/pro/text-to-image,
 # pro=openrouter:sourceful/riverflow-v2.5-pro). Pinning the base nano-banana
 # model here overrides balanced tier and garbles map labels — don't.
 # FAL_IMAGE_MODEL_FAST=fal-ai/nano-banana

--- a/apps/modal-backend/providers/image.py
+++ b/apps/modal-backend/providers/image.py
@@ -57,7 +57,12 @@ class _EmptyFalResult(RuntimeError):
 
 TIER_MODELS: dict[str, str] = {
     "fast":     "fal-ai/nano-banana",
-    "balanced": "fal-ai/nano-banana-pro",
+    # Balanced = seedream v5 pro t2i (2026-08-23 A/B, tests/matrix_bench/sweeps/
+    # map-seedream-ab.json): composite 0.740 vs nano-banana-pro's 0.737 on the
+    # four verified corpus maps, 43% faster (114s vs 199s/cell), $0.0675 vs
+    # $0.15, and the map LETTERING is native-crisp (the oldest failure axis).
+    # FAL_IMAGE_MODEL_BALANCED=fal-ai/nano-banana-pro restores the old pin.
+    "balanced": "bytedance/seedream/v5/pro/text-to-image",
     # Pro = the bakeoff QUALITY winner (docs/research/07: "richest detail", held
     # the medium best — the dense, intricate maps). It's slow (~150-290s) and
     # occasionally returns an empty response, but it is NOW reliable: a single

--- a/apps/modal-backend/providers/model_router.py
+++ b/apps/modal-backend/providers/model_router.py
@@ -22,10 +22,13 @@ MODEL_SLOTS: dict[str, tuple[str | None, str | None]] = {
     "fresh": (None, None),  # tier-based via image.py (FAL_IMAGE_MODEL_*)
     "zoom_continue": ("fal-ai/flux-pro/kontext", "FAL_CONTINUE_MODEL"),
     # Entering a place: an instruction-driven EDIT of the tapped region crop —
-    # nano edit slugs honour image_urls (verified via scripts/verify-fal-models.py)
+    # these edit slugs honour image_urls (verified via scripts/verify-fal-models.py)
     # and tolerate a view change, where Kontext strict-zooms. The enter eval
-    # (tests/continuity_bench/enter_runner.py) A/Bs the candidates.
-    "enter_scene": ("fal-ai/nano-banana-pro/edit", "FAL_ENTER_MODEL"),
+    # (tests/continuity_bench/enter_runner.py) A/Bs the candidates. 2026-08-23
+    # A/B: seedream v5 lite/edit TIED nano-banana-pro/edit on same-place
+    # (8.67 vs 8.67, per-case 8/9/9 both) at $0.035 vs $0.15 — promoted;
+    # FAL_ENTER_MODEL=fal-ai/nano-banana-pro/edit restores the old pin.
+    "enter_scene": ("fal-ai/bytedance/seedream/v5/lite/edit", "FAL_ENTER_MODEL"),
     # World-mode map-zoom REDRAW (SUBMAP_REDRAW): same loose-refs pedigree as
     # enter_scene — honours the region crop, re-synthesizes detail, keeps map
     # lettering legible. Kontext here would defeat the purpose (pixel-freeze).
@@ -131,7 +134,9 @@ def select_outward_op(from_tier: str, to_tier: str) -> str:
 # speed; FAL_ENTER_MODEL_STEEP restores gpt in one env if rings resurface.
 STEEP_ENTER_PROJECTIONS = frozenset({"eye_level", "top_down"})
 STEEP_ENTER_DEFAULT = "fal-ai/nano-banana-pro/edit"
-ENTER_RETRY_DEFAULT = "fal-ai/nano-banana-2/edit"
+# With the cheap seedream first attempt, retry-swap now means ESCALATE: a
+# failed judged attempt re-rolls on the proven (4x pricier) nano pin.
+ENTER_RETRY_DEFAULT = "fal-ai/nano-banana-pro/edit"
 
 
 def select_enter_model(projection: str | None) -> str | None:
@@ -147,8 +152,8 @@ def select_enter_retry_model(first_model: str | None) -> str | None:
     """Retry-only model for VIEW_LOOP enters.
 
     Disabled keeps the original model on every attempt. Enabled swaps only
-    attempts after index 0 to a cheaper/faster fal edit slug from the existing
-    nano family; the first attempt remains the production router pick."""
+    attempts after index 0 to the retry slug (default: the stronger nano
+    pin); the first attempt remains the production router pick."""
     if not env_flag("ENTER_RETRY_MODEL_SWAP", "false"):
         return first_model
     return os.environ.get("FAL_ENTER_RETRY_MODEL") or ENTER_RETRY_DEFAULT
@@ -177,6 +182,11 @@ CAPABILITIES: tuple[tuple[str, ModelCaps], ...] = (
     # (verified no-op; PR #109 removed the inert ref-upload) -> supports_refs=False.
     # Real reference conditioning lives only on the /edit + continue endpoints.
     ("fal-ai/nano-banana-pro", ModelCaps("nano-banana-pro", True, False, True, 0.15, 25)),
+    # seedream v5 (fal, 2026-07-08): lite/edit tied nano-banana-pro/edit on the
+    # judged enter bench at 1/4 the price (up to 10 refs, 9MP out); pro t2i tied
+    # the map composite (0.740 vs 0.737) 43% faster with native map lettering.
+    ("fal-ai/bytedance/seedream/v5/lite/edit", ModelCaps("seedream 5 lite edit", True, True, True, 0.035, 15)),
+    ("bytedance/seedream/v5/pro/text-to-image", ModelCaps("seedream 5 pro", False, False, True, 0.0675, 20)),
     ("fal-ai/nano-banana-2", ModelCaps("nano-banana-2", True, False, True, 0.08, 18)),
     ("fal-ai/nano-banana", ModelCaps("nano-banana", True, False, False, 0.039, 10)),
     ("fal-ai/flux-pro/kontext", ModelCaps("flux kontext", True, False, True, 0.04, 20)),
@@ -211,6 +221,7 @@ def registry() -> list[dict[str, object]]:
 # continue ops carry semantics (refs, masks) a substitute may not honour.
 FALLBACK_CHAINS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("openrouter:sourceful/riverflow-v2.5-pro", ("fal-ai/nano-banana-pro", "fal-ai/nano-banana")),
+    ("bytedance/seedream/v5/pro", ("fal-ai/nano-banana-pro", "fal-ai/nano-banana")),
     ("fal-ai/nano-banana-pro", ("fal-ai/nano-banana-2", "fal-ai/nano-banana")),
     ("fal-ai/nano-banana-2", ("fal-ai/nano-banana",)),
     ("fal-ai/nano-banana", ("fal-ai/nano-banana-2",)),

--- a/apps/modal-backend/providers/spend.py
+++ b/apps/modal-backend/providers/spend.py
@@ -24,6 +24,10 @@ _IMAGE_PRICES: tuple[tuple[str, float], ...] = (
     ("fal-ai/nano-banana-pro", 0.15),
     ("fal-ai/nano-banana-2", 0.08),
     ("fal-ai/nano-banana", 0.039),
+    # seedream v5 lives under BOTH owner prefixes on fal (fal-ai/... is an alias).
+    ("fal-ai/bytedance/seedream/v5/lite", 0.035),
+    ("bytedance/seedream/v5/lite", 0.035),
+    ("bytedance/seedream/v5/pro", 0.0675),
     ("fal-ai/flux-pro/v1/fill", 0.10),
     ("fal-ai/flux-pro/kontext", 0.04),
     ("fal-ai/bria", 0.04),

--- a/apps/modal-backend/scripts/verify-fal-models.py
+++ b/apps/modal-backend/scripts/verify-fal-models.py
@@ -40,6 +40,8 @@ SLUGS = [
     "fal-ai/nano-banana-2",
     "fal-ai/nano-banana-2/edit",
     "fal-ai/bytedance/seedream/v4/text-to-image",
+    "fal-ai/bytedance/seedream/v5/lite/edit",
+    "bytedance/seedream/v5/pro/text-to-image",
     "fal-ai/flux-pro/kontext",
     "fal-ai/flux-pro/v1/fill",
     "fal-ai/bria/expand",

--- a/apps/modal-backend/tests/matrix_bench/sweeps/map-seedream-ab.json
+++ b/apps/modal-backend/tests/matrix_bench/sweeps/map-seedream-ab.json
@@ -1,0 +1,39 @@
+{
+  "name": "map-seedream-ab",
+  "_comment": "Labelled-map A/B: seedream v5 pro text-to-image vs the shipped nano-banana-pro default, on the four verified map-tier corpus maps. The nano-banana-pro cells replay from the map-model-ab cache ($0); only the seedream cells bill. Same judges + weights as map-model-ab so composites compare across sweeps.",
+  "scenarios": [
+    "corpus:fantasy-treasure-island",
+    "corpus:forest-yellowstone-1904",
+    "corpus:scifi-mars-schiaparelli-1888",
+    "corpus:village-medieval-manor"
+  ],
+  "arms": [
+    "graph"
+  ],
+  "models": [
+    "fal-ai/nano-banana-pro",
+    "bytedance/seedream/v5/pro/text-to-image"
+  ],
+  "variants": [
+    "recon_base.v1"
+  ],
+  "params": {
+    "aspect_ratio": "16:9"
+  },
+  "judges": [
+    "style_pair",
+    "map_plausibility",
+    "prompt_alignment"
+  ],
+  "composite_weights": {
+    "presence": 0.2,
+    "pos_aligned": 0.2,
+    "pos_raw": 0.05,
+    "size": 0.1,
+    "height_order": 0.1,
+    "style_pair": 0.15,
+    "map_plausibility": 0.1,
+    "prompt_alignment": 0.1
+  },
+  "budget_usd": 2.5
+}

--- a/apps/modal-backend/tests/test_generate_view.py
+++ b/apps/modal-backend/tests/test_generate_view.py
@@ -404,6 +404,9 @@ async def test_enter_retry_model_swap_only_changes_retries(
     # the production router pick; only retry attempts switch to the configured
     # fal edit slug.
     monkeypatch.setenv("ENTER_RETRY_MODEL_SWAP", "true")
+    # A custom retry slug keeps attempt 0 and the retry distinguishable (the
+    # escalation DEFAULT now equals the steep pick — see ENTER_RETRY_DEFAULT).
+    monkeypatch.setenv("FAL_ENTER_RETRY_MODEL", "fal-ai/custom-retry/edit")
     _mock_plan(monkeypatch)
     edit = _mock_edit(monkeypatch)
     _mock_fresh(monkeypatch)
@@ -415,7 +418,7 @@ async def test_enter_retry_model_swap_only_changes_retries(
 
     assert [c.kwargs["model_override"] for c in edit.await_args_list] == [
         "fal-ai/nano-banana-pro/edit",
-        "fal-ai/nano-banana-2/edit",
+        "fal-ai/custom-retry/edit",
     ]
 
 

--- a/apps/modal-backend/tests/test_model_router.py
+++ b/apps/modal-backend/tests/test_model_router.py
@@ -119,9 +119,13 @@ def test_select_enter_retry_model_is_opt_in(
     )
 
     monkeypatch.setenv("ENTER_RETRY_MODEL_SWAP", "true")
+    # Retry-swap ESCALATES from the cheap seedream first attempt to the
+    # proven nano pin (2026-08-23 promotion).
     assert (
-        model_router.select_enter_retry_model("fal-ai/nano-banana-pro/edit")
-        == "fal-ai/nano-banana-2/edit"
+        model_router.select_enter_retry_model(
+            "fal-ai/bytedance/seedream/v5/lite/edit"
+        )
+        == "fal-ai/nano-banana-pro/edit"
     )
 
     monkeypatch.setenv("FAL_ENTER_RETRY_MODEL", "fal-ai/custom/edit")

--- a/apps/modal-backend/tests/test_provider_fallback.py
+++ b/apps/modal-backend/tests/test_provider_fallback.py
@@ -13,6 +13,9 @@ def _fresh(monkeypatch: pytest.MonkeyPatch):
     breaker.reset_for_tests()
     monkeypatch.delenv("PROVIDER_FALLBACK", raising=False)
     monkeypatch.setenv("FAL_KEY", "test")  # dispatch is mocked; key gate is upstream
+    # These tests exercise the failover MECHANISM on the nano chain; pin the
+    # tier so the seedream balanced default doesn't change what they prove.
+    monkeypatch.setenv("FAL_IMAGE_MODEL_BALANCED", "fal-ai/nano-banana-pro")
     yield
     breaker.reset_for_tests()
 

--- a/docs/COSTS.md
+++ b/docs/COSTS.md
@@ -19,9 +19,9 @@ front:
 | Slot / tier | Default slug | Price | Budget alternative | Budget price |
 |---|---|---|---|---|
 | fresh `fast` | `fal-ai/nano-banana` | **$0.039**/img | — (already the floor) | — |
-| fresh `balanced` (default) | `fal-ai/nano-banana-pro` | **$0.15**/img (1K-2K; 4K $0.30; +$0.015 web search) | `fal-ai/nano-banana-2` | $0.08/img |
+| fresh `balanced` (default) | `bytedance/seedream/v5/pro/text-to-image` | **$0.0675**/img (to 1536²; 2048² $0.135) | `fal-ai/nano-banana-pro` (old pin) | $0.15/img |
 | fresh `pro` | `openrouter:sourceful/riverflow-v2.5-pro` | **~$0.24**/img (+152s) | `nano-banana-pro` | $0.15 |
-| enter (`enter_scene`) | `fal-ai/nano-banana-pro/edit` | **$0.15**/img | `nano-banana-2/edit` | $0.08 |
+| enter (`enter_scene`) | `fal-ai/bytedance/seedream/v5/lite/edit` | **$0.035**/img (10 refs, 9MP) | `fal-ai/nano-banana-pro/edit` (old pin, retry default) | $0.15 |
 | inpaint (`inpaint`) | `fal-ai/flux-pro/v1/fill` | **$0.05/MP** → ~$0.10/edit at 16:9 | none — it's the only true compositor (the mask smoke proved gpt/nano don't honor masks); lower the resolution to drop the MP | scales with px |
 | zoom (`zoom_continue`) | `fal-ai/flux-pro/kontext` | **$0.04**/img | — | — |
 | outpaint (`outpaint`) | `fal-ai/bria/expand` | **~$0.04**/img | — | — |
@@ -53,17 +53,22 @@ already <2% of the total, so the win is marginal. The judges' real cost is
 
 | Operation | fal calls | OpenRouter calls | ≈ cost | the calls |
 |---|---|---|---|---|
-| **Fresh map** | 1 × $0.15 | 4 | **$0.16** | plan + extract + detect + view |
-| **Enter (1 attempt)** | 1 × $0.15 | 9 | **$0.16** | click + plan + **4 judges** + 3 extraction |
-| **Enter (2 attempts)** | 2 × $0.15 | 13 | **$0.32** | + 1 edit + **4 more judges** |
+| **Fresh map** | 1 × $0.0675 | 4 | **$0.08** | plan + extract + detect + view |
+| **Enter (1 attempt)** | 1 × $0.035 | 9 | **$0.05** | click + plan + **4 judges** + 3 extraction |
+| **Enter (2 attempts)** | 2 × $0.035 | 13 | **$0.09** | + 1 edit + **4 more judges** |
 | **Mask edit (1 attempt)** | 1 × ~$0.10 | 5 | **$0.11** | polish + **2 judges** + 2 extraction |
 | **Mask edit (2 attempts)** | 2 × ~$0.10 | 7 | **$0.21** | + 1 inpaint + **2 more judges** |
 | **Judged whole-image edit** | 1 × $0.15 | 5 | **$0.16** | polish + 2 judges + 2 extraction |
 | **Extraction (after EVERY final)** | 0 | 1–3 | **~$0.006** | extract (+ detect + view if geo) |
 
 **A full demo run** (map + 1 mask edit + 2 enters, ~1.5 attempts each) ≈
-**$0.6–1.0**. The Ankh-Morpork re-shoot's ~10 takes was ~$6–9 of fal, almost
-all of it nano-banana-pro/edit on the enters.
+**$0.3–0.5**. Before the 2026-08-23 seedream promotion (map $0.15,
+enter $0.15/attempt on the nano pins) the same run was $0.6–1.0 — the
+Ankh-Morpork re-shoot's ~10 takes was ~$6–9 of fal, almost all of it
+nano-banana-pro/edit on the enters. Bench receipts for the swap:
+tests/continuity_bench (enter same-place tie 8.67/8.67) and
+tests/matrix_bench/sweeps/map-seedream-ab.json (composite 0.740 vs 0.737,
+43% faster).
 
 ### A budget profile (env, no code change)
 
@@ -107,7 +112,8 @@ the upload, parallelize the judges, and a one-shot fast mode. The budget
 profile above is the cheap-and-fast lever today; the upload cache + concurrent
 judges are the code wins worth doing next.
 
-Sources: fal model pages (nano-banana-pro $0.15, nano-banana-2 $0.08,
+Sources: fal model pages (seedream v5 lite/edit $0.035, seedream v5 pro
+$0.0675, nano-banana-pro $0.15, nano-banana-2 $0.08,
 flux-pro/v1/fill $0.05/MP, flux-pro/kontext $0.04, nano-banana $0.039),
 OpenRouter (gemini-3-flash-preview $0.50/$3, gemini-3.1-flash-lite $0.25/$1.50),
 repo `prompt_tokens` logs + Makefile eval cost anchors (eval-view ~$2.5,


### PR DESCRIPTION
## What

Two bench-backed model-default swaps. Both have one-env rollbacks.

1. **Enter tier**: `enter_scene` now defaults to
   `fal-ai/bytedance/seedream/v5/lite/edit`. The judged enter bench
   scored it EQUAL to the nano-banana-pro/edit pin (same-place mean
   8.67 vs 8.67, per-case 8/9/9 on both arms) at **$0.035 vs $0.15**
   per image. Rollback: `FAL_ENTER_MODEL=fal-ai/nano-banana-pro/edit`.
   The steep slot (eye_level/top_down) keeps nano — its 07-14 evidence
   is separate and this bench did not re-test it.
2. **Balanced fresh tier**: `bytedance/seedream/v5/pro/text-to-image`
   replaces nano-banana-pro. New committed sweep
   `map-seedream-ab.json` (4 verified corpus maps, control cells from
   cache): composite **0.740 vs 0.737** (tie), **43% faster** (114s vs
   199s/cell), **$0.0675 vs $0.15**, and the map lettering is
   native-crisp on eyeball review (village + mars receipts in the
   matrix cache). Rollback:
   `FAL_IMAGE_MODEL_BALANCED=fal-ai/nano-banana-pro`.

Supporting changes: seedream prices in `spend.py`; capability rows and
a pro-t2i fallback chain in `model_router.py`; `ENTER_RETRY_DEFAULT`
now escalates to nano-banana-pro/edit (the retry swap used to
economize; with a cheap first attempt it should escalate);
verify-fal-models slugs; COSTS.md refresh; env examples.

## Gotcha

The pro t2i slug exists ONLY under the `bytedance/` owner prefix —
the `fal-ai/` alias 404s (schema probe). The lite edit slug has both.

## Bench spend

~$1.40 (map sweep incl. one 404 dry run) + ~$0.70 (enter bench) ≈ $2.10.

## Tests

Backend suite green locally. Fallback tests pin the balanced tier to
nano so they keep proving the chain mechanics, not the default slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)