### PR TITLE
experiment(outward): preserve source pixels and reject failed composites

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -201,6 +201,14 @@ FAL_EDIT_TIER=balanced
 # outages remain an explicitly unverified fallback. Valid floor range: 0-10.
 # SCALE_OUTWARD_STYLE_LOCK=true
 # SCALE_OUTWARD_ACCEPT_MEDIUM=7.0
+# Experimental lossless same-plane OUTWARD (#252). Opt-in: paints a 2x canvas,
+# restores the native-resolution source pixels at its centre and saves PNG.
+# No resize, feathering, or JPEG re-encode of the preserved source. Both critics
+# must pass on the final composite (including its boundary); outages reject it.
+# Requires inline image bytes; stored images are inlined by the web proxy.
+# Overrides the hop refresh cap for same-plane hops; astronomical hops stay fresh.
+# Oversized canvases (>=25MP) fail before generation instead of shrinking the source.
+# SCALE_OUTWARD_PRESERVE_SOURCE=false
 # World Mode — GRADUATED to default ON (2026-08-21). Taps ENTER places, the
 # world persists on a metric map, and the scale ladder (deeper / ascend /
 # around) is live. One knob restores the classic explainer stack wholesale

--- a/apps/modal-backend/providers/generate_modes/ascend.py
+++ b/apps/modal-backend/providers/generate_modes/ascend.py
@@ -11,6 +11,7 @@ generate.py's stream helpers (`_sse`, `_frame_dims`, `_view_grammar_on`,
 from __future__ import annotations
 
 import asyncio as _asyncio
+import dataclasses
 import math
 import os
 import time as _time
@@ -122,6 +123,54 @@ def _outward_identity_clause(
     return " ".join(parts)
 
 
+async def _judge_ascend(
+    render: Callable[[str], Awaitable[GeneratedImage]],
+    source_url: str,
+    instruction: str,
+    max_attempts: int | None,
+    abort: Callable[[str], Awaitable[None]],
+) -> tuple[GeneratedImage, bool, bool, int]:
+    """Return the final image, unjudged/rejected flags, and billed attempts."""
+    from providers import edit_loop, judge
+    from providers.render_loop import data_url_bytes
+
+    source_bytes = data_url_bytes(source_url)
+    if source_bytes is None:
+        return await render(""), True, False, 1
+    cfg = edit_loop.edit_loop_config_from_env(max_attempts)
+    try:
+        floor = float(os.environ.get("SCALE_OUTWARD_ACCEPT_MEDIUM", 7.0))
+    except (TypeError, ValueError):
+        floor = 7.0
+    if not math.isfinite(floor) or not 0 <= floor <= 10:
+        floor = 7.0
+    cfg = dataclasses.replace(cfg, accept_medium=floor)
+    attempts: list[EditAttempt] = []
+    async for attempt in edit_loop.iter_edit_attempts(
+        render,
+        source_bytes=source_bytes,
+        mask_png=None,
+        region_box=None,
+        judge_alignment=judge.score_prompt_alignment,
+        judge_medium=judge.score_style_pair,
+        instruction=instruction,
+        config=cfg,
+        abort=abort,
+        deadline_s=_time.monotonic() + 720.0,
+    ):
+        attempts.append(attempt)
+    best = edit_loop.conclude_edit(attempts).best
+    unjudged = best.alignment is None or best.medium is None
+    rejected = (
+        best.alignment is not None
+        and (not math.isfinite(best.alignment.score) or not cfg.accept_alignment <= best.alignment.score <= 10)
+    ) or (
+        best.medium is not None
+        and (not math.isfinite(best.medium.score) or not cfg.accept_medium <= best.medium.score <= 10)
+    )
+    return cast("GeneratedImage", best.image), unjudged, rejected, len(attempts)
+
+
 async def stream_ascend(
     body: GenerateBody,
     trace_id: str,
@@ -172,10 +221,10 @@ async def stream_ascend(
     # so nothing changes until it's flipped on.
     _max_hops = int(os.environ.get("SCALE_OUTWARD_MAX_HOPS", "0") or 0)
     outward_refresh = _max_hops > 0 and body.outward_depth >= _max_hops
-    use_outpaint = (
-        env_flag("SCALE_OUTWARD_OUTPAINT")
-        and model_router.select_outward_op(from_tier, to_tier) == "outpaint_zoomout"
-        and not outward_refresh
+    same_plane = model_router.select_outward_op(from_tier, to_tier) == "outpaint_zoomout"
+    preserve_source = env_flag("SCALE_OUTWARD_PRESERVE_SOURCE") and same_plane
+    use_outpaint = same_plane and (
+        preserve_source or (env_flag("SCALE_OUTWARD_OUTPAINT") and not outward_refresh)
     )
     yield _sse({"type": "status", "stage": "rendering"}, trace_id)
     await _abort_if_disconnected("pre-ascend")
@@ -221,11 +270,37 @@ async def stream_ascend(
                 margin += ". " + outward_rider
             if no_lettering:
                 margin += ". " + no_lettering
-            img = await image_edit_provider.expand_image_zoomout(
-                body.image, 3.0, pw, ph, prompt=margin
+            if preserve_source:
+                margin += (
+                    ". One continuous flat chart, with matching palette, linework and scale "
+                    "across the original image boundary. Continue roads, rivers and terrain "
+                    "across that boundary. No inset, frame, poster, desk, photograph, "
+                    "or visible rectangular seam."
+                )
+            source_url = body.image
+
+            def _record_outpaint(model: str) -> None:
+                spend.record_generation(body.session_id, model)
+
+            async def _render_outpaint(suffix: str) -> GeneratedImage:
+                prompt = margin if not suffix else f"{margin}\n\n{suffix}"
+                if preserve_source:
+                    # 2x leaves 25% source area, above BRIA's recommended 15%.
+                    return await image_edit_provider.expand_image_zoomout(
+                        source_url, 2.0, pw, ph, prompt=prompt, preserve_source=True,
+                        on_generated=_record_outpaint,
+                    )
+                return await image_edit_provider.expand_image_zoomout(
+                    source_url, 3.0, pw, ph, prompt=prompt
+                )
+
+            img, render_unjudged, render_rejected, billed_images = await _judge_ascend(
+                _render_outpaint, source_url, margin, body.max_attempts, _abort_if_disconnected
             )
+            # The preservation experiment must not publish unreviewed seams.
+            render_rejected |= preserve_source and render_unjudged
             page_title = f"The surrounding {to_tier.replace('_', ' ')}".title()
-            final_prompt = f"outward outpaint: {from_tier} -> {to_tier}"
+            final_prompt = margin
         else:
             plan_query = (
                 f"the {to_tier.replace('_', ' ')} that contains "
@@ -296,85 +371,15 @@ async def stream_ascend(
                 # (did it zoom out as asked) + medium (same hand as the
                 # source), keep-best, critic feedback folded into the retry,
                 # deadline mirroring generate.INGRESS_TIMEOUT_S - 180s.
-                from providers import edit_loop, judge
-                from providers.render_loop import data_url_bytes
+                source_url = body.image
 
-                source_bytes = data_url_bytes(body.image)
-                if source_bytes is None:
-                    # Remote-ref source can't feed the medium judge — render
-                    # once and say so instead of pretending it was verified.
-                    img = await image_edit_provider.edit_image(
-                        body.image, ascend_instr
-                    )
-                    render_unjudged = True
-                else:
-                    import dataclasses
+                async def _render_ascend(suffix: str) -> GeneratedImage:
+                    instr = ascend_instr if not suffix else f"{ascend_instr}\n\n{suffix}"
+                    return await image_edit_provider.edit_image(source_url, instr)
 
-                    ascend_cfg = edit_loop.edit_loop_config_from_env(
-                        body.max_attempts
-                    )
-                    # #252: a map container scoring AT the shared 6.0 medium
-                    # floor shipped a watercolor restyle. Raise the ascend
-                    # loop's style floor (env SCALE_OUTWARD_ACCEPT_MEDIUM; set
-                    # 6.0 to restore the shared floor) so a borderline break
-                    # retries instead of publishing a borderline restyle.
-                    try:
-                        _asc_floor = float(
-                            os.environ.get("SCALE_OUTWARD_ACCEPT_MEDIUM", 7.0)
-                        )
-                    except (TypeError, ValueError):
-                        _asc_floor = 7.0
-                    if not math.isfinite(_asc_floor) or not 0 <= _asc_floor <= 10:
-                        _asc_floor = 7.0
-                    ascend_cfg = dataclasses.replace(
-                        ascend_cfg, accept_medium=_asc_floor
-                    )
-                    ascend_deadline = _time.monotonic() + 720.0
-                    captured_instr = ascend_instr
-                    source_url: str = body.image
-
-                    async def _render_ascend(suffix: str) -> GeneratedImage:
-                        instr = (
-                            captured_instr
-                            if not suffix
-                            else f"{captured_instr}\n\n{suffix}"
-                        )
-                        return await image_edit_provider.edit_image(
-                            source_url, instr
-                        )
-
-                    ascend_attempts: list[EditAttempt] = []
-                    async for asc_att in edit_loop.iter_edit_attempts(
-                        _render_ascend,
-                        source_bytes=source_bytes,
-                        mask_png=None,
-                        region_box=None,
-                        judge_alignment=judge.score_prompt_alignment,
-                        judge_medium=judge.score_style_pair,
-                        instruction=ascend_instr,
-                        config=ascend_cfg,
-                        abort=_abort_if_disconnected,
-                        deadline_s=ascend_deadline,
-                    ):
-                        ascend_attempts.append(asc_att)
-                    asc_res = edit_loop.conclude_edit(ascend_attempts)
-                    img = cast("Any", asc_res.best.image)
-                    billed_images = max(1, len(ascend_attempts))
-                    # Critic degraded (judge failure → single blind attempt):
-                    # the render shipped without a verdict — flag it.
-                    render_unjudged = (
-                        asc_res.best.alignment is None or asc_res.best.medium is None
-                    )
-                    # A known failure must not become a new persistent root.
-                    # Keep the explicit unverified fallback for critic outages,
-                    # but never let an available critic's rejection pass through.
-                    render_rejected = (
-                        asc_res.best.alignment is not None
-                        and asc_res.best.alignment.score < ascend_cfg.accept_alignment
-                    ) or (
-                        asc_res.best.medium is not None
-                        and asc_res.best.medium.score < ascend_cfg.accept_medium
-                    )
+                img, render_unjudged, render_rejected, billed_images = await _judge_ascend(
+                    _render_ascend, source_url, ascend_instr, body.max_attempts, _abort_if_disconnected
+                )
             else:
                 # Fresh container = a NEW map: state the deliberate
                 # top-down camera (None on astro rungs → legacy bytes).
@@ -424,7 +429,8 @@ async def stream_ascend(
         return
     # Spend accounting: this OUTWARD hop made real paid image calls (one per
     # judged attempt) — record them so the cap actually counts them.
-    spend.record_generation(body.session_id, img.model, images=billed_images)
+    if not preserve_source:
+        spend.record_generation(body.session_id, img.model, images=billed_images)
     if render_rejected:
         yield _sse(
             {

--- a/apps/modal-backend/providers/image_edit.py
+++ b/apps/modal-backend/providers/image_edit.py
@@ -12,9 +12,11 @@ handles both gen and edit on the same endpoint.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import os
 import struct
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -392,6 +394,9 @@ async def expand_image_zoomout(
     height: int = 900,
     model_override: str | None = None,
     prompt: str | None = None,
+    *,
+    preserve_source: bool = False,
+    on_generated: Callable[[str], None] | None = None,
 ) -> GeneratedImage:
     """OUTWARD / zoom-out (B2): paint the CONTAINER around the source — the source
     centered on a `factor`x larger canvas with the full margin outpainted, so it
@@ -399,12 +404,38 @@ async def expand_image_zoomout(
     but the painted MARGIN drifts to photoreal unless `prompt` carries the source's
     medium — so callers MUST pass it. Same BRIA machinery as `expand_image`; only
     the canvas is centered, not edge-pinned. `factor` is clamped to ~1.5-4x. This is
-    the opt-in (SCALE_OUTWARD_OUTPAINT) path; the seamless default is `scale_parent`."""
+    the opt-in (SCALE_OUTWARD_OUTPAINT) path; the default is `scale_parent`.
+    `preserve_source` locally restores native source pixels and emits PNG; it
+    requires inline bytes and rejects a provider canvas with the wrong size.
+    `on_generated` accounts for each paid output before download/compositing."""
     from obs import span
     from providers import mock
+    from providers.outward_pixels import OutwardCanvas
+    from providers.render_loop import data_url_bytes
+
+    f = _clamp_zoom_factor(factor)
+    layout = None
+    if preserve_source:
+        source_bytes = data_url_bytes(image_data_url)
+        if not source_bytes:
+            raise ValueError("Lossless OUTWARD requires an inline source image")
+        layout = await asyncio.to_thread(OutwardCanvas.prepare, source_bytes, f)
+        image_data_url = "data:image/png;base64," + base64.b64encode(layout.source_png).decode()
 
     if mock.on():
         m = mock.mock_image(prompt or f"zoomout {factor}x", op="zoomout")
+        if layout is not None:
+            # Mock only the synthesized margins; run the real compositing path.
+            import io
+
+            from PIL import Image
+
+            with Image.open(io.BytesIO(m.jpeg_bytes)) as raw:
+                canvas = raw.resize(layout.canvas_size)
+            buf = io.BytesIO()
+            canvas.save(buf, "PNG")
+            pixels = await asyncio.to_thread(layout.composite, buf.getvalue())
+            return GeneratedImage(pixels, "image/png", m.model, m.request_id)
         return GeneratedImage(m.jpeg_bytes, m.mime_type, m.model, m.request_id)
     _ensure_fal_key()
     model = (
@@ -412,7 +443,6 @@ async def expand_image_zoomout(
         or os.environ.get("FAL_OUTPAINT_MODEL")
         or EXPAND_MODEL_DEFAULT
     )
-    f = _clamp_zoom_factor(factor)
     # BRIA needs the parent's REAL pixel size or it rescales/seams the original.
     w, h = _dims_from_data_url(image_data_url) or (width, height)
     image_url = await to_fal_url(image_data_url)
@@ -420,8 +450,14 @@ async def expand_image_zoomout(
         result = await _fal_subscribe(
             model, _zoomout_args_for(image_url, f, w, h, prompt), require_images=True
         )
+        if on_generated is not None:
+            # Record paid results even when downloading or compositing fails.
+            on_generated(model)
         image_info = _expand_first_image(result)
         jpeg_bytes, mime = await _fetch_image_bytes(image_info)
+        if layout is not None:
+            jpeg_bytes = await asyncio.to_thread(layout.composite, jpeg_bytes)
+            mime = "image/png"
         ctx["bytes"] = len(jpeg_bytes)
     return GeneratedImage(
         jpeg_bytes=jpeg_bytes,

--- a/apps/modal-backend/providers/outward_pixels.py
+++ b/apps/modal-backend/providers/outward_pixels.py
@@ -1,0 +1,47 @@
+"""Lossless source placement for same-plane OUTWARD outpainting."""
+
+from __future__ import annotations
+
+import io
+import math
+from dataclasses import dataclass
+
+from PIL import Image, ImageOps
+
+
+@dataclass(frozen=True)
+class OutwardCanvas:
+    source_png: bytes
+    source_size: tuple[int, int]
+    canvas_size: tuple[int, int]
+    location: tuple[int, int]
+
+    @classmethod
+    def prepare(cls, source_bytes: bytes, factor: float) -> OutwardCanvas:
+        if not math.isfinite(factor) or not 1.5 <= factor <= 4:
+            raise ValueError("OUTWARD zoom factor must be between 1.5 and 4")
+        with Image.open(io.BytesIO(source_bytes)) as raw:
+            # Reject oversized canvases before decoding/allocating their pixels.
+            # BRIA's documented canvas area limit is strictly below 5000x5000.
+            if int(raw.width * factor) * int(raw.height * factor) >= 25_000_000:
+                raise ValueError("Source is too large for lossless OUTWARD expansion")
+            source = ImageOps.exif_transpose(raw).convert("RGBA")
+        w, h = source.size
+        cw, ch = int(w * factor), int(h * factor)
+        buf = io.BytesIO()
+        source.save(buf, "PNG")
+        return cls(buf.getvalue(), (w, h), (cw, ch), ((cw - w) // 2, (ch - h) // 2))
+
+    def composite(self, generated_bytes: bytes) -> bytes:
+        with Image.open(io.BytesIO(generated_bytes)) as raw:
+            if raw.size != self.canvas_size:
+                # Never stretch a mismatched provider result: the seam would no
+                # longer line up with the source placement sent to the provider.
+                raise ValueError("OUTWARD provider returned the wrong canvas dimensions")
+            canvas = raw.convert("RGBA")
+        with Image.open(io.BytesIO(self.source_png)) as source:
+            # No mask/feathering: every source pixel, including alpha, survives.
+            canvas.paste(source, self.location)
+        buf = io.BytesIO()
+        canvas.save(buf, "PNG")
+        return buf.getvalue()

--- a/apps/modal-backend/tests/continuity_bench/outward_preserve_runner.py
+++ b/apps/modal-backend/tests/continuity_bench/outward_preserve_runner.py
@@ -1,0 +1,122 @@
+"""One paid OUTWARD preservation receipt, using the production stream and judges.
+
+OUTWARD_PRESERVE_BENCH_RUN=1 .venv/bin/python -m \
+    tests.continuity_bench.outward_preserve_runner --source map.png --output /tmp/outward-proof
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import io
+import json
+import os
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from dotenv import load_dotenv
+from PIL import Image
+
+from generate import GenerateBody
+from providers import image_edit, judge
+from providers.generate_modes.ascend import stream_ascend
+from providers.image import GeneratedImage, encode_data_url
+from providers.outward_pixels import OutwardCanvas
+
+
+async def run(source: Path, output: Path) -> dict:
+    data = source.read_bytes()
+    layout = OutwardCanvas.prepare(data, 2)
+    output.mkdir(parents=True, exist_ok=True)
+    (output / "source.png").write_bytes(layout.source_png)
+    renders: list[dict] = []
+    expand = image_edit.expand_image_zoomout
+
+    async def capture(*args: Any, **kwargs: Any) -> GeneratedImage:
+        result = await expand(*args, **kwargs)
+        name = f"attempt-{len(renders) + 1}.png"
+        (output / name).write_bytes(result.jpeg_bytes)
+        image = Image.open(io.BytesIO(result.jpeg_bytes)).convert("RGBA")
+        x, y = layout.location
+        w, h = layout.source_size
+        original = Image.open(io.BytesIO(layout.source_png)).convert("RGBA")
+        exact = image.crop((x, y, x + w, y + h)).tobytes() == original.tobytes()
+        renders.append({"file": name, "model": result.model, "source_pixels_equal": exact})
+        return result
+
+    verdicts: dict[str, dict] = {}
+    alignment_judge, style_judge = judge.score_prompt_alignment, judge.score_style_pair
+
+    async def alignment(prompt: str, image: bytes) -> judge.JudgeResult:
+        result = await alignment_judge(prompt, image)
+        verdicts["alignment"] = {"score": result.score, "rationale": result.rationale}
+        return result
+
+    async def style(first: bytes, second: bytes) -> judge.JudgeResult:
+        result = await style_judge(first, second)
+        verdicts["style"] = {"score": result.score, "rationale": result.rationale}
+        return result
+
+    async def abort(_: str) -> None:
+        pass
+
+    body = GenerateBody(
+        query="Ankh-Morpork",
+        session_id="outward-preserve-bench",
+        mode="ascend",
+        image=encode_data_url(data, "image/png"),
+        max_attempts=1,
+        scene_view=None,
+        session_style_anchor="hand-inked cartography, muted green terrain, sepia paper, fine dark linework",
+        outward_context="Ankh-Morpork on the River Ankh, surrounded by the Sto Plains.",
+        web_search=False,
+    )
+    events: list[dict] = []
+    with (
+        patch.object(image_edit, "expand_image_zoomout", capture),
+        patch.object(judge, "score_prompt_alignment", alignment),
+        patch.object(judge, "score_style_pair", style),
+    ):
+        async for chunk in stream_ascend(
+            body, "outward-preserve-bench",
+            _sse=lambda event, _: json.dumps(event).encode(),
+            _frame_dims=lambda _: (1600, 900),
+            _view_grammar_on=lambda: True,
+            _abort_if_disconnected=abort,
+        ):
+            event = json.loads(chunk)
+            event.pop("image_data_url", None)
+            events.append(event)
+    report = {
+        "source": source.name,
+        "source_size": layout.source_size,
+        "canvas_size": layout.canvas_size,
+        "renders": renders,
+        "judges": verdicts,
+        "accepted": any(e["type"] == "ascend_ready" for e in events),
+        "events": events,
+    }
+    (output / "receipt.json").write_text(json.dumps(report, indent=2))
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    if os.environ.get("OUTWARD_PRESERVE_BENCH_RUN") != "1":
+        raise SystemExit("Set OUTWARD_PRESERVE_BENCH_RUN=1 to authorize one paid render + judges")
+    backend = Path(__file__).resolve().parents[2]
+    load_dotenv(backend / ".env", override=False)
+    load_dotenv(backend.parents[1] / ".env", override=False)
+    os.environ["MOCK_PROVIDERS"] = "0"
+    os.environ["SCALE_OUTWARD_PRESERVE_SOURCE"] = "1"
+    os.environ["SCALE_LADDER_NAV"] = "1"
+    os.environ["SCALE_OUTWARD"] = "1"
+    print(json.dumps(asyncio.run(run(args.source, args.output)), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/modal-backend/tests/test_generate_ascend.py
+++ b/apps/modal-backend/tests/test_generate_ascend.py
@@ -653,3 +653,79 @@ async def test_ascend_invalid_medium_floor_cannot_disable_style_gate(
 
     events = await _collect(_event_stream(_ascend_body(image=_DECODABLE), "t1"))
     assert not any(e["type"] == "ascend_ready" for e in events)
+
+
+@pytest.mark.parametrize("verdict", ["pass", "reject", "offline", "nan"])
+async def test_preserving_outward_judges_the_composite_before_publishing(
+    monkeypatch: pytest.MonkeyPatch, verdict: str,
+) -> None:
+    import io
+
+    from PIL import Image
+
+    from providers import judge, spend
+    from providers.judge import JudgeResult
+    from providers.render_loop import data_url_bytes
+
+    _enable(monkeypatch)
+    monkeypatch.setenv("SCALE_OUTWARD_PRESERVE_SOURCE", "1")
+    monkeypatch.setenv("SCALE_OUTWARD_MAX_HOPS", "1")
+    monkeypatch.setenv("MOCK_PROVIDERS", "0")
+    monkeypatch.setenv("FAL_KEY", "test")
+    source = Image.new("RGB", (32, 24), "blue")
+    buf = io.BytesIO()
+    source.save(buf, "PNG")
+    source_url = image_mod.encode_data_url(buf.getvalue(), "image/png")
+    margin = io.BytesIO()
+    Image.new("RGB", (64, 48), "red").save(margin, "PNG")
+    sub = AsyncMock(return_value={"image": {"url": "https://provider.test/out.png"}})
+    monkeypatch.setattr(image_edit_mod, "_fal_subscribe", sub)
+    monkeypatch.setattr(image_edit_mod, "to_fal_url", AsyncMock(return_value="fal://source"))
+    monkeypatch.setattr(image_edit_mod, "_fetch_image_bytes", AsyncMock(return_value=(margin.getvalue(), "image/png")))
+    alignment = AsyncMock(return_value=JudgeResult(9, "continuous map", ""))
+    monkeypatch.setattr(judge, "score_prompt_alignment", alignment)
+    medium = AsyncMock(return_value=JudgeResult(
+        {"pass": 8, "reject": 5, "nan": float("nan"), "offline": 8}[verdict], "medium", "",
+    ))
+    if verdict == "offline":
+        medium.side_effect = RuntimeError("judge unavailable")
+    monkeypatch.setattr(judge, "score_style_pair", medium)
+    record = MagicMock()
+    monkeypatch.setattr(spend, "record_generation", record)
+    planner = AsyncMock()
+    monkeypatch.setattr(llm_mod, "plan_page", planner)
+
+    # Uploaded roots have no scene_view. Even past the refresh cap, the
+    # explicit preservation flag must not fall back to a fresh re-invention.
+    events = await _collect(_event_stream(_ascend_body(
+        image=source_url, scene_view=None, outward_depth=5, max_attempts=1,
+    ), "preserve-test"))
+    judged = alignment.await_args.args[1]
+    composite = Image.open(io.BytesIO(judged))
+    assert composite.size == (64, 48)
+    assert composite.crop((16, 12, 48, 36)).convert("RGB").tobytes() == source.tobytes()
+    assert "rectangular seam" in alignment.await_args.args[0]
+    assert medium.await_args.args[1] == judged
+    record.assert_called_once_with("s1", "fal-ai/bria/expand")
+    planner.assert_not_awaited()
+    if verdict == "pass":
+        ready = next(e for e in events if e["type"] == "ascend_ready")
+        assert data_url_bytes(ready["image_data_url"]) == judged
+        assert ready["image_data_url"].startswith("data:image/png;")
+    else:
+        assert not any(e["type"] == "ascend_ready" for e in events)
+        assert "unchanged" in next(e["message"] for e in events if e["type"] == "error")
+
+
+async def test_preserving_flag_does_not_outpaint_an_astronomical_hop(monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable(monkeypatch)
+    monkeypatch.setenv("SCALE_OUTWARD_PRESERVE_SOURCE", "1")
+    monkeypatch.setenv("SCALE_OUTWARD_EDIT_REF", "false")
+    gen = _mock_fresh(monkeypatch)
+    outpaint = AsyncMock()
+    monkeypatch.setattr(image_edit_mod, "expand_image_zoomout", outpaint)
+    await _collect(_event_stream(_ascend_body(
+        scene_view=SceneView(node_id="n0", level="map", scale_tier="planet"),
+    ), "astro"))
+    gen.assert_awaited_once()
+    outpaint.assert_not_awaited()

--- a/apps/modal-backend/tests/test_outward_pixels.py
+++ b/apps/modal-backend/tests/test_outward_pixels.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import io
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from PIL import Image, ImageOps
+
+from providers import image_edit
+from providers.image import encode_data_url
+from providers.outward_pixels import OutwardCanvas
+
+
+def _bytes(image: Image.Image, fmt: str = "PNG", **kwargs: object) -> bytes:
+    buf = io.BytesIO()
+    image.save(buf, fmt, **kwargs)
+    return buf.getvalue()
+
+
+def _source() -> Image.Image:
+    image = Image.new("RGBA", (31, 19))
+    image.putdata([(x * 7 % 256, x * 13 % 256, x * 23 % 256, x % 256) for x in range(31 * 19)])
+    return image
+
+
+@pytest.mark.parametrize("factor", [1.5, 2.0, 3.0, 4.0])
+def test_composite_preserves_every_source_pixel_and_the_generated_margin(factor: float) -> None:
+    source = _source()
+    layout = OutwardCanvas.prepare(_bytes(source), factor)
+    margin = Image.new("RGB", layout.canvas_size, (9, 18, 27))
+    result = Image.open(io.BytesIO(layout.composite(_bytes(margin))))
+    x, y = layout.location
+    crop = result.crop((x, y, x + source.width, y + source.height))
+    assert crop.tobytes() == source.tobytes()
+    assert result.getpixel((x - 1, y)) == (9, 18, 27, 255)
+    assert result.getpixel((x + source.width, y)) == (9, 18, 27, 255)
+    assert result.getpixel((x, y - 1)) == (9, 18, 27, 255)
+    assert result.getpixel((x, y + source.height)) == (9, 18, 27, 255)
+    assert result.format == "PNG"
+
+
+def test_jpeg_is_decoded_once_without_lossy_reencoding_and_respects_orientation() -> None:
+    source = _source().convert("RGB")
+    exif = Image.Exif()
+    exif[274] = 6
+    data = _bytes(source, "JPEG", exif=exif)
+    expected = ImageOps.exif_transpose(Image.open(io.BytesIO(data))).convert("RGBA")
+    layout = OutwardCanvas.prepare(data, 2)
+    assert layout.source_size == expected.size
+    assert Image.open(io.BytesIO(layout.source_png)).tobytes() == expected.tobytes()
+
+
+def test_wrong_canvas_dimensions_are_rejected_not_stretched() -> None:
+    layout = OutwardCanvas.prepare(_bytes(_source()), 2)
+    with pytest.raises(ValueError, match="wrong canvas dimensions"):
+        layout.composite(_bytes(Image.new("RGB", (10, 10))))
+
+
+@pytest.mark.parametrize("factor", [float("nan"), float("inf"), 1, 5])
+def test_invalid_factor_is_rejected(factor: float) -> None:
+    with pytest.raises(ValueError, match="zoom factor"):
+        OutwardCanvas.prepare(_bytes(_source()), factor)
+
+
+def test_oversized_canvas_fails_before_pixel_decode(monkeypatch: pytest.MonkeyPatch) -> None:
+    raw = MagicMock(width=2500, height=2500)
+    monkeypatch.setattr(Image, "open", MagicMock(return_value=MagicMock(__enter__=lambda _: raw)))
+    with pytest.raises(ValueError, match="too large"):
+        OutwardCanvas.prepare(b"large-header", 2)
+    raw.load.assert_not_called()
+
+
+@pytest.mark.parametrize("wrong_size", [False, True])
+async def test_provider_preserves_pixels_and_records_paid_output_before_compositing(
+    monkeypatch: pytest.MonkeyPatch, wrong_size: bool,
+) -> None:
+    source = _source()
+    data = _bytes(source)
+    monkeypatch.setenv("MOCK_PROVIDERS", "0")
+    monkeypatch.setenv("FAL_KEY", "test")
+    upload = AsyncMock(return_value="fal://source")
+    sub = AsyncMock(return_value={"image": {"url": "https://provider.test/out.png"}})
+    monkeypatch.setattr(image_edit, "to_fal_url", upload)
+    monkeypatch.setattr(image_edit, "_fal_subscribe", sub)
+    size = (10, 10) if wrong_size else (62, 38)
+    monkeypatch.setattr(image_edit, "_fetch_image_bytes", AsyncMock(return_value=(
+        _bytes(Image.new("RGB", size, "red")), "image/png",
+    )))
+    billed = MagicMock()
+    call = image_edit.expand_image_zoomout(
+        encode_data_url(data, "image/png"), 2, preserve_source=True, on_generated=billed,
+    )
+    if wrong_size:
+        with pytest.raises(ValueError, match="wrong canvas"):
+            await call
+    else:
+        result = await call
+        assert result.mime_type == "image/png"
+        image = Image.open(io.BytesIO(result.jpeg_bytes))
+        assert image.crop((15, 9, 46, 28)).tobytes() == source.tobytes()
+    billed.assert_called_once()
+    args = sub.await_args.args[1]
+    assert args["canvas_size"] == [62, 38]
+    assert args["original_image_location"] == [15, 9]
+
+
+async def test_preservation_requires_inline_bytes_before_a_paid_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    sub = AsyncMock()
+    monkeypatch.setattr(image_edit, "_fal_subscribe", sub)
+    with pytest.raises(ValueError, match="inline source"):
+        await image_edit.expand_image_zoomout("https://example.test/source.png", preserve_source=True)
+    sub.assert_not_awaited()
+
+
+async def test_mock_preservation_runs_real_composite_without_provider_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MOCK_PROVIDERS", "1")
+    sub = AsyncMock()
+    monkeypatch.setattr(image_edit, "_fal_subscribe", sub)
+    source = _source()
+    result = await image_edit.expand_image_zoomout(
+        encode_data_url(_bytes(source), "image/png"), 2, preserve_source=True,
+    )
+    image = Image.open(io.BytesIO(result.jpeg_bytes))
+    assert image.size == (62, 38)
+    assert image.crop((15, 9, 46, 28)).tobytes() == source.tobytes()
+    sub.assert_not_awaited()

--- a/docs/OUTWARD_PRESERVATION.md
+++ b/docs/OUTWARD_PRESERVATION.md
@@ -1,0 +1,52 @@
+# OUTWARD Source Preservation
+
+Status: experimental, disabled by default. This is not a visual sign-off on #252.
+
+`SCALE_OUTWARD_PRESERVE_SOURCE=1` selects centered outpainting for same-plane
+hops, including uploaded roots without `scene_view`. It overrides the hop-refresh
+cap on those hops. Astronomical transitions retain the existing rendering path.
+
+The original image is decoded, EXIF-oriented, and passed to the provider as PNG.
+The canvas grows 2x in each dimension without resizing the source. After generation,
+the full source rectangle is pasted back at the exact requested coordinates. The
+final PNG preserves the source's decoded RGBA pixels, not its original JPEG file
+bytes. Transparent pixels are preserved too. There is no feathering inside it.
+
+Wrong-size provider output is rejected, not stretched. Remote sources must first
+be inlined by the web proxy. Canvases of 25 megapixels or more are refused before
+generation. Paid provider results are accounted for even if download or compositing
+fails. No dependencies were added.
+
+Both alignment and style judges inspect the final composite before persistence.
+Failed or unavailable critics reject the preservation attempt. The normal retry
+budget still applies. The older opt-in outpainting path now uses the shared judged
+loop too; the default reference-edit path remains unchanged.
+
+## Live Ankh Receipt
+
+One render of `ankh-map-full-spec-2026-08-24.jpg`:
+
+- Source: 1376 x 768; output: 2752 x 1536.
+- Decoded source pixels at centre: exactly equal.
+- Style: 9.5/10; prompt alignment: 2/10. Rejected by the production stream.
+- Visual inspection: a framed map floating in a landscape, not continuous terrain.
+
+Preserving the whole source also preserves its printed border and cartouche.
+BRIA interpreted those as a framed object. Pixel identity is therefore proven;
+continuous cartographic composition is not. Do not enable this by default or
+use this output in a public demo. The next experiment needs an explicit protected
+terrain region that excludes page furniture, with its preservation guarantee
+clearly distinguished from whole-sheet identity.
+
+## Reproduce
+
+From `apps/modal-backend` (spends one render plus judges, no automatic rerolls):
+
+```sh
+OUTWARD_PRESERVE_BENCH_RUN=1 .venv/bin/python -m tests.continuity_bench.outward_preserve_runner \
+  --source /path/to/ankh-map-full-spec-2026-08-24.jpg --output /tmp/outward-proof
+```
+
+The harness saves the source, final candidate, and JSON receipt even when the
+production gate rejects the candidate. `.env` is loaded without exposing keys.
+Provider placement constraints: [BRIA Expand API](https://fal.ai/models/fal-ai/bria/expand/api).


### PR DESCRIPTION
## Status: experimental, not visual sign-off

Stacked on #254. The new flag is OFF by default. Do not merge as a claim that #252 is solved.

## Changes
- `SCALE_OUTWARD_PRESERVE_SOURCE=1`: same-plane 2x outpaint followed by local lossless source compositing and PNG output. Uploaded roots are supported; astronomical hops are excluded.
- Reject invalid dimensions and oversized canvases before silently resizing anything. Preserve EXIF-oriented decoded pixels, including alpha.
- Judge the final composite, not the raw provider image. Failed/unavailable critics prevent persistence. Share the OUTWARD judged loop with the existing edit path.
- Record paid outputs before download/compositing so those failures cannot disappear from spend accounting.
- Add exact pixel, provider-contract, and production-stream regressions plus a one-render receipt harness. No new dependencies.

## Live Ankh Result
- Source 1376x768; output 2752x1536; every decoded source pixel at centre exactly equal.
- Style 9.5/10, alignment 2.0/10. The production stream correctly rejected the candidate.
- Visual inspection: BRIA drew a framed map in a landscape. Preserving the whole sheet retains its printed border; this is NOT continuous cartographic terrain.
- No rerolls and no existing world modified. Default remains unchanged. Further work needs an explicit protected terrain region excluding page furniture, not more whole-sheet prompt tuning.

## Verification
- 1,088 backend tests passed, 2 skipped; coverage 87.42% (floor 87%).
- Ruff and mypy (51 modules) pass.
- Brave, isolated mock backend: OUTWARD saved as 2560x1440 PNG, Back restored the original image, 390px mobile layout had no horizontal overflow. Dark Reader caused a hydration warning; a separate pre-existing render-phase navigation warning is being fixed independently.

Details: `docs/OUTWARD_PRESERVATION.md`. Related: #252 (remains open).
