### PR TITLE
Add deterministic source-pixel transitions and zero-cost comparison study

### DIFF
--- a/apps/web/app/api/dev/spatial-assets/[file]/route.ts
+++ b/apps/web/app/api/dev/spatial-assets/[file]/route.ts
@@ -1,0 +1,17 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { spatialAssetPath } from "@/lib/spatial-study";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(_request: Request, { params }: { params: Promise<{ file: string }> }) {
+  if (process.env.SPATIAL_STUDY !== "1" || process.env.NODE_ENV === "production") return new Response(null, { status: 404 });
+  const { file } = await params;
+  const path = spatialAssetPath(file);
+  if (!path) return new Response(null, { status: 404 });
+  try {
+    const data = await readFile(resolve(process.cwd(), "../modal-backend", path));
+    return new Response(data, { headers: { "Content-Type": file.endsWith(".mp4") ? "video/mp4" : "image/jpeg", "Cache-Control": "private, max-age=3600" } });
+  } catch { return new Response(null, { status: 404 }); }
+}

--- a/apps/web/app/dev/spatial-transitions/page.tsx
+++ b/apps/web/app/dev/spatial-transitions/page.tsx
@@ -1,0 +1,7 @@
+import { notFound } from "next/navigation";
+import SpatialStudy from "./study";
+
+export default function Page() {
+  if (process.env.SPATIAL_STUDY !== "1" || process.env.NODE_ENV === "production") notFound();
+  return <SpatialStudy />;
+}

--- a/apps/web/app/dev/spatial-transitions/study.tsx
+++ b/apps/web/app/dev/spatial-transitions/study.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { ArrowLeft, Play, RotateCcw } from "lucide-react";
+import { SpatialTransitionLayer } from "@/components/SpatialTransitionLayer";
+import { useSpatialNavigation, decodeSpatialImage } from "@/hooks/useSpatialNavigation";
+import { planSpatialTransition, type ReframePlan, type SpatialFrame } from "@/lib/spatial-transition";
+import { SPATIAL_STUDY_CASES } from "@/lib/spatial-study";
+
+const asset = (name: string) => `/api/dev/spatial-assets/${name}`;
+
+export default function SpatialStudy() {
+  const [selection, setSelection] = useState(0);
+  const [scene, setScene] = useState(false);
+  const [arrived, setArrived] = useState(false);
+  const [controlImage, setControlImage] = useState<string | null>(null);
+  const [scrub, setScrub] = useState<number | null>(null);
+  const [dimensions, setDimensions] = useState({ width: 1600, height: 900 });
+  const h3 = useRef<HTMLVideoElement>(null);
+  const ltx = useRef<HTMLVideoElement>(null);
+  const player = useSpatialNavigation();
+  const fixture = SPATIAL_STUDY_CASES[selection]!;
+  const source: SpatialFrame = { id: "source", parentId: null, image: asset(scene ? `${fixture.id}-destination.jpg` : fixture.source), view: { node_id: "source", level: scene ? "eye" : "map", observer: null, map_crop: null } };
+  const destination: SpatialFrame = { id: "destination", parentId: "source", image: scene ? controlImage ?? source.image : asset(`${fixture.id}-destination.jpg`), click: { x_pct: scene ? [.15, .5, .85][selection]! : fixture.x, y_pct: scene ? .55 : fixture.y } };
+  const plan = planSpatialTransition(source, destination) as ReframePlan;
+  const reset = () => { player.cancel(); setArrived(false); setScrub(null); h3.current?.pause(); ltx.current?.pause(); };
+  const play = async (back = false) => {
+    setScrub(null);
+    let target = destination;
+    if (scene && !controlImage) {
+      const image = await decodeSpatialImage(source.image);
+      const canvas = document.createElement("canvas");
+      canvas.width = image.naturalWidth; canvas.height = image.naturalHeight;
+      canvas.getContext("2d")!.drawImage(image, plan.crop.x * canvas.width, plan.crop.y * canvas.height, plan.fraction * canvas.width, plan.fraction * canvas.height, 0, 0, canvas.width, canvas.height);
+      const url = canvas.toDataURL("image/png"); setControlImage(url); target = { ...destination, image: url };
+    }
+    if (!back && !scene) for (const video of [h3.current, ltx.current]) if (video) { video.currentTime = 0; void video.play().catch(() => {}); }
+    await player.navigate(back ? target : source, back ? source : target, () => setArrived(!back));
+  };
+  const motion = scrub === null ? player.motion : { plan, progress: scrub, ...dimensions };
+  return <main style={{ maxWidth: 1500, margin: "auto", padding: 24 }}>
+    <h1 style={{ fontSize: 24 }}>Spatial Transition Study</h1>
+    <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 16, margin: "20px 0" }}>
+      <select aria-label="Fixture" value={selection} onChange={e => { reset(); setSelection(Number(e.target.value)); setControlImage(null); }}>
+        {SPATIAL_STUDY_CASES.map((c, i) => <option key={c.id} value={i}>{c.title}</option>)}
+      </select>
+      <label><input type="checkbox" checked={scene} onChange={e => { reset(); setScene(e.target.checked); setControlImage(null); }} /> Scene control</label>
+      <button title="Play" aria-label="Play" onClick={() => { reset(); void play(); }}><Play size={20} /></button>
+      <button title="Back" aria-label="Back" disabled={!arrived || player.pending} onClick={() => void play(true)}><ArrowLeft size={20} /></button>
+      <button title="Reset" aria-label="Reset" onClick={reset}><RotateCcw size={20} /></button>
+      <input aria-label="Reframe progress" type="range" min={0} max={1} step={.01} value={scrub ?? player.motion?.progress ?? 0} onChange={e => { player.cancel(); setArrived(false); setScrub(Number(e.target.value)); }} />
+    </div>
+    <div className="grid grid-cols-1 gap-5 lg:grid-cols-3">
+      <section>
+        <h2 style={{ fontSize: 16 }}>Source pixels</h2>
+        <div data-testid="study-stage" style={{ position: "relative", aspectRatio: "16/9", background: "#111", overflow: "hidden" }}>
+          {/* eslint-disable-next-line @next/next/no-img-element -- exact study fixture */}
+          <img data-testid="study-image" alt={arrived ? "Destination" : "Source"} src={arrived ? destination.image : source.image} style={{ width: "100%", height: "100%", objectFit: "contain" }} onLoad={e => { if (!arrived) setDimensions({ width: e.currentTarget.naturalWidth, height: e.currentTarget.naturalHeight }); }} />
+          <SpatialTransitionLayer motion={motion} />
+        </div>
+        <p>Target: {plan.target.x_pct.toFixed(3)}, {plan.target.y_pct.toFixed(3)}</p>
+        <p>Motion: {scene ? "1.35x / 450 ms" : "2.38x / 800 ms"}. Cut: {arrived ? "arrived" : "pending"}.</p>
+      </section>
+      {!scene && <>{[["H3 (saved)", fixture.h3, h3], ["LTX (saved)", fixture.ltx, ltx]].map(([label, file, ref]) => <section key={String(label)}>
+        <h2 style={{ fontSize: 16 }}>{String(label)}</h2>
+        <video ref={ref as typeof h3} key={String(file)} src={asset(String(file))} controls muted playsInline preload="metadata" style={{ width: "100%", aspectRatio: "16/9", background: "#111", objectFit: "contain" }} />
+      </section>)}</>}
+    </div>
+    <p>Destination identity: {scene ? "same-image crop control" : `FAIL: target is ${fixture.title}; supplied destination is ${fixture.destination}`}.</p>
+    <p>Perceptual continuity: not yet human-rated.</p>
+    {player.error && <button onClick={() => void player.retry()}>{player.error}</button>}
+  </main>;
+}

--- a/apps/web/components/SpatialTransitionLayer.test.tsx
+++ b/apps/web/components/SpatialTransitionLayer.test.tsx
@@ -1,0 +1,27 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { SpatialTransitionLayer } from "./SpatialTransitionLayer";
+import { planSpatialTransition, type ReframePlan } from "@/lib/spatial-transition";
+import { spatialAssetPath, SPATIAL_STUDY_CASES } from "@/lib/spatial-study";
+
+afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); });
+it("uses the contained rectangle, clips pixels and remeasures on resize", () => {
+  let measure!: () => void;
+  vi.stubGlobal("ResizeObserver", class { constructor(fn: () => void) { measure = fn; } observe() {} disconnect() {} });
+  const w = vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(800);
+  vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(600);
+  const plan = planSpatialTransition({ id: "p", parentId: null, image: "source.jpg" }, { id: "c", parentId: "p", image: "dest.jpg", click: { x_pct: .8, y_pct: .2 } }) as ReframePlan;
+  const { rerender } = render(<SpatialTransitionLayer motion={null} />);
+  expect(screen.queryByTestId("spatial-transition")).toBeNull();
+  rerender(<SpatialTransitionLayer motion={{ plan, progress: .5, width: 1600, height: 900 }} />);
+  const content = screen.getByTestId("spatial-content");
+  expect(content.style.top).toBe("75px"); expect(content.style.height).toBe("450px");
+  expect(content.style.overflow).toBe("hidden");
+  expect(content.querySelector("img")!.style.transform).toContain("matrix(1.175, 0, 0, 1.175");
+  w.mockReturnValue(400); act(() => measure());
+  expect(content.style.top).toBe("187.5px"); expect(content.style.width).toBe("400px");
+});
+it("allows only the six frozen images and six saved video names", () => {
+  for (const c of SPATIAL_STUDY_CASES) for (const file of [c.source, `${c.id}-destination.jpg`, c.h3, c.ltx]) expect(spatialAssetPath(file)).not.toBeNull();
+  for (const file of ["../.env", "/etc/passwd", "review.html", "unknown.mp4"]) expect(spatialAssetPath(file)).toBeNull();
+});

--- a/apps/web/components/SpatialTransitionLayer.tsx
+++ b/apps/web/components/SpatialTransitionLayer.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useLayoutEffect, useRef, useState } from "react";
+
+import type { SpatialMotion } from "@/hooks/useSpatialNavigation";
+import { objectContainRect } from "@/lib/image-click";
+import { reframeMatrix } from "@/lib/spatial-transition";
+
+/** Clip to the actual contained image, keeping letterbox bars stationary. */
+export function SpatialTransitionLayer({ motion }: { motion: SpatialMotion | null }) {
+  const root = useRef<HTMLDivElement>(null);
+  const [size, setSize] = useState({ width: 0, height: 0 });
+  const active = !!motion;
+  useLayoutEffect(() => {
+    const el = root.current;
+    if (!el) return;
+    const measure = () => setSize({ width: el.clientWidth, height: el.clientHeight });
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [active]);
+  if (!motion) return null;
+  const rect = objectContainRect(size.width, size.height, motion.width, motion.height);
+  return <div ref={root} data-testid="spatial-transition" data-direction={motion.plan.kind}
+    data-progress={motion.progress} aria-hidden="true"
+    style={{ position: "absolute", inset: 0, zIndex: 30, overflow: "hidden", background: "var(--background, #111)", pointerEvents: "none" }}>
+    {rect && <div data-testid="spatial-content" style={{ position: "absolute", overflow: "hidden", left: rect.offsetX, top: rect.offsetY, width: rect.width, height: rect.height }}>
+      {/* eslint-disable-next-line @next/next/no-img-element -- exact source pixels; no image optimization */}
+      <img src={motion.plan.source.image} alt="" draggable={false}
+        style={{ display: "block", width: "100%", height: "100%", maxWidth: "none", transformOrigin: "0 0", transform: reframeMatrix(motion.plan, motion.progress, rect.width, rect.height) }} />
+    </div>}
+  </div>;
+}

--- a/apps/web/hooks/useSpatialNavigation.test.tsx
+++ b/apps/web/hooks/useSpatialNavigation.test.tsx
@@ -1,0 +1,95 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SpatialFrame } from "@/lib/spatial-transition";
+import { decodeSpatialImage, useSpatialNavigation } from "./useSpatialNavigation";
+
+const from: SpatialFrame = { id: "p", parentId: null, image: "parent.jpg" };
+const to: SpatialFrame = { id: "c", parentId: "p", image: "child.jpg", click: { x_pct: .9, y_pct: .2 } };
+const image = { naturalWidth: 1600, naturalHeight: 900 } as HTMLImageElement;
+let callbacks: Map<number, FrameRequestCallback>;
+let sequence: number;
+function frame(time: number) { act(() => { const queue = [...callbacks.values()]; callbacks.clear(); queue.forEach(fn => fn(time)); }); }
+beforeEach(() => {
+  callbacks = new Map(); sequence = 0;
+  vi.stubGlobal("requestAnimationFrame", (fn: FrameRequestCallback) => { callbacks.set(++sequence, fn); return sequence; });
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => callbacks.delete(id));
+  vi.spyOn(window, "matchMedia").mockReturnValue({ matches: false } as MediaQueryList);
+});
+afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); vi.useRealTimers(); });
+
+describe("spatial navigation lifecycle", () => {
+  it("waits for decode, reframes, holds, then commits once at the cut", async () => {
+    let resolve!: (image: HTMLImageElement) => void;
+    const decode = vi.fn().mockImplementationOnce(() => new Promise(r => { resolve = r; })).mockResolvedValue(image);
+    const commit = vi.fn();
+    const { result } = renderHook(() => useSpatialNavigation(decode));
+    let done!: Promise<boolean>;
+    act(() => { done = result.current.navigate(from, to, commit); });
+    expect(result.current.pending).toBe(true);
+    expect(result.current.motion).toBeNull(); expect(commit).not.toHaveBeenCalled();
+    await act(async () => { resolve(image); });
+    expect(result.current.motion?.progress).toBe(0);
+    frame(0); frame(450); expect(commit).not.toHaveBeenCalled();
+    frame(549); expect(commit).not.toHaveBeenCalled();
+    await act(async () => { frame(550); expect(await done).toBe(true); });
+    expect(commit).toHaveBeenCalledTimes(1); expect(result.current.motion).toBeNull(); expect(result.current.pending).toBe(false);
+  });
+  it("cuts to cropped parent before reversing, without a second commit", async () => {
+    const commit = vi.fn(); const decode = vi.fn().mockResolvedValue(image);
+    const { result } = renderHook(() => useSpatialNavigation(decode));
+    await act(async () => { void result.current.navigate(to, from, commit); });
+    expect(commit).toHaveBeenCalledTimes(1); expect(result.current.motion?.progress).toBe(1);
+    frame(0); frame(225); expect(result.current.motion?.progress).toBe(.5);
+    await act(async () => { frame(550); });
+    expect(commit).toHaveBeenCalledTimes(1); expect(result.current.motion).toBeNull();
+  });
+  it("retains source on destination failure and retries without generation", async () => {
+    const decode = vi.fn().mockRejectedValueOnce(new Error("offline")).mockResolvedValue(image);
+    const commit = vi.fn(); const { result } = renderHook(() => useSpatialNavigation(decode));
+    await act(async () => { expect(await result.current.navigate(from, { ...to, parentId: null }, commit)).toBe(false); });
+    expect(result.current.error).toContain("Try again"); expect(commit).not.toHaveBeenCalled();
+    await act(async () => { expect(await result.current.retry()).toBe(true); });
+    expect(commit).toHaveBeenCalledTimes(1); expect(result.current.error).toBeNull();
+  });
+  it("cancels stale decodes, animation callbacks, and retry state", async () => {
+    let resolve!: (image: HTMLImageElement) => void;
+    const decode = vi.fn().mockImplementationOnce(() => new Promise(r => { resolve = r; })).mockResolvedValue(image);
+    const old = vi.fn(); const latest = vi.fn();
+    const { result } = renderHook(() => useSpatialNavigation(decode));
+    act(() => { void result.current.navigate(from, to, old); });
+    await act(async () => { await result.current.navigate(from, { ...to, parentId: null }, latest); resolve(image); });
+    expect(old).not.toHaveBeenCalled(); expect(latest).toHaveBeenCalledTimes(1);
+    let done!: Promise<boolean>;
+    await act(async () => { done = result.current.navigate(from, to, old); });
+    act(() => result.current.cancel()); frame(1000);
+    expect(await done).toBe(false); expect(old).not.toHaveBeenCalled(); expect(result.current.retry()).toBeUndefined();
+  });
+  it("cuts for reduced motion or unavailable source pixels", async () => {
+    const decode = vi.fn().mockResolvedValueOnce(image).mockRejectedValueOnce(new Error("source"));
+    const commit = vi.fn(); const { result } = renderHook(() => useSpatialNavigation(decode));
+    await act(async () => { expect(await result.current.navigate(from, to, commit)).toBe(true); });
+    expect(commit).toHaveBeenCalledTimes(1);
+    vi.mocked(window.matchMedia).mockReturnValue({ matches: true } as MediaQueryList);
+    decode.mockResolvedValue(image);
+    await act(async () => { expect(await result.current.navigate(from, to, commit)).toBe(true); });
+    expect(result.current.motion).toBeNull(); expect(commit).toHaveBeenCalledTimes(2);
+  });
+  it("unmount prevents any late commit", async () => {
+    let resolve!: (image: HTMLImageElement) => void;
+    const decode = () => new Promise<HTMLImageElement>(r => { resolve = r; }); const commit = vi.fn();
+    const { result, unmount } = renderHook(() => useSpatialNavigation(decode));
+    act(() => { void result.current.navigate(from, to, commit); });
+    unmount(); await act(async () => { resolve(image); }); expect(commit).not.toHaveBeenCalled();
+  });
+  it("decode rejects empty images and bounds hangs", async () => {
+    vi.spyOn(Image.prototype, "decode").mockResolvedValue(undefined);
+    await expect(decodeSpatialImage("empty.jpg")).rejects.toThrow("Empty image");
+    vi.spyOn(Image.prototype, "naturalWidth", "get").mockReturnValue(100);
+    vi.spyOn(Image.prototype, "naturalHeight", "get").mockReturnValue(100);
+    await expect(decodeSpatialImage("good.jpg")).resolves.toBeInstanceOf(Image);
+    vi.useFakeTimers(); vi.mocked(Image.prototype.decode).mockImplementation(() => new Promise(() => {}));
+    const hung = expect(decodeSpatialImage("hung.jpg")).rejects.toThrow("timed out");
+    await vi.advanceTimersByTimeAsync(15000); await hung;
+  });
+});

--- a/apps/web/hooks/useSpatialNavigation.ts
+++ b/apps/web/hooks/useSpatialNavigation.ts
@@ -1,0 +1,95 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { planSpatialTransition, type ReframePlan, type SpatialFrame } from "@/lib/spatial-transition";
+
+export interface SpatialMotion { plan: ReframePlan; progress: number; width: number; height: number }
+
+export async function decodeSpatialImage(url: string): Promise<HTMLImageElement> {
+  const image = new Image();
+  image.src = url;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      image.decode(),
+      new Promise<never>((_, reject) => { timer = setTimeout(() => reject(new Error("Image decode timed out")), 15000); }),
+    ]);
+    if (!image.naturalWidth || !image.naturalHeight) throw new Error("Empty image");
+    return image;
+  } finally { clearTimeout(timer); }
+}
+
+/** Latest navigation wins. A failed destination never replaces the current page. */
+export function useSpatialNavigation(decode = decodeSpatialImage) {
+  const [motion, setMotion] = useState<SpatialMotion | null>(null);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const token = useRef(0);
+  const raf = useRef(0);
+  const settle = useRef<((value: boolean) => void) | null>(null);
+  const retryRef = useRef<(() => Promise<boolean>) | null>(null);
+  const cancel = useCallback(() => {
+    token.current++;
+    cancelAnimationFrame(raf.current);
+    settle.current?.(false);
+    settle.current = null;
+    retryRef.current = null;
+    setMotion(null); setPending(false); setError(null);
+  }, []);
+  useEffect(() => () => { token.current++; cancelAnimationFrame(raf.current); settle.current?.(false); }, []);
+
+  const navigate = useCallback(async (from: SpatialFrame, to: SpatialFrame, commit: () => void): Promise<boolean> => {
+    cancel();
+    const current = token.current;
+    const alive = () => current === token.current;
+    setPending(true);
+    retryRef.current = () => navigate(from, to, commit);
+    try {
+      const destination = await decode(to.image);
+      if (!alive()) return false;
+      const plan = planSpatialTransition(from, to, window.matchMedia("(prefers-reduced-motion: reduce)").matches);
+      if (plan.kind === "cut") {
+        commit(); setPending(false); retryRef.current = null;
+        return true;
+      }
+      let source: HTMLImageElement;
+      try { source = plan.kind === "back" ? destination : await decode(from.image); }
+      catch {
+        if (!alive()) return false;
+        commit(); setPending(false); retryRef.current = null;
+        return true;
+      }
+      if (!alive()) return false;
+      const frame = { plan, width: source.naturalWidth, height: source.naturalHeight };
+      setMotion({ ...frame, progress: plan.kind === "back" ? 1 : 0 });
+      // Back cuts to the real cropped parent before pulling out. Metadata
+      // commits at that same cut, not at the end of the reverse reframe.
+      if (plan.kind === "back") commit();
+      return await new Promise<boolean>(resolve => {
+        settle.current = resolve;
+        let start: number | null = null;
+        const tick = (now: number) => {
+          if (!alive()) return;
+          start ??= now;
+          const elapsed = now - start;
+          const p = Math.min(1, elapsed / plan.duration);
+          if (elapsed >= plan.duration + plan.hold) {
+            if (plan.kind === "forward") commit();
+            setMotion(null); setPending(false); retryRef.current = null; settle.current = null;
+            resolve(true);
+          } else {
+            setMotion({ ...frame, progress: plan.kind === "back" ? 1 - p : p });
+            raf.current = requestAnimationFrame(tick);
+          }
+        };
+        raf.current = requestAnimationFrame(tick);
+      });
+    } catch {
+      if (alive()) { setMotion(null); setPending(false); setError("Image could not load. Try again."); }
+      return false;
+    }
+  }, [cancel, decode]);
+  const retry = useCallback(() => retryRef.current?.(), []);
+  return { motion, pending, error, navigate, cancel, retry };
+}

--- a/apps/web/lib/spatial-study.ts
+++ b/apps/web/lib/spatial-study.ts
@@ -1,0 +1,15 @@
+export const SPATIAL_STUDY_CASES = [
+  { id: "fishing_lighthouse", title: "North Point Lighthouse", source: "fishing_village.jpg", x: .557, y: .192, destination: "Waking Docks", h3: "fishing_lighthouse-h3-c63f6dc519.mp4", ltx: "fishing_lighthouse-ltx-cb4313341e.mp4" },
+  { id: "oasis_citadel", title: "Sandstone Citadel", source: "oasis_town.jpg", x: .631, y: .204, destination: "Oasis of Zaffar", h3: "oasis_citadel-h3-c455972127.mp4", ltx: "oasis_citadel-ltx-8fe4ef43ad.mp4" },
+  { id: "harbor_lighthouse", title: "Crystal Lighthouse", source: "harbor_aethelgard.jpg", x: .138, y: .312, destination: "Grand Harbor", h3: "harbor_lighthouse-h3-b0f5104ef3.mp4", ltx: "harbor_lighthouse-ltx-8c2a03c85c.mp4" },
+] as const;
+
+/** Explicit local fixture allowlist. Never accepts a filesystem path from a URL. */
+export function spatialAssetPath(name: string): string | null {
+  for (const c of SPATIAL_STUDY_CASES) {
+    if (name === c.source) return `tests/click_bench/fixtures/images/real/${c.source}`;
+    if (name === `${c.id}-destination.jpg`) return `tests/video_transition_bench/fixtures/${name}`;
+    if (name === c.h3 || name === c.ltx) return `tests/video_transition_bench/reports/${name}`;
+  }
+  return null;
+}

--- a/apps/web/lib/spatial-transition.test.ts
+++ b/apps/web/lib/spatial-transition.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { objectContainRect } from "./image-click";
+import { bindTransitionContext } from "./transition-context";
+import { planSpatialTransition, reframeMatrix, sampleReframe, type ReframePlan, type SpatialFrame } from "./spatial-transition";
+
+const parent: SpatialFrame = { id: "p", parentId: null, image: "map.jpg", imageKey: "original", view: { node_id: "p", level: "map", observer: null, map_crop: null } };
+const child: SpatialFrame = { id: "c", parentId: "p", image: "scene.jpg", click: { x_pct: .9, y_pct: .1 }, relation: "descend" };
+
+describe("spatial transition planner", () => {
+  it("uses frozen evidence, not a later click or view", () => {
+    const context = bindTransitionContext(null, { id: "p", image_key: "original", scene_view: parent.view! }, child.click, null)!;
+    const plan = planSpatialTransition({ ...parent, view: null }, { ...child, click: { x_pct: .2, y_pct: .2 }, context });
+    expect(plan).toMatchObject({ kind: "forward", target: child.click, fraction: .42, duration: 800, hold: 100 });
+    expect(planSpatialTransition({ ...parent, imageKey: "revision" }, { ...child, context }).kind).toBe("cut");
+    expect(planSpatialTransition({ ...parent, imageKey: undefined }, { ...child, context }).kind).toBe("cut");
+    expect(planSpatialTransition(parent, { ...child, context: { ...context, source_node_id: "other" } }).kind).toBe("cut");
+  });
+  it("reverses the same parent plan for direct back", () => {
+    const forward = planSpatialTransition(parent, child) as ReframePlan;
+    expect(planSpatialTransition(child, parent)).toEqual({ ...forward, kind: "back" });
+  });
+  it("caps scenes and unknown views at 1.35x", () => {
+    for (const view of [null, { ...parent.view!, level: "eye" as const }]) {
+      const plan = planSpatialTransition({ ...parent, view }, child) as ReframePlan;
+      expect(plan.duration).toBe(450);
+      expect(sampleReframe(plan, 1).scale).toBeCloseTo(1.35);
+    }
+  });
+  it("cuts unrelated, edited, outward, unknown and reduced-motion edges", () => {
+    expect(planSpatialTransition(parent, child, true)).toEqual({ kind: "cut", reason: "reduced-motion" });
+    expect(planSpatialTransition(parent, { ...child, parentId: "other" }).kind).toBe("cut");
+    expect(planSpatialTransition(parent, { ...child, click: null }).kind).toBe("cut");
+    expect(planSpatialTransition(parent, { ...child, click: { x_pct: NaN, y_pct: .5 } }).kind).toBe("cut");
+    for (const relation of ["edit", "expand", "ascend"]) expect(planSpatialTransition(parent, { ...child, relation }).kind).toBe("cut");
+  });
+  it("keeps targets visible, moves them monotonically toward center, and exposes no borders", () => {
+    for (const map of [true, false]) for (let x = 0; x <= 100; x++) for (let y = 0; y <= 100; y++) {
+      const point = { x_pct: x / 100, y_pct: y / 100 };
+      const plan = planSpatialTransition({ ...parent, view: map ? parent.view : null }, { ...child, click: point }) as ReframePlan;
+      let lastDistance = Infinity;
+      for (let step = 0; step <= 20; step++) {
+        const m = sampleReframe(plan, step / 20);
+        const qx = m.scale * point.x_pct + m.x;
+        const qy = m.scale * point.y_pct + m.y;
+        const distance = Math.hypot(qx - .5, qy - .5);
+        // Throw once, with coordinates, rather than millions of matcher allocations.
+        if (qx < -1e-9 || qx > 1 + 1e-9 || qy < -1e-9 || qy > 1 + 1e-9 || distance > lastDistance + 1e-9 ||
+            m.x > 1e-9 || m.y > 1e-9 || m.x + m.scale < 1 - 1e-9 || m.y + m.scale < 1 - 1e-9) throw new Error(`Geometry failure: ${map}, ${x}, ${y}, ${step}`);
+        lastDistance = distance;
+      }
+    }
+  });
+  it.each([[1200, 700, 900, 1600], [390, 700, 1600, 900], [800, 800, 800, 800]])("maps the transform into contain content for %j", (w, h, nw, nh) => {
+    const rect = objectContainRect(w, h, nw, nh)!;
+    const plan = planSpatialTransition(parent, child) as ReframePlan;
+    const m = sampleReframe(plan, 1);
+    expect(reframeMatrix(plan, 1, rect.width, rect.height)).toBe(`matrix(${m.scale}, 0, 0, ${m.scale}, ${m.x * rect.width}, ${m.y * rect.height})`);
+    expect(rect.width / rect.height).toBeCloseTo(nw / nh);
+    expect(sampleReframe(plan, -1)).toEqual({ scale: 1, x: -0, y: -0 });
+    expect(sampleReframe(plan, 2)).toEqual(m);
+  });
+});

--- a/apps/web/lib/spatial-transition.ts
+++ b/apps/web/lib/spatial-transition.ts
@@ -1,0 +1,68 @@
+import type { SceneView, TransitionContextV1 } from "@openflipbook/config";
+
+import { validTransitionPoint } from "./transition-context";
+import { REGION_FRAC } from "./image-condition";
+
+export interface SpatialFrame {
+  id: string | null;
+  parentId: string | null;
+  image: string;
+  imageKey?: string | undefined;
+  relation?: string | null | undefined;
+  click?: { x_pct: number; y_pct: number } | null | undefined;
+  view?: SceneView | null | undefined;
+  context?: TransitionContextV1 | null | undefined;
+}
+
+export interface ReframePlan {
+  kind: "forward" | "back";
+  source: SpatialFrame;
+  target: { x_pct: number; y_pct: number };
+  fraction: number;
+  crop: { x: number; y: number };
+  duration: number;
+  hold: number;
+}
+export type SpatialPlan = ReframePlan | { kind: "cut"; reason: string };
+
+/** Screen-space reframing only. Camera snapshots do not imply a 3D route. */
+export function planSpatialTransition(from: SpatialFrame, to: SpatialFrame, reducedMotion = false): SpatialPlan {
+  if (reducedMotion) return { kind: "cut", reason: "reduced-motion" };
+  const forward = !!from.id && to.parentId === from.id;
+  const back = !!to.id && from.parentId === to.id;
+  if (!forward && !back) return { kind: "cut", reason: "unrelated" };
+  const parent = forward ? from : to;
+  const child = forward ? to : from;
+  if (child.relation && child.relation !== "descend") return { kind: "cut", reason: "unsupported-relation" };
+  const context = child.context;
+  if (context && (context.version !== 1 || context.source_node_id !== parent.id ||
+      !parent.imageKey || context.source_image_key !== parent.imageKey)) {
+    return { kind: "cut", reason: "source-mismatch" };
+  }
+  const point = context ? context.target_point : child.click;
+  if (!validTransitionPoint(point)) return { kind: "cut", reason: "unknown-target" };
+  const map = (context ? context.source_view : parent.view)?.level === "map";
+  const fraction = map ? REGION_FRAC : 1 / 1.35;
+  const clamp = (v: number) => Math.min(1 - fraction, Math.max(0, v - fraction / 2));
+  return {
+    kind: forward ? "forward" : "back", source: parent, target: { ...point },
+    fraction, crop: { x: clamp(point.x_pct), y: clamp(point.y_pct) },
+    duration: map ? 800 : 450, hold: 100,
+  };
+}
+
+/** One uniform affine transform for EVERY pixel, in fitted-image coordinates. */
+export function sampleReframe(plan: ReframePlan, progress: number) {
+  const t = Math.min(1, Math.max(0, progress));
+  const ease = t * t * (3 - 2 * t);
+  return {
+    scale: 1 + (1 / plan.fraction - 1) * ease,
+    x: -plan.crop.x / plan.fraction * ease,
+    y: -plan.crop.y / plan.fraction * ease,
+  };
+}
+
+export function reframeMatrix(plan: ReframePlan, progress: number, width: number, height: number): string {
+  const m = sampleReframe(plan, progress);
+  return `matrix(${m.scale}, 0, 0, ${m.scale}, ${m.x * width}, ${m.y * height})`;
+}

--- a/docs/SPATIAL_TRANSITIONS.md
+++ b/docs/SPATIAL_TRANSITIONS.md
@@ -20,3 +20,39 @@ or additional provider calls.
 Source-pixel playback and its opt-in navigation integration are separate from
 this data contract. The existing generated-video route and defaults are not
 changed by recording context.
+
+## Shared Player And Study
+
+`lib/spatial-transition.ts` plans direct descents and their reverse. It uses one
+uniform affine transform, clipped to the image's actual contain rectangle.
+Map views use a 0.42 crop (800 ms); scene/unknown views cap at 1.35x (450 ms).
+Both hold for 100 ms before an explicit cut. Edge crops clamp inside the source,
+so no pixels, borders, rotations, or hidden geometry are invented. Existing
+camera snapshots remain informational, not a promise of physical travel.
+
+`useSpatialNavigation` decodes the destination first. Failed loads retain the
+source and retry decoding only. Cancellation invalidates old decodes and RAF
+callbacks. Direct back cuts to the real cropped parent before reversing the
+same transform. Unrelated, edit/expand/ascend, missing-target, stale-image, and
+reduced-motion transitions cut. Legacy direct edges can use their saved tap;
+a present but mismatched immutable context never falls back to that heuristic.
+
+Run the local comparison at `/dev/spatial-transitions` with `SPATIAL_STUDY=1`.
+The page and allowlisted fixture endpoint are unavailable in production.
+Three map failures compare source pixels with the six already-saved H3/LTX
+clips. Scene controls use left/center/right crops of existing scene images.
+The control destinations are real source crops, not newly generated places.
+
+Offline MP4s, audit stills and a hash-bearing receipt use the same planner:
+
+```sh
+cd scripts/record-demo
+pnpm exec tsx spatial-study.ts /path/to/output
+```
+
+Requires the existing demo-tool dependencies and FFmpeg. No model calls or
+network access. Exports add a 500 ms initial inspection hold; production motion
+timings are unchanged. CPU exports use nearest-neighbor resampling; the browser
+uses native image resampling, with identical transforms. Comparison order is
+source pixels, saved H3, saved LTX. Destination identity failures remain failures;
+motion correctness is separate from identity and human-rated continuity.

--- a/scripts/record-demo/spatial-study.ts
+++ b/scripts/record-demo/spatial-study.ts
@@ -1,0 +1,80 @@
+/** Offline source-pixel renders. No browser, providers, or network access.
+ * pnpm exec tsx spatial-study.ts [output-directory]
+ */
+import { createHash } from "node:crypto";
+import { once } from "node:events";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { resolve } from "node:path";
+import { spawn, execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { objectContainRect } from "../../apps/web/lib/image-click";
+import { planSpatialTransition, sampleReframe, type ReframePlan, type SpatialFrame } from "../../apps/web/lib/spatial-transition";
+import { SPATIAL_STUDY_CASES, spatialAssetPath } from "../../apps/web/lib/spatial-study";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const root = resolve(here, "../..");
+const out = resolve(process.argv[2] ?? resolve(here, "artifacts-spatial"));
+const require = createRequire(resolve(root, "apps/web/package.json"));
+const jpeg = require("jpeg-js") as typeof import("../../apps/web/node_modules/jpeg-js");
+type Bitmap = { width: number; height: number; data: Uint8Array };
+const width = 960, height = 540, fps = 30;
+function decodeFile(path: string): Bitmap {
+  const metadata = JSON.parse(execFileSync("ffprobe", ["-v", "error", "-select_streams", "v:0", "-show_entries", "stream=width,height", "-of", "json", path], { encoding: "utf8" })).streams[0];
+  return { ...metadata, data: execFileSync("ffmpeg", ["-v", "error", "-i", path, "-frames:v", "1", "-f", "rawvideo", "-pix_fmt", "rgba", "pipe:1"], { maxBuffer: 64 * 1024 * 1024 }) };
+}
+
+function render(image: Bitmap, plan: ReframePlan | null, progress: number): Buffer {
+  const frame = Buffer.alloc(width * height * 3, 17);
+  const rect = objectContainRect(width, height, image.width, image.height)!;
+  const m = plan ? sampleReframe(plan, progress) : { scale: 1, x: 0, y: 0 };
+  for (let y = Math.ceil(rect.offsetY); y < rect.offsetY + rect.height; y++) for (let x = Math.ceil(rect.offsetX); x < rect.offsetX + rect.width; x++) {
+    const u = ((x - rect.offsetX) / rect.width - m.x) / m.scale;
+    const v = ((y - rect.offsetY) / rect.height - m.y) / m.scale;
+    const i = (Math.min(image.height - 1, Math.max(0, Math.floor(v * image.height))) * image.width + Math.min(image.width - 1, Math.max(0, Math.floor(u * image.width)))) * 4;
+    const j = (y * width + x) * 3;
+    frame[j] = image.data[i]!; frame[j + 1] = image.data[i + 1]!; frame[j + 2] = image.data[i + 2]!;
+  }
+  return frame;
+}
+function still(rgb: Buffer) {
+  const rgba = Buffer.alloc(width * height * 4, 255);
+  for (let i = 0; i < width * height; i++) rgb.copy(rgba, i * 4, i * 3, i * 3 + 3);
+  return jpeg.encode({ data: rgba, width, height }, 92).data;
+}
+async function movie(name: string, getFrame: (time: number) => Buffer) {
+  const ffmpeg = spawn("ffmpeg", ["-y", "-loglevel", "error", "-f", "rawvideo", "-pix_fmt", "rgb24", "-s", `${width}x${height}`, "-r", String(fps), "-i", "pipe:0", "-an", "-c:v", "libx264", "-crf", "18", "-pix_fmt", "yuv420p", "-movflags", "+faststart", resolve(out, name)], { stdio: ["pipe", "inherit", "inherit"] });
+  const finished = once(ffmpeg, "exit");
+  for (let frame = 0; frame < fps * 4; frame++) if (!ffmpeg.stdin.write(getFrame(frame * 1000 / fps))) await once(ffmpeg.stdin, "drain");
+  ffmpeg.stdin.end();
+  const [code] = await finished;
+  if (code !== 0) throw new Error(`ffmpeg exited ${code}`);
+}
+
+await mkdir(out, { recursive: true });
+const receipts = [];
+for (const [index, fixture] of SPATIAL_STUDY_CASES.entries()) for (const scene of [false, true]) {
+  const sourceName = scene ? `${fixture.id}-destination.jpg` : fixture.source;
+  const sourceBytes = await readFile(resolve(root, "apps/modal-backend", spatialAssetPath(sourceName)!));
+  const destinationBytes = await readFile(resolve(root, "apps/modal-backend", spatialAssetPath(`${fixture.id}-destination.jpg`)!));
+  const source = decodeFile(resolve(root, "apps/modal-backend", spatialAssetPath(sourceName)!));
+  const destination = decodeFile(resolve(root, "apps/modal-backend", spatialAssetPath(`${fixture.id}-destination.jpg`)!));
+  const from: SpatialFrame = { id: "source", parentId: null, image: sourceName, view: { node_id: "source", level: scene ? "eye" : "map", observer: null, map_crop: null } };
+  const to: SpatialFrame = { id: "destination", parentId: "source", image: "destination", click: { x_pct: scene ? [.15, .5, .85][index]! : fixture.x, y_pct: scene ? .55 : fixture.y } };
+  const plan = planSpatialTransition(from, to) as ReframePlan;
+  const prefix = `${fixture.id}-${scene ? "scene-control" : "map"}`;
+  const cut = 500 + plan.duration + plan.hold;
+  const arrival = scene ? render(source, plan, 1) : render(destination, null, 0);
+  await movie(`${prefix}-forward.mp4`, time => time >= cut ? arrival : render(source, plan, Math.max(0, (time - 500) / plan.duration)));
+  await movie(`${prefix}-back.mp4`, time => time < 500 ? arrival : render(source, plan, Math.max(0, 1 - (time - 500) / plan.duration)));
+  for (const progress of [0, .5, 1]) await writeFile(resolve(out, `${prefix}-${progress}.jpg`), still(render(source, plan, progress)));
+  await writeFile(resolve(out, `${prefix}-arrival.jpg`), still(arrival));
+  if (!scene) {
+    const clips = [fixture.h3, fixture.ltx].map(name => resolve(root, "apps/modal-backend", spatialAssetPath(name)!));
+    execFileSync("ffmpeg", ["-y", "-loglevel", "error", "-i", resolve(out, `${prefix}-forward.mp4`), "-i", clips[0]!, "-i", clips[1]!, "-filter_complex", "[0:v]scale=640:360,setsar=1,tpad=stop_mode=clone:stop_duration=4[a];[1:v]scale=640:360:force_original_aspect_ratio=decrease,pad=640:360:(ow-iw)/2:(oh-ih)/2,setsar=1,tpad=start_mode=clone:start_duration=0.5[b];[2:v]scale=640:360:force_original_aspect_ratio=decrease,pad=640:360:(ow-iw)/2:(oh-ih)/2,setsar=1,tpad=start_mode=clone:start_duration=0.5[c];[a][b][c]hstack=inputs=3[v]", "-map", "[v]", "-an", "-t", "7.1", "-r", "30", "-c:v", "libx264", "-crf", "20", "-pix_fmt", "yuv420p", resolve(out, `${prefix}-comparison-pixels-h3-ltx.mp4`)]);
+  }
+  receipts.push({ case: prefix, source_sha256: createHash("sha256").update(sourceBytes).digest("hex"), destination_sha256: scene ? null : createHash("sha256").update(destinationBytes).digest("hex"), target: plan.target, fraction: plan.fraction, duration_ms: plan.duration, hold_ms: plan.hold, study_intro_hold_ms: 500, identity: scene ? "same-image crop control" : `FAIL: ${fixture.title} -> ${fixture.destination}`, continuity: "not human-rated", motion: "shared affine planner; numerical invariants tested", new_model_calls: 0 });
+  console.log(prefix);
+}
+await writeFile(resolve(out, "receipt.json"), JSON.stringify({ new_model_calls: 0, new_model_cost_usd: 0, comparison_order: ["source pixels", "saved H3", "saved LTX"], export_sampling: "nearest-neighbor; browser uses its native image resampling; identical transforms", cases: receipts }, null, 2));
+console.log(out);


### PR DESCRIPTION
## Scope
Second geometry-anchored transition PR. Shared affine planner, contain-aware player, decode-first navigation lifecycle, local gated comparison study and reproducible offline exports. No production navigation wiring or default changes yet.

## Verification
- 20,402 target positions x 21 frames: target visibility, monotonic centering, no exposed borders.
- 17 focused planner/player/layout tests passed; full web coverage and typecheck passed.
- Browser: scrubbed actual source frame, played both saved H3/LTX clips, forward arrival and direct back.
- 15 MP4s plus 24 audit stills and receipt exported locally using existing assets. Zero model calls.

Identity failures remain labeled; this is reframing plus a cut, not reconstructed physical travel.