### PR TITLE
fix(llm): token headroom for the 3.7-flash truncation class

### DIFF
--- a/apps/modal-backend/providers/llm/click.py
+++ b/apps/modal-backend/providers/llm/click.py
@@ -609,7 +609,9 @@ async def precompute_click_candidates(
                 # 8 items x (~90 tokens incl. the 30-word style sentence) plus
                 # the new one-word place_form enum — 900 was sized before that
                 # field (#127 right-sizing); 1000 keeps the same headroom.
-                max_tokens=1000,
+                # 8 pretty-printed candidate objects; the #157-159 truncation
+                # surface. Headroom for 3.7-flash.
+                max_tokens=1600,
                 span_ctx=ctx,
             )
         out = _validate_candidates(parsed.get("candidates", []), max_candidates)

--- a/apps/modal-backend/providers/llm/world.py
+++ b/apps/modal-backend/providers/llm/world.py
@@ -153,7 +153,8 @@ async def propose_neighbors(
             schema=NEIGHBORS_SCHEMA,
             schema_name="neighbors",
             temperature=0.4,
-            max_tokens=1200,
+            # Array-bearing JSON reply; headroom for 3.7-flash pretty-printing.
+            max_tokens=1800,
             span_ctx=ctx,
         )
     return _build_neighbors(parsed, max_neighbors)
@@ -344,7 +345,9 @@ async def edit_entities_nl(
             schema=ENTITY_EDIT_SCHEMA,
             schema_name="entity_edits",
             temperature=0.0,
-            max_tokens=900,
+            # Array-bearing JSON reply; sized for the old 3-flash pin —
+            # 3.7-flash pretty-prints (the plan_page truncation class, #244).
+            max_tokens=1400,
             span_ctx=ctx,
         )
     edits = parse_entity_edits(parsed, valid_ids)


### PR DESCRIPTION
Live logs since the #241 default flip show ONE finish_reason=length
(plan_page, fixed in #244). This sweeps the remaining same-class
sites — array-bearing JSON replies whose caps were sized for the old
3-flash pin: edit_entities 900 -> 1400, neighbors 1200 -> 1800,
click_candidates 1000 -> 1600 (the #157-159 truncation surface).
Fixed-shape sites (view 300, judge 400, click_resolution 400) stay:
zero observed truncation across two days of live demo traffic.
max_tokens is a cap, not a purchase — headroom costs nothing unless
the reply actually grows.
