### PR TITLE
test: bounded place identity pilot and browser receipts

### DIFF
--- a/apps/modal-backend/tests/continuity_bench/place_identity_runner.py
+++ b/apps/modal-backend/tests/continuity_bench/place_identity_runner.py
@@ -1,0 +1,164 @@
+"""Bounded, cached pilot on three checked-in real maps. Never changes defaults.
+
+PLACE_IDENTITY_PILOT=1 .venv/bin/python -m tests.continuity_bench.place_identity_runner
+Both arms get one image attempt, the same model and the same named target.
+The $5 conservative reservation ledger also counts each LLM request. A missing
+cell or failed judge marks the pilot incomplete, never as a zero-score success.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import math
+import os
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from dotenv import load_dotenv
+
+BACKEND = Path(__file__).resolve().parents[2]
+FIXTURES = BACKEND / "tests/click_bench/fixtures"
+OUT = BACKEND / "tests/continuity_bench/reports/place-identity-pilot"
+MODEL = "fal-ai/nano-banana-pro"
+CASES = ("fishing_lighthouse", "oasis_citadel", "harbor_lighthouse")
+
+
+class PilotLedger:
+    """Run-wide reservations survive restarts and UTC day boundaries."""
+
+    def __init__(self, path: Path, cap: float = 4.80):
+        self.path, self.cap = path, cap
+        self.reserved = float(json.loads(path.read_text())["reserved_usd"]) if path.exists() else 0.0
+        if not math.isfinite(self.reserved) or self.reserved < 0:
+            raise ValueError("Invalid pilot ledger; reconcile spend before continuing")
+
+    def reserve(self, amount: float) -> None:
+        if not math.isfinite(amount) or amount < 0:
+            raise ValueError("Invalid reservation")
+        if self.reserved + amount > self.cap:
+            raise RuntimeError("Run-wide pilot budget exhausted")
+        self.reserved = round(self.reserved + amount, 4)
+        self.path.write_text(json.dumps({"reserved_usd": self.reserved}, indent=2))
+
+
+async def main() -> None:
+    if os.environ.get("PLACE_IDENTITY_PILOT") != "1":
+        raise SystemExit("Paid pilot disabled; set PLACE_IDENTITY_PILOT=1 explicitly")
+    load_dotenv(BACKEND / ".env")
+    if os.environ.get("MOCK_PROVIDERS") in {"1", "true"}:
+        raise SystemExit("A mock run is not a visual-quality pilot")
+    sys.modules.setdefault("modal", MagicMock())
+    from generate import GenerateBody, _event_stream
+    from providers import image, image_edit, judge, llm, spend
+    from providers.place_identity import reference_crop
+    from providers.render_budget import RenderBudget
+
+    os.environ.update(WORLD_IDENTITY_STRICT="true", WORLD_MODE="true", VIEW_GRAMMAR="true", PROGRESSIVE_DRAFT="false", VLM_JUDGE_EMPTY_RETRIES="1", MAX_DAILY_SPEND="4.80", MAX_SESSION_SPEND="4.80")
+    OUT.mkdir(parents=True, exist_ok=True)
+    ledger = PilotLedger(OUT / "ledger.json")
+    spend.reset_for_tests()
+    spend.record("pilot", ledger.reserved)
+    raw_reserve = spend.reserve
+
+    def reserve(session_id: str, amount: float) -> float:
+        ledger.reserve(amount)
+        return raw_reserve(session_id, amount)
+
+    spend.reserve = reserve
+    # Actual submission reservations, not a second post-hoc image estimate.
+    spend.record_generation = lambda session_id, model, images=1: spend.session_total(session_id)
+    raw_llm = llm._create_with_retry
+
+    async def bounded_llm(client, **kwargs):
+        reserve("pilot-llm", .02)
+        kwargs["max_retries"] = 0
+        return await raw_llm(client, **kwargs)
+
+    llm._create_with_retry = bounded_llm
+    from providers.llm import client as llm_client
+
+    llm_client._create_with_retry = bounded_llm
+    raw_fal = image._fal_subscribe
+    current_budget = None
+
+    async def bounded_fal(model, arguments, *, require_images=False, budget=None):
+        return await raw_fal(model, arguments, require_images=require_images, budget=budget or current_budget)
+
+    image._fal_subscribe = bounded_fal
+    image_edit._fal_subscribe = bounded_fal
+    cases = json.loads((FIXTURES / "v1.json").read_text())["cases"]
+    results = []
+    for case_id in CASES:
+        case = next(c for c in cases if c["case_id"] == case_id)
+        source = (FIXTURES / case["image_path"]).read_bytes()
+        source_url = image.encode_data_url(source, "image/jpeg")
+        box = {"x_pct": max(0, case["x_pct"] - .11), "y_pct": max(0, case["y_pct"] - .14), "w_pct": .22, "h_pct": .28}
+        crop = reference_crop(source_url, SimpleNamespace(**box))
+        crop_url = image.encode_data_url(crop, "image/png")
+        label = case["alternates"][0]
+        for transition in ("enter", "closeup"):
+            for strict in (False, True):
+                key = f"{case_id}-{transition}-{'strict' if strict else 'baseline'}"
+                receipt = OUT / f"{key}.json"
+                # Include production source hashes so a changed gate cannot
+                # masquerade as a cached receipt from this implementation.
+                sources = [BACKEND / "providers/place_identity.py", BACKEND / "providers/generate_modes/tap.py", BACKEND / "providers/image_edit.py"]
+                digest = hashlib.sha256(source + b"".join(p.read_bytes() for p in sources) + MODEL.encode()).hexdigest()
+                if receipt.exists():
+                    cached = json.loads(receipt.read_text())
+                    if cached.get("source_hash") == digest and cached.get("complete"):
+                        results.append(cached)
+                        continue
+                current_budget = RenderBudget(key, 1, time.monotonic() + 600)
+                started = time.monotonic()
+                row = {"case": key, "source_hash": digest, "complete": False, "accepted": False}
+                try:
+                    body = GenerateBody(
+                        query=case["parent_title"], session_id=key, current_node_id="fixture", mode="tap", image=source_url,
+                        world_mode=True, strict_world=strict, target_geo_id=case_id,
+                        place_reference={"geo_id": case_id, "label": label, "visual": case["notes"], "image_data_url": source_url, "bbox": box} if strict else None,
+                        prefetched_subject=label, prefetched_subject_context=case["notes"],
+                        render_mode="place_scene" if transition == "enter" else "place_submap",
+                        condition_image_urls=[crop_url, source_url], condition_roles=["region", "parent"],
+                        scene_view={"node_id": "fixture", "level": "building" if transition == "enter" else "map", "focus_id": case_id, "closeup": transition == "closeup", "view": {"projection": "oblique" if transition == "enter" else "top_down", "source": "user"}},
+                        image_model=MODEL, max_attempts=1, verify=True, web_search=False,
+                    )
+                    output = None
+                    async for chunk in _event_stream(body, key):
+                        for line in chunk.decode().splitlines():
+                            if line.startswith("data:"):
+                                event = json.loads(line[5:])
+                                if event["type"] in {"final", "error"}:
+                                    output = event
+                    task = asyncio.current_task()
+                    if task and task.cancelling():
+                        raise asyncio.CancelledError()
+                    if not output:
+                        raise RuntimeError("No final result or rejection")
+                    url = output.get("image_data_url") or output.get("candidate_image_data_url")
+                    if not url:
+                        raise RuntimeError(output.get("message", "No image produced"))
+                    from providers.render_loop import data_url_bytes
+
+                    candidate = data_url_bytes(url)
+                    assert candidate is not None
+                    (OUT / f"{key}.jpg").write_bytes(candidate)
+                    identity = await judge.score_entity_consistency(label, case["notes"], crop, candidate)
+                    medium = await judge.score_style_pair(crop, candidate)
+                    row.update(complete=True, accepted=output["type"] == "final", identity=identity.score, medium=medium.score, identity_reason=identity.rationale, medium_reason=medium.rationale, receipt=output.get("view_verdict"), seconds=round(time.monotonic() - started, 2))
+                except Exception as exc:
+                    row["error"] = str(exc)[:240]
+                receipt.write_text(json.dumps(row, indent=2))
+                results.append(row)
+                print(json.dumps(row), flush=True)
+                (OUT / "summary.json").write_text(json.dumps({"complete": len(results) == 12 and all(r["complete"] for r in results), "promotion": False, "reserved_usd": ledger.reserved, "results": results}, indent=2))
+    (OUT / "summary.json").write_text(json.dumps({"complete": len(results) == 12 and all(r["complete"] for r in results), "promotion": False, "reserved_usd": ledger.reserved, "results": results}, indent=2))
+    print(f"Pilot receipts: {OUT}; conservative reservations ${ledger.reserved:.2f}", flush=True)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/apps/modal-backend/tests/test_place_pilot.py
+++ b/apps/modal-backend/tests/test_place_pilot.py
@@ -1,0 +1,30 @@
+import json
+
+import pytest
+
+from tests.continuity_bench.place_identity_runner import PilotLedger, main
+
+
+def test_run_budget_survives_restart_and_daily_accounting_reset(tmp_path):
+    path = tmp_path / "ledger.json"
+    ledger = PilotLedger(path)
+    ledger.reserve(4.60)
+    resumed = PilotLedger(path)
+    resumed.reserve(.20)
+    with pytest.raises(RuntimeError, match="Run-wide"):
+        resumed.reserve(.01)
+    assert json.loads(path.read_text())["reserved_usd"] == 4.80
+
+
+@pytest.mark.parametrize("amount", [float("nan"), float("inf"), -1])
+def test_invalid_reservation_cannot_corrupt_ledger(tmp_path, amount):
+    ledger = PilotLedger(tmp_path / "ledger.json")
+    with pytest.raises(ValueError):
+        ledger.reserve(amount)
+    assert ledger.reserved == 0
+
+
+async def test_pilot_is_opt_in_before_loading_keys(monkeypatch):
+    monkeypatch.delenv("PLACE_IDENTITY_PILOT", raising=False)
+    with pytest.raises(SystemExit, match="disabled"):
+        await main()

--- a/apps/web/scripts/seed-place-inspector.mjs
+++ b/apps/web/scripts/seed-place-inspector.mjs
@@ -1,0 +1,38 @@
+// Isolated browser fixture: local stores only; new IDs on every invocation.
+import { readFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { URL } from "node:url";
+import { log } from "node:console";
+import { MongoClient } from "mongodb";
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+
+const sessionId = `place-test-${randomUUID()}`;
+const rootId = randomUUID();
+const savedId = randomUUID();
+const imageKey = `place-inspector-test/${sessionId}.jpg`;
+const bytes = await readFile(new URL("../../modal-backend/tests/click_bench/fixtures/images/real/fishing_village.jpg", import.meta.url));
+const s3 = new S3Client({ region: "auto", endpoint: "http://127.0.0.1:9000", forcePathStyle: true, credentials: { accessKeyId: "openflipbook", secretAccessKey: "openflipbook-local" } });
+await s3.send(new PutObjectCommand({ Bucket: "openflipbook", Key: imageKey, Body: bytes, ContentType: "image/jpeg" }));
+const client = new MongoClient("mongodb://127.0.0.1:27017/?directConnection=true");
+await client.connect();
+try {
+  const db = client.db("openflipbook_healthcheck");
+  const now = new Date();
+  const base = { session_id: sessionId, query: "Crescent Bay Fishing Village", image_key: imageKey, image_model: "fixture", prompt_author_model: "fixture", aspect_ratio: "16:9", final_prompt: null, click_in_parent: null, created_at: now, sources: [], relation: "descend" };
+  await db.collection("nodes").insertMany([
+    { ...base, _id: rootId, parent_id: null, page_title: "Crescent Bay Fishing Village", scene_view: null },
+    { ...base, _id: savedId, parent_id: rootId, page_title: "Saved North Point view", scene_view: { node_id: savedId, level: "building", observer: null, map_crop: null, focus_id: "north-point" } },
+  ]);
+  const cases = [
+    ["north-point", "North Point Lighthouse", .557, .192, "White stone lighthouse with a red roof"],
+    ["market", "Central Market Square", .414, .594, "An open square ringed by stalls"],
+    ["market-hall", "Market Hall", .43, .594, "The timber hall beside the square"],
+  ];
+  const geos = cases.map(([id, label, x, y, visual]) => ({ id, entity_id: `entity-${id}`, kind: "place", label, pos: { x: x * 100, y: y * 60 }, footprint: { w: 12, d: 12 }, height: 8, visual, state: {}, confidence: 1, source: "user", updated_at: now.toISOString() }));
+  await db.collection("world_map").insertOne({ _id: sessionId, entities: geos, bounds: { x: 0, y: 0, w: 100, h: 60 }, updated_at: now });
+  await db.collection("world_state").insertOne({ _id: sessionId, entities: cases.map(([id, name, x, y, appearance]) => ({ id: `entity-${id}`, kind: "place", name, appearance, aliases: [], facts: [], state: {}, confidence: 1, pinned_by_user: false, first_seen_node_id: rootId, last_seen_node_id: rootId, appears_on_node_ids: [rootId], appearance_bboxes: { [rootId]: { x_pct: x - .06, y_pct: y - .1, w_pct: .12, h_pct: .2 } }, created_at: now, updated_at: now })), updated_at: now });
+  log(JSON.stringify({ sessionId, rootId, savedId, url: `http://127.0.0.1:3001/n/${rootId}` }));
+} finally {
+  await client.close();
+  s3.destroy();
+}

--- a/docs/PLACE_IDENTITY.md
+++ b/docs/PLACE_IDENTITY.md
@@ -1,0 +1,60 @@
+# Place Identity
+
+## Available Controls
+
+World Mode's Place Inspector lists mapped places, their saved views, editable
+names and appearances, and identity locks. A saved session image can be selected
+and cropped as a canonical reference. Enter reuses a matching saved view;
+New view opens the camera picker and deliberately bypasses that reuse.
+Overlapping places get a chooser instead of an arbitrary winner.
+
+Reference metadata stores an immutable image key, node ID, and normalized crop.
+Recropping does not silently swap in a later node revision. Owner-checked PATCH
+writes update linked Codex and geometry metadata in one Mongo transaction.
+Concurrent edits return 409. Mongo must support transactions (a replica set,
+including the existing single-member Compose setup, or Atlas).
+
+Locks protect curated names and appearances from extraction. Re-import preserves
+identity metadata. Fork remaps reference node IDs while retaining original image
+keys; world ZIP exports include reference bytes and `references.json` separately
+from potentially edited page images. No database migration is required.
+
+## Experimental Verification
+
+**Default OFF. Not ready for promotion.** To test locally, enable
+`WORLD_IDENTITY_STRICT=true` on both web server and backend, and build the web
+with `NEXT_PUBLIC_WORLD_IDENTITY_STRICT=true`. World Mode must also be on.
+Compose passes these flags explicitly. A strict client talking to a flag-off
+server gets an error, not an unverified fallback. Rebuild the web with the public
+flag false to roll back; disabling only the server intentionally fails closed.
+
+The server resolves the target, source bytes, canonical reference and spatial
+context from that session. Client-supplied reference bytes are discarded.
+Every applicable judge must return a finite passing score on the final bytes:
+identity (or interior identity), medium, camera, detail, zoom direction, and
+spatial grounding when layout is known. OUTWARD adds source-containment judging.
+No corrective image edit happens after acceptance.
+
+Failed or unavailable judges produce an unpublished candidate with Retry and
+Dismiss. They do not replace the map, save a node, reparent an OUTWARD root, or
+start extraction. Strict requests make at most two image submissions, including
+provider transport retries, and honor smaller caller limits. Reservations count
+failed submissions and enforce existing estimated session/day caps before each
+submission. These are process-local estimates, not an invoice or distributed
+billing ledger. Deadlines bound provider and judge waits.
+
+Thresholds: `WORLD_IDENTITY_ACCEPT_PLACE`, `WORLD_IDENTITY_ACCEPT_MEDIUM`, and
+`WORLD_IDENTITY_ACCEPT_CONFORMANCE` default to 7. Detail uses existing
+`VIEW_LOOP_ACCEPT_DETAIL` / `TAP_ZOOM_DETAIL_ACCEPT`; interiors use
+`INTERIOR_ACCEPT`. Invalid thresholds fall back to finite defaults.
+
+## Verification
+
+Free tests: `pnpm --filter @openflipbook/web test:coverage` and, from the backend,
+`.venv/bin/python -m pytest --cov=providers --cov=generate`.
+The local-only `apps/web/scripts/seed-place-inspector.mjs` creates an isolated
+two-page world in `openflipbook_healthcheck`, with three places and a deliberate
+overlap. It requires the local Mongo/Minio services and never targets production.
+
+The bounded [visual pilot](research/11-place-identity-pilot.md) is not a quality
+graduation. OUTWARD pixel preservation remains off; issue #252 is still open.

--- a/docs/research/11-place-identity-pilot.json
+++ b/docs/research/11-place-identity-pilot.json
@@ -1,0 +1,247 @@
+{
+  "complete": true,
+  "promotion": false,
+  "reserved_usd": 4.2,
+  "results": [
+    {
+      "case": "fishing_lighthouse-enter-baseline",
+      "source_hash": "e730ccee2ca8a4385bd46e708c232169a9d5032b0135d48bfae494438e2d8acd",
+      "complete": true,
+      "accepted": true,
+      "identity": 0,
+      "medium": 8.5,
+      "identity_reason": "The North Point Lighthouse is completely absent in the second image, which depicts a harbor dock scene instead.",
+      "medium_reason": "Both feature an illustrated map-like aesthetic with clean black ink linework, muted watercolor-style coloring, and integrated labels.",
+      "receipt": {
+        "same_place": 0,
+        "conformance": 10,
+        "medium": 9,
+        "detail": 10,
+        "interior": null,
+        "attempts": 1,
+        "accepted": false
+      },
+      "seconds": 38.82
+    },
+    {
+      "case": "fishing_lighthouse-enter-strict",
+      "source_hash": "e730ccee2ca8a4385bd46e708c232169a9d5032b0135d48bfae494438e2d8acd",
+      "complete": true,
+      "accepted": true,
+      "identity": 9,
+      "medium": 9.5,
+      "identity_reason": "The lighthouse in image 2 shares the same cylindrical stone design, dark lantern cap, and labeled text 'North Point Lighthouse' beside it on the coastal cliff.",
+      "medium_reason": "The candidate matches the reference perfectly in medium, fine ink linework, muted watercolor washes, perspective, and labeled cartographic typography.",
+      "receipt": {
+        "same_place": 9,
+        "conformance": 10,
+        "medium": 9.5,
+        "detail": 9,
+        "interior": null,
+        "attempts": 1,
+        "accepted": true
+      },
+      "seconds": 39.17
+    },
+    {
+      "case": "fishing_lighthouse-closeup-baseline",
+      "source_hash": "e730ccee2ca8a4385bd46e708c232169a9d5032b0135d48bfae494438e2d8acd",
+      "complete": true,
+      "accepted": true,
+      "identity": 10,
+      "medium": 10,
+      "identity_reason": "Image 1 is an identical close-up crop of the North Point Lighthouse shown on the full map in Image 2.",
+      "medium_reason": "The candidate image is the full artwork from which the reference is directly cropped, making the style completely identical in line work, coloring, and medium.",
+      "receipt": {
+        "same_place": 0,
+        "conformance": null,
+        "medium": null,
+        "detail": 9,
+        "interior": null,
+        "attempts": 2,
+        "accepted": false
+      },
+      "seconds": 34.27
+    },
+    {
+      "case": "fishing_lighthouse-closeup-strict",
+      "source_hash": "e730ccee2ca8a4385bd46e708c232169a9d5032b0135d48bfae494438e2d8acd",
+      "complete": true,
+      "accepted": false,
+      "identity": 0,
+      "medium": 8,
+      "identity_reason": "The entity North Point Lighthouse is absent in the second image, which instead depicts Beacon Rock Lighthouse.",
+      "medium_reason": "Both feature hand-drawn fantasy map illustrations with black ink outlines and a warm, teal-accented palette, though Image 2 incorporates more visible cross-hatching texture.",
+      "receipt": {
+        "same_place": 0,
+        "conformance": 1,
+        "medium": 8,
+        "detail": 9,
+        "interior": null,
+        "attempts": 1,
+        "accepted": false
+      },
+      "seconds": 36.38
+    },
+    {
+      "case": "oasis_citadel-enter-baseline",
+      "source_hash": "cc34afe4b4a73b4fc745aff2a7ce0685d0d01526e8baf2d59724f7d7f50f15d4",
+      "complete": true,
+      "accepted": true,
+      "identity": 0,
+      "medium": 7.5,
+      "identity_reason": "Image 2 depicts an entirely different location, 'The Sunbaked Oasis of Zaffar', with a different layout, perspective, and core features.",
+      "medium_reason": "Both share a warm parchment-toned palette, black ink linework, and textured shading, though Image 2 shifts from a 2D top-down map perspective to an isometric 3D view.",
+      "receipt": {
+        "same_place": 0,
+        "conformance": 10,
+        "medium": 6.8,
+        "detail": 10,
+        "interior": null,
+        "attempts": 1,
+        "accepted": false
+      },
+      "seconds": 41.05
+    },
+    {
+      "case": "oasis_citadel-enter-strict",
+      "source_hash": "cc34afe4b4a73b4fc745aff2a7ce0685d0d01526e8baf2d59724f7d7f50f15d4",
+      "complete": true,
+      "accepted": false,
+      "identity": 7,
+      "medium": 6,
+      "identity_reason": "The citadel in the perspective view reflects the general sandstone material, crenelated walls, and fortress layout shown in the top-down plan.",
+      "medium_reason": "Both feature clean ink outlines and warm architectural rendering, but the candidate shifts from a top-down parchment map palette to a full-color isometric landscape with prominent greens and blues.",
+      "receipt": {
+        "same_place": 8,
+        "conformance": 10,
+        "medium": 5,
+        "detail": 9,
+        "interior": null,
+        "attempts": 1,
+        "accepted": false
+      },
+      "seconds": 49.16
+    },
+    {
+      "case": "oasis_citadel-closeup-baseline",
+      "source_hash": "cc34afe4b4a73b4fc745aff2a7ce0685d0d01526e8baf2d59724f7d7f50f15d4",
+      "complete": true,
+      "accepted": true,
+      "identity": 8,
+      "medium": 10,
+      "identity_reason": "The outer citadel walls, towers, and layout match identically, though the central structure inside the citadel has been redesigned with minarets and domes.",
+      "medium_reason": "Both images share the exact same hand-drawn cartographic style, warm parchment palette, ink linework, and top-down perspective.",
+      "receipt": {
+        "same_place": 5,
+        "conformance": null,
+        "medium": null,
+        "detail": 9,
+        "interior": null,
+        "attempts": 2,
+        "accepted": false
+      },
+      "seconds": 38.52
+    },
+    {
+      "case": "oasis_citadel-closeup-strict",
+      "source_hash": "cc34afe4b4a73b4fc745aff2a7ce0685d0d01526e8baf2d59724f7d7f50f15d4",
+      "complete": true,
+      "accepted": false,
+      "identity": 9,
+      "medium": 8.5,
+      "identity_reason": "The layout of the fortress at the top of the map in image 2 matches the detailed layout in image 1 with identical towers, keep structure, and wall configurations.",
+      "medium_reason": "Both share a classic hand-drawn fantasy cartography style with detailed ink outlines, top-down perspective, and warm parchment-toned watercolor washes.",
+      "receipt": {
+        "same_place": 10,
+        "conformance": 0,
+        "medium": 8,
+        "detail": 10,
+        "interior": null,
+        "attempts": 1,
+        "accepted": false
+      },
+      "seconds": 45.05
+    },
+    {
+      "case": "harbor_lighthouse-enter-baseline",
+      "source_hash": "45acbbd0142df4ec916fe39eb4dfa619547ac9a42464fc32a01a10911026c146",
+      "complete": true,
+      "accepted": true,
+      "identity": 0,
+      "medium": 8.5,
+      "identity_reason": "The Crystal Lighthouse is entirely absent from the second image.",
+      "medium_reason": "Both images share a matching fantasy map-illustration style with crisp ink line work, isometric perspective, and similar architectural rendering, though the candidate's palette is slightly more muted.",
+      "receipt": {
+        "same_place": 1,
+        "conformance": 10,
+        "medium": 8.5,
+        "detail": 10,
+        "interior": null,
+        "attempts": 1,
+        "accepted": false
+      },
+      "seconds": 44.4
+    },
+    {
+      "case": "harbor_lighthouse-enter-strict",
+      "source_hash": "45acbbd0142df4ec916fe39eb4dfa619547ac9a42464fc32a01a10911026c146",
+      "complete": true,
+      "accepted": false,
+      "identity": 5,
+      "medium": 9.5,
+      "identity_reason": "While both depict a lighthouse on the left cliff with blue crystal elements, Image 2 features an enclosed lantern with a solid crystal cone roof rather than the floating crystal diamond and flanking stone wings of Image 1.",
+      "medium_reason": "The candidate matches the reference image's hand-drawn ink linework, fantasy cartographic perspective, and watercolor-like digital shading almost perfectly.",
+      "receipt": {
+        "same_place": 4,
+        "conformance": 10,
+        "medium": 9.5,
+        "detail": 9,
+        "interior": null,
+        "attempts": 1,
+        "accepted": false
+      },
+      "seconds": 53.56
+    },
+    {
+      "case": "harbor_lighthouse-closeup-baseline",
+      "source_hash": "45acbbd0142df4ec916fe39eb4dfa619547ac9a42464fc32a01a10911026c146",
+      "complete": true,
+      "accepted": true,
+      "identity": 10,
+      "medium": 10,
+      "identity_reason": "Image 1 is a direct close-up crop of the exact same lighthouse featured in the map overview of Image 2.",
+      "medium_reason": "Image 1 is a direct crop from the same illustrated fantasy map as Image 2, sharing identical linework, rendering, and palette.",
+      "receipt": {
+        "same_place": 0,
+        "conformance": null,
+        "medium": null,
+        "detail": 9.5,
+        "interior": null,
+        "attempts": 2,
+        "accepted": false
+      },
+      "seconds": 41.19
+    },
+    {
+      "case": "harbor_lighthouse-closeup-strict",
+      "source_hash": "45acbbd0142df4ec916fe39eb4dfa619547ac9a42464fc32a01a10911026c146",
+      "complete": true,
+      "accepted": false,
+      "identity": 9,
+      "medium": 7,
+      "identity_reason": "The Crystal Lighthouse appears on the left headland labeled clearly on the map with a matching tower structure and floating crystal top consistent with the close-up.",
+      "medium_reason": "Both share the same hand-drawn ink cartography line work and architectural stylization, though the candidate has a much more muted, desaturated map palette compared to the vibrant reference.",
+      "receipt": {
+        "same_place": 8,
+        "conformance": 0,
+        "medium": 8.5,
+        "detail": 9.5,
+        "interior": null,
+        "attempts": 1,
+        "accepted": false
+      },
+      "seconds": 40.97
+    }
+  ]
+}

--- a/docs/research/11-place-identity-pilot.md
+++ b/docs/research/11-place-identity-pilot.md
@@ -1,0 +1,83 @@
+# Canonical Place Pilot, 2026-09-06/07
+
+## Decision
+
+Keep strict generation experimental and OFF. Canonical references plus rejecting
+failed outputs are useful, but this pilot does not establish reliable entering
+or zooming. No production flags or deployments were changed.
+
+## Method
+
+Three checked-in, verified illustrated maps from `tests/click_bench/fixtures`:
+fishing village / North Point Lighthouse, oasis / citadel, harbor / Crystal
+Lighthouse. Each target gets enter and close-up, baseline versus strict, for
+12 cells. Both arms use nano-banana-pro and at most one actual image submission
+per cell. Text/judges used the configured Gemini 3.7 Flash route. This is a
+small diagnostic comparison, not a statistically powered benchmark.
+
+The runner invokes the real generation stream but does not save app nodes.
+Production receipts and a separate identity/style audit are recorded. Baseline
+`accepted` in the artifact means a final event was published, not that its
+quality judges passed. Some baseline close-ups attempted a second render; the
+pilot stopped those before submission, so their legacy receipt's attempts=2
+does not mean two paid image calls occurred.
+
+| Target / Transition | Baseline Published | Strict Published | Main Failure |
+| --- | --- | --- | --- |
+| North Point / enter | yes | yes | Strict lighthouse still distant, behind foreground houses |
+| North Point / close-up | yes | no | Wrong lighthouse; baseline returned the wider map |
+| Oasis citadel / enter | yes | no | Identity/style drift |
+| Oasis citadel / close-up | yes | no | Wider map, not a closer view |
+| Crystal Lighthouse / enter | yes | no | Architecture changed despite matching medium |
+| Crystal Lighthouse / close-up | yes | no | Wider map, not a closer view |
+
+Strict rejected five of six candidates; baseline published all six despite
+failing receipts. The sole strict pass scored identity 9, medium 9.5, and
+camera 10, but visual inspection shows it does not adequately enter the target.
+This is a judge false positive on target framing, not a successful demo shot.
+The harbor strict enter visibly replaces the distinctive crystal assembly
+with a different lantern/roof. Style similarity alone does not prove identity.
+
+## Budget and Artifacts
+
+Original cap: $5. Final conservative reservations: **$4.20**, including an
+overestimated $3.60 carry-forward after an interrupted first pass. This is not
+the provider invoice. The first accounting implementation crossed UTC midnight;
+the resumed run used a persistent run-wide ledger, now regression-tested.
+Cancelled cells and failures were not treated as free. No further paid calls
+were made after the 12-cell completion.
+
+The frozen [JSON receipt](11-place-identity-pilot.json) records the implementation
+hash used for each source. Later changes to SSE camera stamping and UI handling
+were covered by free tests, not another paid rerender. Full images and per-cell
+receipts remain locally under
+`apps/modal-backend/tests/continuity_bench/reports/place-identity-pilot/`.
+
+Runner, from the backend directory:
+`PLACE_IDENTITY_PILOT=1 .venv/bin/python -m tests.continuity_bench.place_identity_runner`.
+It resumes completed hash-matching cells and retains its budget across runs.
+Run one process at a time. Do not delete the ledger to reroll without a new
+spend approval. Missing cells or failed audit calls make the report incomplete.
+
+## Browser Receipt
+
+Brave, isolated mock backend and Mongo database, at 390x844 and desktop:
+Inspector rename/lock/crop persisted; old name remained an alias; saved-view
+Enter reused an existing node; overlap chooser listed both market places;
+New view opened and submitted the camera picker. Forced mock rejection and
+Retry kept the source permalink and page count unchanged, with a separate
+unpublished-candidate preview and no acceptance override. Mock spend labels are
+synthetic estimates, not additional pilot charges.
+
+The browser uncovered two mobile bugs fixed here: wrapping image controls
+covered tap targets, and the camera picker was clipped by the image frame.
+Controls now flow below the mobile image; the picker is portaled and bounded
+to the viewport. Component/API tests cover stale writes, reload, ownership,
+reference immutability, malformed input, cancelled work, and fork/export.
+
+## Next Evidence Needed
+
+Measure target prominence/arrival, not just whether the place appears somewhere
+in the image. Expand to interior and multi-hop transitions, diverse media, and
+independent human review before promotion. OUTWARD compositing and exact centre
+pixels remain a separate experiment under #252, with no new success claim here.


### PR DESCRIPTION
## Stack
Third PR, on top of #257 and the strict-generation backend PR.

## Scope
- Reproducible three-map, enter/close-up, baseline/strict pilot with opt-in paid calls, source-hash caching and a persistent run-wide budget.
- Tests prevent budget reset across resumed runs and reject invalid reservations.
- Local-only browser fixture in an isolated Mongo database.
- Frozen 12-cell receipt, browser findings, setup/rollback documentation.

## Honest Result
Strict published 1/6; baseline published 6/6 despite failing quality receipts. Visual inspection found the sole strict pass still left the target lighthouse in the background. This is NOT a quality graduation: defaults remain OFF, OUTWARD pixel preservation remains OFF, and #252 stays open.

Conservative pilot reservations were .20 against the original  cap, including interrupted work. No additional paid rerolls and no deployment/config changes.

## Verification
Full backend suite: 1125 passed, 2 skipped, coverage 87.45%. Web coverage floors, TypeScript, lint, and production build pass. Brave tested Inspector edits/reuse, overlap selection, camera submission, and rejection/retry with unchanged root and node count. No auto-merge.