### PR TITLE
chore(ci): ratchet the coverage floors — web 78/78/81/86, backend 87

### DIFF
--- a/apps/modal-backend/pyproject.toml
+++ b/apps/modal-backend/pyproject.toml
@@ -54,7 +54,7 @@ markers = [
 # PR that drops the total below this FAILS; a PR that raises coverage bumps
 # the floor. Never lower it to make a PR pass — that defeats the ratchet.
 [tool.coverage.report]
-fail_under = 85
+fail_under = 87
 
 [tool.mypy]
 python_version = "3.12"

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -36,9 +36,9 @@ export default defineConfig({
       // FAILS; a PR that raises coverage bumps the floor to the new number.
       // Never lower these to make a PR pass — that defeats the ratchet.
       thresholds: {
-        lines: 77,
-        statements: 77,
-        functions: 80,
+        lines: 78,
+        statements: 78,
+        functions: 81,
         branches: 86,
       },
     },


### PR DESCRIPTION
Raise-only, per the ratchet rule: web measured 78.25-78.46 lines
(descent-clip + azgaar-import + outward-context tests landed this
week), backend measured 88. Floors move to one point under measured.
