### PR TITLE
feat(llm): default the planner/VLM stack to gemini-3.7-flash

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,8 +29,8 @@ OPENROUTER_API_KEY=
 # Planner + click-resolution VLM. Defaults to Gemini 3 Flash (multimodal,
 # 1M ctx, cheap). Override with google/gemini-3-pro-preview for frontier
 # reasoning, or any other OpenRouter slug.
-OPENROUTER_VLM_MODEL=google/gemini-3-flash-preview
-OPENROUTER_TEXT_MODEL=google/gemini-3-flash-preview
+OPENROUTER_VLM_MODEL=google/gemini-3.7-flash
+OPENROUTER_TEXT_MODEL=google/gemini-3.7-flash
 # Web search: Gemini routes through OpenRouter's `web` plugin automatically;
 # other models append ":online" (Exa-backed). Disable to skip both.
 OPENROUTER_ENABLE_WEB_SEARCH=true

--- a/apps/modal-backend/.env.example
+++ b/apps/modal-backend/.env.example
@@ -6,8 +6,8 @@ OPENROUTER_API_KEY=
 # Gemini 3 Flash: cheap ($0.50/M in, $3/M out), fast, strong multimodal
 # grounding, and on your own credits — unlike the free Qwen tier that
 # rate-limits (429) under any real use.
-OPENROUTER_VLM_MODEL=google/gemini-3-flash-preview
-OPENROUTER_TEXT_MODEL=google/gemini-3-flash-preview
+OPENROUTER_VLM_MODEL=google/gemini-3.7-flash
+OPENROUTER_TEXT_MODEL=google/gemini-3.7-flash
 OPENROUTER_ENABLE_WEB_SEARCH=true
 # VLM judge transport bounds. Judges still see the same images, but as compact
 # JPEG data URLs; larger inline payloads can make OpenRouter/Gemini reset reads.

--- a/apps/modal-backend/providers/detector.py
+++ b/apps/modal-backend/providers/detector.py
@@ -29,7 +29,7 @@ class Detection(TypedDict):
 def _detector_model() -> str:
     return os.environ.get(
         "WORLD_BENCH_JUDGE_MODEL",
-        os.environ.get("OPENROUTER_VLM_MODEL", "google/gemini-3-flash-preview"),
+        os.environ.get("OPENROUTER_VLM_MODEL", "google/gemini-3.7-flash"),
     )
 
 

--- a/apps/modal-backend/providers/judge.py
+++ b/apps/modal-backend/providers/judge.py
@@ -37,7 +37,7 @@ class JudgeResult:
 def _judge_model() -> str:
     return os.environ.get(
         "CONTINUITY_BENCH_JUDGE_MODEL",
-        os.environ.get("OPENROUTER_VLM_MODEL", "google/gemini-3-flash-preview"),
+        os.environ.get("OPENROUTER_VLM_MODEL", "google/gemini-3.7-flash"),
     )
 
 

--- a/apps/modal-backend/providers/llm/client.py
+++ b/apps/modal-backend/providers/llm/client.py
@@ -31,8 +31,8 @@ from _env import env_flag
 from providers import llm as _llm
 
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
-DEFAULT_VLM_MODEL = "google/gemini-3-flash-preview"
-DEFAULT_TEXT_MODEL = "google/gemini-3-flash-preview"
+DEFAULT_VLM_MODEL = "google/gemini-3.7-flash"
+DEFAULT_TEXT_MODEL = "google/gemini-3.7-flash"
 
 # Built-in base URLs per provider. This is DATA, not a behavior registry —
 # every target speaks the OpenAI wire protocol, so the only thing that varies

--- a/apps/modal-backend/providers/segmenter.py
+++ b/apps/modal-backend/providers/segmenter.py
@@ -47,7 +47,7 @@ _SAM3_CONCURRENCY = 4  # in-flight SAM3 calls — bound provider rate-limit pres
 def _segmenter_model() -> str:
     return os.environ.get(
         "WORLD_BENCH_JUDGE_MODEL",
-        os.environ.get("OPENROUTER_VLM_MODEL", "google/gemini-3-flash-preview"),
+        os.environ.get("OPENROUTER_VLM_MODEL", "google/gemini-3.7-flash"),
     )
 
 

--- a/apps/modal-backend/providers/view_estimator.py
+++ b/apps/modal-backend/providers/view_estimator.py
@@ -58,7 +58,7 @@ DEFAULT_VIEW: ViewEstimate = {
 def _model() -> str:
     return os.environ.get(
         "WORLD_BENCH_JUDGE_MODEL",
-        os.environ.get("OPENROUTER_VLM_MODEL", "google/gemini-3-flash-preview"),
+        os.environ.get("OPENROUTER_VLM_MODEL", "google/gemini-3.7-flash"),
     )
 
 

--- a/apps/modal-backend/tests/test_view_estimator.py
+++ b/apps/modal-backend/tests/test_view_estimator.py
@@ -174,7 +174,7 @@ def test_model_env_override(monkeypatch) -> None:
 
     monkeypatch.delenv("WORLD_BENCH_JUDGE_MODEL", raising=False)
     monkeypatch.delenv("OPENROUTER_VLM_MODEL", raising=False)
-    assert _model() == "google/gemini-3-flash-preview"
+    assert _model() == "google/gemini-3.7-flash"
     monkeypatch.setenv("OPENROUTER_VLM_MODEL", "qwen/qwen-vl")
     assert _model() == "qwen/qwen-vl"
     monkeypatch.setenv("WORLD_BENCH_JUDGE_MODEL", "judge/x")

--- a/docs/COSTS.md
+++ b/docs/COSTS.md
@@ -34,7 +34,7 @@ alternative" column is just a documented value for those.
 
 | Role | Default | Price | Budget alternative | Budget price |
 |---|---|---|---|---|
-| planner / instruction polish | `google/gemini-3-flash-preview` | **$0.50/M in · $3/M out** | `google/gemini-3.1-flash-lite-preview` | **$0.25 / $1.50** (½) |
+| planner / instruction polish | `google/gemini-3.7-flash` | **$0.375/M in · $1.875/M out** (25-37% under the old 3-flash-preview pin) | `google/gemini-3.1-flash-lite-preview` | **$0.25 / $1.50** |
 | VLM (click resolve, extract, detect, view) | same | same | flash-lite | ½ |
 | judges (conformance / same-place / detail / medium / alignment) | same (`CONTINUITY_BENCH_JUDGE_MODEL` override) | same | flash-lite | ½ |
 


### PR DESCRIPTION
## What

Every code-level LLM fallback moves from `google/gemini-3-flash-preview`
to `google/gemini-3.7-flash` (released 2026-08-13): planner, VLM,
detector, segmenter, view estimator, judge, and both env examples.
Pricing $0.375/M in · $1.875/M out — 25-37% under the old pin.

`OPENROUTER_TEXT_MODEL` / `OPENROUTER_VLM_MODEL` overrides are
untouched. **A .env that pins the old model keeps the old model** —
update your own .env by hand if you want the new default.

## Validation (~$0.10)

- Detector smoke: 3/10 detected, 0 parse warnings — identical to the
  old-pin control run.
- Planner canary (live nest check): 7 entities, 4 nested inside,
  solver-compatible, drift 2e-5.
- Judge A/B on the enter-bench images: 3.7-flash reproduced the old
  judge's ranking on all 6 (case × arm) pairs with the same score
  scale and coherent rationales.

## Deliberately NOT flipped

The bench runners' `WORLD_BENCH_JUDGE_MODEL` setdefault stays on
gemini-3-flash-preview so every committed baseline stays comparable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)