### PR TITLE
feat(import): Azgaar map import — drop the export JSON, get the real names

### DIFF
--- a/apps/web/app/api/world/[sessionId]/import-map/route.ts
+++ b/apps/web/app/api/world/[sessionId]/import-map/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import {
+  importedEntitiesToGeos,
+  validateImportedEntities,
+} from "@/lib/azgaar-import";
+import { isSafeId } from "@/lib/ids";
+import { requireOwner } from "@/lib/session-owner";
+import { upsertEntityGeos } from "@/lib/world-map";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface Params {
+  params: Promise<{ sessionId: string }>;
+}
+
+// Map-generator import (Azgaar & friends): the CLIENT parses the export
+// file and sends only the capped, normalized entity list — never the
+// multi-MB raw JSON. Deterministic geo ids make a re-import an update.
+export async function POST(req: Request, { params }: Params) {
+  const { sessionId } = await params;
+  if (!isSafeId(sessionId)) {
+    return NextResponse.json({ error: "invalid session id" }, { status: 400 });
+  }
+  const owner = await requireOwner(sessionId);
+  if (!owner.ok) return owner.res;
+
+  const body = (await req.json().catch(() => null)) as {
+    entities?: unknown;
+    map_name?: unknown;
+  } | null;
+  const entities = validateImportedEntities(body?.entities);
+  if (!entities) {
+    return NextResponse.json({ error: "invalid entities" }, { status: 400 });
+  }
+  const geos = importedEntitiesToGeos(entities, new Date().toISOString());
+  const snapshot = await upsertEntityGeos(sessionId, geos);
+  return NextResponse.json({
+    ok: true,
+    imported: geos.length,
+    total_entities: snapshot.entities.length,
+  });
+}

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -135,6 +135,7 @@ import { sseData } from "@/lib/sse";
 import { selectNeighbors } from "@/lib/scale-neighbors";
 import { buildOutwardContext } from "@/lib/outward-context";
 import { shouldAutoDescend } from "@/lib/descent-clip";
+import { parseAzgaarExport } from "@/lib/azgaar-import";
 import { sceneCloseupSpec } from "@/lib/scene-closeup";
 import { childrenOf, projectTopDown, toAbsoluteEntities } from "@/lib/world-geometry";
 import { viewNeutralAppearance } from "@/lib/appearance";
@@ -1437,14 +1438,57 @@ export default function PlayPage() {
 
   const onDragLeave = useCallback(() => setIsDraggingFile(false), []);
 
+  // Map-generator import: dropping an Azgaar "export JSON (full)" file onto
+  // the canvas seeds the world map with the generator's OWN named places at
+  // their exact positions — pair it with the exported PNG uploaded as the
+  // page. Parsing happens client-side; only the capped list crosses the wire.
+  const acceptImportJson = useCallback(
+    async (file: File) => {
+      try {
+        const parsed = parseAzgaarExport(JSON.parse(await file.text()));
+        if (!parsed) {
+          setError(
+            "That JSON isn't an Azgaar full export. In the generator: Export → to JSON → full.",
+          );
+          return;
+        }
+        const res = await fetch(
+          `/api/world/${encodeURIComponent(sessionId)}/import-map`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              map_name: parsed.mapName,
+              entities: parsed.entities,
+            }),
+          },
+        );
+        const data = (await res.json()) as { imported?: number; error?: string };
+        if (!res.ok) throw new Error(data.error ?? `HTTP ${res.status}`);
+        setStatusMsg(
+          `Imported ${data.imported} places from “${parsed.mapName}” — names and positions are live.`,
+        );
+        void geoRefetch();
+      } catch (err) {
+        setError(`Map import failed: ${(err as Error).message}`);
+      }
+    },
+    [sessionId, geoRefetch]
+  );
+
   const onDrop = useCallback(
     (e: DragEvent<HTMLElement>) => {
       e.preventDefault();
       setIsDraggingFile(false);
       const file = e.dataTransfer.files?.[0];
-      if (file) void acceptUploadedImage(file);
+      if (!file) return;
+      if (file.name.endsWith(".json") || file.type === "application/json") {
+        void acceptImportJson(file);
+        return;
+      }
+      void acceptUploadedImage(file);
     },
-    [acceptUploadedImage]
+    [acceptUploadedImage, acceptImportJson]
   );
 
   const submitQuery = useCallback(

--- a/apps/web/lib/azgaar-fixture.json
+++ b/apps/web/lib/azgaar-fixture.json
@@ -1,0 +1,131 @@
+{
+  "info": {
+    "version": "1.149.2",
+    "description": "Azgaar's Fantasy Map Generator output: azgaar.github.io/Fantasy-map-generator",
+    "exportedAt": "2026-08-27T20:02:22.600Z",
+    "mapName": "Bones",
+    "width": 1164,
+    "height": 1157,
+    "seed": "916170902",
+    "mapId": 1787860879069
+  },
+  "pack": {
+    "burgs": [
+      0,
+      {
+        "cell": 1360,
+        "x": 50.67,
+        "y": 586.24,
+        "i": 1,
+        "state": 1,
+        "culture": 1,
+        "name": "Chawleigh",
+        "feature": 8,
+        "capital": 1,
+        "port": 1,
+        "population": 49.385,
+        "type": "Naval",
+        "citadel": 1,
+        "walls": 1,
+        "shanty": 1,
+        "temple": 1,
+        "group": "capital",
+        "market": 2,
+        "plaza": 1
+      },
+      {
+        "cell": 1846,
+        "x": 615.96,
+        "y": 661.13,
+        "i": 2,
+        "state": 2,
+        "culture": 4,
+        "name": "Hertford",
+        "feature": 21,
+        "capital": 1,
+        "port": 1,
+        "population": 4.906,
+        "type": "Naval",
+        "citadel": 1,
+        "walls": 1,
+        "shanty": 0,
+        "temple": 0,
+        "group": "capital",
+        "market": 15,
+        "plaza": 0
+      },
+      {
+        "cell": 277,
+        "x": 734.94,
+        "y": 272.74,
+        "i": 3,
+        "state": 3,
+        "culture": 8,
+        "name": "Louth",
+        "feature": 2,
+        "capital": 1,
+        "population": 6.617,
+        "type": "Generic",
+        "citadel": 1,
+        "walls": 1,
+        "shanty": 0,
+        "temple": 0,
+        "group": "capital",
+        "market": 11,
+        "plaza": 0
+      },
+      {
+        "cell": 1638,
+        "x": 696.58,
+        "y": 634.85,
+        "i": 4,
+        "state": 2,
+        "culture": 4,
+        "name": "Ely",
+        "feature": 21,
+        "population": 1.271,
+        "type": "Generic",
+        "citadel": 0,
+        "walls": 0,
+        "shanty": 0,
+        "temple": 0,
+        "group": "town",
+        "market": 0,
+        "plaza": 1
+      },
+      {
+        "cell": 900,
+        "x": 320.5,
+        "y": 410.0,
+        "i": 5,
+        "state": 1,
+        "culture": 1,
+        "name": "Removedton",
+        "removed": true,
+        "population": 2.0,
+        "type": "Generic"
+      }
+    ],
+    "states": [
+      { "i": 0, "name": "Neutrals" },
+      {
+        "i": 1,
+        "name": "Chawleigh",
+        "fullName": "Kingdom of Chawleigh",
+        "capital": 1,
+        "center": 1360,
+        "pole": [180.4, 620.9]
+      },
+      {
+        "i": 2,
+        "name": "Hertfordia",
+        "fullName": "Duchy of Hertfordia",
+        "capital": 2,
+        "center": 1846,
+        "pole": [640.2, 700.1]
+      }
+    ],
+    "markers": [],
+    "provinces": [0]
+  }
+}

--- a/apps/web/lib/azgaar-import.test.ts
+++ b/apps/web/lib/azgaar-import.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import fixture from "./azgaar-fixture.json";
+import {
+  AZGAAR_IMPORT_CAP,
+  importedEntitiesToGeos,
+  parseAzgaarExport,
+  validateImportedEntities,
+} from "./azgaar-import";
+
+describe("parseAzgaarExport (real v1.149.2 fixture)", () => {
+  it("parses burgs into frame-relative entities, capitals first", () => {
+    const parsed = parseAzgaarExport(fixture);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.mapName).toBe("Bones");
+    // burgs[0] placeholder + the removed burg are skipped: 4 real burgs.
+    expect(parsed!.entities).toHaveLength(4);
+    // Chawleigh: biggest capital first, coords normalized by info.width/height.
+    const first = parsed!.entities[0]!;
+    expect(first.name).toBe("Chawleigh");
+    expect(first.x_pct).toBeCloseTo(50.67 / 1164, 5);
+    expect(first.y_pct).toBeCloseTo(586.24 / 1157, 5);
+    expect(first.note).toBe("capital of Kingdom of Chawleigh, port");
+    // Ely: a plain town — no note, sorted after the capitals.
+    const ely = parsed!.entities.find((e) => e.name === "Ely")!;
+    expect(ely.note).toBe("");
+    expect(parsed!.entities.indexOf(ely)).toBe(3);
+  });
+
+  it("rejects non-Azgaar shapes", () => {
+    expect(parseAzgaarExport(null)).toBeNull();
+    expect(parseAzgaarExport({})).toBeNull();
+    expect(parseAzgaarExport({ info: { width: 100 } })).toBeNull();
+    expect(
+      parseAzgaarExport({ info: { width: 100, height: 100 }, pack: { burgs: [0] } }),
+    ).toBeNull();
+  });
+
+  it("caps a burg flood at the import cap, keeping the important ones", () => {
+    const burgs: unknown[] = [0];
+    for (let i = 1; i <= 80; i++) {
+      burgs.push({ i, name: `Town ${i}`, x: i, y: i, population: i });
+    }
+    const parsed = parseAzgaarExport({
+      info: { width: 100, height: 100 },
+      pack: { burgs },
+    })!;
+    expect(parsed.entities).toHaveLength(AZGAAR_IMPORT_CAP);
+    expect(parsed.entities[0]!.name).toBe("Town 80"); // biggest population
+  });
+});
+
+describe("importedEntitiesToGeos", () => {
+  it("maps pct coords into the 100x60 map frame with deterministic ids", () => {
+    const geos = importedEntitiesToGeos(
+      parseAzgaarExport(fixture)!.entities.slice(0, 2),
+      "2026-08-27T00:00:00.000Z",
+    );
+    expect(geos[0]!.id).toBe("geo_import_chawleigh");
+    expect(geos[0]!.pos.x).toBeCloseTo((50.67 / 1164) * 100, 4);
+    expect(geos[0]!.pos.y).toBeCloseTo((586.24 / 1157) * 60, 4);
+    expect(geos[0]!.kind).toBe("place");
+    expect(geos[0]!.footprint).toEqual({ w: 3, d: 3 }); // a capital reads larger
+    // Re-import stability: same name -> same id.
+    const again = importedEntitiesToGeos(
+      parseAzgaarExport(fixture)!.entities.slice(0, 2),
+      "2026-08-27T00:00:00.000Z",
+    );
+    expect(again[0]!.id).toBe(geos[0]!.id);
+  });
+});
+
+describe("validateImportedEntities", () => {
+  const good = [{ name: "Chawleigh", x_pct: 0.1, y_pct: 0.9, note: "", weight: 1 }];
+
+  it("accepts a clean list", () => {
+    expect(validateImportedEntities(good)).toHaveLength(1);
+  });
+
+  it.each([
+    ["empty", []],
+    ["not a list", { name: "x" }],
+    ["missing name", [{ x_pct: 0.5, y_pct: 0.5 }]],
+    ["coords out of range", [{ name: "A", x_pct: 1.5, y_pct: 0.5 }]],
+    ["oversized name", [{ name: "a".repeat(90), x_pct: 0.5, y_pct: 0.5 }]],
+    ["over the cap", Array.from({ length: 41 }, (_, i) => ({ name: `T${i}`, x_pct: 0.5, y_pct: 0.5 }))],
+  ])("rejects %s", (_name, value) => {
+    expect(validateImportedEntities(value)).toBeNull();
+  });
+});

--- a/apps/web/lib/azgaar-import.ts
+++ b/apps/web/lib/azgaar-import.ts
@@ -1,0 +1,171 @@
+// Azgaar Fantasy Map Generator import: parse the "Export to JSON (full)"
+// file into named, positioned places for the world map — so a map made in
+// the TTRPG scene's beloved generator becomes an enterable world with the
+// RIGHT names at the RIGHT spots, no VLM guessing.
+//
+// Schema verified against a real v1.149.2 export (2026-08-27):
+//   { info: { mapName, width, height, ... },
+//     pack: { burgs: [0, {i, name, x, y, capital?, port?, population,
+//                         removed?, ...}],
+//             states: [{i:0 neutrals}, {i, name, fullName, pole: [x,y]}] } }
+// burgs[0] and states[0] are PLACEHOLDERS (0 / neutrals) — skip them.
+// x/y are map-pixel coords in the info.width × info.height frame.
+
+import type { WorldEntityGeo } from "@openflipbook/config";
+
+export interface ImportedMapEntity {
+  name: string;
+  x_pct: number; // 0..1 of the source map frame
+  y_pct: number;
+  note: string; // one line of provenance ("capital of X, port")
+  weight: number; // importance (population + flags) — used to cap the list
+}
+
+export interface ParsedAzgaarMap {
+  mapName: string;
+  entities: ImportedMapEntity[];
+}
+
+export const AZGAAR_IMPORT_CAP = 40;
+
+interface AzgaarBurg {
+  i?: number;
+  name?: string;
+  x?: number;
+  y?: number;
+  capital?: number;
+  port?: number;
+  population?: number;
+  removed?: boolean;
+  state?: number;
+}
+
+function cleanName(value: unknown): string {
+  return typeof value === "string" ? value.replace(/\s+/g, " ").trim() : "";
+}
+
+/** Parse an Azgaar full-JSON export. Null when the shape isn't Azgaar's. */
+export function parseAzgaarExport(json: unknown): ParsedAzgaarMap | null {
+  if (typeof json !== "object" || json === null) return null;
+  const doc = json as {
+    info?: { mapName?: unknown; width?: unknown; height?: unknown };
+    pack?: { burgs?: unknown; states?: unknown };
+  };
+  const width = Number(doc.info?.width);
+  const height = Number(doc.info?.height);
+  const burgs = doc.pack?.burgs;
+  if (!Number.isFinite(width) || width <= 0) return null;
+  if (!Number.isFinite(height) || height <= 0) return null;
+  if (!Array.isArray(burgs)) return null;
+
+  const states = Array.isArray(doc.pack?.states)
+    ? (doc.pack!.states as { i?: number; fullName?: unknown; name?: unknown }[])
+    : [];
+  const stateName = (i: number | undefined): string => {
+    if (!i) return ""; // state 0 = neutrals
+    const s = states.find((st) => st && st.i === i);
+    return cleanName(s?.fullName) || cleanName(s?.name);
+  };
+
+  const entities: ImportedMapEntity[] = [];
+  for (const raw of burgs) {
+    // burgs[0] is the literal number 0; removed burgs stay in the array.
+    if (typeof raw !== "object" || raw === null) continue;
+    const b = raw as AzgaarBurg;
+    const name = cleanName(b.name);
+    if (!name || b.removed) continue;
+    const x = Number(b.x);
+    const y = Number(b.y);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+    const x_pct = x / width;
+    const y_pct = y / height;
+    if (x_pct < 0 || x_pct > 1 || y_pct < 0 || y_pct > 1) continue;
+    const noteParts: string[] = [];
+    if (b.capital) {
+      const owner = stateName(b.state);
+      noteParts.push(owner ? `capital of ${owner}` : "capital");
+    }
+    if (b.port) noteParts.push("port");
+    const pop = Number(b.population);
+    entities.push({
+      name: name.slice(0, 80),
+      x_pct,
+      y_pct,
+      note: noteParts.join(", "),
+      weight:
+        (Number.isFinite(pop) ? pop : 0) +
+        (b.capital ? 1000 : 0) +
+        (b.port ? 10 : 0),
+    });
+  }
+  if (entities.length === 0) return null;
+  entities.sort((a, b) => b.weight - a.weight);
+  return {
+    mapName: cleanName((doc.info as { mapName?: unknown })?.mapName) || "Imported map",
+    entities: entities.slice(0, AZGAAR_IMPORT_CAP),
+  };
+}
+
+// The world-map frame every geo consumer reads (geo-tap MAP_IMAGE_FRAME).
+const FRAME_W = 100;
+const FRAME_H = 60;
+
+/** Imported entities → world-map geos in the standard map frame. Ids are
+ *  deterministic per name so a re-import UPDATES instead of duplicating. */
+export function importedEntitiesToGeos(
+  entities: ImportedMapEntity[],
+  nowIso: string,
+): WorldEntityGeo[] {
+  return entities.map((e) => {
+    const slug = e.name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "")
+      .slice(0, 48);
+    const major = e.weight >= 1000; // capitals read larger on the map
+    return {
+      id: `geo_import_${slug}`,
+      entity_id: null,
+      parent_id: null,
+      kind: "place",
+      label: e.name,
+      pos: { x: e.x_pct * FRAME_W, y: e.y_pct * FRAME_H },
+      height: major ? 2 : 1,
+      footprint: major ? { w: 3, d: 3 } : { w: 2, d: 2 },
+      visual: e.note,
+      state: {},
+      // Author-supplied coordinates from the generator's own data — a USER
+      // placement (it wins over later derived/extracted guesses).
+      confidence: 1,
+      source: "user" as const,
+      updated_at: nowIso,
+    };
+  });
+}
+
+/** Server-side body validation for the import route. */
+export function validateImportedEntities(
+  value: unknown,
+): ImportedMapEntity[] | null {
+  if (!Array.isArray(value) || value.length === 0) return null;
+  if (value.length > AZGAAR_IMPORT_CAP) return null;
+  const out: ImportedMapEntity[] = [];
+  for (const raw of value) {
+    if (typeof raw !== "object" || raw === null) return null;
+    const e = raw as Partial<ImportedMapEntity>;
+    const name = cleanName(e.name);
+    const x = Number(e.x_pct);
+    const y = Number(e.y_pct);
+    if (!name || name.length > 80) return null;
+    if (!Number.isFinite(x) || x < 0 || x > 1) return null;
+    if (!Number.isFinite(y) || y < 0 || y > 1) return null;
+    out.push({
+      name,
+      x_pct: x,
+      y_pct: y,
+      note: cleanName(e.note).slice(0, 120),
+      weight: Number.isFinite(Number(e.weight)) ? Number(e.weight) : 0,
+    });
+  }
+  return out;
+}


### PR DESCRIPTION
The TTRPG bridge from the outward scan: a map made in Azgaar's Fantasy
Map Generator becomes an enterable world with the generator's OWN
place names at their exact positions — no VLM guessing.

- lib/azgaar-import.ts (~170 lines of OUR code, ZERO new
  dependencies): parses the 'Export to JSON (full)' file. Schema
  verified against a real v1.149.2 export captured live from the
  running generator (burgs[0] is a literal 0 placeholder; removed
  burgs stay in the array; x/y are pixels in the info.width x height
  frame). Capitals + population rank the cap-40 list; state names
  ride the notes ('capital of Kingdom of Chawleigh, port').
- POST /api/world/[sessionId]/import-map: owner-gated; the CLIENT
  parses and sends only the capped entity list (the raw export is
  multi-MB). Deterministic geo_import_<slug> ids make re-imports
  updates, not duplicates. Geos land source='user', confidence 1 —
  author-supplied positions beat later VLM guesses.
- play page: dropping a .json on the canvas routes to the importer
  (images keep today's path); pair it with the exported PNG uploaded
  as the seed page.

Live-verified: 3 fixture entities POSTed from the owning browser ->
200 imported:3 -> world_map rows with correct frame coords.
14 new tests on the real fixture (parse, placeholder/removed
skipping, cap ordering, geo mapping, route validation).
