### PR TITLE
feat(maps): DETAILED_MAP — root maps from a full cartographer's spec

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -155,6 +155,12 @@ FAL_EDIT_TIER=balanced
 # byte-identical. INTERIOR_ACCEPT is the 0-10 acceptance floor.
 # INTERIOR_ENTERS=true
 # INTERIOR_ACCEPT=6.0
+# Detailed maps (default off): a ROOT world map skips the planner's
+# <=120-word compression — one LLM call (~$0.005) expands the query into a
+# full cartographer's spec (positioned districts, label tiers, detail
+# density) rendered verbatim on the long-spec model. Off = today's bytes.
+# DETAILED_MAP=1
+# DETAILED_MAP_MODEL=fal-ai/nano-banana-pro
 # Real map zoom: map zooms (place_submap, world AND classic) are RE-DRAWN at
 # the closer scale — the region crop rides the EDIT/continue seam with a
 # loose-refs model, instead of Kontext's crop-upscale. Kontext magnifies

--- a/apps/modal-backend/providers/generate_modes/tap.py
+++ b/apps/modal-backend/providers/generate_modes/tap.py
@@ -371,19 +371,44 @@ async def stream_tap(
             entities=len(world_context_payload),
             first_name=world_context_payload[0].get("name"),
         )
-    plan = await llm.plan_page(
-        query=effective_query,
-        web_search=effective_web_search,
-        style_anchor=style_anchor,
-        output_locale=body.output_locale,
-        parent_title=body.parent_title,
-        parent_query=body.parent_query,
-        subject_context=subject_context,
-        world_context=world_context_payload,
-        render_mode=render_mode or "explainer",
-        surroundings=surroundings_for_plan,
-        label_free=body.suppress_map_labels,
+    # DETAILED_MAP (default off): a ROOT world map skips the planner's
+    # <=120-word compression — one LLM call expands the query into a full
+    # cartographer's spec (positioned districts, label tiers, detail
+    # density) rendered verbatim, routed to the long-spec model below.
+    # Fail-open: a thin/failed spec falls back to the ordinary plan.
+    detailed_map = (
+        env_flag("DETAILED_MAP", "false")
+        and render_mode == "place_submap"
+        and not body.condition_image_urls  # a ROOT map, not a zoom/continue
+        and body.mode != "edit"
     )
+    plan = None
+    if detailed_map:
+        map_spec = await llm.expand_map_spec(
+            effective_query,
+            style_anchor=style_anchor,
+            output_locale=body.output_locale,
+            label_free=body.suppress_map_labels,
+        )
+        if map_spec is not None:
+            # facts stay empty: the spec embeds its own labels, so the
+            # "Labels to include" append below is a natural no-op.
+            plan = llm.PagePlan(map_spec.page_title, map_spec.spec, [], [])
+        detailed_map = plan is not None
+    if plan is None:
+        plan = await llm.plan_page(
+            query=effective_query,
+            web_search=effective_web_search,
+            style_anchor=style_anchor,
+            output_locale=body.output_locale,
+            parent_title=body.parent_title,
+            parent_query=body.parent_query,
+            subject_context=subject_context,
+            world_context=world_context_payload,
+            render_mode=render_mode or "explainer",
+            surroundings=surroundings_for_plan,
+            label_free=body.suppress_map_labels,
+        )
 
     composed_prompt = plan.prompt
     if style_anchor:
@@ -1034,12 +1059,20 @@ async def stream_tap(
                 )
             )
     else:
+        # DETAILED_MAP routes the long spec to the compliance winner: on the
+        # 2026-08-24 full-spec A/B nano-banana-pro nailed labels/layout where
+        # seedream mangled tier-2 text. An explicit user model still wins.
+        detailed_model = (
+            os.environ.get("DETAILED_MAP_MODEL") or "fal-ai/nano-banana-pro"
+            if detailed_map
+            else None
+        )
         main_task = _asyncio.create_task(
             image_provider.generate_image(
                 prompt=main_prompt,
                 aspect_ratio=body.aspect_ratio,
                 tier=body.image_tier,
-                model_override=body.image_model,
+                model_override=body.image_model or detailed_model,
                 reference_urls=cond_refs,
             )
         )

--- a/apps/modal-backend/providers/llm/__init__.py
+++ b/apps/modal-backend/providers/llm/__init__.py
@@ -86,6 +86,10 @@ from .extraction import (
     _parse_extraction,
     extract_entities,
 )
+from .map_spec import (
+    MapSpec,
+    expand_map_spec,
+)
 from .planner import (
     PLAN_SCHEMA,
     Citation,

--- a/apps/modal-backend/providers/llm/map_spec.py
+++ b/apps/modal-backend/providers/llm/map_spec.py
@@ -1,0 +1,129 @@
+"""DETAILED_MAP: expand a short query into a full cartographer's spec.
+
+The planner compresses every query into a <=120-word image prompt, so a
+one-line query can never yield a dense map (live receipt, 2026-08-24: the
+hand-written Ankh-Morpork spec rendered VERBATIM produced a map in a
+different league from the planner path). This module makes that recipe a
+mode: one text-LLM call turns the query into a structured spec — global
+style, frame furniture, a spine feature, positioned districts and
+landmarks on a 100x100 grid, label tiers, detail density, negative
+constraints — and the caller renders the spec DIRECTLY.
+
+Fail-open by design: any error returns None and the caller falls back to
+the ordinary plan_page path, so the flag can never break a generation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from providers import llm as _llm
+
+from .client import _system_message, _text_model
+
+SPEC_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "page_title": {"type": "string"},
+        "spec": {"type": "string"},
+    },
+    "required": ["page_title", "spec"],
+}
+
+_SYSTEM = (
+    "You are a master fantasy cartographer writing a COMPLETE rendering "
+    "specification for a single, extremely detailed 2D top-down map, to be "
+    "given verbatim to a text-capable image model. Return JSON with keys: "
+    'page_title (<=8 words, the place\'s name) and spec (the full spec text). '
+    "The spec MUST contain these sections, in order:\n"
+    "1. One opening sentence: what the map depicts, 16:9 landscape, the art "
+    "medium (match the requested style; default to an antique hand-inked "
+    "cartographer's chart with muted watercolor washes).\n"
+    "2. COORDINATE CONVENTION: a 100x100 grid, x left-to-right, y "
+    "top-to-bottom; positions below given as (x, y); everything fully inside "
+    "the canvas with a 2% margin.\n"
+    "3. GLOBAL STYLE: base material, ink color, 3-5 named wash colors with "
+    "roles, what gold/accent is reserved for, and 'no pure black, no "
+    "saturated colors, flat 2D plan view, no perspective, no isometric'.\n"
+    "4. FRAME FURNITURE: a title cartouche with the place name, a compass "
+    "rose, a legend box with 4-6 symbol rows, a scale bar — each at fixed "
+    "(x, y) positions.\n"
+    "5. A SPINE FEATURE (river, chasm, grand avenue, coastline...) with 5-8 "
+    "(x, y) control points and how it divides or organizes the map.\n"
+    "6. DISTRICTS: 5-8 named districts, each with an (x, y) extent, one "
+    "sentence of character, and 2-4 named landmarks at (x, y) positions "
+    "with one visual detail each. Invent evocative, internally consistent "
+    "names that fit the query's world.\n"
+    "7. ROADS/CONNECTIONS: 3-5 named routes with start/end positions.\n"
+    "8. TYPOGRAPHY RULES: three label tiers (district / landmark / "
+    "street-and-jokes), 'every label crisply legible and correctly "
+    "spelled; fewer, larger, correct labels beat many mangled ones; no "
+    "label overlaps another'.\n"
+    "9. DETAIL DENSITY: 40-80 individual building footprints per district "
+    "block, oriented to streets, plus 3-5 tiny life details (smoke wisps, "
+    "boats, animals, laundry lines).\n"
+    "10. NEGATIVE CONSTRAINTS: no modern objects, no photorealism, no 3D, "
+    "no watermark, no empty dead areas — every part of the map contains "
+    "streets/terrain detail.\n"
+    "Write the spec as compact section blocks. Do not include any text "
+    "outside the JSON."
+)
+
+
+@dataclass
+class MapSpec:
+    page_title: str
+    spec: str
+
+
+async def expand_map_spec(
+    query: str,
+    *,
+    style_anchor: str | None = None,
+    output_locale: str | None = None,
+    label_free: bool = False,
+) -> MapSpec | None:
+    """One LLM call: query -> full cartographer spec. None on any failure."""
+    from obs import log, span
+
+    user = f"Query: {query.strip()}"
+    if style_anchor:
+        user += f"\n\nArt style to match exactly: {style_anchor}"
+    if output_locale and output_locale.lower() not in ("en", "auto"):
+        user += (
+            f"\n\nAll in-map lettering and names in locale: {output_locale}"
+        )
+    if label_free:
+        user += (
+            "\n\nIMPORTANT: the image must contain NO lettering at all — "
+            "replace the typography section with 'no text anywhere; the "
+            "interface overlays names separately'. Keep positions and density."
+        )
+    try:
+        text_model = _text_model(online=False)
+        async with span("planner.map_spec", model=text_model) as ctx:
+            parsed = await _llm._complete_json(
+                model=text_model,
+                messages=[
+                    _system_message(_SYSTEM),
+                    {"role": "user", "content": user},
+                ],
+                schema=SPEC_SCHEMA,
+                schema_name="map_spec",
+                temperature=0.8,
+                # The whole point is length — a full spec runs 1.5-2.5k
+                # tokens. Cap well above it (cap, not purchase).
+                max_tokens=3600,
+                span_ctx=ctx,
+            )
+        title = " ".join(str(parsed.get("page_title", "")).split())
+        spec = str(parsed.get("spec", "")).strip()
+        # A spec shorter than a planner prompt defeats the mode — fall back.
+        if not title or len(spec) < 600:
+            log("warn", "map_spec.thin", spec_chars=len(spec))
+            return None
+        return MapSpec(page_title=title[:80], spec=spec)
+    except Exception as exc:
+        log("warn", "map_spec.failed", error=f"{type(exc).__name__}: {exc}")
+        return None

--- a/apps/modal-backend/tests/test_detailed_map.py
+++ b/apps/modal-backend/tests/test_detailed_map.py
@@ -1,0 +1,191 @@
+"""DETAILED_MAP: the root-map spec expander and its tap.py wiring.
+
+Flag off = byte-identical plan_page path. Flag on = expand_map_spec
+replaces the plan on ROOT world maps only, the spec renders verbatim,
+and the fresh gen routes to the long-spec model. Fail-open: a thin or
+failed spec falls back to plan_page.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.modules.setdefault("modal", MagicMock())
+
+import providers.image as image_mod  # noqa: E402
+import providers.llm as llm_mod  # noqa: E402
+from generate import GenerateBody, _event_stream  # noqa: E402
+from providers.image import GeneratedImage  # noqa: E402
+from providers.llm import MapSpec, PagePlan  # noqa: E402
+from providers.llm.map_spec import expand_map_spec  # noqa: E402
+
+LONG_SPEC = "SPEC " + ("districts and landmarks at (x, y). " * 40)
+
+
+async def _collect(agen: Any) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    async for chunk in agen:
+        text = chunk.decode() if isinstance(chunk, bytes) else chunk
+        for block in text.strip().split("\n\n"):
+            block = block.strip()
+            if block.startswith("data:"):
+                events.append(json.loads(block[len("data:") :].strip()))
+    return events
+
+
+def _root_map_body() -> GenerateBody:
+    return GenerateBody(
+        query="a walled harbor city",
+        session_id="s1",
+        mode="query",
+        web_search=False,
+        world_mode=True,
+        render_mode="place_submap",
+        session_style_anchor="woodcut",
+    )
+
+
+def _mock_gen(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    gen = AsyncMock(
+        return_value=GeneratedImage(b"jpeg", "image/jpeg", "fal-ai/nano-banana-pro", "r1")
+    )
+    monkeypatch.setattr(image_mod, "generate_image", gen)
+    return gen
+
+
+@pytest.fixture(autouse=True)
+def _quiet(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("PROGRESSIVE_DRAFT", "false")
+    yield
+
+
+async def test_flag_off_keeps_the_plan_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    plan = AsyncMock(return_value=PagePlan("Harborville", "a fine map", [], []))
+    spec = AsyncMock()
+    monkeypatch.setattr(llm_mod, "plan_page", plan)
+    monkeypatch.setattr(llm_mod, "expand_map_spec", spec)
+    gen = _mock_gen(monkeypatch)
+
+    await _collect(_event_stream(_root_map_body(), "t1"))
+
+    plan.assert_awaited_once()
+    spec.assert_not_awaited()
+    assert gen.await_args.kwargs["model_override"] is None
+
+
+async def test_flag_on_renders_the_spec_on_the_long_spec_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DETAILED_MAP", "1")
+    plan = AsyncMock()
+    spec = AsyncMock(return_value=MapSpec("Harborville", LONG_SPEC))
+    monkeypatch.setattr(llm_mod, "plan_page", plan)
+    monkeypatch.setattr(llm_mod, "expand_map_spec", spec)
+    gen = _mock_gen(monkeypatch)
+
+    events = await _collect(_event_stream(_root_map_body(), "t1"))
+
+    plan.assert_not_awaited()
+    assert LONG_SPEC in gen.await_args.kwargs["prompt"]
+    assert gen.await_args.kwargs["model_override"] == "fal-ai/nano-banana-pro"
+    final = next(e for e in events if e["type"] == "final")
+    assert final["page_title"] == "Harborville"
+
+    # An explicit env slot re-routes; an explicit request model beats both.
+    monkeypatch.setenv("DETAILED_MAP_MODEL", "fal-ai/custom-map")
+    await _collect(_event_stream(_root_map_body(), "t2"))
+    assert gen.await_args.kwargs["model_override"] == "fal-ai/custom-map"
+
+
+async def test_flag_on_explicit_request_model_wins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DETAILED_MAP", "1")
+    monkeypatch.setattr(
+        llm_mod, "expand_map_spec", AsyncMock(return_value=MapSpec("T", LONG_SPEC))
+    )
+    monkeypatch.setattr(llm_mod, "plan_page", AsyncMock())
+    gen = _mock_gen(monkeypatch)
+
+    body = _root_map_body()
+    body.image_model = "fal-ai/operator-pick"
+    await _collect(_event_stream(body, "t1"))
+    assert gen.await_args.kwargs["model_override"] == "fal-ai/operator-pick"
+
+
+async def test_failed_spec_falls_back_to_the_plan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DETAILED_MAP", "1")
+    plan = AsyncMock(return_value=PagePlan("Fallback", "plain prompt", [], []))
+    monkeypatch.setattr(llm_mod, "plan_page", plan)
+    monkeypatch.setattr(llm_mod, "expand_map_spec", AsyncMock(return_value=None))
+    gen = _mock_gen(monkeypatch)
+
+    await _collect(_event_stream(_root_map_body(), "t1"))
+
+    plan.assert_awaited_once()
+    # Fallback must NOT ride the detailed model routing.
+    assert gen.await_args.kwargs["model_override"] is None
+
+
+async def test_non_root_renders_never_expand(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A zoom/continue (condition images present) keeps the plan path even
+    # with the flag on — detailed mode is ROOT maps only.
+    monkeypatch.setenv("DETAILED_MAP", "1")
+    plan = AsyncMock(return_value=PagePlan("Zoom", "closer map", [], []))
+    spec = AsyncMock()
+    monkeypatch.setattr(llm_mod, "plan_page", plan)
+    monkeypatch.setattr(llm_mod, "expand_map_spec", spec)
+    _mock_gen(monkeypatch)
+    import providers.image_edit as image_edit_mod
+
+    monkeypatch.setattr(
+        image_edit_mod,
+        "continue_image",
+        AsyncMock(
+            return_value=GeneratedImage(b"jpeg", "image/jpeg", "m", "r2")
+        ),
+    )
+
+    body = _root_map_body()
+    body.condition_image_urls = ["data:image/jpeg;base64,QUFB"]
+    body.condition_roles = ["region"]
+    await _collect(_event_stream(body, "t1"))
+    spec.assert_not_awaited()
+
+
+# ── the expander itself (LLM mocked) ─────────────────────────────────────────
+
+
+async def test_expander_parses_and_caps(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        llm_mod,
+        "_complete_json",
+        AsyncMock(return_value={"page_title": "  Port   Vane  ", "spec": LONG_SPEC}),
+    )
+    out = await expand_map_spec("a port")
+    assert out is not None
+    assert out.page_title == "Port Vane"
+    assert out.spec == LONG_SPEC.strip()
+
+
+async def test_expander_rejects_thin_specs(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        llm_mod,
+        "_complete_json",
+        AsyncMock(return_value={"page_title": "T", "spec": "too short"}),
+    )
+    assert await expand_map_spec("a port") is None
+
+
+async def test_expander_fails_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        llm_mod, "_complete_json", AsyncMock(side_effect=RuntimeError("boom"))
+    )
+    assert await expand_map_spec("a port") is None


### PR DESCRIPTION
The planner compresses every query to <=120 words, so a one-line query
can never yield a dense map (the 2026-08-24 Ankh-Morpork receipt: the
hand-written spec rendered verbatim was in a different league). This
makes that recipe a flag-gated mode:

- providers/llm/map_spec.py: expand_map_spec — ONE text-LLM call
  (~$0.005) turns the query into a structured spec: 100x100-grid
  coordinate convention, global style, frame furniture, a spine
  feature, positioned districts + landmarks, roads, three label
  tiers, detail density, negative constraints. Fail-open: thin or
  failed specs return None.
- tap.py: DETAILED_MAP (default off) fires on ROOT world maps only
  (place_submap, no condition images, not an edit). The spec replaces
  the plan verbatim (facts empty -> the labels append no-ops) and the
  fresh gen routes to DETAILED_MAP_MODEL (default nano-banana-pro —
  the long-spec compliance winner from the Ankh A/B; seedream mangles
  tier-2 text on long specs). An explicit request model still wins.
  Flag off = byte-identical bytes.

A/B receipt (one query, ~$0.25): planner+seedream drew a pretty
picture of ONE district with ~8 labels; spec+nano drew a true city
chart — 'Port Valcove', ~25 named features, legend, scale bar in
nautical cables, dense flat-plan fabric, all crisply spelled.
Receipt image: Desktop ofb-visuals/detailed-map-port-valcove.

8 new tests: flag off untouched, spec renders on the routed model,
env + request-model precedence, fail-open fallback, root-only gating,
expander parse/thin/error paths.
