### PR TITLE
fix(web): move history navigation effects out of render

### DIFF
--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -4486,7 +4486,9 @@ export default function PlayPage() {
 
       <DebugHud />
 
-      {viewMode !== "map" && history.items.length >= 2 && (
+      {/* Both navigation overlays occupy the bottom edge; keep the active
+          scrubber unobstructed, including its close button on narrow screens. */}
+      {viewMode !== "map" && !scrubberOpen && history.items.length >= 2 && (
         <SessionMinimap
           pages={history.items
             .filter((p): p is Page & { nodeId: string } => Boolean(p.nodeId))

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -1972,14 +1972,9 @@ export default function PlayPage() {
     [page?.nodeId, history.items],
   );
 
-  const navigateToTrailIdx = (
-    prev: typeof history,
-    nextIdx: number
-  ): typeof history => {
-    const id = prev.trail[nextIdx];
-    if (!id) return prev;
-    const target = prev.items.find((p) => p.nodeId === id);
-    if (!target) return prev;
+  // Navigation is an event-side effect. Running this inside setHistory's
+  // updater can update Next's Router while React is rendering PlayPage.
+  const showHistoryPage = useCallback((target: Page) => {
     setPage(target);
     setPhase("ready");
     setError(null);
@@ -1991,41 +1986,35 @@ export default function PlayPage() {
       url.pathname = `/n/${target.nodeId}`;
       window.history.replaceState({}, "", url.toString());
     }
-    return { ...prev, trailIdx: nextIdx };
-  };
+  }, [setMorphFx]);
+
+  const navigateToTrailIdx = useCallback((nextIdx: number) => {
+    if (nextIdx === history.trailIdx) return;
+    const id = history.trail[nextIdx];
+    const target = history.items.find((p) => p.nodeId === id);
+    if (!id || !target) return;
+    showHistoryPage(target);
+    setHistory((prev) => ({ ...prev, trailIdx: nextIdx }));
+  }, [history, showHistoryPage]);
 
   const goBack = useCallback(() => {
     setEditVerdictChip(null);
-    setHistory((prev) =>
-      prev.trailIdx <= 0 ? prev : navigateToTrailIdx(prev, prev.trailIdx - 1)
-    );
-  }, []);
+    if (history.trailIdx > 0) navigateToTrailIdx(history.trailIdx - 1);
+  }, [history.trailIdx, navigateToTrailIdx]);
 
   const goForward = useCallback(() => {
     setEditVerdictChip(null);
-    setHistory((prev) =>
-      prev.trailIdx >= prev.trail.length - 1
-        ? prev
-        : navigateToTrailIdx(prev, prev.trailIdx + 1)
-    );
-  }, []);
+    if (history.trailIdx < history.trail.length - 1) {
+      navigateToTrailIdx(history.trailIdx + 1);
+    }
+  }, [history.trailIdx, history.trail.length, navigateToTrailIdx]);
 
   const selectFromMap = useCallback((nodeId: string) => {
     setEditVerdictChip(null);
+    const target = history.items.find((p) => p.nodeId === nodeId);
+    if (!target) return;
+    showHistoryPage(target);
     setHistory((prev) => {
-      const target = prev.items.find((p) => p.nodeId === nodeId);
-      if (!target) return prev;
-      setPage(target);
-      setPhase("ready");
-      setError(null);
-      setStatusMsg(null);
-      setMorphFx(null);
-      abortRef.current?.abort();
-      if (target.nodeId) {
-        const url = new URL(window.location.href);
-        url.pathname = `/n/${target.nodeId}`;
-        window.history.replaceState({}, "", url.toString());
-      }
       // Append to trail (truncating forward) so back/forward walks the
       // visited path even after a map jump.
       const trail = [
@@ -2035,7 +2024,7 @@ export default function PlayPage() {
       return { ...prev, trail, trailIdx: trail.length - 1 };
     });
     setViewMode("page");
-  }, []);
+  }, [history.items, showHistoryPage]);
 
   // OUTWARD / zoom-out landed: mirror the persisted reparent into the live
   // session — insert the container P, re-point the old root C under it (so the
@@ -4401,11 +4390,7 @@ export default function PlayPage() {
               title: p.title,
             }))}
           currentIdx={history.trailIdx}
-          onJump={(idx) => {
-            setHistory((prev) =>
-              idx === prev.trailIdx ? prev : navigateToTrailIdx(prev, idx)
-            );
-          }}
+          onJump={navigateToTrailIdx}
           onClose={() => setScrubberOpen(false)}
         />
       )}

--- a/apps/web/e2e/outward.spec.ts
+++ b/apps/web/e2e/outward.spec.ts
@@ -22,6 +22,11 @@ for (const viewport of [
     await page.setViewportSize(viewport);
     const errors: string[] = [];
     page.on("pageerror", (error) => errors.push(error.message));
+    page.on("console", (message) => {
+      if (message.type() === "error" && message.text().includes("Cannot update a component")) {
+        errors.push(message.text());
+      }
+    });
     let sessionId = "";
     let generations = 0;
     page.on("request", (req) => {
@@ -45,6 +50,12 @@ for (const viewport of [
     const parent = await saveResponse.json() as { parent_node_id: string };
     await expect(page).toHaveURL(new RegExp(`/n/${parent.parent_node_id}`));
     await waitForStableImage(page);
+    await page.keyboard.press("t");
+    await page.getByRole("button", { name: `Jump to ${originalNode.page_title}`, exact: true }).click();
+    await expect(page).toHaveURL(new RegExp(`/n/${root.id}`));
+    await page.getByRole("button", { name: "Close time-scrubber", exact: true }).click();
+    await page.getByRole("navigation", { name: "Location", exact: true }).getByRole("button").first().click();
+    await expect(page).toHaveURL(new RegExp(`/n/${parent.parent_node_id}`));
     expect(generations).toBe(2);
 
     const savedSource = await (await page.request.get(`/api/nodes/${root.id}`)).json();
@@ -69,6 +80,10 @@ for (const viewport of [
     const returnedScreenshot = testInfo.outputPath(`${viewport.name}-returned.png`);
     await page.screenshot({ path: returnedScreenshot, fullPage: true });
     await testInfo.attach(`${viewport.name}-returned`, { path: returnedScreenshot, contentType: "image/png" });
+    await page.getByRole("button", { name: "forward →", exact: true }).click();
+    await expect(page).toHaveURL(new RegExp(`/n/${parent.parent_node_id}`));
+    await waitForStableImage(page);
+    expect(generations).toBe(2);
     expect(errors).toEqual([]);
   });
 }

--- a/apps/web/e2e/outward.spec.ts
+++ b/apps/web/e2e/outward.spec.ts
@@ -50,10 +50,16 @@ for (const viewport of [
     const parent = await saveResponse.json() as { parent_node_id: string };
     await expect(page).toHaveURL(new RegExp(`/n/${parent.parent_node_id}`));
     await waitForStableImage(page);
+    const minimapExpand = page.getByTitle("Open the full map (M)");
+    await expect(minimapExpand).toBeVisible();
     await page.keyboard.press("t");
+    await expect(page.getByRole("region", { name: "Session time-scrubber", exact: true })).toBeVisible();
+    await expect(minimapExpand).toBeHidden();
     await page.getByRole("button", { name: `Jump to ${originalNode.page_title}`, exact: true }).click();
     await expect(page).toHaveURL(new RegExp(`/n/${root.id}`));
     await page.getByRole("button", { name: "Close time-scrubber", exact: true }).click();
+    await expect(page.getByRole("region", { name: "Session time-scrubber", exact: true })).toBeHidden();
+    await expect(minimapExpand).toBeVisible();
     await page.getByRole("navigation", { name: "Location", exact: true }).getByRole("button").first().click();
     await expect(page).toHaveURL(new RegExp(`/n/${parent.parent_node_id}`));
     expect(generations).toBe(2);


### PR DESCRIPTION
## Summary
Stacked on #254; independent of the experimental #255.

Brave testing reproduced React's `Cannot update a component (Router) while rendering a different component (PlayPage)` warning on Back navigation. The history state updater invoked URL navigation and several other state setters during render.

- Move page/URL navigation side effects into event handlers shared by Back, Forward, map selection, and time-scrubber jumps.
- Keep history updaters pure and give callbacks current dependencies (also removes three existing hook warnings).
- Extend desktop/mobile OUTWARD E2E coverage to fail on render-phase-update console errors and exercise Forward, scrubber jumps, and breadcrumb navigation without new generation.

## Verification
- TypeScript and full web coverage suite pass; ESLint has no errors (5 remaining pre-existing warnings in PlayPage).
- Direct Brave regression: session-map selection, Back, Forward, and time-scrubber jump all restore the correct saved image with zero new render-phase-update errors.
- Dark Reader hydration warning was identified separately; no user extension settings were changed.

No paid calls, dependency changes, deployment, or merge.
