### PR TITLE
Fix read-only viewer marker alignment and loading states

### DIFF
--- a/apps/web/components/embed-viewer.test.tsx
+++ b/apps/web/components/embed-viewer.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import EmbedViewer from "./embed-viewer";
 
@@ -13,7 +13,7 @@ const CHILDREN = [
     id: "kid1",
     page_title: "The Tower",
     image_url: "https://r2/kid1.jpg",
-    click_in_parent: { x_pct: 0.25, y_pct: 0.5 },
+    click_in_parent: { x_pct: 0.25, y_pct: 0.25 },
   },
   {
     id: "kid2",
@@ -38,7 +38,32 @@ function stubChildren(byParent: Record<string, unknown[]>) {
 
 const INITIAL = { id: "root", title: "The Map", imageUrl: "https://r2/root.jpg" };
 
-afterEach(() => vi.unstubAllGlobals());
+let resize: () => void;
+let width: number;
+let height: number;
+
+beforeEach(() => {
+  width = 800;
+  height = 600;
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(() =>
+    ({ width, height, left: 0, top: 0, right: width, bottom: height } as DOMRect));
+  vi.spyOn(HTMLImageElement.prototype, "naturalWidth", "get").mockReturnValue(1200);
+  vi.spyOn(HTMLImageElement.prototype, "naturalHeight", "get").mockReturnValue(600);
+  vi.stubGlobal("ResizeObserver", class {
+    constructor(cb: () => void) { resize = cb; }
+    observe() {}
+    disconnect() {}
+  });
+});
+
+afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); });
+
+async function mount() {
+  await act(async () => {
+    render(<EmbedViewer sessionId="s1" initial={INITIAL} continueUrl="/play?continue=s1" />);
+  });
+  fireEvent.load(screen.getByRole("img"));
+}
 
 describe("EmbedViewer", () => {
   it("renders entry dots only for children with a recorded tap point", async () => {
@@ -48,6 +73,7 @@ describe("EmbedViewer", () => {
         <EmbedViewer sessionId="s1" initial={INITIAL} continueUrl="/play?continue=s1" />
       );
     });
+    fireEvent.load(screen.getByRole("img"));
     expect(screen.getByTitle("Enter The Tower")).toBeTruthy();
     expect(screen.queryByTitle("Enter The Harbor")).toBeNull();
     expect(screen.getByText("1 place to enter")).toBeTruthy();
@@ -60,16 +86,17 @@ describe("EmbedViewer", () => {
         <EmbedViewer sessionId="s1" initial={INITIAL} continueUrl="/play?continue=s1" />
       );
     });
+    fireEvent.load(screen.getByRole("img"));
     await act(async () => {
       fireEvent.click(screen.getByTitle("Enter The Tower"));
     });
     expect(screen.getByText("The Tower")).toBeTruthy();
     expect(screen.getByText("world frontier")).toBeTruthy(); // no children
     await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: "← back" }));
+      fireEvent.click(screen.getByRole("button", { name: "Back" }));
     });
     expect(screen.getByText("The Map")).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "← back" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Back" })).toBeNull();
   });
 
   it("a tap on unexplored ground shows the continue hint at the tap point", async () => {
@@ -79,22 +106,27 @@ describe("EmbedViewer", () => {
         <EmbedViewer sessionId="s1" initial={INITIAL} continueUrl="/play?continue=s1" />
       );
     });
+    fireEvent.load(screen.getByRole("img"));
     await act(async () => {
-      fireEvent.click(screen.getByTestId("embed-stage"));
+      fireEvent.click(screen.getByTestId("embed-stage"), { clientX: 400, clientY: 300 });
     });
     const hint = screen.getByText(/unexplored — continue this world/);
     expect(hint.getAttribute("href")).toBe("/play?continue=s1");
   });
 
-  it("keeps rendering (dotless) when the children fetch fails", async () => {
+  it("distinguishes a failed fetch from the frontier and retries", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false })));
     await act(async () => {
       render(
         <EmbedViewer sessionId="s1" initial={INITIAL} continueUrl="/play?continue=s1" />
       );
     });
-    expect(screen.getByText("world frontier")).toBeTruthy();
+    expect(screen.getByText("Places unavailable")).toBeTruthy();
+    expect(screen.queryByText("world frontier")).toBeNull();
     expect(screen.getByRole("link", { name: /Continue this world/ })).toBeTruthy();
+    stubChildren({ root: [] });
+    await act(async () => { fireEvent.click(screen.getByRole("button", { name: "Retry places" })); });
+    expect(screen.getByText("world frontier")).toBeTruthy();
   });
 
   it("shows the receipt on the initial node only", async () => {
@@ -109,6 +141,7 @@ describe("EmbedViewer", () => {
         />
       );
     });
+    fireEvent.load(screen.getByRole("img"));
     expect(screen.getByText(/arrival verified/)).toBeTruthy();
     await act(async () => {
       fireEvent.click(screen.getByTitle("Enter The Tower"));
@@ -116,5 +149,97 @@ describe("EmbedViewer", () => {
     // Off the initial node the footer reverts to the generic line.
     expect(screen.queryByText(/arrival verified/)).toBeNull();
     expect(screen.getByText("an openflipbook world")).toBeTruthy();
+  });
+
+  it("positions markers within letterboxed pixels and recalculates on resize", async () => {
+    stubChildren({ root: CHILDREN });
+    await mount();
+    const dot = screen.getByTitle("Enter The Tower");
+    expect(dot.style.left).toBe("200px");
+    expect(dot.style.top).toBe("200px");
+    width = 400;
+    height = 800;
+    await act(async () => resize());
+    expect(dot.style.left).toBe("100px");
+    expect(dot.style.top).toBe("350px");
+  });
+
+  it("positions markers within pillarboxed portrait images", async () => {
+    vi.spyOn(HTMLImageElement.prototype, "naturalWidth", "get").mockReturnValue(300);
+    vi.spyOn(HTMLImageElement.prototype, "naturalHeight", "get").mockReturnValue(600);
+    stubChildren({ root: CHILDREN });
+    await mount();
+    expect(screen.getByTitle("Enter The Tower").style.left).toBe("325px");
+    expect(screen.getByTitle("Enter The Tower").style.top).toBe("150px");
+  });
+
+  it("measures cached images that loaded before hydration", async () => {
+    vi.spyOn(HTMLImageElement.prototype, "complete", "get").mockReturnValue(true);
+    stubChildren({ root: CHILDREN });
+    await act(async () => { render(<EmbedViewer sessionId="s1" initial={INITIAL} continueUrl="/play" />); });
+    expect(screen.getByTitle("Enter The Tower").style.left).toBe("200px");
+  });
+
+  it("ignores letterbox clicks and keeps edge hints and labels inside the stage", async () => {
+    width = 320;
+    height = 600;
+    stubChildren({ root: CHILDREN });
+    await mount();
+    fireEvent.click(screen.getByTestId("embed-stage"), { clientX: 20, clientY: 10 });
+    expect(screen.queryByText(/unexplored/)).toBeNull();
+    fireEvent.focus(screen.getByTitle("Enter The Tower"));
+    expect(screen.getByRole("tooltip").style.left).toBe("8px");
+    fireEvent.click(screen.getByTestId("embed-stage"), { clientX: 319, clientY: 300 });
+    const hint = screen.getByText(/unexplored/);
+    expect(Number.parseFloat(hint.style.left) + Number.parseFloat(hint.style.width)).toBeLessThanOrEqual(312);
+  });
+
+  it("hides overlays until the current image loads, including after navigation", async () => {
+    stubChildren({ root: CHILDREN, kid1: [{ ...CHILDREN[0], id: "nested" }] });
+    await act(async () => { render(<EmbedViewer sessionId="s1" initial={INITIAL} continueUrl="/play" />); });
+    expect(screen.queryByTitle("Enter The Tower")).toBeNull();
+    fireEvent.load(screen.getByRole("img"));
+    await act(async () => fireEvent.click(screen.getByTitle("Enter The Tower")));
+    expect(screen.queryByTitle("Enter The Tower")).toBeNull();
+    fireEvent.load(screen.getByRole("img"));
+    expect(screen.getByTitle("Enter The Tower")).toBeTruthy();
+    fireEvent.error(screen.getByRole("img"));
+    expect(screen.queryByTitle("Enter The Tower")).toBeNull();
+    expect(screen.getByRole("alert").textContent).toContain("Image unavailable");
+    fireEvent.click(screen.getByRole("button", { name: "Retry image" }));
+    fireEvent.load(screen.getByRole("img"));
+    expect(screen.getByTitle("Enter The Tower")).toBeTruthy();
+  });
+
+  it("rejects malformed and out-of-range marker positions", async () => {
+    stubChildren({ root: [null, ...[NaN, Infinity, -0.1, 1.1, "0.5"].map((x) => ({
+      ...CHILDREN[0], click_in_parent: { x_pct: x, y_pct: 0.5 },
+    }))] });
+    await mount();
+    expect(screen.queryByTitle("Enter The Tower")).toBeNull();
+  });
+
+  it("does not apply late child responses to a different node", async () => {
+    let finish!: (value: unknown) => void;
+    vi.stubGlobal("fetch", vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ children: CHILDREN }) })
+      .mockImplementationOnce(() => new Promise((resolve) => { finish = resolve; }))
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ children: CHILDREN }) }));
+    await mount();
+    await act(async () => fireEvent.click(screen.getByTitle("Enter The Tower")));
+    expect(screen.getByText("Loading places...")).toBeTruthy();
+    await act(async () => fireEvent.click(screen.getByRole("button", { name: "Back" })));
+    fireEvent.load(screen.getByRole("img"));
+    await act(async () => finish({ ok: true, json: async () => ({ children: [] }) }));
+    expect(screen.getByTitle("Enter The Tower")).toBeTruthy();
+  });
+
+  it("handles network errors and invalid response bodies", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ children: null }) }));
+    await mount();
+    expect(screen.getByText("Places unavailable")).toBeTruthy();
+    await act(async () => fireEvent.click(screen.getByRole("button", { name: "Retry places" })));
+    expect(screen.getByText("Places unavailable")).toBeTruthy();
   });
 });

--- a/apps/web/components/embed-viewer.tsx
+++ b/apps/web/components/embed-viewer.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ArrowLeft, RotateCw } from "lucide-react";
 
 import TourButton from "@/components/tour-button";
+import { objectContainRect } from "@/lib/image-click";
 
 // Read-only navigable world viewer for the /embed surface. Zero model calls:
 // every navigation is a hop to an ALREADY-GENERATED node via the public
@@ -40,143 +42,247 @@ export default function EmbedViewer({
 }: EmbedViewerProps) {
   const [current, setCurrent] = useState<EmbedNode>(initial);
   const [stack, setStack] = useState<EmbedNode[]>([]);
-  const [children, setChildren] = useState<ChildRow[]>([]);
+  const [childState, setChildState] = useState<{
+    nodeId: string;
+    status: "ready" | "error";
+    rows: ChildRow[];
+  } | null>(null);
+  const [retry, setRetry] = useState(0);
+  const imageRef = useRef<HTMLImageElement>(null);
+  const stageRef = useRef<HTMLDivElement>(null);
+  const [loadedNode, setLoadedNode] = useState<string | null>(null);
+  const [failedImage, setFailedImage] = useState<string | null>(null);
+  const [imageRetry, setImageRetry] = useState(0);
+  const [stage, setStage] = useState({ width: 0, height: 0 });
+  const [label, setLabel] = useState<string | null>(null);
   const [hint, setHint] = useState<{ x: number; y: number } | null>(null);
   const hintTimer = useRef<number | null>(null);
 
+  const measure = useCallback(() => {
+    const rect = stageRef.current?.getBoundingClientRect();
+    if (rect) setStage({ width: rect.width, height: rect.height });
+  }, []);
+
+  useEffect(() => {
+    measure();
+    const observer = new ResizeObserver(measure);
+    if (stageRef.current) observer.observe(stageRef.current);
+    return () => observer.disconnect();
+  }, [measure]);
+
+  useEffect(() => () => {
+    if (hintTimer.current) window.clearTimeout(hintTimer.current);
+  }, []);
+
+  useEffect(() => {
+    // A cached SSR image can finish before hydration installs onLoad.
+    if (imageRef.current?.complete && imageRef.current.naturalWidth > 0) {
+      setLoadedNode(current.id);
+      measure();
+    }
+  }, [current.id, imageRetry, measure]);
+
   useEffect(() => {
     let cancelled = false;
-    setChildren([]);
+    setChildState(null);
     (async () => {
       try {
         const res = await fetch(
           `/api/nodes/${encodeURIComponent(current.id)}/children`,
           { cache: "no-store" }
         );
-        if (!res.ok) return;
+        if (!res.ok) throw new Error("Places unavailable");
         const json = (await res.json()) as { children: ChildRow[] };
-        if (!cancelled) setChildren(json.children ?? []);
+        if (!Array.isArray(json.children)) throw new Error("Invalid places");
+        if (!cancelled) setChildState({ nodeId: current.id, status: "ready", rows: json.children });
       } catch {
-        /* frontier stays dotless; the continue link is always visible */
+        if (!cancelled) setChildState({ nodeId: current.id, status: "error", rows: [] });
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, [current.id]);
+  }, [current.id, retry]);
+
+  const clearOverlays = () => {
+    setLoadedNode(null);
+    setFailedImage(null);
+    setHint(null);
+    setLabel(null);
+    if (hintTimer.current) window.clearTimeout(hintTimer.current);
+  };
 
   const enter = (c: ChildRow) => {
     setStack((s) => [...s, current]);
     setCurrent({ id: c.id, title: c.page_title, imageUrl: c.image_url });
-    setHint(null);
+    clearOverlays();
   };
 
   const back = () => {
-    setStack((s) => {
-      const prev = s[s.length - 1];
-      if (prev) setCurrent(prev);
-      return s.slice(0, -1);
-    });
-    setHint(null);
+    const prev = stack[stack.length - 1];
+    if (prev) setCurrent(prev);
+    setStack((s) => s.slice(0, -1));
+    clearOverlays();
   };
+
+  const status = childState?.nodeId === current.id ? childState.status : "loading";
+  const content = loadedNode === current.id && imageRef.current
+    ? objectContainRect(stage.width, stage.height, imageRef.current.naturalWidth, imageRef.current.naturalHeight)
+    : null;
 
   // A tap that misses every dot = unexplored ground: show a transient hint
   // anchored at the tap instead of doing nothing.
   const onGroundClick = (e: React.MouseEvent<HTMLDivElement>) => {
     const rect = e.currentTarget.getBoundingClientRect();
-    setHint({
-      x: (e.clientX - rect.left) / rect.width,
-      y: (e.clientY - rect.top) / rect.height,
-    });
+    if (!content || status !== "ready") return;
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    if (x < content.offsetX || x > content.offsetX + content.width ||
+        y < content.offsetY || y > content.offsetY + content.height) return;
+    setHint({ x, y });
     if (hintTimer.current) window.clearTimeout(hintTimer.current);
     hintTimer.current = window.setTimeout(() => setHint(null), 2600);
   };
 
-  const dots = children.filter(
+  const dots = (status === "ready" ? childState!.rows : []).filter(
     (c): c is ChildRow & { click_in_parent: { x_pct: number; y_pct: number } } =>
-      c.click_in_parent != null
+      c?.click_in_parent != null && typeof c.id === "string" &&
+      typeof c.page_title === "string" && typeof c.image_url === "string" &&
+      [c.click_in_parent.x_pct, c.click_in_parent.y_pct].every(
+        (v) => Number.isFinite(v) && v >= 0 && v <= 1
+      )
   );
+
+  const positioned = content ? dots.map((c) => ({
+    ...c,
+    x: content.offsetX + c.click_in_parent.x_pct * content.width,
+    y: content.offsetY + c.click_in_parent.y_pct * content.height,
+  })) : [];
+  const activeLabel = positioned.find((c) => c.id === label);
+  const overlayStyle = (point: { x: number; y: number }) => ({
+    width: Math.max(0, Math.min(280, stage.width - 16)),
+    left: Math.max(8, Math.min(point.x - 140, stage.width - 288)),
+    top: Math.max(8, Math.min(point.y + 24, stage.height - 88)),
+    maxHeight: Math.max(0, stage.height - Math.max(8, Math.min(point.y + 24, stage.height - 88)) - 8),
+    overflow: "hidden" as const,
+  });
 
   return (
     <div className="flex h-dvh flex-col bg-[#faf7f1] text-[#1c1917]">
-      <header className="flex items-center justify-between gap-2 px-3 py-2 text-xs">
+      <header className="flex flex-wrap items-center justify-between gap-2 px-3 py-2 text-xs">
         <div className="flex min-w-0 items-center gap-2">
           {stack.length > 0 && (
             <button
               type="button"
               onClick={back}
-              className="rounded-full border border-black/25 px-2.5 py-0.5 hover:bg-black/5"
+              aria-label="Back"
+              title="Back"
+              className="flex h-11 w-11 shrink-0 items-center justify-center rounded border border-black/25 hover:bg-black/5"
             >
-              ← back
+              <ArrowLeft size={16} aria-hidden="true" />
             </button>
           )}
           <span className="truncate font-medium">{current.title}</span>
         </div>
         <span className="flex shrink-0 items-center gap-2">
-          <span className="opacity-50">
-            {dots.length > 0
+          <span className="opacity-60" role="status">
+            {status === "loading" ? "Loading places..." : status === "error" ? "Places unavailable" : dots.length > 0
               ? `${dots.length} place${dots.length === 1 ? "" : "s"} to enter`
               : "world frontier"}
           </span>
+          {status === "error" && (
+            <button type="button" aria-label="Retry places" title="Retry places"
+              className="flex h-11 w-11 items-center justify-center rounded border border-black/25"
+              onClick={() => { setChildState(null); setRetry((n) => n + 1); }}>
+              <RotateCw size={16} aria-hidden="true" />
+            </button>
+          )}
           <TourButton
             sessionId={sessionId}
             continueUrl={continueUrl}
-            className="rounded-full border border-black/25 px-2.5 py-0.5 hover:bg-black/5 disabled:opacity-50"
+            className="min-h-11 rounded border border-black/25 px-2.5 py-0.5 hover:bg-black/5 disabled:opacity-50"
           />
         </span>
       </header>
 
       <div
+        ref={stageRef}
         className="relative min-h-0 flex-1 cursor-pointer overflow-hidden"
         onClick={onGroundClick}
         data-testid="embed-stage"
       >
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
+          key={`${current.id}:${imageRetry}`}
+          ref={imageRef}
           src={current.imageUrl}
           alt={current.title}
           className="h-full w-full object-contain"
           draggable={false}
+          onLoad={(e) => {
+            if (e.currentTarget !== imageRef.current) return;
+            setLoadedNode(current.id);
+            setFailedImage(null);
+            measure();
+          }}
+          onError={(e) => {
+            if (e.currentTarget !== imageRef.current) return;
+            setLoadedNode(null);
+            setFailedImage(current.id);
+          }}
         />
-        {dots.map((c) => (
+        {failedImage === current.id && (
+          <div className="absolute inset-0 flex items-center justify-center gap-2" role="alert">
+            Image unavailable
+            <button type="button" aria-label="Retry image" title="Retry image"
+              className="flex h-11 w-11 items-center justify-center rounded border border-black/25"
+              onClick={(e) => { e.stopPropagation(); setFailedImage(null); setImageRetry((n) => n + 1); }}>
+              <RotateCw size={16} aria-hidden="true" />
+            </button>
+          </div>
+        )}
+        {positioned.map((c) => (
           <button
             key={c.id}
             type="button"
             title={`Enter ${c.page_title}`}
+            aria-label={`Enter ${c.page_title}`}
+            onMouseEnter={() => setLabel(c.id)}
+            onMouseLeave={() => setLabel(null)}
+            onFocus={() => setLabel(c.id)}
+            onBlur={() => setLabel(null)}
             onClick={(e) => {
               e.stopPropagation();
               enter(c);
             }}
-            className="group absolute -translate-x-1/2 -translate-y-1/2"
+            className="group absolute flex h-11 w-11 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded focus-visible:outline-2"
             style={{
-              left: `${c.click_in_parent.x_pct * 100}%`,
-              top: `${c.click_in_parent.y_pct * 100}%`,
+              left: c.x,
+              top: c.y,
             }}
           >
             <span className="block h-3.5 w-3.5 rounded-full border-2 border-white bg-amber-500 shadow-md transition-transform group-hover:scale-125" />
-            <span className="pointer-events-none absolute left-1/2 top-4 z-10 hidden -translate-x-1/2 whitespace-nowrap rounded bg-black/75 px-1.5 py-0.5 text-[10px] text-white group-hover:block">
-              {c.page_title}
-            </span>
           </button>
         ))}
-        {hint && (
+        {activeLabel && !hint && (
+          <span role="tooltip" className="pointer-events-none absolute z-10 break-words rounded bg-black/80 px-2 py-1 text-xs text-white [overflow-wrap:anywhere]"
+            style={overlayStyle(activeLabel)}>{activeLabel.page_title}</span>
+        )}
+        {hint && content && (
           <a
             href={continueUrl}
             target="_blank"
             rel="noopener"
             onClick={(e) => e.stopPropagation()}
-            className="absolute z-20 -translate-x-1/2 whitespace-nowrap rounded-full bg-black/80 px-3 py-1 text-[11px] text-white shadow-lg"
-            style={{
-              left: `${hint.x * 100}%`,
-              top: `${Math.min(hint.y * 100 + 4, 92)}%`,
-            }}
+            className="absolute z-20 rounded bg-black/80 px-3 py-2 text-xs text-white shadow-lg [overflow-wrap:anywhere]"
+            style={overlayStyle(hint)}
           >
             unexplored — continue this world on openflipbook →
           </a>
         )}
       </div>
 
-      <footer className="flex items-center justify-between gap-2 px-3 py-2 text-[11px]">
+      <footer className="flex flex-wrap items-center justify-between gap-2 px-3 py-2 text-[11px]">
         <span className="truncate opacity-50">
           {initialReceipt && current.id === initial.id
             ? initialReceipt
@@ -186,7 +292,7 @@ export default function EmbedViewer({
           href={continueUrl}
           target="_blank"
           rel="noopener"
-          className="rounded-full border border-black/25 px-3 py-1 font-medium hover:bg-black/5"
+          className="flex min-h-11 items-center rounded border border-black/25 px-3 py-1 font-medium hover:bg-black/5"
         >
           Continue this world →
         </a>

--- a/apps/web/e2e/embed.spec.ts
+++ b/apps/web/e2e/embed.spec.ts
@@ -50,6 +50,20 @@ test("embed viewer is publish-gated, navigates generated nodes, serves oEmbed", 
   });
   expect(pub.ok()).toBeTruthy();
 
+  const rows = await page.request.get(`/api/nodes/${root.id}/children`);
+  const savedChildren = (await rows.json()).children as {
+    id: string; click_in_parent: { x_pct: number; y_pct: number };
+  }[];
+  // Use an off-centre API fixture: a centre pin cannot expose letterboxing bugs.
+  const point = { x_pct: 0.27, y_pct: 0.31 };
+  await page.route(`**/api/nodes/${root.id}/children`, (route) => route.fulfill({
+    json: { children: savedChildren.map((c) => ({ ...c, click_in_parent: point })) },
+  }));
+  let generates = 0;
+  page.on("request", (req) => {
+    if (/\/api\/(generate-page|animate|ltx)(?:[/?-]|$)/.test(req.url())) generates += 1;
+  });
+
   // 2) Gate open: the viewer renders the root with the child's entry dot.
   await page.goto(`/embed/${encodeURIComponent(sessionId)}`);
   await expect(page.getByTestId("embed-stage").locator("img")).toBeVisible({
@@ -57,24 +71,47 @@ test("embed viewer is publish-gated, navigates generated nodes, serves oEmbed", 
   });
   const dot = page.locator('button[title^="Enter "]');
   await expect(dot).toBeVisible({ timeout: 15_000 });
+  const rootImage = await page.getByTestId("embed-stage").locator("img").getAttribute("src");
+
+  // The marker centre must match IMAGE pixels, not the letterboxed stage.
+  for (const viewport of [{ width: 1280, height: 800 }, { width: 390, height: 844 }, { width: 844, height: 390 }]) {
+    await page.setViewportSize(viewport);
+    await expect.poll(async () => {
+      const image = await page.getByTestId("embed-stage").locator("img").evaluate((img: HTMLImageElement) => {
+        const r = img.getBoundingClientRect();
+        const scale = Math.min(r.width / img.naturalWidth, r.height / img.naturalHeight);
+        return { x: r.x + (r.width - img.naturalWidth * scale) / 2,
+          y: r.y + (r.height - img.naturalHeight * scale) / 2,
+          width: img.naturalWidth * scale, height: img.naturalHeight * scale };
+      });
+      const pin = (await dot.boundingBox())!;
+      return Math.max(Math.abs(pin.x + pin.width / 2 - image.x - point.x_pct * image.width),
+        Math.abs(pin.y + pin.height / 2 - image.y - point.y_pct * image.height));
+    }).toBeLessThan(2);
+    await dot.focus();
+    await expect(page.getByRole("tooltip")).toBeVisible();
+    const label = (await page.getByRole("tooltip").boundingBox())!;
+    expect(label.x).toBeGreaterThanOrEqual(0);
+    expect(label.x + label.width).toBeLessThanOrEqual(viewport.width);
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+  }
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.screenshot({ path: "test-results/embed-mobile.png" });
 
   // 3) Dot navigation: enter the child (ZERO generates on this surface),
   // then back returns to the root.
-  let generates = 0;
-  page.on("request", (req) => {
-    if (req.url().includes("/api/generate-page") && req.method() === "POST") {
-      generates += 1;
-    }
-  });
   await dot.click();
-  await expect(page.getByRole("button", { name: "← back" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Back" })).toBeVisible();
   // The child is the frontier — no children of its own.
   await expect(page.getByText("world frontier")).toBeVisible({ timeout: 15_000 });
 
   // 4) Frontier tap → the continue hint, not silence (the /n/ dead-tap lesson).
-  await page.getByTestId("embed-stage").click({ position: { x: 40, y: 40 } });
+  await page.getByTestId("embed-stage").locator("img").click();
   await expect(page.getByText(/unexplored — continue this world/)).toBeVisible();
   expect(generates).toBe(0);
+  await page.getByRole("button", { name: "Back" }).click();
+  await expect(page.getByTestId("embed-stage").locator("img")).toHaveAttribute("src", rootImage!);
+  await expect(dot).toBeVisible();
 
   // 5) oEmbed provider: a /n/ permalink resolves to the published session's
   // interactive iframe.


### PR DESCRIPTION
## Changes
- Anchor entry markers to contained image pixels across desktop/mobile resizing.
- Handle cached hydration, failed image/places loads, and stale navigation responses.
- Add accessible touch targets and bounded labels/hints.

## Verification
- 13 focused component tests pass; full web coverage suite and typecheck pass.
- Brave mobile enter/back and cached-image reload checked.
- Extended mock browser regression covers off-centre alignment and zero generation/animation calls.
- Production generation defaults unchanged.