### PR TITLE
fix(outward): anchor the ascend container on the map's own identity

### DIFF
--- a/apps/modal-backend/generate.py
+++ b/apps/modal-backend/generate.py
@@ -341,6 +341,10 @@ class GenerateBody(BaseModel):
     # (multi-hop drift, chain_runner.py: even the anchored path loses delicate
     # media by ~hop 2). Default 0 + flag off → byte-identical to old clients.
     outward_depth: int = 0
+    # OUTWARD identity anchor for uploaded / generic roots. The web client builds
+    # this from extracted Codex/geometric labels so an upload titled "Uploaded
+    # image" still zooms out from the established map, not the placeholder.
+    outward_context: str | None = None
     # The transition tap's origin (tap descent ladder): the SOURCE frame was a
     # closeup of the entered place — the establishing shot already happened,
     # so the enter descends to ground level instead of another aerial.

--- a/apps/modal-backend/providers/generate_modes/ascend.py
+++ b/apps/modal-backend/providers/generate_modes/ascend.py
@@ -30,6 +30,97 @@ if TYPE_CHECKING:
     from providers.prompt_library.types import ViewSpec as ViewSpecDict
 
 
+_GENERIC_SOURCE_LABELS = {
+    "",
+    "uploaded image",
+    "uploaded map",
+    "image upload",
+    "untitled image",
+    "untitled map",
+}
+
+
+def _clean_text(value: str | None, limit: int = 800) -> str:
+    text = " ".join((value or "").split())
+    if limit > 3 and len(text) > limit:
+        return text[: limit - 3].rstrip() + "..."
+    return text
+
+
+def _is_generic_source_label(value: str | None) -> bool:
+    return _clean_text(value).lower() in _GENERIC_SOURCE_LABELS
+
+
+def _outward_world_context(body: GenerateBody) -> list[dict[str, Any]]:
+    """Planner-ready source entities, capped before they hit prompt text."""
+
+    out: list[dict[str, Any]] = []
+    for entity in body.world_context[:8]:
+        data = entity.model_dump(exclude_none=True)
+        name = _clean_text(str(data.get("name", "")), 120)
+        if not name or _is_generic_source_label(name):
+            continue
+        data["name"] = name
+        out.append(data)
+    return out
+
+
+def _source_entity_names(world_context: list[dict[str, Any]]) -> list[str]:
+    def _kind(entry: dict[str, Any]) -> str:
+        return _clean_text(str(entry.get("kind", ""))).lower()
+
+    names: list[str] = []
+    for entry in [
+        *(e for e in world_context if _kind(e) == "place"),
+        *(e for e in world_context if _kind(e) != "place"),
+    ]:
+        name = _clean_text(str(entry.get("name", "")), 120)
+        if not name or _is_generic_source_label(name):
+            continue
+        key = name.lower()
+        if any(existing.lower() == key for existing in names):
+            continue
+        names.append(name)
+        if len(names) >= 8:
+            break
+    return names
+
+
+def _outward_source_label(
+    body: GenerateBody, world_context: list[dict[str, Any]], source_identity: str
+) -> str:
+    label = _clean_text(body.query, 160)
+    if label and not _is_generic_source_label(label):
+        return label
+    names = _source_entity_names(world_context)
+    if names:
+        return f"the established source map of {names[0]}"
+    if source_identity:
+        return "this established source map"
+    return "this place"
+
+
+def _outward_identity_clause(
+    body: GenerateBody, world_context: list[dict[str, Any]]
+) -> str:
+    parts: list[str] = []
+    outward_context = _clean_text(body.outward_context, 1000)
+    if outward_context:
+        parts.append(outward_context)
+    names = _source_entity_names(world_context)
+    if names:
+        summary = f"Known source entities: {', '.join(names)}."
+        if summary.lower() not in outward_context.lower():
+            parts.append(summary)
+    if not parts:
+        return ""
+    parts.append(
+        "The wider container MUST contain this exact source at its centre "
+        "and must not rename it as a different world."
+    )
+    return " ".join(parts)
+
+
 async def stream_ascend(
     body: GenerateBody,
     trace_id: str,
@@ -60,6 +151,11 @@ async def stream_ascend(
         return
     pw, ph = _frame_dims(body.aspect_ratio)
     style_lock = (body.session_style_anchor or "").strip() or None
+    outward_world_context = _outward_world_context(body)
+    source_identity = _outward_identity_clause(body, outward_world_context)
+    outward_source_label = _outward_source_label(
+        body, outward_world_context, source_identity
+    )
     # DEFAULT = the fresh `scale_parent` container: a seamless wider view of
     # the SAME world in the SAME medium, the source as a small sub-region
     # (live-verified far more coherent than the outpaint, which leaves the
@@ -117,6 +213,8 @@ async def stream_ascend(
                 f"{to_tier.replace('_', ' ')}, drawn in the SAME style as the "
                 "centre — one continuous view, NOT a photograph, no photorealism"
             )
+            if source_identity:
+                margin += ". SOURCE IDENTITY LOCK: " + source_identity
             if outward_rider:
                 margin += ". " + outward_rider
             if no_lettering:
@@ -127,13 +225,17 @@ async def stream_ascend(
             page_title = f"The surrounding {to_tier.replace('_', ' ')}".title()
             final_prompt = f"outward outpaint: {from_tier} -> {to_tier}"
         else:
+            plan_query = (
+                f"the {to_tier.replace('_', ' ')} that contains "
+                f"{outward_source_label}"
+            )
+            if source_identity:
+                plan_query += ". " + source_identity
             plan = await llm.plan_page(
-                query=(
-                    f"the {to_tier.replace('_', ' ')} that contains "
-                    f"{body.query or 'this place'}"
-                ),
+                query=plan_query,
                 web_search=False,
                 style_anchor=style_lock,
+                world_context=outward_world_context or None,
                 render_mode="scale_parent",
             )
             if env_flag("SCALE_OUTWARD_EDIT_REF", "true") and not outward_refresh:
@@ -150,6 +252,8 @@ async def stream_ascend(
                     f"keeping this exact view as the centre. {medium}; one continuous "
                     "view in that style, NOT a photograph, no photorealism."
                 )
+                if source_identity:
+                    ascend_instr += " SOURCE IDENTITY LOCK: " + source_identity
                 if outward_rider:
                     ascend_instr += " " + outward_rider
                 if no_lettering:
@@ -214,6 +318,8 @@ async def stream_ascend(
                 # Fresh container = a NEW map: state the deliberate
                 # top-down camera (None on astro rungs → legacy bytes).
                 ascend_prompt = plan.prompt
+                if source_identity:
+                    ascend_prompt += "\n\nSOURCE IDENTITY LOCK: " + source_identity
                 if no_lettering:
                     ascend_prompt += f"\n\n{no_lettering}"
                 if _view_grammar_on():

--- a/apps/modal-backend/providers/llm/planner.py
+++ b/apps/modal-backend/providers/llm/planner.py
@@ -290,7 +290,10 @@ async def plan_page(
             schema=PLAN_SCHEMA,
             schema_name="page_plan",
             temperature=0.7,
-            max_tokens=900,
+            # 900 was sized for gemini-3-flash-preview; 3.7-flash pretty-prints
+            # past it (live 2026-08-26: finish_reason=length -> salvage -> the
+            # page title fell back to the raw query). Headroom is ~$0.001/plan.
+            max_tokens=1400,
             extra_body=_web_plugin_extra(text_model, online=web_search) or None,
             span_ctx=ctx,
             response_sink=response_sink,

--- a/apps/modal-backend/tests/test_generate_ascend.py
+++ b/apps/modal-backend/tests/test_generate_ascend.py
@@ -98,6 +98,54 @@ async def test_ascend_container_continues_source_via_edit_by_default(
     outpaint.assert_not_awaited()  # NOT the outpaint
 
 
+async def test_ascend_uploaded_root_uses_extracted_source_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Uploaded roots are titled "Uploaded image" in the graph. OUTWARD must plan
+    # from the map's extracted identity instead of inventing a container for the
+    # placeholder label.
+    _enable(monkeypatch)
+    _mock_fresh(monkeypatch)
+    edit = AsyncMock(
+        return_value=GeneratedImage(b"jpeg", "image/jpeg", "fal-ai/nano-banana-pro", "r")
+    )
+    monkeypatch.setattr(image_edit_mod, "edit_image", edit)
+
+    body = _ascend_body(
+        query="Uploaded image",
+        outward_context=(
+            "Known names on the source map: Ankh-Morpork, The Mended Drum, "
+            "The Shades."
+        ),
+        world_context=[
+            {
+                "id": "e1",
+                "kind": "place",
+                "name": "Ankh-Morpork",
+                "appearance": "walled river city map split by the Ankh",
+            },
+            {
+                "id": "e2",
+                "kind": "place",
+                "name": "The Mended Drum",
+                "appearance": "tavern south of the river near The Shades",
+            },
+        ],
+    )
+    await _collect(_event_stream(body, "t1"))
+
+    plan_kwargs = llm_mod.plan_page.await_args.kwargs
+    assert "Uploaded image" not in plan_kwargs["query"]
+    assert "Ankh-Morpork" in plan_kwargs["query"]
+    assert "The Mended Drum" in plan_kwargs["query"]
+    assert plan_kwargs["world_context"][0]["name"] == "Ankh-Morpork"
+
+    instr = edit.await_args.args[1]
+    assert "SOURCE IDENTITY LOCK" in instr
+    assert "Ankh-Morpork" in instr
+    assert "The Mended Drum" in instr
+
+
 async def test_ascend_edit_ref_kill_switch_reverts_to_fresh(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -113,6 +161,28 @@ async def test_ascend_edit_ref_kill_switch_reverts_to_fresh(
     assert ready["page_title"] == "The Vallen Sea and Coastline"
     gen.assert_awaited_once()  # the fresh scale_parent container
     edit.assert_not_awaited()
+
+
+async def test_ascend_fresh_container_carries_outward_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable(monkeypatch)
+    monkeypatch.setenv("SCALE_OUTWARD_EDIT_REF", "false")
+    gen = _mock_fresh(monkeypatch)
+
+    await _collect(
+        _event_stream(
+            _ascend_body(
+                query="Uploaded image",
+                outward_context="Known names on the source map: Ankh-Morpork.",
+            ),
+            "t1",
+        )
+    )
+
+    prompt = gen.await_args.args[0]
+    assert "SOURCE IDENTITY LOCK" in prompt
+    assert "Ankh-Morpork" in prompt
 
 
 async def test_ascend_refresh_past_hop_cap_drops_the_drifting_ref(
@@ -160,13 +230,20 @@ async def test_ascend_outpaint_under_flag_steers_the_medium(monkeypatch: pytest.
     mock = AsyncMock(return_value=img)
     monkeypatch.setattr(image_edit_mod, "expand_image_zoomout", mock)
 
-    body = _ascend_body(session_style_anchor="hand-drawn engraving, sepia ink, cross-hatching")
+    body = _ascend_body(
+        session_style_anchor="hand-drawn engraving, sepia ink, cross-hatching",
+        query="Uploaded image",
+        outward_context="Known names on the source map: Ankh-Morpork.",
+    )
     events = await _collect(_event_stream(body, "t1"))
     ready = next(e for e in events if e["type"] == "ascend_ready")
     assert ready["image_model"] == "fal-ai/bria/expand"
     mock.assert_awaited_once()
     # The medium MUST reach BRIA, or the painted margin comes back photoreal.
-    assert "engraving" in (mock.await_args.kwargs.get("prompt") or "")
+    prompt = mock.await_args.kwargs.get("prompt") or ""
+    assert "engraving" in prompt
+    assert "SOURCE IDENTITY LOCK" in prompt
+    assert "Ankh-Morpork" in prompt
 
 
 async def test_ascend_kill_switch_refuses(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -133,6 +133,7 @@ import { matchEntityLabel } from "@/lib/entity-label-match";
 import { focusOnMap } from "@/lib/click-route";
 import { sseData } from "@/lib/sse";
 import { selectNeighbors } from "@/lib/scale-neighbors";
+import { buildOutwardContext } from "@/lib/outward-context";
 import { sceneCloseupSpec } from "@/lib/scene-closeup";
 import { childrenOf, projectTopDown, toAbsoluteEntities } from "@/lib/world-geometry";
 import { viewNeutralAppearance } from "@/lib/appearance";
@@ -2057,8 +2058,24 @@ export default function PlayPage() {
       styleAnchor: styleAnchor?.style ?? null,
       suppressMapLabels: worldEnabled && worldDomLabels,
       outwardDepth: outwardDepthRef.current,
+      outwardContext: buildOutwardContext({
+        nodeId: page.nodeId,
+        title: page.title,
+        query: page.query,
+        entities: worldState.entities,
+        geos: geoMap.entities,
+      }),
     });
-  }, [page, sessionId, startAscend, styleAnchor, worldEnabled, worldDomLabels]);
+  }, [
+    page,
+    sessionId,
+    startAscend,
+    styleAnchor,
+    worldEnabled,
+    worldDomLabels,
+    worldState.entities,
+    geoMap.entities,
+  ]);
 
   useKeyboardShortcuts({
     onBack: goBack,

--- a/apps/web/hooks/useAscend.test.tsx
+++ b/apps/web/hooks/useAscend.test.tsx
@@ -137,17 +137,23 @@ describe("useAscend", () => {
     const bare = bodyOf(fn.mock.calls[0]!);
     expect("session_style_anchor" in bare).toBe(false);
     expect("suppress_map_labels" in bare).toBe(false);
+    expect("outward_context" in bare).toBe(false);
 
     act(() =>
       result.current.start(
         "s1",
-        root({ styleAnchor: "woodcut, sepia", suppressMapLabels: true }),
+        root({
+          styleAnchor: "woodcut, sepia",
+          suppressMapLabels: true,
+          outwardContext: "Known names on the source map: Ankh-Morpork.",
+        }),
       ),
     );
     await waitFor(() => expect(onAscended).toHaveBeenCalledTimes(2));
     const armed = bodyOf(fn.mock.calls[2]!);
     expect(armed.session_style_anchor).toBe("woodcut, sepia");
     expect(armed.suppress_map_labels).toBe(true);
+    expect(armed.outward_context).toBe("Known names on the source map: Ankh-Morpork.");
   });
 
   it("surfaces render_unjudged=true through the callback", async () => {

--- a/apps/web/hooks/useAscend.ts
+++ b/apps/web/hooks/useAscend.ts
@@ -30,6 +30,9 @@ export interface AscendRoot {
   // re-anchors past SCALE_OUTWARD_MAX_HOPS so a long zoom-out chain doesn't
   // drift off the original medium.
   outwardDepth?: number;
+  // Semantic identity for generic/uploaded roots. Without this, the backend
+  // only sees "Uploaded image" and may invent a container for a placeholder.
+  outwardContext?: string | null;
 }
 
 export interface Ascended {
@@ -104,6 +107,7 @@ export function useAscend(onAscended: (a: Ascended) => void): {
                 : {}),
               ...(root.suppressMapLabels ? { suppress_map_labels: true } : {}),
               ...(root.outwardDepth ? { outward_depth: root.outwardDepth } : {}),
+              ...(root.outwardContext ? { outward_context: root.outwardContext } : {}),
               trace_id: traceId,
             }),
             signal: ac.signal,

--- a/apps/web/lib/outward-context.test.ts
+++ b/apps/web/lib/outward-context.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { buildOutwardContext } from "./outward-context";
+
+describe("buildOutwardContext", () => {
+  it("uses extracted map names instead of a generic upload title", () => {
+    const ctx = buildOutwardContext({
+      nodeId: "root",
+      title: "Uploaded image",
+      query: "Uploaded image",
+      geos: [
+        { label: "Ankh-Morpork", parent_id: null },
+        { label: "Tower of Art", parent_id: "geo_uu" },
+      ],
+      entities: [
+        {
+          name: "The Mended Drum",
+          kind: "place",
+          appearance: "low tavern south of the river near The Shades",
+          facts: ["Sits in Morpork near The Shades"],
+          appears_on_node_ids: ["root"],
+          first_seen_node_id: "root",
+          last_seen_node_id: "root",
+        },
+      ],
+    });
+
+    expect(ctx).toContain("Ankh-Morpork");
+    expect(ctx).toContain("The Mended Drum");
+    expect(ctx).not.toContain("Uploaded image");
+    expect(ctx).not.toContain("Tower of Art");
+  });
+
+  it("returns null when only placeholder labels are available", () => {
+    expect(
+      buildOutwardContext({
+        nodeId: "root",
+        title: "Uploaded image",
+        query: "Uploaded image",
+        geos: [],
+        entities: [],
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/lib/outward-context.ts
+++ b/apps/web/lib/outward-context.ts
@@ -1,0 +1,98 @@
+import type { Entity, WorldEntityGeo } from "@openflipbook/config";
+
+interface OutwardContextInput {
+  nodeId: string | null;
+  title?: string | null;
+  query?: string | null;
+  entities: Pick<
+    Entity,
+    | "name"
+    | "kind"
+    | "appearance"
+    | "facts"
+    | "appears_on_node_ids"
+    | "first_seen_node_id"
+    | "last_seen_node_id"
+  >[];
+  geos: Pick<WorldEntityGeo, "label" | "parent_id">[];
+}
+
+const GENERIC_ROOT_TITLES = new Set([
+  "",
+  "uploaded image",
+  "uploaded map",
+  "image upload",
+  "untitled image",
+  "untitled map",
+]);
+
+function cleanText(value: string | null | undefined): string {
+  return (value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function isGenericRootTitle(value: string | null | undefined): boolean {
+  return GENERIC_ROOT_TITLES.has(cleanText(value).toLowerCase());
+}
+
+function pushUnique(out: string[], value: string | null | undefined): void {
+  const text = cleanText(value);
+  if (!text || isGenericRootTitle(text)) return;
+  const key = text.toLowerCase();
+  if (out.some((v) => v.toLowerCase() === key)) return;
+  out.push(text);
+}
+
+function entityOnNode(
+  entity: OutwardContextInput["entities"][number],
+  nodeId: string | null,
+): boolean {
+  if (!nodeId) return true;
+  return (
+    entity.first_seen_node_id === nodeId ||
+    entity.last_seen_node_id === nodeId ||
+    entity.appears_on_node_ids.includes(nodeId)
+  );
+}
+
+export function buildOutwardContext({
+  nodeId,
+  title,
+  query,
+  entities,
+  geos,
+}: OutwardContextInput): string | null {
+  const names: string[] = [];
+  if (!isGenericRootTitle(title)) pushUnique(names, title);
+  if (!isGenericRootTitle(query)) pushUnique(names, query);
+
+  for (const geo of geos) {
+    if (geo.parent_id) continue;
+    pushUnique(names, geo.label);
+    if (names.length >= 14) break;
+  }
+
+  const onPage = entities.filter((e) => entityOnNode(e, nodeId));
+  const places = onPage.filter((e) => e.kind === "place");
+  const others = onPage.filter((e) => e.kind !== "place");
+  for (const entity of [...places, ...others]) {
+    pushUnique(names, entity.name);
+    if (names.length >= 14) break;
+  }
+
+  const details: string[] = [];
+  for (const entity of [...places, ...others]) {
+    const fact = entity.facts.find((f) => cleanText(f).length > 0);
+    const detail = cleanText(fact || entity.appearance);
+    if (!detail) continue;
+    details.push(`${cleanText(entity.name)}: ${detail.slice(0, 120)}`);
+    if (details.length >= 5) break;
+  }
+
+  if (!names.length && !details.length) return null;
+  const parts = [
+    names.length ? `Known names on the source map: ${names.join(", ")}.` : "",
+    details.length ? `Source map details: ${details.join("; ")}.` : "",
+    "OUTWARD must contain this exact established map at the centre; do not invent an unrelated geography or title.",
+  ].filter(Boolean);
+  return parts.join(" ");
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -188,6 +188,11 @@ export interface GenerateRequestBody {
   // SCALE_OUTWARD_MAX_HOPS the backend re-anchors to the original medium
   // instead of the drifting previous hop (multi-hop drift). Default-absent.
   outward_depth?: number;
+  // OUTWARD identity anchor for uploaded / generic roots. Built from the
+  // current page's extracted Codex/geometric names so an upload titled
+  // "Uploaded image" still zooms out from the established map, not from the
+  // placeholder title.
+  outward_context?: string;
   // Tap descent ladder: the SOURCE frame of this enter was a closeup of the
   // place — the establishing shot already happened, so the enter goes to
   // ground level (grounds/courtyard) instead of another aerial.


### PR DESCRIPTION
## The bug

An uploaded root's page title is "Uploaded image", so OUTWARD's
planner had no name to anchor the container above it. Live receipt
(2026-08-24 demo shoot): ascending from the Ankh-Morpork seed map
produced **"The Emerald Caldera Archipelago"** — invented geography
with the source's identity gone.

## The fix

- **web**: `lib/outward-context.ts` builds a compact identity string
  from the page's top-level geo labels and on-page Codex entities
  (generic titles like "Uploaded image" filtered out); the play page
  sends it as `outward_context` on ascend. Optional field — absent
  keeps every old client byte-identical.
- **backend**: `ascend.py` folds `outward_context` + the request's
  `world_context` into the planner query and appends a SOURCE
  IDENTITY LOCK to all three container paths (fresh plan, edit-ref
  instruction, outpaint margin). Names cleaned, deduped, capped.
- **planner**: `plan_page` max_tokens 900 → 1400. Sized for the old
  gemini-3-flash-preview pin; 3.7-flash pretty-prints past 900 — the
  live run hit `finish_reason=length` → JSON salvage → the page
  title fell back to the raw query. ~$0.001/plan of headroom.

## Verified

- Full backend suite + full web suite (coverage 78.27, floors hold),
  `tsc` clean.
- **Live A/B on the real stack**: forked the Ankh demo session (the
  fork path itself got dogfooded — writes to the original are 403'd
  by ownership, as designed), ascended from the uploaded root. The
  container is now the city's OWN region: walled city at the centre,
  river continuing to the estuary, and the geo layer re-registered
  the source entities (Ankh-Morpork, Unseen University, The Mended
  Drum…) into the wider frame. Judged edit-ref path, alignment 9.5.

This closes the gap that kept the OUTWARD beat out of the journey
demo (#243).

🤖 Generated with [Claude Code](https://claude.com/claude-code)