### PR TITLE
fix(outward): keep the source map's cartographic style in the container (#252)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -191,6 +191,14 @@ FAL_EDIT_TIER=balanced
 # re-renders fresh from the ORIGINAL style text. 0 = OFF (no cap); the trade is
 # medium fidelity over pixel-continuity past the cap.
 # SCALE_OUTWARD_MAX_HOPS=0
+# OUTWARD style continuity (#252). The container was restyling the source map
+# into a soft label-free watercolor (style-judge medium 4.5). STYLE_LOCK sends
+# a cartographic-continuity instruction (A/B: medium 4.5 -> 7.5); false = the
+# pre-#252 generic instruction, byte-identical. ACCEPT_MEDIUM is the ascend
+# loop's style floor (raised from the shared 6.0 so a borderline restyle
+# retries instead of shipping); set 6.0 to restore the old floor.
+# SCALE_OUTWARD_STYLE_LOCK=true
+# SCALE_OUTWARD_ACCEPT_MEDIUM=7.0
 # World Mode — GRADUATED to default ON (2026-08-21). Taps ENTER places, the
 # world persists on a metric map, and the scale ladder (deeper / ascend /
 # around) is live. One knob restores the classic explainer stack wholesale

--- a/apps/modal-backend/providers/generate_modes/ascend.py
+++ b/apps/modal-backend/providers/generate_modes/ascend.py
@@ -247,17 +247,22 @@ async def stream_ascend(
                 # hop cap) skips it too: the drifting previous hop is exactly what
                 # we must NOT condition on — fall through to the fresh text render.
                 medium = style_lock or "the same hand-drawn art style as the centre"
-                # #252: the container is ALWAYS a wider map continuing a map
-                # source, but the generic "same art style" let nano-banana
-                # restyle it into a soft label-free watercolor (medium judge
-                # 6.0 — accepted at the floor). Demand cartographic continuity
-                # explicitly. Kill-switch SCALE_OUTWARD_STYLE_LOCK=false =
-                # the pre-#252 instruction, byte-identical.
+                # #252: the container is ALWAYS a wider top-down MAP continuing a
+                # map source, but the generic "same art style" let nano-banana
+                # crayon-restyle it (style judge medium 4.5, accepted at the
+                # 6.0 floor). Demand cartographic continuity + the no-inset
+                # framing (A/B on the Ankh map: 4.5 -> 7.5). NOT gated on a map
+                # scene_view: uploaded-map roots carry scene_view=null (verified
+                # in Mongo), so a map-level guard would skip the exact demo
+                # case. Kill-switch SCALE_OUTWARD_STYLE_LOCK=false = pre-#252.
                 if env_flag("SCALE_OUTWARD_STYLE_LOCK", "true"):
-                    # A/B'd against the old generic wording (style-judge medium
-                    # 4.5 crayon-restyle -> 7.5 here): "ONE SINGLE continuous
-                    # chart" + the explicit no-inset/no-desk clause kill the
-                    # map-within-a-map framing nano-banana falls into.
+                    # This exact wording is A/B-chosen. The composition clause
+                    # ("ONE SINGLE continuous chart", no-inset/no-desk) is robust
+                    # across renders; the explicit "its exact palette" holds
+                    # COLOR better than the canonical medium_lock() helper, which
+                    # went monochrome (medium 6.0 vs this wording's 7.5) — output
+                    # beats code-reuse here. The raised floor below retries any
+                    # palette dip regardless.
                     ascend_instr = (
                         "Zoom OUT / pull the camera back to reveal the surrounding "
                         f"{to_tier.replace('_', ' ')} around this map, as ONE SINGLE "

--- a/apps/modal-backend/providers/generate_modes/ascend.py
+++ b/apps/modal-backend/providers/generate_modes/ascend.py
@@ -247,11 +247,35 @@ async def stream_ascend(
                 # hop cap) skips it too: the drifting previous hop is exactly what
                 # we must NOT condition on — fall through to the fresh text render.
                 medium = style_lock or "the same hand-drawn art style as the centre"
-                ascend_instr = (
-                    f"Zoom OUT to reveal the surrounding {to_tier.replace('_', ' ')}, "
-                    f"keeping this exact view as the centre. {medium}; one continuous "
-                    "view in that style, NOT a photograph, no photorealism."
-                )
+                # #252: the container is ALWAYS a wider map continuing a map
+                # source, but the generic "same art style" let nano-banana
+                # restyle it into a soft label-free watercolor (medium judge
+                # 6.0 — accepted at the floor). Demand cartographic continuity
+                # explicitly. Kill-switch SCALE_OUTWARD_STYLE_LOCK=false =
+                # the pre-#252 instruction, byte-identical.
+                if env_flag("SCALE_OUTWARD_STYLE_LOCK", "true"):
+                    # A/B'd against the old generic wording (style-judge medium
+                    # 4.5 crayon-restyle -> 7.5 here): "ONE SINGLE continuous
+                    # chart" + the explicit no-inset/no-desk clause kill the
+                    # map-within-a-map framing nano-banana falls into.
+                    ascend_instr = (
+                        "Zoom OUT / pull the camera back to reveal the surrounding "
+                        f"{to_tier.replace('_', ' ')} around this map, as ONE SINGLE "
+                        "continuous hand-inked cartographer's chart at one consistent "
+                        "scale on one sheet. The original walled place stays at the "
+                        "EXACT CENTRE — same shape and same labels — now drawn smaller "
+                        "and ringed by its surrounding lands. Keep the source's exact "
+                        f"style ({medium}): the same inked linework, lettering and "
+                        "palette. This is a FLAT top-down map only: do NOT draw a "
+                        "map-within-a-map or an inset, no desk or table, no hand, no "
+                        "photo border, NOT a photograph, no soft watercolor."
+                    )
+                else:
+                    ascend_instr = (
+                        f"Zoom OUT to reveal the surrounding {to_tier.replace('_', ' ')}, "
+                        f"keeping this exact view as the centre. {medium}; one continuous "
+                        "view in that style, NOT a photograph, no photorealism."
+                    )
                 if source_identity:
                     ascend_instr += " SOURCE IDENTITY LOCK: " + source_identity
                 if outward_rider:
@@ -277,8 +301,24 @@ async def stream_ascend(
                     )
                     render_unjudged = True
                 else:
+                    import dataclasses
+
                     ascend_cfg = edit_loop.edit_loop_config_from_env(
                         body.max_attempts
+                    )
+                    # #252: a map container scoring AT the shared 6.0 medium
+                    # floor shipped a watercolor restyle. Raise the ascend
+                    # loop's style floor (env SCALE_OUTWARD_ACCEPT_MEDIUM; set
+                    # 6.0 to restore the shared floor) so a borderline break
+                    # retries and keeps the best-styled attempt.
+                    try:
+                        _asc_floor = float(
+                            os.environ.get("SCALE_OUTWARD_ACCEPT_MEDIUM", 7.0)
+                        )
+                    except (TypeError, ValueError):
+                        _asc_floor = 7.0
+                    ascend_cfg = dataclasses.replace(
+                        ascend_cfg, accept_medium=_asc_floor
                     )
                     ascend_deadline = _time.monotonic() + 720.0
                     captured_instr = ascend_instr

--- a/apps/modal-backend/tests/test_generate_ascend.py
+++ b/apps/modal-backend/tests/test_generate_ascend.py
@@ -515,8 +515,8 @@ async def test_ascend_edit_instruction_locks_cartographic_style(
     instr = edit.await_args_list[0].args[1]
     assert "ONE SINGLE" in instr
     assert "EXACT CENTRE" in instr
-    assert "inked linework" in instr
     assert "do NOT draw a map-within-a-map" in instr
+    assert "inked linework, lettering and palette" in instr
 
 
 async def test_ascend_style_lock_off_restores_generic_instruction(

--- a/apps/modal-backend/tests/test_generate_ascend.py
+++ b/apps/modal-backend/tests/test_generate_ascend.py
@@ -499,3 +499,72 @@ async def test_ascend_suppresses_lettering_in_dom_labels_mode(
     assert next(e for e in events if e["type"] == "ascend_ready")
     instr = edit.await_args.args[1]
     assert NO_LETTERING in instr
+
+
+async def test_ascend_edit_instruction_locks_cartographic_style(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # #252: the container edit must demand cartographic continuity (exact
+    # linework, labels, palette) — the generic "same art style" let
+    # nano-banana restyle the map into a soft label-free watercolor.
+    _enable(monkeypatch)
+    _mock_fresh(monkeypatch)
+    edit = AsyncMock(return_value=GeneratedImage(b"jpeg", "image/jpeg", "m", "r"))
+    monkeypatch.setattr(image_edit_mod, "edit_image", edit)
+    await _collect(_event_stream(_ascend_body(image=_DECODABLE), "t1"))
+    instr = edit.await_args_list[0].args[1]
+    assert "ONE SINGLE" in instr
+    assert "EXACT CENTRE" in instr
+    assert "inked linework" in instr
+    assert "do NOT draw a map-within-a-map" in instr
+
+
+async def test_ascend_style_lock_off_restores_generic_instruction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Kill-switch: SCALE_OUTWARD_STYLE_LOCK=false = the pre-#252 instruction.
+    _enable(monkeypatch)
+    monkeypatch.setenv("SCALE_OUTWARD_STYLE_LOCK", "false")
+    _mock_fresh(monkeypatch)
+    edit = AsyncMock(return_value=GeneratedImage(b"jpeg", "image/jpeg", "m", "r"))
+    monkeypatch.setattr(image_edit_mod, "edit_image", edit)
+    await _collect(_event_stream(_ascend_body(image=_DECODABLE), "t1"))
+    instr = edit.await_args_list[0].args[1]
+    assert "THIS EXACT MAP" not in instr
+    assert "keeping this exact view as the centre" in instr
+
+
+async def test_ascend_medium_floor_retries_borderline_style(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # #252: a container scoring 6.5 style (a soft restyle) used to SHIP at the
+    # shared 6.0 floor. The raised ascend floor (7.0 default) retries it;
+    # SCALE_OUTWARD_ACCEPT_MEDIUM=6.0 restores the accept-at-6.0 behaviour.
+    from providers import judge as judge_mod
+    from providers.judge import JudgeResult
+
+    _enable(monkeypatch)
+    _mock_fresh(monkeypatch)
+    monkeypatch.setattr(
+        judge_mod,
+        "score_prompt_alignment",
+        AsyncMock(return_value=JudgeResult(9.0, "zoomed out", "")),
+    )
+    monkeypatch.setattr(
+        judge_mod,
+        "score_style_pair",
+        AsyncMock(return_value=JudgeResult(6.5, "soft restyle", "")),
+    )
+
+    # Default raised floor 7.0: 6.5 < 7.0 -> retry -> two edit calls.
+    edit = AsyncMock(return_value=GeneratedImage(b"jpeg", "image/jpeg", "m", "r"))
+    monkeypatch.setattr(image_edit_mod, "edit_image", edit)
+    await _collect(_event_stream(_ascend_body(image=_DECODABLE), "t1"))
+    assert edit.await_count == 2
+
+    # Restore the old floor: 6.5 >= 6.0 -> accepted on the first attempt.
+    monkeypatch.setenv("SCALE_OUTWARD_ACCEPT_MEDIUM", "6.0")
+    edit2 = AsyncMock(return_value=GeneratedImage(b"jpeg", "image/jpeg", "m", "r"))
+    monkeypatch.setattr(image_edit_mod, "edit_image", edit2)
+    await _collect(_event_stream(_ascend_body(image=_DECODABLE), "t2"))
+    assert edit2.await_count == 1


### PR DESCRIPTION
Closes the loud half of #252.

## The bug (from the demo film)
OUTWARD's container kept the right NAME (#244 — 'The Sto Plains', right
entities) but restyled the map into a soft label-free watercolor. A
viewer reads it as a random city — Eren, watching the cut: "what the
fuck even is that."

## Root cause (two compounding, both env-revertible)
1. **Instruction too generic.** `the same hand-drawn art style` let
   nano-banana-pro (a strong labeled-map model — not a model problem)
   crayon-restyle the chart. A/B on the Ankh map, scored by the same
   style judge that gates the loop:
   - old wording → **medium 4.5** (crayon sketch, a photo hand drawing on it)
   - new wording → **medium 7.5** (a proper in-style region map: walled
     city at the exact centre, ringed by farmland/forest, river delta,
     compass rose, scale bar; no map-within-a-map, no desk)
   Kill-switch `SCALE_OUTWARD_STYLE_LOCK=false` = the old instruction.
2. **Floor was a pass-through at the failure value.** `accept_medium=6.0`,
   check `score < 6.0` — the Sto Plains render scored **exactly 6.0** and
   shipped. The ascend loop now floors medium at **7.0**
   (`SCALE_OUTWARD_ACCEPT_MEDIUM`; 6.0 restores the shared floor) so a
   borderline restyle retries and keeps the best-styled attempt.

## Honest scope
Fixes the **medium + composition** (the loud part). Does NOT make the
centre pixel-identical to the specific source city — the render is
still an in-style re-invention. True centre-identity is the
**compositing follow-up** (#252 stays open for that; item 4 on its
ladder: keep the real source pixels at centre, synthesize only margins).

## Verified
- Full backend suite green; 3 new tests (instruction clause, kill-switch
  byte-identical revert, floor retries a mocked 6.5 restyle).
- Live A/B receipts on Desktop:
  `252-outward-OLD-crayon-medium4.5.jpg` vs
  `252-outward-FIXED-inked-medium7.5.jpg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)