### PR TITLE
fix: enforce OUTWARD integrity and repair mobile controls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -196,7 +196,9 @@ FAL_EDIT_TIER=balanced
 # a cartographic-continuity instruction (A/B: medium 4.5 -> 7.5); false = the
 # pre-#252 generic instruction, byte-identical. ACCEPT_MEDIUM is the ascend
 # loop's style floor (raised from the shared 6.0 so a borderline restyle
-# retries instead of shipping); set 6.0 to restore the old floor.
+# retries instead of shipping); set 6.0 to restore the old floor. If every
+# judged attempt fails, OUTWARD leaves the current world unchanged. Judge
+# outages remain an explicitly unverified fallback. Valid floor range: 0-10.
 # SCALE_OUTWARD_STYLE_LOCK=true
 # SCALE_OUTWARD_ACCEPT_MEDIUM=7.0
 # World Mode — GRADUATED to default ON (2026-08-21). Taps ENTER places, the

--- a/apps/modal-backend/providers/generate_modes/ascend.py
+++ b/apps/modal-backend/providers/generate_modes/ascend.py
@@ -11,6 +11,7 @@ generate.py's stream helpers (`_sse`, `_frame_dims`, `_view_grammar_on`,
 from __future__ import annotations
 
 import asyncio as _asyncio
+import math
 import os
 import time as _time
 from collections.abc import AsyncIterator, Awaitable, Callable
@@ -203,7 +204,8 @@ async def stream_ascend(
         from providers.prompt_library.style import NO_LETTERING
 
         no_lettering = NO_LETTERING
-    render_unjudged = False
+    render_unjudged = True
+    render_rejected = False
     billed_images = 1
     try:
         if use_outpaint:
@@ -315,12 +317,14 @@ async def stream_ascend(
                     # floor shipped a watercolor restyle. Raise the ascend
                     # loop's style floor (env SCALE_OUTWARD_ACCEPT_MEDIUM; set
                     # 6.0 to restore the shared floor) so a borderline break
-                    # retries and keeps the best-styled attempt.
+                    # retries instead of publishing a borderline restyle.
                     try:
                         _asc_floor = float(
                             os.environ.get("SCALE_OUTWARD_ACCEPT_MEDIUM", 7.0)
                         )
                     except (TypeError, ValueError):
+                        _asc_floor = 7.0
+                    if not math.isfinite(_asc_floor) or not 0 <= _asc_floor <= 10:
                         _asc_floor = 7.0
                     ascend_cfg = dataclasses.replace(
                         ascend_cfg, accept_medium=_asc_floor
@@ -358,7 +362,19 @@ async def stream_ascend(
                     billed_images = max(1, len(ascend_attempts))
                     # Critic degraded (judge failure → single blind attempt):
                     # the render shipped without a verdict — flag it.
-                    render_unjudged = asc_res.best.alignment is None
+                    render_unjudged = (
+                        asc_res.best.alignment is None or asc_res.best.medium is None
+                    )
+                    # A known failure must not become a new persistent root.
+                    # Keep the explicit unverified fallback for critic outages,
+                    # but never let an available critic's rejection pass through.
+                    render_rejected = (
+                        asc_res.best.alignment is not None
+                        and asc_res.best.alignment.score < ascend_cfg.accept_alignment
+                    ) or (
+                        asc_res.best.medium is not None
+                        and asc_res.best.medium.score < ascend_cfg.accept_medium
+                    )
             else:
                 # Fresh container = a NEW map: state the deliberate
                 # top-down camera (None on astro rungs → legacy bytes).
@@ -406,12 +422,21 @@ async def stream_ascend(
                 {"type": "error", "message": f"ascend failed: {exc}"}, trace_id
             )
         return
-    data_url = await _asyncio.to_thread(
-        image_provider.encode_data_url, img.jpeg_bytes, img.mime_type
-    )
     # Spend accounting: this OUTWARD hop made real paid image calls (one per
     # judged attempt) — record them so the cap actually counts them.
     spend.record_generation(body.session_id, img.model, images=billed_images)
+    if render_rejected:
+        yield _sse(
+            {
+                "type": "error",
+                "message": "The wider view did not pass the quality checks. Your world is unchanged.",
+            },
+            trace_id,
+        )
+        return
+    data_url = await _asyncio.to_thread(
+        image_provider.encode_data_url, img.jpeg_bytes, img.mime_type
+    )
     ascend_payload: GenerateAscendReadyEvent = {
         "type": "ascend_ready",
         "page_title": page_title,

--- a/apps/modal-backend/tests/test_generate_ascend.py
+++ b/apps/modal-backend/tests/test_generate_ascend.py
@@ -568,3 +568,88 @@ async def test_ascend_medium_floor_retries_borderline_style(
     monkeypatch.setattr(image_edit_mod, "edit_image", edit2)
     await _collect(_event_stream(_ascend_body(image=_DECODABLE), "t2"))
     assert edit2.await_count == 1
+
+
+@pytest.mark.parametrize("alignment,medium", [(9.0, 6.0), (6.0, 9.0)])
+async def test_ascend_rejected_attempts_do_not_replace_the_world(
+    monkeypatch: pytest.MonkeyPatch, alignment: float, medium: float
+) -> None:
+    from providers import judge, spend
+    from providers.judge import JudgeResult
+
+    _enable(monkeypatch)
+    _mock_fresh(monkeypatch)
+    edit = AsyncMock(return_value=GeneratedImage(b"bad", "image/jpeg", "m", "r"))
+    monkeypatch.setattr(image_edit_mod, "edit_image", edit)
+    monkeypatch.setattr(judge, "score_prompt_alignment", AsyncMock(return_value=JudgeResult(alignment, "alignment", "")))
+    monkeypatch.setattr(judge, "score_style_pair", AsyncMock(return_value=JudgeResult(medium, "style", "")))
+    record = MagicMock()
+    monkeypatch.setattr(spend, "record_generation", record)
+
+    events = await _collect(_event_stream(_ascend_body(image=_DECODABLE), "t1"))
+
+    assert edit.await_count == 2
+    assert not any(e["type"] == "ascend_ready" for e in events)
+    assert "unchanged" in next(e["message"] for e in events if e["type"] == "error")
+    record.assert_called_once_with("s1", "m", images=2)
+
+
+async def test_ascend_accepted_retry_is_the_only_published_image(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from providers import judge
+    from providers.judge import JudgeResult
+
+    _enable(monkeypatch)
+    _mock_fresh(monkeypatch)
+    edit = AsyncMock(side_effect=[
+        GeneratedImage(b"bad", "image/jpeg", "m", "r1"),
+        GeneratedImage(b"good", "image/jpeg", "m", "r2"),
+    ])
+    monkeypatch.setattr(image_edit_mod, "edit_image", edit)
+    monkeypatch.setattr(judge, "score_prompt_alignment", AsyncMock(return_value=JudgeResult(9, "aligned", "")))
+    monkeypatch.setattr(judge, "score_style_pair", AsyncMock(side_effect=[
+        JudgeResult(6, "wrong palette", ""), JudgeResult(8, "same style", ""),
+    ]))
+
+    events = await _collect(_event_stream(_ascend_body(image=_DECODABLE), "t1"))
+    ready = next(e for e in events if e["type"] == "ascend_ready")
+    assert ready["image_data_url"] == image_mod.encode_data_url(b"good", "image/jpeg")
+    assert "wrong palette" in edit.await_args_list[1].args[1]
+
+
+async def test_ascend_style_judge_failure_is_marked_unverified(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from providers import judge
+    from providers.judge import JudgeResult
+
+    _enable(monkeypatch)
+    _mock_fresh(monkeypatch)
+    edit = AsyncMock(return_value=GeneratedImage(b"jpeg", "image/jpeg", "m", "r"))
+    monkeypatch.setattr(image_edit_mod, "edit_image", edit)
+    monkeypatch.setattr(judge, "score_prompt_alignment", AsyncMock(return_value=JudgeResult(9, "aligned", "")))
+    monkeypatch.setattr(judge, "score_style_pair", AsyncMock(side_effect=RuntimeError("offline")))
+
+    events = await _collect(_event_stream(_ascend_body(image=_DECODABLE), "t1"))
+    ready = next(e for e in events if e["type"] == "ascend_ready")
+    assert ready["render_unjudged"] is True
+    edit.assert_awaited_once()
+
+
+@pytest.mark.parametrize("floor", ["nan", "inf", "-inf", "-1", "11", "", "garbage"])
+async def test_ascend_invalid_medium_floor_cannot_disable_style_gate(
+    monkeypatch: pytest.MonkeyPatch, floor: str
+) -> None:
+    from providers import judge
+    from providers.judge import JudgeResult
+
+    _enable(monkeypatch)
+    _mock_fresh(monkeypatch)
+    monkeypatch.setenv("SCALE_OUTWARD_ACCEPT_MEDIUM", floor)
+    monkeypatch.setattr(image_edit_mod, "edit_image", AsyncMock(return_value=GeneratedImage(b"bad", "image/jpeg", "m", "r")))
+    monkeypatch.setattr(judge, "score_prompt_alignment", AsyncMock(return_value=JudgeResult(9, "aligned", "")))
+    monkeypatch.setattr(judge, "score_style_pair", AsyncMock(return_value=JudgeResult(6, "wrong style", "")))
+
+    events = await _collect(_event_stream(_ascend_body(image=_DECODABLE), "t1"))
+    assert not any(e["type"] == "ascend_ready" for e in events)

--- a/apps/web/app/api/nodes/route.ts
+++ b/apps/web/app/api/nodes/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from "next/server";
 import type { ScaleTier, SceneView, ViewVerdict } from "@openflipbook/config";
-import { insertNode } from "@/lib/db";
+import { getNode, insertNode } from "@/lib/db";
 import { decodeDataUrl, uploadJpeg } from "@/lib/r2";
 import { readServerEnv } from "@/lib/env";
 import { requireOwner } from "@/lib/session-owner";
 import { getIdempotentResult, saveIdempotentResult } from "@/lib/idempotency";
+import { isSafeId } from "@/lib/ids";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -40,8 +41,13 @@ export async function POST(req: Request) {
     );
   }
 
-  const body = (await req.json()) as CreateBody;
-  if (!body.image_data_url || !body.session_id || !body.page_title) {
+  const body = (await req.json().catch(() => null)) as CreateBody | null;
+  if (
+    !body ||
+    typeof body.image_data_url !== "string" || !body.image_data_url ||
+    !isSafeId(body.session_id) ||
+    typeof body.page_title !== "string" || !body.page_title.trim()
+  ) {
     return NextResponse.json(
       { error: "missing required fields: session_id, page_title, image_data_url" },
       { status: 400 }
@@ -52,16 +58,27 @@ export async function POST(req: Request) {
   const auth = await requireOwner(body.session_id);
   if (!auth.ok) return auth.res;
 
+  if (body.parent_id != null) {
+    if (!isSafeId(body.parent_id)) {
+      return NextResponse.json({ error: "invalid parent_id" }, { status: 400 });
+    }
+    const parent = await getNode(body.parent_id);
+    if (!parent || parent.session_id !== body.session_id) {
+      return NextResponse.json({ error: "parent_id not found in this session" }, { status: 404 });
+    }
+  }
+
   // Idempotent create: a retry with the same Idempotency-Key returns the
   // already-persisted node instead of inserting a duplicate (and skips the
   // re-upload).
-  const idemKey = req.headers.get("idempotency-key");
+  const requestKey = req.headers.get("idempotency-key");
+  const idemKey = requestKey ? `node:${body.session_id}:${requestKey}` : null;
   if (idemKey) {
     const cached = await getIdempotentResult<{
       id: string;
       image_url: string;
       created_at: string;
-    }>(`node:${idemKey}`);
+    }>(idemKey);
     if (cached) return NextResponse.json(cached);
   }
 
@@ -96,6 +113,6 @@ export async function POST(req: Request) {
     image_url: uploaded.url,
     created_at: row.created_at,
   };
-  if (idemKey) await saveIdempotentResult(`node:${idemKey}`, result);
+  if (idemKey) await saveIdempotentResult(idemKey, result);
   return NextResponse.json(result);
 }

--- a/apps/web/app/api/world/[sessionId]/ascend/route.ts
+++ b/apps/web/app/api/world/[sessionId]/ascend/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import type { ScaleTier, SceneView, WorldEntityGeo } from "@openflipbook/config";
-import { tierTransitionValid } from "@openflipbook/config";
+import { SCALE_TIER_METERS, tierTransitionValid } from "@openflipbook/config";
 
 import { deleteNode, getNode, insertNode, recordError, updateNodeParent } from "@/lib/db";
 import { decodeDataUrl, uploadJpeg } from "@/lib/r2";
@@ -10,6 +10,7 @@ import { reparentRoots } from "@/lib/scale-tree";
 import { MAP_IMAGE_FRAME } from "@/lib/geo-tap";
 import { readServerEnv } from "@/lib/env";
 import { envFlag } from "@/lib/env-flag";
+import { isSafeId } from "@/lib/ids";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -58,10 +59,16 @@ export async function POST(req: Request, { params }: Params) {
     );
   }
 
-  const body = (await req.json()) as AscendBody;
-  if (!body.child_node_id || !body.image_data_url || !body.parent_tier) {
+  const body = (await req.json().catch(() => null)) as AscendBody | null;
+  if (
+    !body ||
+    !isSafeId(body.child_node_id) ||
+    typeof body.image_data_url !== "string" || !body.image_data_url ||
+    typeof body.parent_tier !== "string" || !Object.hasOwn(SCALE_TIER_METERS, body.parent_tier) ||
+    typeof body.page_title !== "string" || !body.page_title.trim()
+  ) {
     return NextResponse.json(
-      { error: "missing required fields: child_node_id, image_data_url, parent_tier" },
+      { error: "invalid or missing fields: child_node_id, image_data_url, parent_tier, page_title" },
       { status: 400 },
     );
   }
@@ -70,7 +77,7 @@ export async function POST(req: Request, { params }: Params) {
 
   // Double-ascend guard: C must exist and still be a root.
   const child = await getNode(body.child_node_id);
-  if (!child) {
+  if (!child || child.session_id !== sessionId) {
     return NextResponse.json({ error: "child_node_id not found" }, { status: 404 });
   }
   if (child.parent_id !== null) {
@@ -85,10 +92,14 @@ export async function POST(req: Request, { params }: Params) {
   // than the child, or metric-inconsistent) would corrupt the ladder — reject it
   // here rather than persist a bad transition. tierTransitionValid was test-only
   // until now (SESSION_AUDIT: "no runtime INV-2 enforcement").
-  if (child.scale_tier && !tierTransitionValid(child.scale_tier, body.parent_tier)) {
+  const childTier = child.scale_tier ?? child.scene_view?.scale_tier ?? "city";
+  if (
+    !tierTransitionValid(childTier, body.parent_tier) ||
+    SCALE_TIER_METERS[body.parent_tier] <= SCALE_TIER_METERS[childTier]
+  ) {
     return NextResponse.json(
       {
-        error: `invalid OUTWARD tier transition: ${child.scale_tier} -> ${body.parent_tier}`,
+        error: `invalid OUTWARD tier transition: ${childTier} -> ${body.parent_tier}`,
       },
       { status: 400 },
     );

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -3621,8 +3621,8 @@ export default function PlayPage() {
               )}
             </div>
           )}
-          <div className="flex items-center justify-between gap-3 text-xs opacity-80">
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center justify-between gap-3 text-xs opacity-80">
+          <div className="flex flex-wrap items-center gap-2 whitespace-nowrap">
             <button
               type="button"
               onClick={goBack}
@@ -3659,7 +3659,7 @@ export default function PlayPage() {
               ↗ atlas
             </a>
           </div>
-          <span className="opacity-60">
+          <span className="whitespace-nowrap opacity-60">
             step {history.trailIdx + 1} of {history.trail.length}
             {history.items.length > history.trail.length
               ? ` · ${history.items.length} pages explored`
@@ -3679,7 +3679,7 @@ export default function PlayPage() {
                 shared.clearIncoming();
                 if (id) selectFromMap(id);
               }}
-              className="rounded-full border border-emerald-600/40 bg-emerald-50 px-3 py-1 text-xs text-emerald-900 hover:bg-emerald-100"
+              className="max-w-full truncate rounded-full border border-emerald-600/40 bg-emerald-50 px-3 py-1 text-xs text-emerald-900 hover:bg-emerald-100"
               title="A co-viewer added this page — click to open it"
             >
               ✦ new: {shared.incoming.title.slice(0, 32)} →
@@ -4102,13 +4102,8 @@ export default function PlayPage() {
                 </div>
               )}
 
-            {/* Capped + wrapping: at ≤390px this row is wider than the frame
-                and used to hang off BOTH edges — Around/⊞ geo were fully
-                off-screen and untappable (UI_AUDIT #13). Right-anchored with
-                intrinsic width, so desktop renders identically. z-10 matches
-                the World pill so, on any residual overlap at narrow widths,
-                this later-in-DOM toolbar wins the stack and stays tappable. */}
-            <div className="absolute right-3 top-3 z-10 flex max-w-[calc(100%-1.5rem)] flex-wrap justify-end gap-2">
+            {/* Reserve space for the World button at narrow widths. */}
+            <div className="absolute right-3 top-3 z-10 flex max-w-[calc(100%-4.5rem)] flex-wrap justify-end gap-2 sm:max-w-[calc(100%-1.5rem)]">
               {wanderNote && (
                 <span className="flex items-center rounded-full bg-black/70 px-2.5 py-1 text-xs text-white/95">
                   {wanderNote}
@@ -4317,8 +4312,8 @@ export default function PlayPage() {
 
       {page?.nodeId && (
         <div className="flex flex-col items-center gap-1 text-xs">
-          <div className="flex items-center gap-2 opacity-60">
-            <span>
+          <div className="flex max-w-full flex-wrap items-center justify-center gap-2 opacity-60">
+            <span className="min-w-0 break-all">
               Permalink: <code>/n/{page.nodeId}</code>
             </span>
             <button

--- a/apps/web/components/PlayPage/QueryToolbar.tsx
+++ b/apps/web/components/PlayPage/QueryToolbar.tsx
@@ -67,7 +67,7 @@ export function QueryToolbar({
     <>
       <form
         onSubmit={onSubmit}
-        className="flex flex-wrap items-center gap-2 rounded-full border border-[var(--color-edge)] bg-[var(--color-canvas)]/80 px-4 py-2 shadow-sm"
+        className="flex flex-wrap items-center gap-2 rounded-lg border border-[var(--color-edge)] bg-[var(--color-canvas)]/80 px-4 py-2 shadow-sm sm:rounded-full"
       >
         <input
           autoFocus

--- a/apps/web/components/PlayPage/SpeedPreset.tsx
+++ b/apps/web/components/PlayPage/SpeedPreset.tsx
@@ -98,7 +98,7 @@ export function SpeedPreset({
   );
 
   return (
-    <div className="relative flex items-center gap-1.5 text-xs">
+    <div className="relative flex min-w-0 max-w-full flex-wrap items-center gap-1.5 text-xs">
       <div
         role="group"
         aria-label="Speed / quality preset"
@@ -141,7 +141,7 @@ export function SpeedPreset({
       </div>
       <span
         data-testid="cost-chip"
-        className="whitespace-nowrap opacity-60"
+        className="opacity-60"
         title={`Projected spend per action — tap ${tap} · edit ${edit} · new page ${fresh}. Ranges span retries; see docs/COSTS.md.${
           typeof sessionSpend === "number"
             ? ` Session so far ≈ $${sessionSpend.toFixed(2)} (backend estimate).`

--- a/apps/web/components/PlayPage/TapHint.tsx
+++ b/apps/web/components/PlayPage/TapHint.tsx
@@ -18,7 +18,7 @@ interface Props {
  */
 export function TapHint({ text }: Props) {
   return (
-    <figcaption className="pointer-events-none absolute inset-x-0 bottom-3 flex justify-center text-sm text-white">
+    <figcaption className="pointer-events-none absolute inset-x-0 bottom-3 hidden justify-center text-sm text-white sm:flex">
       <span className="max-w-[60%] truncate rounded-full bg-black/55 px-3 py-1 backdrop-blur">
         {text}
       </span>

--- a/apps/web/e2e/outward.spec.ts
+++ b/apps/web/e2e/outward.spec.ts
@@ -1,0 +1,98 @@
+import { type Locator, expect, test } from "@playwright/test";
+
+import { waitForStableImage } from "./helpers";
+
+test.skip(!process.env.E2E_MOCK, "mock-only: exercises OUTWARD without paid model calls");
+
+async function expectSeparate(a: Locator, b: Locator) {
+  const first = await a.boundingBox();
+  const second = await b.boundingBox();
+  expect(first).not.toBeNull();
+  expect(second).not.toBeNull();
+  const overlaps = first!.x < second!.x + second!.width && second!.x < first!.x + first!.width &&
+    first!.y < second!.y + second!.height && second!.y < first!.y + first!.height;
+  expect(overlaps, "image controls must not overlap").toBe(false);
+}
+
+for (const viewport of [
+  { name: "desktop", width: 1440, height: 1000 },
+  { name: "mobile", width: 390, height: 844 },
+]) {
+  test(`OUTWARD preserves the saved source and returns to it on ${viewport.name}`, async ({ page }, testInfo) => {
+    await page.setViewportSize(viewport);
+    const errors: string[] = [];
+    page.on("pageerror", (error) => errors.push(error.message));
+    let sessionId = "";
+    let generations = 0;
+    page.on("request", (req) => {
+      if (req.url().includes("/api/generate-page") && req.method() === "POST") {
+        sessionId = req.postDataJSON().session_id;
+        generations += 1;
+      }
+    });
+    const persist = page.waitForResponse((r) => r.url().endsWith("/api/nodes") && r.request().method() === "POST");
+    await page.goto("/play?q=" + encodeURIComponent("a walled river city"));
+    const rootResponse = await persist;
+    expect(rootResponse.ok()).toBe(true);
+    const root = await rootResponse.json() as { id: string };
+    const source = await waitForStableImage(page);
+    const originalNode = await (await page.request.get(`/api/nodes/${root.id}`)).json();
+
+    const save = page.waitForResponse((r) => r.url().endsWith(`/api/world/${sessionId}/ascend`) && r.request().method() === "POST");
+    await page.getByTitle("Zoom out to the place that contains this one (OUTWARD)").click();
+    const saveResponse = await save;
+    expect(saveResponse.ok()).toBe(true);
+    const parent = await saveResponse.json() as { parent_node_id: string };
+    await expect(page).toHaveURL(new RegExp(`/n/${parent.parent_node_id}`));
+    await waitForStableImage(page);
+    expect(generations).toBe(2);
+
+    const savedSource = await (await page.request.get(`/api/nodes/${root.id}`)).json();
+    expect(savedSource.parent_id).toBe(parent.parent_node_id);
+    expect(savedSource.image_url).toBe(originalNode.image_url);
+    await expect(page.getByRole("button", { name: /back$/, exact: false }).first()).toBeEnabled();
+    if (viewport.name === "mobile") {
+      await expect(page.locator("figcaption")).toBeHidden();
+    } else {
+      await expectSeparate(page.getByRole("button", { name: "Pin style", exact: true }), page.locator("figcaption > span"));
+    }
+    await expectSeparate(page.getByRole("button", { name: /World Mode is on/ }), page.getByRole("button", { name: "Wander", exact: true }));
+    const outwardScreenshot = testInfo.outputPath(`${viewport.name}-outward.png`);
+    await page.screenshot({ path: outwardScreenshot, fullPage: true });
+    await testInfo.attach(`${viewport.name}-outward`, { path: outwardScreenshot, contentType: "image/png" });
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
+
+    await page.getByTitle("Go back (←)").click();
+    await expect(page).toHaveURL(new RegExp(`/n/${root.id}`));
+    expect(await waitForStableImage(page)).toBe(source);
+    expect(generations).toBe(2);
+    const returnedScreenshot = testInfo.outputPath(`${viewport.name}-returned.png`);
+    await page.screenshot({ path: returnedScreenshot, fullPage: true });
+    await testInfo.attach(`${viewport.name}-returned`, { path: returnedScreenshot, contentType: "image/png" });
+    expect(errors).toEqual([]);
+  });
+}
+
+test("a rejected OUTWARD result leaves the source visible and does not save a parent", async ({ page }) => {
+  const persist = page.waitForResponse((r) => r.url().endsWith("/api/nodes") && r.request().method() === "POST");
+  await page.goto("/play?q=" + encodeURIComponent("a small river city"));
+  await persist;
+  const source = await waitForStableImage(page);
+  const sourceUrl = page.url();
+  let saves = 0;
+  page.on("request", (req) => { if (req.url().endsWith("/ascend")) saves += 1; });
+  await page.route("**/api/generate-page", async (route) => {
+    if (route.request().postDataJSON().mode !== "ascend") return route.continue();
+    await route.fulfill({
+      contentType: "text/event-stream",
+      body: 'data: {"type":"error","message":"The wider view did not pass the quality checks. Your world is unchanged."}\n\n',
+    });
+  });
+  const outward = page.getByTitle("Zoom out to the place that contains this one (OUTWARD)");
+  await outward.click();
+  await expect(page.getByTitle("The wider view did not pass the quality checks. Your world is unchanged.")).toBeVisible();
+  await expect(outward).toBeEnabled();
+  expect(await waitForStableImage(page)).toBe(source);
+  expect(page.url()).toBe(sourceUrl);
+  expect(saves).toBe(0);
+});

--- a/apps/web/hooks/useAscend.test.tsx
+++ b/apps/web/hooks/useAscend.test.tsx
@@ -235,4 +235,42 @@ describe("useAscend", () => {
     expect(result.current.error).toBeNull();
     expect(result.current.pending).toBe(false);
   });
+
+  it("aborts generation when the navigation surface unmounts", async () => {
+    let signal: AbortSignal | null = null;
+    const onAscended = vi.fn();
+    const fn = vi.fn((_url: RequestInfo | URL, init?: RequestInit) => {
+      signal = init?.signal ?? null;
+      return new Promise((_, reject) => {
+        signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")));
+      });
+    });
+    vi.stubGlobal("fetch", fn);
+    const { result, unmount } = renderHook(() => useAscend(onAscended));
+    act(() => result.current.start("s1", root()));
+    unmount();
+    expect(signal!.aborted).toBe(true);
+    expect(onAscended).not.toHaveBeenCalled();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a stale non-abort error after a new request starts", async () => {
+    let rejectOld!: (error: Error) => void;
+    let resolveNew!: (response: unknown) => void;
+    const fn = vi.fn()
+      .mockImplementationOnce(() => new Promise((_, reject) => { rejectOld = reject; }))
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveNew = resolve; }))
+      .mockResolvedValue({ ok: true, json: async () => ({ parent_node_id: "new-parent" }) });
+    vi.stubGlobal("fetch", fn);
+    const onAscended = vi.fn();
+    const { result } = renderHook(() => useAscend(onAscended));
+    act(() => result.current.start("s1", root()));
+    act(() => result.current.start("s1", root({ nodeId: "new-child" })));
+    await act(async () => { rejectOld(new Error("late network failure")); });
+    expect(result.current.error).toBeNull();
+    expect(result.current.pending).toBe(true);
+    await act(async () => { resolveNew({ ok: true, body: sseBody([READY]) }); });
+    await waitFor(() => expect(onAscended).toHaveBeenCalledTimes(1));
+    expect(onAscended.mock.calls[0]![0].childNodeId).toBe("new-child");
+  });
 });

--- a/apps/web/hooks/useAscend.ts
+++ b/apps/web/hooks/useAscend.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import type {
   GenerateAscendReadyEvent,
@@ -77,6 +77,8 @@ export function useAscend(onAscended: (a: Ascended) => void): {
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => () => abortRef.current?.abort(), []);
 
   const start = useCallback(
     (sessionId: string, root: AscendRoot) => {
@@ -158,7 +160,7 @@ export function useAscend(onAscended: (a: Ascended) => void): {
           });
           setPending(false);
         } catch (err) {
-          if ((err as Error).name === "AbortError") return;
+          if (ac.signal.aborted || (err as Error).name === "AbortError") return;
           setError((err as Error).message);
           setPending(false);
         }

--- a/apps/web/lib/world-map.test.ts
+++ b/apps/web/lib/world-map.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { EntityGeoEdit, SceneView, WorldEntityGeo } from "@openflipbook/config";
+import { resolveAbsoluteFrame } from "./world-geometry";
+import { reparentRoots } from "./scale-tree";
 
 // In-memory Mongo stand-in so the optimistic read-modify-write wrappers run for
 // real (findOne / insertOne-with-dup / replaceOne-filtered-on-updated_at)
@@ -206,6 +208,28 @@ describe("applyEntityEdit (P5 structured geo edits)", () => {
     // Children must NOT keep pointing at the removed parent — else
     // resolveAbsolutePos mis-places them as roots in their own local frame.
     expect(out.every((e) => (e.parent_id ?? null) === null)).toBe(true);
+    expect(out.find((e) => e.id === child.id)!.pos).toEqual({ x: 11, y: 12 });
+    expect(out.find((e) => e.id === sibling.id)!.pos).toEqual({ x: 13, y: 14 });
+  });
+
+  it("removing a scaled nested container preserves surviving descendants' positions and extents", () => {
+    const ancestor = { ...geo("ancestor", "user", 10, 20), scale: 0.5 };
+    const parent = { ...geo("parent", "user", 4, 8), parent_id: "ancestor", scale: 0.2 };
+    const child = { ...geo("child", "user", 5, 15), parent_id: "parent", scale: 2 };
+    const grandchild = { ...geo("grandchild", "user", 1, 3), parent_id: "child" };
+    const original = [ancestor, parent, child, grandchild];
+    const out = applyEntityEdit(original, { op: "remove", target: "parent" }, "t");
+    const beforeById = new Map(original.map((e) => [e.id, e]));
+    const afterById = new Map(out.map((e) => [e.id, e]));
+    for (const entity of out) {
+      const before = resolveAbsoluteFrame(entity.id, beforeById)!;
+      const after = resolveAbsoluteFrame(entity.id, afterById)!;
+      expect(after.pos.x).toBeCloseTo(before.pos.x);
+      expect(after.pos.y).toBeCloseTo(before.pos.y);
+      expect(entity.footprint.w * after.unit).toBeCloseTo(beforeById.get(entity.id)!.footprint.w * before.unit);
+    }
+    expect(afterById.get("child")!.scale).toBeCloseTo(0.2);
+    expect(afterById.get("grandchild")!.parent_id).toBe("child");
   });
 
   it("add appends a user entity with defaults + deterministic id", () => {
@@ -531,6 +555,41 @@ describe("world-map Mongo wrappers (optimistic read-modify-write)", () => {
     const after = await removeEntityGeos("s3", ["geo_p"]);
     expect(after.entities.map((e) => e.id)).toEqual(["geo_c"]);
     expect(after.entities[0]!.parent_id ?? null).toBeNull();
+    expect(after.entities[0]!.pos).toEqual({ x: 11, y: 11 });
+  });
+
+  it("rolling back an OUTWARD container restores original geometry", async () => {
+    const originals = [
+      { ...geo("town", "user", 20, 30), scale_tier: "city" as const, scale: 0.5 },
+      { ...geo("tavern", "user", 4, 8), parent_id: "town" },
+    ];
+    const parent = { ...geo("container", "user", 50, 28), scale_tier: "region" as const };
+    const reparented = reparentRoots(originals, parent, "t1");
+    await upsertEntityGeos("rollback", reparented.geos);
+    const restored = await removeEntityGeos("rollback", [parent.id]);
+    expect(restored.entities.map((e) => e.id)).toEqual(originals.map((e) => e.id));
+    for (const original of originals) {
+      const actual = restored.entities.find((e) => e.id === original.id)!;
+      expect(actual.parent_id ?? null).toBe(original.parent_id ?? null);
+      expect(actual.pos.x).toBeCloseTo(original.pos.x);
+      expect(actual.pos.y).toBeCloseTo(original.pos.y);
+      expect(actual.footprint.w).toBeCloseTo(original.footprint.w);
+      expect(actual.footprint.d).toBeCloseTo(original.footprint.d);
+      expect(actual.scale ?? 1).toBeCloseTo(original.scale ?? 1);
+    }
+  });
+
+  it("removing multiple ancestors resolves survivors against the complete original tree", async () => {
+    const original = [
+      { ...geo("outer", "user", 10, 20), scale: 0.5 },
+      { ...geo("inner", "user", 4, 8), parent_id: "outer", scale: 0.2 },
+      { ...geo("survivor", "user", 5, 15), parent_id: "inner" },
+    ];
+    await upsertEntityGeos("multi-remove", original);
+    const out = await removeEntityGeos("multi-remove", ["outer", "inner"]);
+    expect(out.entities).toHaveLength(1);
+    expect(out.entities[0]!.pos).toEqual({ x: 12.5, y: 25.5 });
+    expect(out.entities[0]!.footprint.w).toBeCloseTo(0.6);
   });
 });
 

--- a/apps/web/lib/world-map.ts
+++ b/apps/web/lib/world-map.ts
@@ -27,6 +27,7 @@ import {
   localBounds,
   localExtent,
   mapPolygonToCrop,
+  resolveAbsoluteFrame,
   siblingsOf,
   toAbsoluteEntities,
   type SimilarityFit,
@@ -160,21 +161,27 @@ function slugLabel(label: string): string {
     .replace(/^_+|_+$/g, "");
 }
 
-/** Re-root (parent_id = null) any survivor whose parent points at a removed id.
- *  Without this, `resolveAbsolutePos` treats the orphan as a root and composes
- *  its LOCAL pos as if it were absolute — silently mis-placing it and skewing
- *  `recomputeBounds`. Pure; entities whose parent survives are returned as-is. */
-function rerootOrphans(
+/** Remove entries and re-express orphaned survivors in the absolute frame.
+ *  Resolve against the original tree before deleting ancestors; position,
+ *  footprint and child-frame scale must all survive a container rollback. */
+function removeAndReroot(
   entities: WorldEntityGeo[],
   removedIds: Iterable<string>,
 ): WorldEntityGeo[] {
   const removed = new Set(removedIds);
   if (removed.size === 0) return entities;
-  return entities.map((e) =>
-    e.parent_id != null && removed.has(e.parent_id)
-      ? { ...e, parent_id: null }
-      : e,
-  );
+  const byId = new Map(entities.map((e) => [e.id, e]));
+  return entities.filter((e) => !removed.has(e.id)).map((e) => {
+    if (e.parent_id == null || !removed.has(e.parent_id)) return e;
+    const frame = resolveAbsoluteFrame(e.id, byId)!;
+    return {
+      ...e,
+      parent_id: null,
+      pos: frame.pos,
+      footprint: { w: e.footprint.w * frame.unit, d: e.footprint.d * frame.unit },
+      scale: (e.scale ?? 1) * frame.unit,
+    };
+  });
 }
 
 /** Apply one structured geo edit to the entity list. Pure + total: an edit whose
@@ -212,11 +219,8 @@ export function applyEntityEdit(
   }
   if (edit.op === "remove") {
     // Drop the target AND re-root its children — leaving a dangling parent_id
-    // silently mis-places them (see rerootOrphans).
-    return rerootOrphans(
-      entities.filter((e) => e.id !== edit.target),
-      [edit.target],
-    );
+    // silently mis-places them (see removeAndReroot).
+    return removeAndReroot(entities, [edit.target]);
   }
   return entities.map((e) => {
     if (e.id !== edit.target) return e;
@@ -380,17 +384,13 @@ export async function removeEntityGeos(
   ids: string[],
 ): Promise<WorldMapSnapshot> {
   if (ids.length === 0) return getWorldMap(sessionId);
-  const removeSet = new Set(ids);
   const col = await collection();
   const next = await optimisticReplace<WorldMapDoc>(
     col,
     sessionId,
     (existing) => {
       const now = new Date();
-      const kept = rerootOrphans(
-        (existing ? existing.entities : []).filter((e) => !removeSet.has(e.id)),
-        ids,
-      );
+      const kept = removeAndReroot(existing ? existing.entities : [], ids);
       return {
         _id: sessionId,
         entities: kept,

--- a/apps/web/tests/node-write-routes.test.ts
+++ b/apps/web/tests/node-write-routes.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getNode: vi.fn(),
+  insertNode: vi.fn(),
+  deleteNode: vi.fn(),
+  updateNodeParent: vi.fn(),
+  recordError: vi.fn(),
+  requireOwner: vi.fn(),
+  uploadJpeg: vi.fn(),
+  decodeDataUrl: vi.fn(),
+  getIdempotentResult: vi.fn(),
+  saveIdempotentResult: vi.fn(),
+  getWorldMap: vi.fn(),
+  upsertEntityGeos: vi.fn(),
+  removeEntityGeos: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => mocks);
+vi.mock("@/lib/r2", () => mocks);
+vi.mock("@/lib/session-owner", () => mocks);
+vi.mock("@/lib/idempotency", () => mocks);
+vi.mock("@/lib/world-map", () => mocks);
+vi.mock("@/lib/env", () => ({
+  readServerEnv: () => ({ MONGODB_URI: "mongodb://test", MONGODB_DB: "test", R2_BUCKET: "test" }),
+}));
+vi.mock("@/lib/env-flag", () => ({ envFlag: () => true }));
+
+import { POST as createNode } from "@/app/api/nodes/route";
+import { POST as ascend } from "@/app/api/world/[sessionId]/ascend/route";
+
+const child = { id: "child", parent_id: null, session_id: "s1", scale_tier: "city", aspect_ratio: "16:9" };
+const createBody = { session_id: "s1", page_title: "Town", image_data_url: "data:image/jpeg;base64,YQ==" };
+const ascendBody = { child_node_id: "child", page_title: "Region", image_data_url: createBody.image_data_url, parent_tier: "region" };
+const params = { params: Promise.resolve({ sessionId: "s1" }) };
+
+function request(body: unknown, key?: string) {
+  return new Request("http://localhost/api/nodes", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...(key ? { "Idempotency-Key": key } : {}) },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mocks.requireOwner.mockResolvedValue({ ok: true });
+  mocks.getNode.mockResolvedValue(child);
+  mocks.insertNode.mockResolvedValue({ id: "saved", created_at: "2026-09-05" });
+  mocks.decodeDataUrl.mockReturnValue({ bytes: Buffer.from("a"), contentType: "image/jpeg" });
+  mocks.uploadJpeg.mockResolvedValue({ key: "image.jpg", url: "https://images.test/image.jpg" });
+  mocks.getIdempotentResult.mockResolvedValue(null);
+  mocks.saveIdempotentResult.mockResolvedValue(undefined);
+  mocks.getWorldMap.mockResolvedValue({ entities: [] });
+  mocks.updateNodeParent.mockResolvedValue(true);
+  mocks.deleteNode.mockResolvedValue(true);
+});
+
+describe("node write session boundaries", () => {
+  it("refuses to reparent a root from another session before any writes", async () => {
+    mocks.getNode.mockResolvedValue({ ...child, session_id: "other" });
+    const res = await ascend(request(ascendBody), params);
+    expect(res.status).toBe(404);
+    expect(mocks.uploadJpeg).not.toHaveBeenCalled();
+    expect(mocks.updateNodeParent).not.toHaveBeenCalled();
+    expect(mocks.upsertEntityGeos).not.toHaveBeenCalled();
+  });
+
+  it("refuses to insert a child under another session's node", async () => {
+    mocks.getNode.mockResolvedValue({ ...child, session_id: "other" });
+    const res = await createNode(request({ ...createBody, parent_id: "child" }));
+    expect(res.status).toBe(404);
+    expect(mocks.uploadJpeg).not.toHaveBeenCalled();
+    expect(mocks.insertNode).not.toHaveBeenCalled();
+  });
+
+  it("allows a child whose parent belongs to the same session", async () => {
+    const res = await createNode(request({ ...createBody, parent_id: "child" }));
+    expect(res.status).toBe(200);
+    expect(mocks.insertNode).toHaveBeenCalledWith(expect.objectContaining({ parent_id: "child", session_id: "s1" }));
+  });
+
+  it("does not reuse another session's node-save retry result", async () => {
+    const cache = new Map<string, unknown>();
+    mocks.getIdempotentResult.mockImplementation(async (key: string) => cache.get(key) ?? null);
+    mocks.saveIdempotentResult.mockImplementation(async (key: string, value: unknown) => { cache.set(key, value); });
+    mocks.insertNode.mockResolvedValueOnce({ id: "first", created_at: "today" });
+    mocks.insertNode.mockResolvedValueOnce({ id: "second", created_at: "today" });
+    await createNode(request(createBody, "retry-1"));
+    const second = await createNode(request({ ...createBody, session_id: "s2" }, "retry-1"));
+    expect((await second.json()).id).toBe("second");
+    const replay = await createNode(request(createBody, "retry-1"));
+    expect((await replay.json()).id).toBe("first");
+    expect(mocks.insertNode).toHaveBeenCalledTimes(2);
+  });
+
+  it("checks ownership before reading cached save results", async () => {
+    mocks.requireOwner.mockResolvedValue({ ok: false, res: new Response(null, { status: 403 }) });
+    const res = await createNode(request(createBody, "retry-1"));
+    expect(res.status).toBe(403);
+    expect(mocks.getIdempotentResult).not.toHaveBeenCalled();
+  });
+
+  it.each([null, [], { ...ascendBody, child_node_id: { $ne: null } }])("rejects malformed ascend body %j", async (body) => {
+    expect((await ascend(request(body), params)).status).toBe(400);
+    expect(mocks.getNode).not.toHaveBeenCalled();
+  });
+
+  it.each([null, [], { ...createBody, session_id: { $ne: null } }])("rejects malformed node body %j", async (body) => {
+    expect((await createNode(request(body))).status).toBe(400);
+    expect(mocks.insertNode).not.toHaveBeenCalled();
+  });
+});
+
+describe("OUTWARD tier boundary", () => {
+  it.each(["building", "city", "invalid", "toString"])("rejects non-coarser tier %s", async (parent_tier) => {
+    expect((await ascend(request({ ...ascendBody, parent_tier }), params)).status).toBe(400);
+    expect(mocks.insertNode).not.toHaveBeenCalled();
+  });
+
+  it("validates uploaded roots with the backend's city fallback", async () => {
+    mocks.getNode.mockResolvedValue({ ...child, scale_tier: null, scene_view: null });
+    expect((await ascend(request({ ...ascendBody, parent_tier: "building" }), params)).status).toBe(400);
+  });
+
+  it("persists a valid wider container", async () => {
+    expect((await ascend(request(ascendBody), params)).status).toBe(200);
+    expect(mocks.updateNodeParent).toHaveBeenCalledWith("child", expect.any(String));
+  });
+});


### PR DESCRIPTION
## Summary
- Refuse known rejected OUTWARD renders before persistence, while accounting for paid attempts and flagging unavailable critics.
- Validate session boundaries and coarser scale transitions on node writes; scope node retry keys to their session.
- Preserve absolute geometry when removing parent entities and cancel stale OUTWARD requests.
- Fix mobile toolbar overflow and overlapping image controls.

## Verification
- Backend: 1,068 passed, 2 skipped; coverage 87.27% (87% floor).
- Web: full coverage suite and TypeScript checks pass; coverage floors unchanged.
- Ruff passes; affected frontend lint has no errors (8 existing hook warnings).
- Earlier browser run: 19 mock-backed E2E tests passed, including new desktop/mobile OUTWARD and rejection cases.
- Brave extension smoke: live app and saved-world Gallery load successfully.

## Scope
This does not claim the generated OUTWARD centre is pixel-identical to the source. That remains the separate #252 compositing follow-up. No deployment or automatic merge is included.
