### PR TITLE
feat(video): descend clip — the tap hard-cut becomes a camera move

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -1164,6 +1164,10 @@ class AnimateBody(BaseModel):
     duration: int = 5
     video_tier: str | None = None
     trace_id: str | None = None
+    # Descent transition: when set, image_data_url is the PARENT map (first
+    # frame) and this is the entered page (last frame) — the clip is the
+    # camera move between them, not an ambient animation.
+    end_image_data_url: str | None = None
 
 
 @fastapi_app.post("/animate")
@@ -1190,25 +1194,37 @@ async def animate(req: Request, body: AnimateBody) -> JSONResponse:
         prompt_len=len(body.prompt or ""),
         image_kb=img_size_kb,
         duration=body.duration,
+        descent=bool(body.end_image_data_url),
     )
-    motion_prompt = await llm_provider.rewrite_motion_prompt(
-        page_title=body.prompt or "",
-        image_data_url=body.image_data_url,
-        duration_seconds=body.duration,
-    )
-    if motion_prompt and motion_prompt != body.prompt:
-        log(
-            "info",
-            "animate.prompt_rewritten",
-            orig_len=len(body.prompt or ""),
-            new_len=len(motion_prompt),
+    if body.end_image_data_url:
+        # A descent clip carries a fixed camera brief — the ambient motion
+        # rewriter would fight the first→last-frame move.
+        motion_prompt = (
+            "Smooth cinematic camera descent: the view dives from the "
+            f"overhead map down into {body.prompt or 'the place below'}, "
+            "ending exactly on the final frame. Keep the art style constant "
+            "throughout; no new objects."
         )
+    else:
+        motion_prompt = await llm_provider.rewrite_motion_prompt(
+            page_title=body.prompt or "",
+            image_data_url=body.image_data_url,
+            duration_seconds=body.duration,
+        )
+        if motion_prompt and motion_prompt != body.prompt:
+            log(
+                "info",
+                "animate.prompt_rewritten",
+                orig_len=len(body.prompt or ""),
+                new_len=len(motion_prompt),
+            )
     try:
         clip = await video_provider.animate_image(
             image_data_url=body.image_data_url,
             prompt=motion_prompt or body.prompt,
             duration=body.duration,
             tier=body.video_tier,
+            end_image_data_url=body.end_image_data_url,
         )
     except Exception as exc:
         record_error("animate", exc, image_kb=img_size_kb)

--- a/apps/modal-backend/providers/video.py
+++ b/apps/modal-backend/providers/video.py
@@ -24,6 +24,14 @@ from .image import _fal_subscribe
 
 DEFAULT_ANIMATE_MODEL = "fal-ai/ltx-video/image-to-video"
 PRO_ANIMATE_MODEL = "fal-ai/ltx-2/image-to-video"
+# First+last-frame DESCENT clips (the tap hard-cut becomes a camera move):
+# start = the parent map, end = the entered page. 2026-08-23 probe: this slug
+# and minimax/h3/image-to-video both honour `end_image_url` and land square
+# on the arrival frame in-style; ltx-2.3 fast is the cheaper pick (~$0.04/s).
+# Descent has its OWN slot (FAL_DESCENT_MODEL) — the tier table and the
+# FAL_ANIMATE_MODEL override stay ambient-only, because a model without
+# end_image_url support would silently drop the arrival frame.
+DESCENT_ANIMATE_MODEL = "fal-ai/ltx-2.3/image-to-video/fast"
 
 # Video tier → fal model. Mirrors the image-tier pattern in providers/image.py.
 # `balanced` defaults to Wan 2.2 i2v which has the best motion quality among
@@ -74,6 +82,7 @@ async def animate_image(
     prompt: str,
     duration: int = 5,
     tier: str | None = None,
+    end_image_data_url: str | None = None,
 ) -> AnimatedClip:
     from obs import span
 
@@ -92,8 +101,21 @@ async def animate_image(
         raise RuntimeError("FAL_KEY is not set")
 
     image_url = await to_fal_url(image_data_url)
+    if end_image_data_url:
+        # Descent transition: dedicated slot, no tier/override routing (see
+        # DESCENT_ANIMATE_MODEL). No duration/resolution knobs — the probe ran
+        # clean on schema defaults, and ltx-2.3's enums differ from ltx-2's.
+        model = os.environ.get("FAL_DESCENT_MODEL") or DESCENT_ANIMATE_MODEL
+        arguments = {
+            "image_url": image_url,
+            "end_image_url": await to_fal_url(end_image_data_url),
+            "prompt": prompt,
+        }
+        async with span("video.animate", model=model, duration=duration):
+            result = await _fal_subscribe(model, arguments)
+        return _clip_from_result(result, model, duration)
     model = _animate_model(tier)
-    arguments: dict = {
+    arguments = {
         "image_url": image_url,
         "prompt": prompt,
     }
@@ -111,7 +133,10 @@ async def animate_image(
 
     async with span("video.animate", model=model, duration=duration):
         result = await _fal_subscribe(model, arguments)
+    return _clip_from_result(result, model, duration)
 
+
+def _clip_from_result(result: dict, model: str, duration: int) -> AnimatedClip:
     video = result.get("video")
     if not isinstance(video, dict):
         raise RuntimeError(f"fal animate returned no video payload: {result!r:.300}")

--- a/apps/modal-backend/providers/video.py
+++ b/apps/modal-backend/providers/video.py
@@ -106,7 +106,7 @@ async def animate_image(
         # DESCENT_ANIMATE_MODEL). No duration/resolution knobs — the probe ran
         # clean on schema defaults, and ltx-2.3's enums differ from ltx-2's.
         model = os.environ.get("FAL_DESCENT_MODEL") or DESCENT_ANIMATE_MODEL
-        arguments = {
+        arguments: dict = {
             "image_url": image_url,
             "end_image_url": await to_fal_url(end_image_data_url),
             "prompt": prompt,

--- a/apps/modal-backend/tests/test_video.py
+++ b/apps/modal-backend/tests/test_video.py
@@ -117,6 +117,33 @@ async def test_wan_clamps_duration_into_num_frames(
     assert "duration" not in arguments
 
 
+async def test_descent_uses_the_dedicated_slot_and_sends_both_frames(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # An end frame routes to DESCENT_ANIMATE_MODEL (NOT the tier table, NOT
+    # FAL_ANIMATE_MODEL — an ambient override may not honour end_image_url)
+    # and sends exactly first+last frame + prompt, no knobs.
+    monkeypatch.setenv("FAL_ANIMATE_MODEL", "fal-ai/ambient-override")
+    clip, subscribe = await _animate(
+        monkeypatch, tier="pro", end_image_data_url="data:image/png;base64,BBBB"
+    )
+    model, arguments = subscribe.await_args.args
+    assert model == video.DESCENT_ANIMATE_MODEL
+    assert arguments == {
+        "image_url": "https://fal.media/in.png",
+        "end_image_url": "https://fal.media/in.png",
+        "prompt": "gentle pan",
+    }
+    assert clip.model == video.DESCENT_ANIMATE_MODEL
+
+    monkeypatch.setenv("FAL_DESCENT_MODEL", "fal-ai/custom-descent")
+    _, subscribe = await _animate(
+        monkeypatch, end_image_data_url="data:image/png;base64,BBBB"
+    )
+    model, _ = subscribe.await_args.args
+    assert model == "fal-ai/custom-descent"
+
+
 async def test_no_video_payload_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     with pytest.raises(RuntimeError, match="no video payload"):
         await _animate(monkeypatch, result={"images": []})

--- a/apps/web/app/api/animate/route.ts
+++ b/apps/web/app/api/animate/route.ts
@@ -22,14 +22,22 @@ export async function POST(req: Request) {
   // Same inline-before-forward treatment the resolve-click and
   // generate-page proxies already have; animate was the one that skipped it.
   try {
-    const parsed = JSON.parse(body) as { image_data_url?: string };
-    if (parsed.image_data_url && !parsed.image_data_url.startsWith("data:")) {
-      const inlined = await inlineStoredImage(parsed.image_data_url);
-      if (inlined) {
-        parsed.image_data_url = inlined;
-        body = JSON.stringify(parsed);
+    const parsed = JSON.parse(body) as {
+      image_data_url?: string;
+      end_image_data_url?: string;
+    };
+    let changed = false;
+    for (const key of ["image_data_url", "end_image_data_url"] as const) {
+      const url = parsed[key];
+      if (url && !url.startsWith("data:")) {
+        const inlined = await inlineStoredImage(url);
+        if (inlined) {
+          parsed[key] = inlined;
+          changed = true;
+        }
       }
     }
+    if (changed) body = JSON.stringify(parsed);
   } catch {
     /* non-JSON body — forward as-is, the backend rejects it */
   }

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -1007,6 +1007,11 @@ export default function PlayPage() {
               query: body.query,
               title: evt.page_title,
               imageDataUrl: evt.image_data_url,
+              // The LIVE page must carry its parent like the history copy
+              // does — the zoom heuristic, the OUTWARD root gate, and the
+              // descent clip all read page.parentId (it was silently absent
+              // here, so entered pages looked like roots until a reload).
+              parentId: body.current_node_id || null,
               sources: evtSources,
               // Mirror the persist body: an edit is a REVISION. Tap/fresh
               // stay absent = descend.
@@ -3290,6 +3295,58 @@ export default function PlayPage() {
     setStreamStatus("playing");
   }, [fallbackVideoUrl]);
 
+  const requestClip = useCallback(async (body: Record<string, unknown>) => {
+    animateAbortRef.current?.abort();
+    const ac = new AbortController();
+    animateAbortRef.current = ac;
+    const timeoutId = window.setTimeout(() => ac.abort(), 180_000);
+    setStreamStatus("connecting");
+    try {
+      const res = await fetch("/api/animate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: ac.signal,
+      });
+      const data = (await res.json()) as {
+        video_url?: string;
+        error?: string;
+      };
+      if (!res.ok || !data.video_url) {
+        throw new Error(data.error ?? `HTTP ${res.status}`);
+      }
+      setFallbackVideoUrl(data.video_url);
+      setShowVideo(true);
+      setStreamStatus("playing");
+    } catch (err) {
+      if ((err as Error).name === "AbortError") {
+        setStreamStatus("error");
+        setError("Animate timed out after 3 minutes. Try again or stop.");
+      } else {
+        setStreamStatus("error");
+        setError((err as Error).message);
+      }
+    } finally {
+      window.clearTimeout(timeoutId);
+      if (animateAbortRef.current === ac) animateAbortRef.current = null;
+    }
+  }, []);
+
+  // Descent clip: first frame = the parent map, last frame = this page — the
+  // tap hard-cut replayed as a real camera move (fal ltx-2.3 first+last mode).
+  const descentParentImage = page?.parentId
+    ? history.items.find((p) => p.nodeId === page.parentId)?.imageDataUrl
+    : undefined;
+  const descendClip = useCallback(() => {
+    if (!page?.imageDataUrl || !descentParentImage) return;
+    void requestClip({
+      image_data_url: descentParentImage,
+      end_image_data_url: page.imageDataUrl,
+      prompt: page.title,
+      video_tier: videoTier,
+    });
+  }, [page, descentParentImage, requestClip, videoTier]);
+
   const connectStream = useCallback(async () => {
     if (!page?.imageDataUrl) return;
     const wsUrl = getWSUrl();
@@ -3317,45 +3374,12 @@ export default function PlayPage() {
     // Cheap fallback via fal. fal LTX video gen typically takes 30-90s; cap
     // the wait at 3 minutes so a stuck request surfaces rather than hanging
     // the UI silently.
-    animateAbortRef.current?.abort();
-    const ac = new AbortController();
-    animateAbortRef.current = ac;
-    const timeoutId = window.setTimeout(() => ac.abort(), 180_000);
-    setStreamStatus("connecting");
-    try {
-      const res = await fetch("/api/animate", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          image_data_url: page.imageDataUrl,
-          prompt: page.title,
-          video_tier: videoTier,
-        }),
-        signal: ac.signal,
-      });
-      const data = (await res.json()) as {
-        video_url?: string;
-        error?: string;
-      };
-      if (!res.ok || !data.video_url) {
-        throw new Error(data.error ?? `HTTP ${res.status}`);
-      }
-      setFallbackVideoUrl(data.video_url);
-      setShowVideo(true);
-      setStreamStatus("playing");
-    } catch (err) {
-      if ((err as Error).name === "AbortError") {
-        setStreamStatus("error");
-        setError("Animate timed out after 3 minutes. Try again or stop.");
-      } else {
-        setStreamStatus("error");
-        setError((err as Error).message);
-      }
-    } finally {
-      window.clearTimeout(timeoutId);
-      if (animateAbortRef.current === ac) animateAbortRef.current = null;
-    }
-  }, [page, videoTier]);
+    await requestClip({
+      image_data_url: page.imageDataUrl,
+      prompt: page.title,
+      video_tier: videoTier,
+    });
+  }, [page, videoTier, requestClip]);
 
   return (
     <main
@@ -4094,6 +4118,18 @@ export default function PlayPage() {
                       ? t.generatingClip
                       : `… ${streamStatus}`}
               </button>
+              {streamStatus === "off" &&
+                descentParentImage &&
+                page?.imageDataUrl && (
+                  <button
+                    type="button"
+                    onClick={descendClip}
+                    className="rounded-full bg-black/60 px-3 py-1 text-xs text-white"
+                    title="Replay your arrival as a camera move: the parent map dives down into this page (first→last-frame clip via fal ltx-2.3)"
+                  >
+                    ⤵ {t.descendClip}
+                  </button>
+                )}
             </div>
             {editMode ? (
               <EditForm

--- a/apps/web/lib/i18n.ts
+++ b/apps/web/lib/i18n.ts
@@ -14,6 +14,7 @@ export type LocaleStrings = {
   go: string;
   generating: string;
   animateClip: string;
+  descendClip: string;
   animateStream: string;
   animateStop: string;
   generatingClip: string;
@@ -35,6 +36,7 @@ const en: LocaleStrings = {
   go: "Go",
   generating: "…",
   animateClip: "Animate (5s clip)",
+  descendClip: "Descend (5s clip)",
   animateStream: "Animate (stream)",
   animateStop: "Stop",
   generatingClip: "Generating clip…",
@@ -57,6 +59,7 @@ const STRINGS: Record<string, Partial<LocaleStrings>> = {
     upload: "⬆ Subir",
     go: "Ir",
     animateClip: "Animar (5s)",
+    descendClip: "Descender (5s)",
     animateStream: "Animar (stream)",
     animateStop: "Detener",
     generatingClip: "Generando clip…",
@@ -76,6 +79,7 @@ const STRINGS: Record<string, Partial<LocaleStrings>> = {
     upload: "⬆ Importer",
     go: "Aller",
     animateClip: "Animer (5s)",
+    descendClip: "Descendre (5s)",
     animateStream: "Animer (stream)",
     animateStop: "Arrêter",
     generatingClip: "Génération du clip…",
@@ -95,6 +99,7 @@ const STRINGS: Record<string, Partial<LocaleStrings>> = {
     upload: "⬆ Hochladen",
     go: "Los",
     animateClip: "Animieren (5s)",
+    descendClip: "Abstieg (5s)",
     animateStream: "Animieren (Stream)",
     animateStop: "Stopp",
     generatingClip: "Erzeuge Clip…",
@@ -114,6 +119,7 @@ const STRINGS: Record<string, Partial<LocaleStrings>> = {
     upload: "⬆ Yükle",
     go: "Git",
     animateClip: "Animasyon (5s)",
+    descendClip: "İniş (5s)",
     animateStream: "Animasyon (akış)",
     animateStop: "Durdur",
     generatingClip: "Klip oluşturuluyor…",
@@ -133,6 +139,7 @@ const STRINGS: Record<string, Partial<LocaleStrings>> = {
     upload: "⬆ アップロード",
     go: "実行",
     animateClip: "アニメ化 (5s)",
+    descendClip: "降下 (5s)",
     animateStream: "アニメ化 (ストリーム)",
     animateStop: "停止",
     generatingClip: "クリップ生成中…",
@@ -152,6 +159,7 @@ const STRINGS: Record<string, Partial<LocaleStrings>> = {
     upload: "⬆ 上传",
     go: "开始",
     animateClip: "动画 (5秒)",
+    descendClip: "俯冲 (5秒)",
     animateStream: "动画 (流式)",
     animateStop: "停止",
     generatingClip: "正在生成片段…",
@@ -171,6 +179,7 @@ const STRINGS: Record<string, Partial<LocaleStrings>> = {
     upload: "⬆ رفع",
     go: "ابدأ",
     animateClip: "تحريك (٥ث)",
+    descendClip: "هبوط (٥ث)",
     animateStream: "تحريك (بث)",
     animateStop: "إيقاف",
     generatingClip: "جارٍ توليد المقطع…",


### PR DESCRIPTION
## What

Every enter today is a hard cut: overhead map, then suddenly the place.
This PR adds a **⤵ Descend (5s clip)** button on any entered page: it
sends the PARENT map as the first frame and the current page as the
last frame, and fal ltx-2.3 renders the camera dive between them.

- `animate_image` gains `end_image_data_url`. An end frame routes to a
  dedicated model slot (`FAL_DESCENT_MODEL`, default
  `fal-ai/ltx-2.3/image-to-video/fast`, ~$0.04/s) — deliberately NOT
  the tier table or `FAL_ANIMATE_MODEL`, because an ambient override
  may not honour `end_image_url` and would silently drop the arrival.
- Descent skips the ambient motion-prompt rewriter for a fixed camera
  brief (the rewriter would fight the first→last move).
- The web proxy inlines BOTH frames before forwarding (the #232
  inline-before-forward rule) — hydrated pages carry R2 URLs fal
  rejects.
- The button reuses the whole existing clip plumbing (same player,
  same replay, same abort/timeout) via an extracted `requestClip`.
  Additive: the Animate button is untouched.

## Root-cause fix the button surfaced

The LIVE `setPage` after a generation dropped `parentId` — only the
history copy carried it. So on live (un-reloaded) sessions, entered
pages read as ROOTS: the right-click zoom heuristic took the map
branch and the OUTWARD ascend button appeared where the design says
roots-only (both code comments state entered pages must carry their
parent). The live page now mirrors the persist body's parentId.

## Verified live

Full path on the docker stack with real providers: fresh seedream map
→ tap-enter (seedream lite, judged retry worked: attempt 0 medium=0
rejected, attempt 1 accepted) → ⤵ Descend → `animate.request
descent:true` → ltx-2.3 → 6.1s clip playing in-product, mid-frame a
genuine intermediate aerial over the bell tower, last frame square on
the arrival render. Receipts:
`~/Desktop/ofb-visuals-2026-07-02/descent-clips-2026-08-23/`.

Cost: one descent clip ≈ $0.24. Nothing auto-generates — the button
is the only trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)